### PR TITLE
feat: add cw dev-queue run dispatch loop

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -25,6 +25,7 @@ from cw.config import (
 )
 from cw.daemon import run_watcher_tick
 from cw.dev_queue import add_ticket, list_tickets, resolve_client
+from cw.dispatch import run_dispatch_loop
 from cw.events import advance_cursor, read_events, record_event
 from cw.exceptions import CwError
 from cw.models import (
@@ -35,7 +36,6 @@ from cw.models import (
     QueueItem,
     QueueItemStatus,
     Session,
-    SessionOrigin,
     SessionPurpose,
     SessionStatus,
     TaskSpec,
@@ -59,6 +59,7 @@ from cw.session import (
     resume_session,
     start_session,
 )
+from cw.spawn import spawn_create_impl
 from cw.wrapper import run_claude_wrapper, signal_idle
 
 
@@ -848,6 +849,26 @@ def dev_queue_status(client: str | None) -> None:
         )
 
 
+@dev_queue.command(name="run")
+@click.option(
+    "--max-parallel",
+    "-p",
+    default=None,
+    type=int,
+    help="Override per-client concurrency cap.",
+)
+@click.option(
+    "--once",
+    is_flag=True,
+    default=False,
+    help="Run a single dispatch tick and exit.",
+)
+@handle_errors
+def dev_queue_run(max_parallel: int | None, once: bool) -> None:
+    """Run the dispatch loop, spawning sessions for pending tickets."""
+    run_dispatch_loop(max_parallel=max_parallel, once=once)
+
+
 # --- Spawn command group ---
 
 
@@ -864,27 +885,17 @@ def _spawn_create_impl(
 
     Separated from the Click command so tests can inject adapters directly.
     Returns the new session's ID.
+
+    Delegates to :func:`cw.spawn.spawn_create_impl`.
     """
-    prompt_content = prompt_file.read_text()
-    workspace = client.cmux_workspace or client.name
-    command = f"claude -w {worktree} --print {prompt_content!r}"
-    surface_ref = adapter.spawn(workspace, command, surface)
-
-    session_label = label or "daemon"
-    sess = Session(
-        name=f"{client.name}/{session_label}",
-        client=client.name,
-        purpose=SessionPurpose.IMPL,
-        origin=SessionOrigin.DAEMON,
-        workspace_path=client.workspace_path,
-        worktree_path=worktree,
-        surface_ref=surface_ref,
+    return spawn_create_impl(
+        client=client,
+        worktree=worktree,
+        prompt_file=prompt_file,
+        surface=surface,
+        label=label,
+        adapter=adapter,
     )
-
-    state = load_state()
-    state.sessions.append(sess)
-    save_state(state)
-    return sess.id
 
 
 def _spawn_close_impl(

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -1,0 +1,188 @@
+"""Tick-based dispatch loop: claim pending TicketTasks and spawn Claude sessions."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from cw.cmux import get_cmux_adapter
+from cw.config import load_clients, load_orchestrator_config, load_state
+from cw.dev_queue import _lock, load_dev_queue, save_dev_queue
+from cw.events import advance_cursor, read_events, record_event
+from cw.models import (
+    OrchestratorEventType,
+    QueueItemStatus,
+    SessionOrigin,
+    SessionStatus,
+)
+from cw.spawn import spawn_create_impl
+from cw.worktree import worktree_path_for
+
+if TYPE_CHECKING:
+    from cw.cmux import CmuxAdapter
+    from cw.models import OrchestratorConfig, TicketTask
+
+_DISPATCH_CONSUMER = "dispatch"
+
+
+def _claim_next_pending(client_name: str) -> TicketTask | None:
+    """Atomically claim the next PENDING task for a client.
+
+    Acquires the dev-queue file lock, loads the queue, marks the first
+    PENDING task for *client_name* as RUNNING, saves, and returns it.
+    Returns None if no pending task exists for the client.
+    """
+    with _lock():
+        store = load_dev_queue()
+        for task in store.tasks:
+            if task.client == client_name and task.status == QueueItemStatus.PENDING:
+                task.status = QueueItemStatus.RUNNING
+                save_dev_queue(store)
+                return task
+    return None
+
+
+def dispatch_tick(
+    config: OrchestratorConfig,
+    adapter: CmuxAdapter | None = None,
+) -> int:
+    """Run one dispatch tick.
+
+    For each client that has pending TicketTasks, check how many DAEMON
+    sessions are currently ACTIVE or IDLE and compare against the
+    per-client cap from *config*.  If below the cap, claim one pending
+    task and spawn a Claude session for it.
+
+    Returns:
+        Number of sessions spawned during this tick.
+    """
+    resolved_adapter = adapter or get_cmux_adapter()
+    clients = load_clients()
+    state = load_state()
+    spawned = 0
+
+    for client in clients.values():
+        # Count running daemon sessions for this client
+        running_count = sum(
+            1
+            for s in state.sessions
+            if s.client == client.name
+            and s.origin == SessionOrigin.DAEMON
+            and s.status in (SessionStatus.ACTIVE, SessionStatus.IDLE)
+        )
+
+        cap = config.per_client_max_parallel.get(client.name, 1)
+
+        while running_count < cap:
+            task = _claim_next_pending(client.name)
+            if task is None:
+                break
+
+            branch = f"auto-dev/{task.ticket_id}"
+            worktree_path = worktree_path_for(client, branch)
+            worktree_path.mkdir(parents=True, exist_ok=True)
+
+            prompt_path = worktree_path / ".cw-prompt.txt"
+            prompt_path.write_text(f"/auto-dev {task.ticket_id}")
+
+            label = f"auto-dev/{task.ticket_id}"
+            session_id = spawn_create_impl(
+                client=client,
+                worktree=worktree_path,
+                prompt_file=prompt_path,
+                surface="split",
+                label=label,
+                adapter=resolved_adapter,
+            )
+
+            record_event(
+                OrchestratorEventType.SESSION_SPAWNED,
+                {
+                    "ticket_id": task.ticket_id,
+                    "client": client.name,
+                    "session_id": session_id,
+                },
+            )
+
+            running_count += 1
+            spawned += 1
+
+    return spawned
+
+
+def consume_completed_sessions() -> int:
+    """Process session.completed events and mark tasks COMPLETED in the queue.
+
+    Reads new SESSION_COMPLETED events from the inbox since the last
+    cursor position for the "dispatch" consumer.  For each event that
+    carries a ``ticket_id`` in its payload, the corresponding TicketTask
+    (if found in RUNNING state) is marked COMPLETED.
+
+    Advances the cursor after processing.
+
+    Returns:
+        Number of TicketTasks transitioned to COMPLETED.
+    """
+    events = read_events(
+        consumer=_DISPATCH_CONSUMER,
+        event_types=[OrchestratorEventType.SESSION_COMPLETED],
+    )
+    if not events:
+        return 0
+
+    completed = 0
+    with _lock():
+        store = load_dev_queue()
+        for event in events:
+            ticket_id = event.payload.get("ticket_id")
+            if not ticket_id:
+                continue
+            for task in store.tasks:
+                if (
+                    task.ticket_id == ticket_id
+                    and task.status == QueueItemStatus.RUNNING
+                ):
+                    task.status = QueueItemStatus.COMPLETED
+                    completed += 1
+                    break
+        if completed:
+            save_dev_queue(store)
+
+    # Advance cursor to the last event processed
+    advance_cursor(_DISPATCH_CONSUMER, events[-1].id)
+
+    return completed
+
+
+def run_dispatch_loop(
+    *,
+    max_parallel: int | None = None,
+    once: bool = False,
+    adapter: CmuxAdapter | None = None,
+) -> None:
+    """Run the dispatch loop, optionally overriding per-client concurrency caps.
+
+    Args:
+        max_parallel: If set, override all per-client caps with this value.
+        once: If True, run a single tick and return immediately.
+        adapter: Optional CmuxAdapter for testing.  Defaults to
+            ``get_cmux_adapter()`` at call time.
+    """
+    config = load_orchestrator_config()
+
+    if max_parallel is not None:
+        overridden: dict[str, int] = dict.fromkeys(
+            config.per_client_max_parallel, max_parallel
+        )
+        config = config.model_copy(update={"per_client_max_parallel": overridden})
+
+    resolved_adapter = adapter or get_cmux_adapter()
+
+    while True:
+        consume_completed_sessions()
+        dispatch_tick(config, adapter=resolved_adapter)
+
+        if once:
+            return
+
+        time.sleep(config.tick_interval_seconds)

--- a/src/cw/spawn.py
+++ b/src/cw/spawn.py
@@ -1,0 +1,50 @@
+"""Session spawn helpers shared between CLI and dispatch loop."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cw.config import load_state, save_state
+from cw.models import Session, SessionOrigin, SessionPurpose
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from cw.cmux import CmuxAdapter
+    from cw.models import ClientConfig
+
+
+def spawn_create_impl(
+    *,
+    client: ClientConfig,
+    worktree: Path,
+    prompt_file: Path,
+    surface: str,
+    label: str | None,
+    adapter: CmuxAdapter,
+) -> str:
+    """Create a daemon-spawned session.
+
+    Separated from the Click command so tests and the dispatch loop can
+    inject adapters directly.  Returns the new session's ID.
+    """
+    prompt_content = prompt_file.read_text()
+    workspace = client.cmux_workspace or client.name
+    command = f"claude -w {worktree} --print {prompt_content!r}"
+    surface_ref = adapter.spawn(workspace, command, surface)
+
+    session_label = label or "daemon"
+    sess = Session(
+        name=f"{client.name}/{session_label}",
+        client=client.name,
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        workspace_path=client.workspace_path,
+        worktree_path=worktree,
+        surface_ref=surface_ref,
+    )
+
+    state = load_state()
+    state.sessions.append(sess)
+    save_state(state)
+    return sess.id

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,365 @@
+"""Tests for cw.dispatch - tick-based dispatch loop."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cw.cmux import FakeCmuxAdapter
+from cw.config import load_state, save_state
+from cw.dev_queue import add_ticket, load_dev_queue, save_dev_queue
+from cw.dispatch import consume_completed_sessions, dispatch_tick
+from cw.events import record_event
+from cw.models import (
+    ClientConfig,
+    CwState,
+    DevQueueStore,
+    OrchestratorConfig,
+    OrchestratorEventType,
+    QueueItemStatus,
+    Session,
+    SessionOrigin,
+    SessionPurpose,
+    SessionStatus,
+    TicketTask,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_dispatch_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    """Redirect all config/state/events/dev-queue paths to tmp_path."""
+    config_dir = tmp_path / ".config" / "cw"
+    state_dir = tmp_path / ".local" / "share" / "cw"
+    config_dir.mkdir(parents=True)
+    state_dir.mkdir(parents=True)
+
+    clients_file = config_dir / "clients.yaml"
+    state_file = state_dir / "sessions.json"
+    history_dir = state_dir / "history"
+    history_dir.mkdir(parents=True)
+    queues_dir = state_dir / "queues"
+    queues_dir.mkdir(parents=True)
+    events_dir = state_dir / "events"
+    events_dir.mkdir(parents=True)
+    dev_queue_file = state_dir / "dev_queue.json"
+    dev_queue_lock = state_dir / ".dev_queue.lock"
+
+    monkeypatch.setattr("cw.config.CONFIG_DIR", config_dir)
+    monkeypatch.setattr("cw.config.STATE_DIR", state_dir)
+    monkeypatch.setattr("cw.config.CLIENTS_FILE", clients_file)
+    monkeypatch.setattr("cw.config.STATE_FILE", state_file)
+    monkeypatch.setattr("cw.config.HISTORY_DIR", history_dir)
+    monkeypatch.setattr("cw.config.EVENTS_DIR", events_dir)
+    monkeypatch.setattr("cw.config.DEV_QUEUE_FILE", dev_queue_file)
+    monkeypatch.setattr("cw.config.DEV_QUEUE_LOCK", dev_queue_lock)
+
+    # Patch module-level imported references
+    monkeypatch.setattr("cw.events.EVENTS_DIR", events_dir)
+    monkeypatch.setattr("cw.dev_queue.DEV_QUEUE_FILE", dev_queue_file)
+    monkeypatch.setattr("cw.dev_queue.DEV_QUEUE_LOCK", dev_queue_lock)
+
+    return tmp_path
+
+
+@pytest.fixture
+def workspace_dir(tmp_path: Path) -> Path:
+    """Return a workspace directory for a fake client."""
+    ws = tmp_path / "workspace" / "test-project"
+    ws.mkdir(parents=True)
+    return ws
+
+
+@pytest.fixture
+def sample_client_config(workspace_dir: Path) -> ClientConfig:
+    """A ClientConfig for use with dispatch tests."""
+    return ClientConfig(
+        name="test-client",
+        workspace_path=workspace_dir,
+        default_branch="main",
+    )
+
+
+@pytest.fixture
+def simple_config() -> OrchestratorConfig:
+    """OrchestratorConfig with cap=1 for test-client."""
+    return OrchestratorConfig(
+        tick_interval_seconds=30,
+        per_client_max_parallel={"test-client": 1},
+    )
+
+
+@pytest.fixture
+def cap2_config() -> OrchestratorConfig:
+    """OrchestratorConfig with cap=2 for test-client."""
+    return OrchestratorConfig(
+        tick_interval_seconds=30,
+        per_client_max_parallel={"test-client": 2},
+    )
+
+
+def _make_clients_yaml(tmp_path: Path, client: ClientConfig) -> None:
+    """Write a minimal clients.yaml for the given client."""
+    config_dir = tmp_path / ".config" / "cw"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    clients_file = config_dir / "clients.yaml"
+    clients_file.write_text(
+        f"clients:\n"
+        f"  {client.name}:\n"
+        f"    workspace_path: {client.workspace_path}\n"
+        f"    default_branch: {client.default_branch}\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestDispatchTickSpawnsSession
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchTickSpawnsSession:
+    def test_dispatch_tick_spawns_session(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """Enqueue one task, run tick, confirm session created and task is RUNNING."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        task = TicketTask(
+            ticket_id="GEN-100",
+            client="test-client",
+        )
+        add_ticket(task)
+
+        adapter = FakeCmuxAdapter()
+        spawned = dispatch_tick(simple_config, adapter=adapter)
+
+        assert spawned == 1
+
+        # Task should now be RUNNING
+        store = load_dev_queue()
+        running = store.running()
+        assert len(running) == 1
+        assert running[0].ticket_id == "GEN-100"
+        assert running[0].status == QueueItemStatus.RUNNING
+
+        # Session should have been created
+        state = load_state()
+        assert len(state.sessions) == 1
+        sess = state.sessions[0]
+        assert sess.origin == SessionOrigin.DAEMON
+        assert "GEN-100" in sess.name
+
+        # Adapter should have been called
+        assert len(adapter.calls["spawn"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestPerClientCapRespected
+# ---------------------------------------------------------------------------
+
+
+class TestPerClientCapRespected:
+    def test_per_client_cap_respected(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        cap2_config: OrchestratorConfig,
+    ) -> None:
+        """Enqueue 3 tasks, cap=2, tick spawns exactly 2."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        for i in range(3):
+            add_ticket(TicketTask(ticket_id=f"GEN-{i}", client="test-client"))
+
+        adapter = FakeCmuxAdapter()
+        spawned = dispatch_tick(cap2_config, adapter=adapter)
+
+        assert spawned == 2
+        assert len(adapter.calls["spawn"]) == 2
+
+        store = load_dev_queue()
+        assert len(store.running()) == 2
+        assert len(store.pending()) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestNoDoubleDispatch
+# ---------------------------------------------------------------------------
+
+
+class TestNoDoubleDispatch:
+    def test_no_double_dispatch(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """Two ticks with cap=1: second tick skips (task already RUNNING)."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        add_ticket(TicketTask(ticket_id="GEN-200", client="test-client"))
+
+        adapter = FakeCmuxAdapter()
+
+        # First tick claims the task
+        spawned1 = dispatch_tick(simple_config, adapter=adapter)
+        assert spawned1 == 1
+
+        # Second tick: running_count=1 >= cap=1, should skip
+        spawned2 = dispatch_tick(simple_config, adapter=adapter)
+        assert spawned2 == 0
+
+        # Only one spawn call total
+        assert len(adapter.calls["spawn"]) == 1
+
+        store = load_dev_queue()
+        assert len(store.running()) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestConsumeCompletesTasks
+# ---------------------------------------------------------------------------
+
+
+class TestConsumeCompletesTasks:
+    def test_consume_completes_task(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """Write a session.completed event with ticket_id; task becomes COMPLETED."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        # Put a RUNNING task in the queue
+        task = TicketTask(
+            ticket_id="GEN-300",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+        )
+        store = DevQueueStore(tasks=[task])
+        save_dev_queue(store)
+
+        # Write a session.completed event referencing the ticket
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {"ticket_id": "GEN-300", "client": "test-client"},
+        )
+
+        completed = consume_completed_sessions()
+        assert completed == 1
+
+        updated_store = load_dev_queue()
+        assert updated_store.tasks[0].status == QueueItemStatus.COMPLETED
+
+    def test_consume_ignores_events_without_ticket_id(
+        self,
+        tmp_dispatch_dirs: Path,
+    ) -> None:
+        """session.completed events without ticket_id do not affect the queue."""
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {"session_id": "some-session", "client": "other-client"},
+        )
+
+        completed = consume_completed_sessions()
+        assert completed == 0
+
+    def test_consume_advances_cursor(
+        self,
+        tmp_dispatch_dirs: Path,
+    ) -> None:
+        """Cursor advances after consuming so events aren't re-processed."""
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {"ticket_id": "GEN-400", "client": "test-client"},
+        )
+
+        # First consume: returns 0 because no matching task in queue
+        consume_completed_sessions()
+
+        # Second consume: cursor advanced, no new events
+        completed2 = consume_completed_sessions()
+        assert completed2 == 0
+
+
+# ---------------------------------------------------------------------------
+# TestDispatchTickReturnsCount
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchTickReturnsCount:
+    def test_dispatch_tick_returns_count(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        cap2_config: OrchestratorConfig,
+    ) -> None:
+        """Enqueue 2 tasks with cap=2; tick returns 2."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        add_ticket(TicketTask(ticket_id="GEN-500", client="test-client"))
+        add_ticket(TicketTask(ticket_id="GEN-501", client="test-client"))
+
+        adapter = FakeCmuxAdapter()
+        count = dispatch_tick(cap2_config, adapter=adapter)
+
+        assert count == 2
+
+    def test_dispatch_tick_returns_zero_when_empty(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """Empty queue returns 0."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        adapter = FakeCmuxAdapter()
+        count = dispatch_tick(simple_config, adapter=adapter)
+
+        assert count == 0
+
+    def test_running_sessions_count_toward_cap(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """Pre-existing DAEMON ACTIVE sessions count toward the per-client cap."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        # Put an already-running session in state
+        existing_session = Session(
+            name="test-client/auto-dev/GEN-999",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+            workspace_path=sample_client_config.workspace_path,
+        )
+        state = CwState(sessions=[existing_session])
+        save_state(state)
+
+        # Enqueue a task
+        add_ticket(TicketTask(ticket_id="GEN-600", client="test-client"))
+
+        adapter = FakeCmuxAdapter()
+        # cap=1, running=1 => should not spawn
+        count = dispatch_tick(simple_config, adapter=adapter)
+
+        assert count == 0
+        assert len(adapter.calls["spawn"]) == 0


### PR DESCRIPTION
## Summary
- New `src/cw/spawn.py` — extracted spawn logic from cli.py to avoid circular imports
- New `src/cw/dispatch.py` — `dispatch_tick`, `consume_completed_sessions`, `run_dispatch_loop`
- `cw dev-queue run [--max-parallel <n>] [--once]` CLI command
- Per-client concurrency cap from `OrchestratorConfig`
- File-locked task claiming (no double-dispatch)
- `SESSION_SPAWNED` event emitted per spawn; completed sessions consumed each tick

Closes #9

## Test plan
- [ ] `uv run pytest tests/test_dispatch.py -v` passes
- [ ] `uv run mypy src/` passes