### PR TITLE
feat: add PR event watcher daemon

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -19,6 +19,7 @@ from cw.config import (
     load_state,
     show_config,
 )
+from cw.daemon import run_watcher_tick
 from cw.dev_queue import add_ticket, list_tickets, resolve_client
 from cw.events import advance_cursor, read_events, record_event
 from cw.exceptions import CwError
@@ -718,6 +719,31 @@ def pane_exited(client: str, purpose: str, exit_code: int) -> None:
     """
     signal_idle(client, purpose, exit_code=exit_code)
     click.echo(f"Signaled IDLE for {client}/{purpose} (exit code {exit_code}).")
+
+
+@main.command(name="daemon")
+@click.option(
+    "--once",
+    is_flag=True,
+    default=False,
+    help="Run one tick and exit (useful for testing or cron).",
+)
+@handle_errors
+def daemon(once: bool) -> None:
+    """Run the PR event watcher daemon.
+
+    Polls review-monitor state files and emits orchestrator events
+    for PR lifecycle changes (merged, CI failed, review received, mergeable).
+
+    \b
+    Run continuously (default):
+      cw daemon
+
+    \b
+    Single tick (e.g. from cron):
+      cw daemon --once
+    """
+    run_watcher_tick(once=once)
 
 
 _COMPLETION_SCRIPTS = {

--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -42,6 +42,7 @@ STATE_DIR = (
 QUEUES_DIR = STATE_DIR / "queues"
 EVENTS_DIR = STATE_DIR / "events"
 HISTORY_DIR = STATE_DIR / "history"
+PR_WATCHER_DIR = STATE_DIR / "pr_watcher"
 CLIENTS_FILE = CONFIG_DIR / "clients.yaml"
 STATE_FILE = STATE_DIR / "sessions.json"
 

--- a/src/cw/daemon.py
+++ b/src/cw/daemon.py
@@ -1,0 +1,309 @@
+"""PR event watcher daemon with tick-based polling loop."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field
+
+from cw.config import STATE_DIR, load_clients, load_orchestrator_config, load_state
+from cw.events import record_event
+from cw.models import OrchestratorEventType, SessionStatus
+
+if TYPE_CHECKING:
+    from cw.models import ClientConfig, CwState, OrchestratorEvent
+
+# Directory where review-monitor state files live
+REVIEW_MONITOR_DIR: Path = Path.home() / ".claude" / "review-monitor"
+
+# Directory for persisted watcher snapshots (one file per client)
+PR_WATCHER_DIR: Path = STATE_DIR / "pr_watcher"
+
+# CI-failure keywords to look for in delta_findings messages
+_CI_KEYWORDS = frozenset(
+    {"ci", "check", "failure", "failed", "failing", "test", "build"}
+)
+
+
+class WatcherSnapshot(BaseModel):
+    """Persisted last-seen state per client, to enable delta detection."""
+
+    pr_states: dict[str, str] = Field(default_factory=dict)
+    # key: "repo#pr_number"
+    ci_fail_prs: set[str] = Field(default_factory=set)
+    review_prs: set[str] = Field(default_factory=set)
+    mergeable_prs: set[str] = Field(default_factory=set)
+
+
+class ThrottleStore(BaseModel):
+    """Prevents duplicate session dispatches per (client, pr_number, role) tuple."""
+
+    active_dispatches: dict[str, str] = Field(default_factory=dict)
+    # key: "client|repo#pr|role"  →  session_id
+
+    def is_throttled(
+        self, client_name: str, pr_key: str, role: str, state: CwState
+    ) -> bool:
+        """Return True if a non-completed session for this key exists."""
+        dispatch_key = f"{client_name}|{pr_key}|{role}"
+        session_id = self.active_dispatches.get(dispatch_key)
+        if session_id is None:
+            return False
+        for session in state.sessions:
+            if session.id == session_id and session.status != SessionStatus.COMPLETED:
+                return True
+        return False
+
+    def mark_dispatched(
+        self, client_name: str, pr_key: str, role: str, session_id: str
+    ) -> None:
+        """Record that a session was dispatched for this (client, pr_key, role)."""
+        dispatch_key = f"{client_name}|{pr_key}|{role}"
+        self.active_dispatches[dispatch_key] = session_id
+
+    def clear_completed(self, state: CwState) -> None:
+        """Remove dispatch entries whose sessions are now completed."""
+        completed_ids = {
+            s.id for s in state.sessions if s.status == SessionStatus.COMPLETED
+        }
+        self.active_dispatches = {
+            k: v for k, v in self.active_dispatches.items() if v not in completed_ids
+        }
+
+
+def _load_snapshot(client_name: str) -> WatcherSnapshot:
+    """Load a WatcherSnapshot for a client from disk, or return an empty one."""
+    PR_WATCHER_DIR.mkdir(parents=True, exist_ok=True)
+    path = PR_WATCHER_DIR / f"{client_name}.json"
+    if not path.exists():
+        return WatcherSnapshot()
+    return WatcherSnapshot.model_validate_json(path.read_text())
+
+
+def _save_snapshot(client_name: str, snapshot: WatcherSnapshot) -> None:
+    """Persist a WatcherSnapshot for a client."""
+    PR_WATCHER_DIR.mkdir(parents=True, exist_ok=True)
+    path = PR_WATCHER_DIR / f"{client_name}.json"
+    path.write_text(snapshot.model_dump_json(indent=2))
+
+
+def _load_throttle() -> ThrottleStore:
+    """Load the global ThrottleStore from disk."""
+    path = STATE_DIR / "pr_dispatch_throttle.json"
+    if not path.exists():
+        return ThrottleStore()
+    return ThrottleStore.model_validate_json(path.read_text())
+
+
+def _save_throttle(store: ThrottleStore) -> None:
+    """Persist the global ThrottleStore."""
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    path = STATE_DIR / "pr_dispatch_throttle.json"
+    path.write_text(store.model_dump_json(indent=2))
+
+
+def _load_monitor_files() -> list[dict[str, Any]]:
+    """Load all MonitorState JSON files from REVIEW_MONITOR_DIR.
+
+    Returns a list of raw dicts, each corresponding to one file's contents.
+    """
+    if not REVIEW_MONITOR_DIR.exists():
+        return []
+    result: list[dict[str, Any]] = []
+    for path in REVIEW_MONITOR_DIR.glob("*.json"):
+        try:
+            raw: dict[str, Any] = json.loads(path.read_text())
+            result.append(raw)
+        except (json.JSONDecodeError, OSError):
+            continue
+    return result
+
+
+def _has_ci_failure(delta_findings: list[dict[str, Any]]) -> bool:
+    """Return True if any delta_finding contains CI/failure keywords."""
+    for finding in delta_findings:
+        message = str(finding.get("message", "")).lower()
+        if any(kw in message for kw in _CI_KEYWORDS):
+            return True
+    return False
+
+
+def _count_unresolved_threads(thread_status: dict[str, Any]) -> int:
+    """Count unresolved threads from a thread_status dict."""
+    count = 0
+    for thread_data in thread_status.values():
+        resolved = False
+        if isinstance(thread_data, dict):
+            resolved = bool(thread_data.get("resolved", False))
+        if not resolved:
+            count += 1
+    return count
+
+
+def _all_threads_addressed(thread_status: dict[str, Any]) -> bool:
+    """Return True if all threads are marked resolved."""
+    if not thread_status:
+        return True
+    return all(
+        bool(v.get("resolved", False)) if isinstance(v, dict) else False
+        for v in thread_status.values()
+    )
+
+
+def watch_prs_for_client(
+    client: ClientConfig,
+    snapshot: WatcherSnapshot,
+) -> tuple[list[OrchestratorEvent], WatcherSnapshot]:
+    """Scan review-monitor files for this client and emit delta events.
+
+    Args:
+        client: The client config whose workspace path filters PRs.
+        snapshot: Previously-saved snapshot of last-seen PR states.
+
+    Returns:
+        A tuple of (new events emitted, updated snapshot).
+    """
+    workspace_str = str(client.workspace_path)
+
+    monitor_files = _load_monitor_files()
+
+    events: list[OrchestratorEvent] = []
+    new_snapshot = WatcherSnapshot(
+        pr_states=dict(snapshot.pr_states),
+        ci_fail_prs=set(snapshot.ci_fail_prs),
+        review_prs=set(snapshot.review_prs),
+        mergeable_prs=set(snapshot.mergeable_prs),
+    )
+
+    for file_data in monitor_files:
+        active_prs: dict[str, Any] = file_data.get("active", {})
+        for pr_data in active_prs.values():
+            if not isinstance(pr_data, dict):
+                continue
+
+            repo_path = str(pr_data.get("repo_path", ""))
+            if not repo_path.startswith(workspace_str):
+                continue
+
+            repo = str(pr_data.get("repo", ""))
+            pr_number = pr_data.get("pr_number", 0)
+            status = str(pr_data.get("status", "watching"))
+            role = str(pr_data.get("role", "author"))
+            thread_status: dict[str, Any] = pr_data.get("thread_status", {})
+            delta_findings: list[dict[str, Any]] = pr_data.get("delta_findings", [])
+
+            pr_key = f"{repo}#{pr_number}"
+            prev_status = new_snapshot.pr_states.get(pr_key)
+
+            # --- PR_MERGED: status transitioned to complete or abandoned ---
+            if status in ("complete", "abandoned") and prev_status not in (
+                "complete",
+                "abandoned",
+            ):
+                event = record_event(
+                    OrchestratorEventType.PR_MERGED,
+                    {
+                        "client": client.name,
+                        "repo": repo,
+                        "pr_number": pr_number,
+                        "role": role,
+                        "status": status,
+                    },
+                )
+                events.append(event)
+                new_snapshot.pr_states[pr_key] = status
+                continue
+
+            # Update state for watching PRs
+            new_snapshot.pr_states[pr_key] = status
+
+            if status != "watching":
+                continue
+
+            unresolved_now = _count_unresolved_threads(thread_status)
+
+            # --- PR_REVIEW_RECEIVED: new unresolved threads since last tick ---
+            if unresolved_now > 0 and pr_key not in new_snapshot.review_prs:
+                event = record_event(
+                    OrchestratorEventType.PR_REVIEW_RECEIVED,
+                    {
+                        "client": client.name,
+                        "repo": repo,
+                        "pr_number": pr_number,
+                        "role": role,
+                        "unresolved_threads": unresolved_now,
+                    },
+                )
+                events.append(event)
+                new_snapshot.review_prs.add(pr_key)
+
+            # --- PR_MERGEABLE: all threads addressed (and we've seen review before) ---
+            if (
+                pr_key in new_snapshot.review_prs
+                and pr_key not in new_snapshot.mergeable_prs
+                and _all_threads_addressed(thread_status)
+                and unresolved_now == 0
+                and thread_status  # at least one thread existed
+            ):
+                event = record_event(
+                    OrchestratorEventType.PR_MERGEABLE,
+                    {
+                        "client": client.name,
+                        "repo": repo,
+                        "pr_number": pr_number,
+                        "role": role,
+                    },
+                )
+                events.append(event)
+                new_snapshot.mergeable_prs.add(pr_key)
+
+            # --- PR_CI_FAILED: delta_findings mention CI failure ---
+            if (
+                pr_key not in new_snapshot.ci_fail_prs
+                and delta_findings
+                and _has_ci_failure(delta_findings)
+            ):
+                event = record_event(
+                    OrchestratorEventType.PR_CI_FAILED,
+                    {
+                        "client": client.name,
+                        "repo": repo,
+                        "pr_number": pr_number,
+                        "role": role,
+                        "findings_count": len(delta_findings),
+                    },
+                )
+                events.append(event)
+                new_snapshot.ci_fail_prs.add(pr_key)
+
+    return events, new_snapshot
+
+
+def run_watcher_tick(*, once: bool = False) -> None:
+    """Run the PR watcher daemon loop.
+
+    Args:
+        once: If True, run a single tick and return. Otherwise loop forever.
+    """
+    config = load_orchestrator_config()
+    interval = config.tick_interval_seconds
+
+    while True:
+        clients = load_clients()
+        state = load_state()
+        throttle = _load_throttle()
+        throttle.clear_completed(state)
+        _save_throttle(throttle)
+
+        for client_name, client in clients.items():
+            snapshot = _load_snapshot(client_name)
+            _events, updated_snapshot = watch_prs_for_client(client, snapshot)
+            _save_snapshot(client_name, updated_snapshot)
+
+        if once:
+            return
+
+        time.sleep(interval)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,436 @@
+"""Tests for cw.daemon — PR event watcher."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cw.daemon import (
+    ThrottleStore,
+    WatcherSnapshot,
+    watch_prs_for_client,
+)
+from cw.models import (
+    ClientConfig,
+    CwState,
+    OrchestratorEventType,
+    Session,
+    SessionPurpose,
+    SessionStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_monitor_file(
+    directory: Path,
+    repo: str,
+    pr_number: int,
+    repo_path: str,
+    *,
+    status: str = "watching",
+    role: str = "author",
+    thread_status: dict[str, Any] | None = None,
+    delta_findings: list[dict[str, Any]] | None = None,
+) -> Path:
+    """Write a MonitorState JSON file to directory and return its path."""
+    pr_key = f"{repo}#{pr_number}"
+    pr_data: dict[str, Any] = {
+        "role": role,
+        "repo": repo,
+        "repo_path": repo_path,
+        "pr_number": pr_number,
+        "last_seen_sha": "abc123",
+        "status": status,
+        "thread_status": thread_status or {},
+        "delta_findings": delta_findings or [],
+    }
+    state: dict[str, Any] = {
+        "active": {pr_key: pr_data},
+        "completed": {},
+    }
+    # filename: owner--repo.json
+    filename = repo.replace("/", "--") + ".json"
+    file_path = directory / filename
+    file_path.write_text(json.dumps(state, indent=2))
+    return file_path
+
+
+@pytest.fixture
+def tmp_review_monitor_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect cw.daemon.REVIEW_MONITOR_DIR to a temp directory."""
+    monitor_dir = tmp_path / "review-monitor"
+    monitor_dir.mkdir(parents=True)
+    monkeypatch.setattr("cw.daemon.REVIEW_MONITOR_DIR", monitor_dir)
+    return monitor_dir
+
+
+@pytest.fixture
+def tmp_pr_watcher_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect cw.daemon.PR_WATCHER_DIR to a temp directory."""
+    watcher_dir = tmp_path / "pr_watcher"
+    watcher_dir.mkdir(parents=True)
+    monkeypatch.setattr("cw.daemon.PR_WATCHER_DIR", watcher_dir)
+    return watcher_dir
+
+
+@pytest.fixture
+def tmp_state_dir_for_daemon(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect cw.daemon.STATE_DIR and cw.config.STATE_DIR to tmp_path."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    events_dir = state_dir / "events"
+    events_dir.mkdir(parents=True)
+    monkeypatch.setattr("cw.daemon.STATE_DIR", state_dir)
+    monkeypatch.setattr("cw.config.STATE_DIR", state_dir)
+    monkeypatch.setattr("cw.events.EVENTS_DIR", events_dir)
+    monkeypatch.setattr("cw.config.EVENTS_DIR", events_dir)
+    return state_dir
+
+
+@pytest.fixture
+def workspace_path(tmp_path: Path) -> Path:
+    """Create and return a fake workspace directory."""
+    workspace = tmp_path / "workspace" / "my-project"
+    workspace.mkdir(parents=True)
+    return workspace
+
+
+@pytest.fixture
+def sample_client(workspace_path: Path) -> ClientConfig:
+    """A ClientConfig pointing at workspace_path."""
+    return ClientConfig(
+        name="test-client",
+        workspace_path=workspace_path,
+        default_branch="main",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: watch_prs_for_client
+# ---------------------------------------------------------------------------
+
+
+class TestNoPRsFound:
+    def test_no_monitor_files(
+        self,
+        tmp_review_monitor_dir: Path,
+        tmp_pr_watcher_dir: Path,
+        tmp_state_dir_for_daemon: Path,
+        sample_client: ClientConfig,
+    ) -> None:
+        """Empty monitor dir → no events emitted."""
+        snapshot = WatcherSnapshot()
+        events, updated = watch_prs_for_client(sample_client, snapshot)
+        assert events == []
+        assert updated.pr_states == {}
+
+    def test_monitor_file_different_repo_path(
+        self,
+        tmp_review_monitor_dir: Path,
+        tmp_pr_watcher_dir: Path,
+        tmp_state_dir_for_daemon: Path,
+        sample_client: ClientConfig,
+        tmp_path: Path,
+    ) -> None:
+        """PRs from unrelated repo paths are ignored."""
+        other_workspace = str(tmp_path / "other-workspace" / "other-project")
+        _make_monitor_file(
+            tmp_review_monitor_dir,
+            "owner/other-repo",
+            42,
+            other_workspace,
+            status="complete",
+        )
+        snapshot = WatcherSnapshot()
+        events, _ = watch_prs_for_client(sample_client, snapshot)
+        assert events == []
+
+
+class TestPRMerged:
+    def test_pr_merged_event(
+        self,
+        tmp_review_monitor_dir: Path,
+        tmp_pr_watcher_dir: Path,
+        tmp_state_dir_for_daemon: Path,
+        sample_client: ClientConfig,
+        workspace_path: Path,
+    ) -> None:
+        """A PR with status='complete' emits PR_MERGED."""
+        _make_monitor_file(
+            tmp_review_monitor_dir,
+            "owner/my-repo",
+            99,
+            str(workspace_path),
+            status="complete",
+        )
+        snapshot = WatcherSnapshot()
+        events, updated = watch_prs_for_client(sample_client, snapshot)
+
+        assert len(events) == 1
+        assert events[0].type == OrchestratorEventType.PR_MERGED
+        assert events[0].payload["pr_number"] == 99
+        assert events[0].payload["repo"] == "owner/my-repo"
+        assert updated.pr_states.get("owner/my-repo#99") == "complete"
+
+    def test_pr_abandoned_emits_merged(
+        self,
+        tmp_review_monitor_dir: Path,
+        tmp_pr_watcher_dir: Path,
+        tmp_state_dir_for_daemon: Path,
+        sample_client: ClientConfig,
+        workspace_path: Path,
+    ) -> None:
+        """A PR with status='abandoned' also emits PR_MERGED."""
+        _make_monitor_file(
+            tmp_review_monitor_dir,
+            "owner/my-repo",
+            55,
+            str(workspace_path),
+            status="abandoned",
+        )
+        snapshot = WatcherSnapshot()
+        events, updated = watch_prs_for_client(sample_client, snapshot)
+
+        assert len(events) == 1
+        assert events[0].type == OrchestratorEventType.PR_MERGED
+        assert updated.pr_states.get("owner/my-repo#55") == "abandoned"
+
+    def test_no_duplicate_merged(
+        self,
+        tmp_review_monitor_dir: Path,
+        tmp_pr_watcher_dir: Path,
+        tmp_state_dir_for_daemon: Path,
+        sample_client: ClientConfig,
+        workspace_path: Path,
+    ) -> None:
+        """Second call with same merged file emits nothing (snapshot updated)."""
+        _make_monitor_file(
+            tmp_review_monitor_dir,
+            "owner/my-repo",
+            99,
+            str(workspace_path),
+            status="complete",
+        )
+        snapshot = WatcherSnapshot()
+        events_first, updated_snapshot = watch_prs_for_client(sample_client, snapshot)
+        assert len(events_first) == 1
+
+        # Second call with updated snapshot — no new event
+        events_second, _ = watch_prs_for_client(sample_client, updated_snapshot)
+        assert events_second == []
+
+
+class TestCIFailed:
+    def test_delta_findings_ci_failed(
+        self,
+        tmp_review_monitor_dir: Path,
+        tmp_pr_watcher_dir: Path,
+        tmp_state_dir_for_daemon: Path,
+        sample_client: ClientConfig,
+        workspace_path: Path,
+    ) -> None:
+        """delta_findings with CI keyword → PR_CI_FAILED emitted."""
+        _make_monitor_file(
+            tmp_review_monitor_dir,
+            "owner/my-repo",
+            77,
+            str(workspace_path),
+            status="watching",
+            delta_findings=[{"message": "CI check failed on tests"}],
+        )
+        snapshot = WatcherSnapshot()
+        events, updated = watch_prs_for_client(sample_client, snapshot)
+
+        ci_events = [e for e in events if e.type == OrchestratorEventType.PR_CI_FAILED]
+        assert len(ci_events) == 1
+        assert ci_events[0].payload["pr_number"] == 77
+        assert "owner/my-repo#77" in updated.ci_fail_prs
+
+    def test_no_duplicate_ci_failed(
+        self,
+        tmp_review_monitor_dir: Path,
+        tmp_pr_watcher_dir: Path,
+        tmp_state_dir_for_daemon: Path,
+        sample_client: ClientConfig,
+        workspace_path: Path,
+    ) -> None:
+        """Second call with same CI failure → no duplicate event."""
+        _make_monitor_file(
+            tmp_review_monitor_dir,
+            "owner/my-repo",
+            77,
+            str(workspace_path),
+            status="watching",
+            delta_findings=[{"message": "CI check failed"}],
+        )
+        snapshot = WatcherSnapshot()
+        _, updated_snapshot = watch_prs_for_client(sample_client, snapshot)
+        events_second, _ = watch_prs_for_client(sample_client, updated_snapshot)
+
+        ci_events = [
+            e for e in events_second if e.type == OrchestratorEventType.PR_CI_FAILED
+        ]
+        assert ci_events == []
+
+    def test_non_ci_findings_no_event(
+        self,
+        tmp_review_monitor_dir: Path,
+        tmp_pr_watcher_dir: Path,
+        tmp_state_dir_for_daemon: Path,
+        sample_client: ClientConfig,
+        workspace_path: Path,
+    ) -> None:
+        """delta_findings without CI keywords → no PR_CI_FAILED."""
+        _make_monitor_file(
+            tmp_review_monitor_dir,
+            "owner/my-repo",
+            33,
+            str(workspace_path),
+            status="watching",
+            delta_findings=[{"message": "style nit: trailing whitespace"}],
+        )
+        snapshot = WatcherSnapshot()
+        events, _ = watch_prs_for_client(sample_client, snapshot)
+
+        ci_events = [e for e in events if e.type == OrchestratorEventType.PR_CI_FAILED]
+        assert ci_events == []
+
+
+class TestReviewReceived:
+    def test_review_received_on_new_threads(
+        self,
+        tmp_review_monitor_dir: Path,
+        tmp_pr_watcher_dir: Path,
+        tmp_state_dir_for_daemon: Path,
+        sample_client: ClientConfig,
+        workspace_path: Path,
+    ) -> None:
+        """New unresolved threads → PR_REVIEW_RECEIVED emitted."""
+        _make_monitor_file(
+            tmp_review_monitor_dir,
+            "owner/my-repo",
+            10,
+            str(workspace_path),
+            status="watching",
+            thread_status={"t1": {"resolved": False}},
+        )
+        snapshot = WatcherSnapshot()
+        events, updated = watch_prs_for_client(sample_client, snapshot)
+
+        review_events = [
+            e for e in events if e.type == OrchestratorEventType.PR_REVIEW_RECEIVED
+        ]
+        assert len(review_events) == 1
+        assert "owner/my-repo#10" in updated.review_prs
+
+
+class TestMergeable:
+    def test_mergeable_after_threads_resolved(
+        self,
+        tmp_review_monitor_dir: Path,
+        tmp_pr_watcher_dir: Path,
+        tmp_state_dir_for_daemon: Path,
+        sample_client: ClientConfig,
+        workspace_path: Path,
+    ) -> None:
+        """All threads resolved after prior review → PR_MERGEABLE emitted."""
+        # First tick: unresolved thread → PR_REVIEW_RECEIVED
+        _make_monitor_file(
+            tmp_review_monitor_dir,
+            "owner/my-repo",
+            20,
+            str(workspace_path),
+            status="watching",
+            thread_status={"t1": {"resolved": False}},
+        )
+        snapshot = WatcherSnapshot()
+        _, snapshot_after_review = watch_prs_for_client(sample_client, snapshot)
+        assert "owner/my-repo#20" in snapshot_after_review.review_prs
+
+        # Second tick: thread now resolved → PR_MERGEABLE
+        _make_monitor_file(
+            tmp_review_monitor_dir,
+            "owner/my-repo",
+            20,
+            str(workspace_path),
+            status="watching",
+            thread_status={"t1": {"resolved": True}},
+        )
+        events_second, _ = watch_prs_for_client(sample_client, snapshot_after_review)
+
+        mergeable_events = [
+            e for e in events_second if e.type == OrchestratorEventType.PR_MERGEABLE
+        ]
+        assert len(mergeable_events) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: ThrottleStore
+# ---------------------------------------------------------------------------
+
+
+class TestThrottleStore:
+    def _make_active_session(self, session_id: str, workspace: Path) -> Session:
+        return Session(
+            id=session_id,
+            name="test-client/impl",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=workspace,
+        )
+
+    def _make_completed_session(self, session_id: str, workspace: Path) -> Session:
+        return Session(
+            id=session_id,
+            name="test-client/impl",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.COMPLETED,
+            workspace_path=workspace,
+        )
+
+    def test_not_throttled_when_empty(self) -> None:
+        """No dispatches → is_throttled returns False."""
+        store = ThrottleStore()
+        state = CwState()
+        assert not store.is_throttled("client", "owner/repo#1", "author", state)
+
+    def test_throttled_when_active_session_exists(self, tmp_path: Path) -> None:
+        """Marking dispatch and having active session → is_throttled True."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        store = ThrottleStore()
+        state = CwState(sessions=[self._make_active_session("sess001", workspace)])
+        store.mark_dispatched("client", "owner/repo#1", "author", "sess001")
+        assert store.is_throttled("client", "owner/repo#1", "author", state)
+
+    def test_not_throttled_after_clear_completed(self, tmp_path: Path) -> None:
+        """After clear_completed removes completed session → is_throttled False."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        store = ThrottleStore()
+        state = CwState(sessions=[self._make_completed_session("sess002", workspace)])
+        store.mark_dispatched("client", "owner/repo#2", "author", "sess002")
+
+        # Before clearing: session is completed but still in active_dispatches
+        store.clear_completed(state)
+
+        # After clearing, throttle entry is removed
+        assert not store.is_throttled("client", "owner/repo#2", "author", state)
+
+    def test_throttle_different_role_not_throttled(self, tmp_path: Path) -> None:
+        """Different role → not throttled even if same repo+pr."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        store = ThrottleStore()
+        state = CwState(sessions=[self._make_active_session("sess003", workspace)])
+        store.mark_dispatched("client", "owner/repo#3", "author", "sess003")
+        # "reviewer" role is different from "author"
+        assert not store.is_throttled("client", "owner/repo#3", "reviewer", state)


### PR DESCRIPTION
## Summary
- Add `src/cw/daemon.py` with `WatcherSnapshot`, `ThrottleStore`, `watch_prs_for_client`, `run_watcher_tick`
- Add `PR_WATCHER_DIR` constant to config.py
- Add `cw daemon [--once]` CLI command
- Delta detection: PR_MERGED, PR_REVIEW_RECEIVED, PR_MERGEABLE, PR_CI_FAILED from review-monitor JSON files
- Throttle prevents duplicate dispatches per (client, pr, role) tuple

Closes #11

## Test plan
- [ ] `uv run pytest tests/test_daemon.py -v` passes (15 tests)
- [ ] `uv run mypy src/` passes
- [ ] `uv run ruff check src/ tests/` clean