### PR TITLE
feat: add PR responder dispatch (fix-ci / address-review)

### DIFF
--- a/src/cw/daemon.py
+++ b/src/cw/daemon.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 from cw.config import STATE_DIR, load_clients, load_orchestrator_config, load_state
 from cw.events import record_event
 from cw.models import OrchestratorEventType, SessionStatus
+from cw.pr_responder import clear_completed_pr_sessions, respond_to_pr_events
 
 if TYPE_CHECKING:
     from cw.models import ClientConfig, CwState, OrchestratorEvent
@@ -302,6 +303,11 @@ def run_watcher_tick(*, once: bool = False) -> None:
             snapshot = _load_snapshot(client_name)
             _events, updated_snapshot = watch_prs_for_client(client, snapshot)
             _save_snapshot(client_name, updated_snapshot)
+
+        # Respond to queued PR events and clean up completed dispatch records
+        state = load_state()
+        clear_completed_pr_sessions(state)
+        respond_to_pr_events()
 
         if once:
             return

--- a/src/cw/pr_responder.py
+++ b/src/cw/pr_responder.py
@@ -1,0 +1,235 @@
+"""PR event responder: decision table that reacts to PR events by spawning sessions."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from cw.cmux import get_cmux_adapter
+from cw.config import STATE_DIR, load_clients, load_state, save_state
+from cw.events import advance_cursor, read_events
+from cw.models import (
+    OrchestratorEventType,
+    Session,
+    SessionOrigin,
+    SessionPurpose,
+    SessionStatus,
+)
+from cw.worktree import worktree_path_for
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from cw.cmux import CmuxAdapter
+    from cw.models import ClientConfig, CwState
+
+logger = logging.getLogger(__name__)
+
+_CONSUMER = "pr_responder"
+
+_PR_EVENT_TYPES = [
+    OrchestratorEventType.PR_CI_FAILED,
+    OrchestratorEventType.PR_REVIEW_RECEIVED,
+    OrchestratorEventType.PR_MERGEABLE,
+    OrchestratorEventType.PR_MERGED,
+]
+
+_DISPATCH_FILE_NAME = "pr_dispatch.json"
+_LOG_ONLY_TYPES = frozenset(
+    {OrchestratorEventType.PR_MERGEABLE, OrchestratorEventType.PR_MERGED}
+)
+
+
+class PRDispatchRecord(BaseModel):
+    """Tracks in-flight PR response sessions."""
+
+    # key: "repo#pr_number|role"  (role = "fix-ci" or "address-review")
+    active: dict[str, str] = Field(default_factory=dict)
+
+
+def _load_dispatch_record() -> PRDispatchRecord:
+    """Load PRDispatchRecord from STATE_DIR, or return an empty one."""
+    path = STATE_DIR / _DISPATCH_FILE_NAME
+    if not path.exists():
+        return PRDispatchRecord()
+    return PRDispatchRecord.model_validate_json(path.read_text())
+
+
+def _save_dispatch_record(record: PRDispatchRecord) -> None:
+    """Persist PRDispatchRecord to STATE_DIR."""
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    path = STATE_DIR / _DISPATCH_FILE_NAME
+    path.write_text(record.model_dump_json(indent=2))
+
+
+def _is_session_active(session_id: str, state: CwState) -> bool:
+    """Return True if session_id exists and is not COMPLETED."""
+    for session in state.sessions:
+        if session.id == session_id and session.status != SessionStatus.COMPLETED:
+            return True
+    return False
+
+
+def _spawn_session(
+    *,
+    client: ClientConfig,
+    worktree: Path,
+    prompt_file: Path,
+    surface: str,
+    label: str,
+    adapter: CmuxAdapter,
+) -> str:
+    """Spawn a daemon-managed Claude session and persist it to state.
+
+    Mirrors the logic in cli._spawn_create_impl to avoid a circular import
+    (daemon -> pr_responder -> cli -> daemon).
+
+    Returns:
+        The new session's ID.
+    """
+    prompt_content = prompt_file.read_text()
+    workspace = client.cmux_workspace or client.name
+    command = f"claude -w {worktree} --print {prompt_content!r}"
+    surface_ref = adapter.spawn(workspace, command, surface)
+
+    sess = Session(
+        name=f"{client.name}/{label}",
+        client=client.name,
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        workspace_path=client.workspace_path,
+        worktree_path=worktree,
+        surface_ref=surface_ref,
+    )
+
+    state = load_state()
+    state.sessions.append(sess)
+    save_state(state)
+    return sess.id
+
+
+def respond_to_pr_events(adapter: CmuxAdapter | None = None) -> int:
+    """Read unprocessed PR events and spawn sessions per the decision table.
+
+    Decision table:
+        pr.ci_failed        → spawn /fix-ci <pr_number>          (1 concurrent per PR)
+        pr.review_received  → spawn /address-review <pr_number>  (1 concurrent per PR)
+        pr.mergeable        → log only, no spawn
+        pr.merged           → log only, no spawn
+
+    Args:
+        adapter: CmuxAdapter to use. Defaults to get_cmux_adapter().
+
+    Returns:
+        Count of sessions spawned.
+    """
+    events = read_events(consumer=_CONSUMER, event_types=_PR_EVENT_TYPES)
+    if not events:
+        return 0
+
+    resolved_adapter = adapter or get_cmux_adapter()
+    clients = load_clients()
+    state = load_state()
+    dispatch_record = _load_dispatch_record()
+    spawned_count = 0
+
+    for event in events:
+        payload = event.payload
+        event_type = event.type
+
+        # Log-only events — advance cursor and continue
+        if event_type in _LOG_ONLY_TYPES:
+            logger.info("PR event %s (log-only): %s", event_type, payload)
+            advance_cursor(_CONSUMER, event.id)
+            continue
+
+        client_name: str = str(payload.get("client", ""))
+        repo: str = str(payload.get("repo", ""))
+        pr_number: int = int(payload.get("pr_number", 0))
+        branch: str = str(payload.get("branch", str(pr_number)))
+
+        if event_type == OrchestratorEventType.PR_CI_FAILED:
+            role = "fix-ci"
+            skill_cmd = f"/fix-ci {pr_number}"
+        else:
+            # PR_REVIEW_RECEIVED
+            role = "address-review"
+            skill_cmd = f"/address-review {pr_number}"
+
+        dispatch_key = f"{repo}#{pr_number}|{role}"
+
+        # Throttle: skip if an active session already handles this dispatch key
+        existing_session_id = dispatch_record.active.get(dispatch_key)
+        if existing_session_id is not None and _is_session_active(
+            existing_session_id, state
+        ):
+            throttle_msg = (
+                f"Throttled {role} for {dispatch_key}"
+                f" (session {existing_session_id} still active)"
+            )
+            logger.info(throttle_msg)
+            advance_cursor(_CONSUMER, event.id)
+            continue
+
+        # Resolve client config — skip gracefully if unknown
+        if client_name not in clients:
+            unknown_client_msg = f"Unknown client {client_name!r} in PR event, skipping"
+            logger.warning(unknown_client_msg)
+            advance_cursor(_CONSUMER, event.id)
+            continue
+
+        client_cfg = clients[client_name]
+
+        # Resolve worktree path; ensure directory exists so prompt file can be written
+        worktree_path = worktree_path_for(client_cfg, branch)
+        worktree_path.mkdir(parents=True, exist_ok=True)
+
+        # Write prompt file
+        prompt_file = worktree_path / ".cw-pr-prompt.txt"
+        prompt_file.write_text(skill_cmd)
+
+        # Spawn session
+        session_label = f"{role}/{pr_number}"
+        session_id = _spawn_session(
+            client=client_cfg,
+            worktree=worktree_path,
+            prompt_file=prompt_file,
+            surface="split",
+            label=session_label,
+            adapter=resolved_adapter,
+        )
+
+        # Record dispatch and persist
+        dispatch_record.active[dispatch_key] = session_id
+        _save_dispatch_record(dispatch_record)
+
+        # Reload state so subsequent throttle checks see the new session
+        state = load_state()
+
+        advance_cursor(_CONSUMER, event.id)
+        spawned_count += 1
+
+        spawned_msg = f"Spawned session {session_id} for {dispatch_key} ({role})"
+        logger.info(spawned_msg)
+
+    return spawned_count
+
+
+def clear_completed_pr_sessions(state: CwState) -> None:
+    """Remove PRDispatchRecord entries whose sessions are completed.
+
+    Args:
+        state: Current CwState used to determine completed session IDs.
+    """
+    dispatch_record = _load_dispatch_record()
+    completed_ids = {
+        s.id for s in state.sessions if s.status == SessionStatus.COMPLETED
+    }
+    dispatch_record.active = {
+        key: sid
+        for key, sid in dispatch_record.active.items()
+        if sid not in completed_ids
+    }
+    _save_dispatch_record(dispatch_record)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,8 @@ def tmp_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr("cw.history.HISTORY_DIR", history_dir)
     with contextlib.suppress(AttributeError):
         monkeypatch.setattr("cw.events.EVENTS_DIR", events_dir)
+    with contextlib.suppress(AttributeError):
+        monkeypatch.setattr("cw.pr_responder.STATE_DIR", state_dir)
 
     return tmp_path
 

--- a/tests/test_pr_responder.py
+++ b/tests/test_pr_responder.py
@@ -1,0 +1,286 @@
+"""Tests for cw.pr_responder — PR event dispatch decision table."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cw.cmux import FakeCmuxAdapter
+from cw.events import record_event
+from cw.models import (
+    ClientConfig,
+    CwState,
+    OrchestratorEvent,
+    OrchestratorEventType,
+    Session,
+    SessionPurpose,
+    SessionStatus,
+)
+from cw.pr_responder import (
+    PRDispatchRecord,
+    clear_completed_pr_sessions,
+    respond_to_pr_events,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ci_failed_event(
+    client_name: str,
+    repo: str,
+    pr_number: int,
+    branch: str = "feat/fix-thing",
+) -> OrchestratorEvent:
+    """Record a PR_CI_FAILED event and return it."""
+    return record_event(
+        OrchestratorEventType.PR_CI_FAILED,
+        {
+            "client": client_name,
+            "repo": repo,
+            "pr_number": pr_number,
+            "branch": branch,
+        },
+    )
+
+
+def _make_review_received_event(
+    client_name: str,
+    repo: str,
+    pr_number: int,
+    branch: str = "feat/my-feature",
+) -> OrchestratorEvent:
+    """Record a PR_REVIEW_RECEIVED event and return it."""
+    return record_event(
+        OrchestratorEventType.PR_REVIEW_RECEIVED,
+        {
+            "client": client_name,
+            "repo": repo,
+            "pr_number": pr_number,
+            "branch": branch,
+        },
+    )
+
+
+def _make_mergeable_event(
+    client_name: str,
+    repo: str,
+    pr_number: int,
+) -> OrchestratorEvent:
+    """Record a PR_MERGEABLE event and return it."""
+    return record_event(
+        OrchestratorEventType.PR_MERGEABLE,
+        {
+            "client": client_name,
+            "repo": repo,
+            "pr_number": pr_number,
+        },
+    )
+
+
+def _write_client_config(tmp_config_dir: Path, name: str, workspace: Path) -> None:
+    """Write a minimal clients.yaml entry for the given client."""
+    clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
+    lines = [
+        "clients:",
+        f"  {name}:",
+        f"    workspace_path: {workspace}",
+        "    default_branch: main",
+        "",
+    ]
+    clients_file.write_text("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def adapter() -> FakeCmuxAdapter:
+    """Fresh FakeCmuxAdapter for each test."""
+    return FakeCmuxAdapter()
+
+
+@pytest.fixture
+def client_workspace(tmp_path: Path) -> Path:
+    """A real workspace directory for the default test client."""
+    workspace = tmp_path / "workspace" / "myproject"
+    workspace.mkdir(parents=True, exist_ok=True)
+    return workspace
+
+
+@pytest.fixture
+def configured_client(tmp_config_dir: Path, client_workspace: Path) -> ClientConfig:
+    """Write clients.yaml and return the matching ClientConfig."""
+    _write_client_config(tmp_config_dir, "myproject", client_workspace)
+    return ClientConfig(
+        name="myproject",
+        workspace_path=client_workspace,
+        default_branch="main",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCIFailedSpawnsFixCI:
+    def test_ci_failed_spawns_fix_ci(
+        self,
+        configured_client: ClientConfig,
+        adapter: FakeCmuxAdapter,
+    ) -> None:
+        """A pr.ci_failed event spawns a session with /fix-ci <pr> in the command."""
+        _make_ci_failed_event("myproject", "owner/repo", 42, "feat/ci-branch")
+
+        spawned = respond_to_pr_events(adapter=adapter)
+
+        assert spawned == 1
+        assert len(adapter.calls["spawn"]) == 1
+        _workspace, command, _surface = adapter.calls["spawn"][0]
+        assert "/fix-ci 42" in command
+        assert configured_client.name == "myproject"
+
+
+class TestReviewReceivedSpawnsAddressReview:
+    def test_review_received_spawns_address_review(
+        self,
+        configured_client: ClientConfig,
+        adapter: FakeCmuxAdapter,
+    ) -> None:
+        """A pr.review_received event spawns a session with /address-review <pr>."""
+        _make_review_received_event("myproject", "owner/repo", 17, "feat/my-feature")
+
+        spawned = respond_to_pr_events(adapter=adapter)
+
+        assert spawned == 1
+        assert len(adapter.calls["spawn"]) == 1
+        _workspace, command, _surface = adapter.calls["spawn"][0]
+        assert "/address-review 17" in command
+        assert configured_client.name == "myproject"
+
+
+class TestThrottlePreventsDuplicateSpawn:
+    def test_throttle_prevents_double_spawn(
+        self,
+        configured_client: ClientConfig,
+        adapter: FakeCmuxAdapter,
+    ) -> None:
+        """Second pr.ci_failed for same PR does not spawn a second session."""
+        # First event — should spawn
+        _make_ci_failed_event("myproject", "owner/repo", 99, "feat/branch")
+        spawned_first = respond_to_pr_events(adapter=adapter)
+        assert spawned_first == 1
+        assert len(adapter.calls["spawn"]) == 1
+
+        # Second event for same PR — session still active, should be throttled
+        _make_ci_failed_event("myproject", "owner/repo", 99, "feat/branch")
+        spawned_second = respond_to_pr_events(adapter=adapter)
+        assert spawned_second == 0
+        assert len(adapter.calls["spawn"]) == 1  # no additional spawn
+
+        assert configured_client.name == "myproject"
+
+
+class TestMergeableNoSpawn:
+    def test_mergeable_no_spawn(
+        self,
+        configured_client: ClientConfig,
+        adapter: FakeCmuxAdapter,
+    ) -> None:
+        """A pr.mergeable event produces no spawn and advances the cursor."""
+        _make_mergeable_event("myproject", "owner/repo", 5)
+
+        spawned = respond_to_pr_events(adapter=adapter)
+
+        assert spawned == 0
+        assert adapter.calls["spawn"] == []
+
+        # Calling again should produce 0 (cursor was advanced)
+        spawned_again = respond_to_pr_events(adapter=adapter)
+        assert spawned_again == 0
+
+        assert configured_client.name == "myproject"
+
+
+class TestMergedNoSpawn:
+    def test_merged_no_spawn(
+        self,
+        configured_client: ClientConfig,
+        adapter: FakeCmuxAdapter,
+    ) -> None:
+        """A pr.merged event produces no spawn and advances the cursor."""
+        record_event(
+            OrchestratorEventType.PR_MERGED,
+            {"client": "myproject", "repo": "owner/repo", "pr_number": 7},
+        )
+
+        spawned = respond_to_pr_events(adapter=adapter)
+        assert spawned == 0
+        assert adapter.calls["spawn"] == []
+
+        assert configured_client.name == "myproject"
+
+
+class TestClearCompletedRemovesRecord:
+    def test_clear_completed_removes_record(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        """A completed session's dispatch record is removed by clear_completed."""
+        state_dir = tmp_config_dir / ".local" / "share" / "cw"
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+
+        # Set up a PRDispatchRecord with an active dispatch key
+        dispatch_key = "owner/repo#42|fix-ci"
+        session_id = "abc12345"
+        initial_record = PRDispatchRecord(active={dispatch_key: session_id})
+        dispatch_file = state_dir / "pr_dispatch.json"
+        dispatch_file.write_text(initial_record.model_dump_json())
+
+        # Build a CwState with that session marked COMPLETED
+        state = CwState(
+            sessions=[
+                Session(
+                    id=session_id,
+                    name="myproject/fix-ci-42",
+                    client="myproject",
+                    purpose=SessionPurpose.IMPL,
+                    status=SessionStatus.COMPLETED,
+                    workspace_path=workspace,
+                )
+            ]
+        )
+
+        clear_completed_pr_sessions(state)
+
+        # Reload and verify the dispatch key was removed
+        updated = PRDispatchRecord.model_validate_json(dispatch_file.read_text())
+        assert dispatch_key not in updated.active
+
+
+class TestUnknownClientSkipped:
+    def test_unknown_client_skips_without_crash(
+        self,
+        tmp_config_dir: Path,
+        adapter: FakeCmuxAdapter,
+    ) -> None:
+        """Event referencing unknown client is skipped gracefully (cursor advanced)."""
+        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
+        clients_file.write_text("clients: {}\n")
+
+        _make_ci_failed_event("unknown-client", "owner/repo", 1, "feat/x")
+
+        spawned = respond_to_pr_events(adapter=adapter)
+        assert spawned == 0
+        assert adapter.calls["spawn"] == []
+
+        # Calling again should still be 0 (cursor advanced past the event)
+        spawned_again = respond_to_pr_events(adapter=adapter)
+        assert spawned_again == 0


### PR DESCRIPTION
## Summary
- New `src/cw/pr_responder.py`: reacts to PR events by spawning CC sessions
- Decision table: `pr.ci_failed` → `/fix-ci <pr>`, `pr.review_received` → `/address-review <pr>`, mergeable/merged → log only
- Per-PR concurrency cap via `PRDispatchRecord`
- Wired into `daemon.py` tick loop
- `/fix-ci` and `/address-review` skill stubs written to `~/.claude/skills/` (not in this repo)

Closes #12

## Test plan
- [ ] `uv run pytest tests/test_pr_responder.py -v` passes
- [ ] `uv run mypy src/` passes