### PR TITLE
feat: add cw spawn and spawn close commands

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -7,27 +7,34 @@ import json
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 import click
 from click.shell_completion import CompletionItem
 
 from cw import __version__
+from cw.cmux import CmuxAdapter, get_cmux_adapter
 from cw.config import (
+    get_client,
     init_client,
     load_clients,
     load_orchestrator_config,
     load_state,
+    save_state,
     show_config,
 )
 from cw.dev_queue import add_ticket, list_tickets, resolve_client
 from cw.events import advance_cursor, read_events, record_event
 from cw.exceptions import CwError
 from cw.models import (
+    ClientConfig,
+    CompletionReason,
     CwState,
     OrchestratorEventType,
     QueueItem,
     QueueItemStatus,
     Session,
+    SessionOrigin,
     SessionPurpose,
     SessionStatus,
     TaskSpec,
@@ -813,3 +820,161 @@ def dev_queue_status(client: str | None) -> None:
             f"{client_name:<20} {len(pending_tasks):>7}  {len(running_tasks):>7}"
             f"  {len(completed_tasks):>9}  {ticket_ids}"
         )
+
+
+# --- Spawn command group ---
+
+
+def _spawn_create_impl(
+    *,
+    client: ClientConfig,
+    worktree: Path,
+    prompt_file: Path,
+    surface: str,
+    label: str | None,
+    adapter: CmuxAdapter,
+) -> str:
+    """Create a daemon-spawned session.
+
+    Separated from the Click command so tests can inject adapters directly.
+    Returns the new session's ID.
+    """
+    prompt_content = prompt_file.read_text()
+    workspace = client.cmux_workspace or client.name
+    command = f"claude -w {worktree} --print {prompt_content!r}"
+    surface_ref = adapter.spawn(workspace, command, surface)
+
+    session_label = label or "daemon"
+    sess = Session(
+        name=f"{client.name}/{session_label}",
+        client=client.name,
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        workspace_path=client.workspace_path,
+        worktree_path=worktree,
+        surface_ref=surface_ref,
+    )
+
+    state = load_state()
+    state.sessions.append(sess)
+    save_state(state)
+    return sess.id
+
+
+def _spawn_close_impl(
+    *,
+    session_id: str,
+    adapter: CmuxAdapter,
+) -> None:
+    """Close a daemon-spawned session.
+
+    Separated from the Click command so tests can inject adapters directly.
+    """
+    state = load_state()
+    sess = state.find_by_name_or_id(session_id)
+    if sess is None:
+        msg = f"Session '{session_id}' not found."
+        raise CwError(msg)
+    if sess.status == SessionStatus.COMPLETED:
+        msg = f"Session '{session_id}' is already completed."
+        raise CwError(msg)
+
+    if sess.surface_ref is not None:
+        adapter.close(sess.surface_ref)
+
+    sess.status = SessionStatus.COMPLETED
+    sess.completed_at = datetime.now(UTC)
+    sess.completed_reason = CompletionReason.USER
+    save_state(state)
+
+
+@main.group(invoke_without_command=True)
+@click.option("--client", "-c", default=None, help="Client name.")
+@click.option("--worktree", "-w", default=None, help="Worktree path.")
+@click.option("--prompt-file", "-f", default=None, help="Path to prompt file.")
+@click.option(
+    "--surface",
+    "-s",
+    default="split",
+    type=click.Choice(["split", "tab"]),
+    help="Surface type.",
+)
+@click.option("--label", "-l", default=None, help="Session label (default: daemon).")
+@click.pass_context
+@handle_errors
+def spawn(
+    ctx: click.Context,
+    client: str | None,
+    worktree: str | None,
+    prompt_file: str | None,
+    surface: str,
+    label: str | None,
+) -> None:
+    """Spawn a daemon-managed Claude session or manage spawned sessions.
+
+    When called directly (not via a subcommand), spawns a new session:
+
+    \b
+      cw spawn --client my-client --worktree /path/to/worktree --prompt-file prompt.txt
+
+    Subcommands:
+      close  Close a spawned session by session ID.
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+
+    # Invoked as `cw spawn --client ...` (top-level create)
+    missing: list[str] = []
+    if client is None:
+        missing.append("--client")
+    if worktree is None:
+        missing.append("--worktree")
+    if prompt_file is None:
+        missing.append("--prompt-file")
+    if missing:
+        opts = ", ".join(missing)
+        msg = f"Missing required option(s): {opts}"
+        raise CwError(msg)
+
+    # At this point client/worktree/prompt_file are guaranteed non-None
+    # (the `if missing` guard above raised CwError if any were absent).
+    client_config = get_client(cast("str", client))
+    adapter = get_cmux_adapter()
+    session_id = _spawn_create_impl(
+        client=client_config,
+        worktree=Path(cast("str", worktree)),
+        prompt_file=Path(cast("str", prompt_file)),
+        surface=surface,
+        label=label,
+        adapter=adapter,
+    )
+    click.echo(session_id)
+
+
+@spawn.command(name="close")
+@click.argument("session_id")
+@handle_errors
+def spawn_close(session_id: str) -> None:
+    """Close a spawned session by session ID.
+
+    Calls adapter.close on the associated surface and marks the session
+    as COMPLETED.
+
+    \b
+    Example:
+      cw spawn close abc12345
+    """
+    # Validate session exists before acquiring the adapter (adapter may fail on
+    # non-macOS when cmux is not installed).
+    state = load_state()
+    sess = state.find_by_name_or_id(session_id)
+    if sess is None:
+        not_found_msg = f"Session '{session_id}' not found."
+        raise CwError(not_found_msg)
+    if sess.status == SessionStatus.COMPLETED:
+        already_done_msg = f"Session '{session_id}' is already completed."
+        raise CwError(already_done_msg)
+
+    adapter = get_cmux_adapter()
+    _spawn_close_impl(session_id=session_id, adapter=adapter)
+    click.echo(f"Closed session: {session_id}")

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -32,6 +32,7 @@ class CompletionReason(StrEnum):
 
 class SessionOrigin(StrEnum):
     USER = "user"
+    DAEMON = "daemon"
 
 
 class QueueItemStatus(StrEnum):

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -1,0 +1,369 @@
+"""Tests for cw spawn and spawn close commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner
+
+from cw.cli import main
+from cw.cmux import FakeCmuxAdapter
+from cw.config import load_state, save_state
+from cw.exceptions import CwError
+from cw.models import (
+    ClientConfig,
+    CompletionReason,
+    CwState,
+    Session,
+    SessionOrigin,
+    SessionPurpose,
+    SessionStatus,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_client(tmp_path: Path, name: str = "test-client") -> ClientConfig:
+    """Create a ClientConfig pointing at a tmp workspace directory."""
+    workspace = tmp_path / "workspace" / name
+    workspace.mkdir(parents=True)
+    return ClientConfig(
+        name=name,
+        workspace_path=workspace,
+        default_branch="main",
+    )
+
+
+def _make_prompt_file(tmp_path: Path, content: str = "Do the thing.") -> Path:
+    """Write a prompt file and return its path."""
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text(content)
+    return prompt_file
+
+
+# ---------------------------------------------------------------------------
+# Unit-level tests (no Click runner, adapter injected directly)
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnCreate:
+    """Tests for the spawn_create business logic."""
+
+    def test_happy_path_creates_session(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn create: happy path stores session with correct fields."""
+        from cw.cli import _spawn_create_impl
+
+        client = _make_client(tmp_path)
+        prompt_file = _make_prompt_file(tmp_path, "Implement the feature.")
+        adapter = FakeCmuxAdapter()
+        worktree = tmp_path / "worktree" / "feat-branch"
+        worktree.mkdir(parents=True)
+
+        session_id = _spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt_file=prompt_file,
+            surface="split",
+            label="my-task",
+            adapter=adapter,
+        )
+
+        # Session persisted
+        state = load_state()
+        assert len(state.sessions) == 1
+        sess = state.sessions[0]
+        assert sess.id == session_id
+        assert sess.name == "test-client/my-task"
+        assert sess.client == "test-client"
+        assert sess.purpose == SessionPurpose.IMPL
+        assert sess.origin == SessionOrigin.DAEMON
+        assert sess.worktree_path == worktree
+        assert sess.workspace_path == client.workspace_path
+        assert sess.surface_ref is not None
+        assert sess.status == SessionStatus.ACTIVE
+
+    def test_default_label_is_daemon(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn create: default label produces 'client/daemon' session name."""
+        from cw.cli import _spawn_create_impl
+
+        client = _make_client(tmp_path)
+        prompt_file = _make_prompt_file(tmp_path)
+        adapter = FakeCmuxAdapter()
+        worktree = tmp_path / "worktree"
+        worktree.mkdir(parents=True)
+
+        _spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt_file=prompt_file,
+            surface="split",
+            label=None,
+            adapter=adapter,
+        )
+
+        state = load_state()
+        assert state.sessions[0].name == "test-client/daemon"
+
+    def test_adapter_receives_correct_spawn_args(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn create: adapter.spawn is called with workspace, command, surface."""
+        from cw.cli import _spawn_create_impl
+
+        client = _make_client(tmp_path, name="acme")
+        prompt_content = "Fix the login bug."
+        prompt_file = _make_prompt_file(tmp_path, prompt_content)
+        adapter = FakeCmuxAdapter()
+        worktree = tmp_path / "worktree"
+        worktree.mkdir(parents=True)
+
+        _spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt_file=prompt_file,
+            surface="tab",
+            label=None,
+            adapter=adapter,
+        )
+
+        assert len(adapter.calls["spawn"]) == 1
+        workspace_arg, command_arg, surface_arg = adapter.calls["spawn"][0]
+        assert workspace_arg == "acme"
+        assert str(worktree) in command_arg
+        assert prompt_content in command_arg
+        assert surface_arg == "tab"
+
+    def test_cmux_workspace_overrides_client_name(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn create: cmux_workspace field is used as workspace arg if set."""
+        from cw.cli import _spawn_create_impl
+
+        workspace = tmp_path / "workspace" / "acme"
+        workspace.mkdir(parents=True)
+        client = ClientConfig(
+            name="acme",
+            workspace_path=workspace,
+            cmux_workspace="my-custom-ws",
+        )
+        prompt_file = _make_prompt_file(tmp_path)
+        adapter = FakeCmuxAdapter()
+        worktree = tmp_path / "worktree"
+        worktree.mkdir(parents=True)
+
+        _spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt_file=prompt_file,
+            surface="split",
+            label=None,
+            adapter=adapter,
+        )
+
+        workspace_arg, _cmd, _surface = adapter.calls["spawn"][0]
+        assert workspace_arg == "my-custom-ws"
+
+    def test_surface_ref_stored_from_adapter(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn create: surface_ref on session matches the adapter return value."""
+        from cw.cli import _spawn_create_impl
+
+        client = _make_client(tmp_path)
+        prompt_file = _make_prompt_file(tmp_path)
+        adapter = FakeCmuxAdapter()
+        worktree = tmp_path / "worktree"
+        worktree.mkdir(parents=True)
+
+        _spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt_file=prompt_file,
+            surface="split",
+            label=None,
+            adapter=adapter,
+        )
+
+        state = load_state()
+        # FakeCmuxAdapter returns "fake-pane-1" for first spawn call
+        assert state.sessions[0].surface_ref == "fake-pane-1"
+
+
+class TestSpawnClose:
+    """Tests for the spawn close business logic."""
+
+    def _seed_daemon_session(self, tmp_path: Path, tmp_config_dir: Path) -> Session:
+        """Save a DAEMON session to state and return it."""
+        workspace = tmp_path / "workspace" / "test-client"
+        workspace.mkdir(parents=True)
+        sess = Session(
+            id="dead1234",
+            name="test-client/my-task",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+            workspace_path=workspace,
+            surface_ref="fake-pane-99",
+        )
+        state = CwState(sessions=[sess])
+        save_state(state)
+        return sess
+
+    def test_happy_path_marks_completed(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn close: session marked COMPLETED after close."""
+        from cw.cli import _spawn_close_impl
+
+        sess = self._seed_daemon_session(tmp_path, tmp_config_dir)
+        adapter = FakeCmuxAdapter()
+
+        _spawn_close_impl(session_id=sess.id, adapter=adapter)
+
+        state = load_state()
+        closed = state.find_by_name_or_id(sess.id)
+        assert closed is not None
+        assert closed.status == SessionStatus.COMPLETED
+        assert closed.completed_reason == CompletionReason.USER
+        assert closed.completed_at is not None
+
+    def test_adapter_close_called_with_surface_ref(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn close: adapter.close receives the session's surface_ref."""
+        from cw.cli import _spawn_close_impl
+
+        sess = self._seed_daemon_session(tmp_path, tmp_config_dir)
+        adapter = FakeCmuxAdapter()
+
+        _spawn_close_impl(session_id=sess.id, adapter=adapter)
+
+        assert len(adapter.calls["close"]) == 1
+        assert adapter.calls["close"][0] == ("fake-pane-99",)
+
+    def test_missing_session_raises_cw_error(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn close: raises CwError when session_id not found."""
+        from cw.cli import _spawn_close_impl
+
+        adapter = FakeCmuxAdapter()
+        error_msg = ""
+        try:
+            _spawn_close_impl(session_id="nonexistent", adapter=adapter)
+        except CwError as exc:
+            error_msg = str(exc)
+        else:
+            pytest.fail("Expected CwError was not raised")
+
+        assert "nonexistent" in error_msg
+
+    def test_already_completed_raises_cw_error(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn close: raises CwError when session is already completed."""
+        from cw.cli import _spawn_close_impl
+
+        workspace = tmp_path / "workspace" / "test-client"
+        workspace.mkdir(parents=True)
+        sess = Session(
+            id="done1234",
+            name="test-client/my-task",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.COMPLETED,
+            workspace_path=workspace,
+        )
+        save_state(CwState(sessions=[sess]))
+        adapter = FakeCmuxAdapter()
+
+        with pytest.raises(CwError, match="already completed"):
+            _spawn_close_impl(session_id="done1234", adapter=adapter)
+
+    def test_no_surface_ref_skips_adapter_close(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn close: adapter.close NOT called if surface_ref is None."""
+        from cw.cli import _spawn_close_impl
+
+        workspace = tmp_path / "workspace" / "test-client"
+        workspace.mkdir(parents=True)
+        sess = Session(
+            id="nosurf1",
+            name="test-client/my-task",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+            workspace_path=workspace,
+            surface_ref=None,
+        )
+        save_state(CwState(sessions=[sess]))
+        adapter = FakeCmuxAdapter()
+
+        _spawn_close_impl(session_id="nosurf1", adapter=adapter)
+
+        assert adapter.calls["close"] == []
+        state = load_state()
+        closed = state.find_by_name_or_id("nosurf1")
+        assert closed is not None
+        assert closed.status == SessionStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests via Click CliRunner
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnCLI:
+    """CLI-layer tests using CliRunner (adapter injected via env/monkeypatch)."""
+
+    def test_spawn_create_missing_client_shows_error(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """cw spawn --client unknown: exits with error about unknown client."""
+        runner = CliRunner()
+        prompt_file = _make_prompt_file(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        result = runner.invoke(
+            main,
+            [
+                "spawn",
+                "--client",
+                "no-such-client",
+                "--worktree",
+                str(worktree),
+                "--prompt-file",
+                str(prompt_file),
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "no-such-client" in result.output
+
+    def test_spawn_close_missing_session_shows_error(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """cw spawn close nonexistent: exits with error about missing session."""
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["spawn", "close", "nonexistent-id"])
+
+        assert result.exit_code != 0
+        assert "nonexistent-id" in result.output


### PR DESCRIPTION
## Summary
- Add `SessionOrigin.DAEMON` to models.py
- Add `cw spawn --client --worktree --prompt-file [--surface] [--label]` command
- Add `cw spawn close <session-id>` to close a daemon-spawned session
- All tests use `FakeCmuxAdapter` (Linux CI safe)

Closes #5

## Test plan
- [ ] `uv run pytest tests/test_spawn.py -v` passes (12 new tests)
- [ ] `uv run mypy src/` passes
- [ ] `uv run ruff check src/ tests/` clean