### PR TITLE
fix: --max-parallel overrides cap for all clients

### DIFF
--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -171,9 +171,8 @@ def run_dispatch_loop(
     config = load_orchestrator_config()
 
     if max_parallel is not None:
-        overridden: dict[str, int] = dict.fromkeys(
-            config.per_client_max_parallel, max_parallel
-        )
+        clients = load_clients()
+        overridden: dict[str, int] = dict.fromkeys(clients, max_parallel)
         config = config.model_copy(update={"per_client_max_parallel": overridden})
 
     resolved_adapter = adapter or get_cmux_adapter()


### PR DESCRIPTION
## Summary

`dict.fromkeys(config.per_client_max_parallel, max_parallel)` only covered clients explicitly listed in `orchestrator.yaml`. Any client relying on the default cap of 1 was silently unaffected by `--max-parallel N`.

Fix: build the override dict from `load_clients()` (all configured clients), so the flag actually applies everywhere.

## Test plan
- [ ] Existing `test_dispatch.py` passes
- [ ] `cw dev-queue run --max-parallel 3` with an unconfigured client now runs up to 3 concurrent sessions