### PR TITLE
feat: add /orchestrate-plan skill and cw dev-queue plan (#10)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -41,6 +41,7 @@ from cw.models import (
     TaskSpec,
     TicketTask,
 )
+from cw.plan import run_planner
 from cw.queue import (
     add_item,
     claim_by_id,
@@ -863,10 +864,89 @@ def dev_queue_status(client: str | None) -> None:
     default=False,
     help="Run a single dispatch tick and exit.",
 )
+@click.option(
+    "--use-plan",
+    is_flag=True,
+    default=False,
+    help="Respect the persisted DispatchPlan ordering when claiming tasks.",
+)
 @handle_errors
-def dev_queue_run(max_parallel: int | None, once: bool) -> None:
+def dev_queue_run(max_parallel: int | None, once: bool, use_plan: bool) -> None:
     """Run the dispatch loop, spawning sessions for pending tickets."""
-    run_dispatch_loop(max_parallel=max_parallel, once=once)
+    run_dispatch_loop(max_parallel=max_parallel, once=once, use_plan=use_plan)
+
+
+_PLAN_DEFAULT_TIMEOUT = 300
+
+
+def _run_plan_impl(
+    *,
+    client_name: str,
+    timeout: int,
+    adapter: CmuxAdapter,
+    client_filter: str | None,
+) -> int:
+    """Spawn the planner, persist the result, and report status.
+
+    Separated from the Click command so tests can inject the cmux adapter
+    directly.  Returns 0 on success, 1 on validation/timeout failure.
+    """
+    client_config = get_client(client_name)
+    result = run_planner(
+        client=client_config,
+        adapter=adapter,
+        timeout_seconds=timeout,
+        client_filter=client_filter,
+    )
+    plan = result.plan
+    if plan is None:
+        click.echo(
+            f"Planner failed: {result.error} (queue order unchanged)",
+            err=True,
+        )
+        return 1
+    click.echo(f"Plan persisted: {len(plan.tasks)} tasks (session {result.session_id})")
+    return 0
+
+
+@dev_queue.command(name="plan")
+@click.option(
+    "--client",
+    "-c",
+    required=True,
+    shell_complete=_complete_client,
+    help="Client whose cmux workspace will host the planner session.",
+)
+@click.option(
+    "--timeout",
+    type=int,
+    default=_PLAN_DEFAULT_TIMEOUT,
+    help="Seconds to wait for the planner JSON output (default: 300).",
+)
+@click.option(
+    "--filter-client",
+    default=None,
+    help="Only include pending tickets for this client in the planner prompt.",
+)
+@handle_errors
+def dev_queue_plan(client: str, timeout: int, filter_client: str | None) -> None:
+    """Spawn /orchestrate-plan to produce a DispatchPlan for pending tickets.
+
+    Runs a one-shot Claude session via cw spawn, waits for it to write a
+    DispatchPlan JSON file, validates it, and persists it for use by
+    ``cw dev-queue run --use-plan``.
+
+    On validation failure or timeout, the dev queue is left unchanged.
+    """
+    adapter = get_cmux_adapter()
+    exit_code = _run_plan_impl(
+        client_name=client,
+        timeout=timeout,
+        adapter=adapter,
+        client_filter=filter_client,
+    )
+    if exit_code != 0:
+        raise click.exceptions.Exit(exit_code)
 
 
 # --- Spawn command group ---

--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -50,6 +50,9 @@ ORCHESTRATOR_CONFIG_DIR = Path.home() / ".claude-workspace"
 ORCHESTRATOR_CONFIG_FILE = ORCHESTRATOR_CONFIG_DIR / "orchestrator.yaml"
 DEV_QUEUE_FILE = STATE_DIR / "dev_queue.json"
 DEV_QUEUE_LOCK = STATE_DIR / ".dev_queue.lock"
+DEV_PLAN_FILE = STATE_DIR / "dev_plan.json"
+DEV_PLAN_LOCK = STATE_DIR / ".dev_plan.lock"
+DEV_PLAN_OUTPUT_DIR = STATE_DIR / "plan_output"
 
 _DEFAULT_ORCHESTRATOR_YAML = """\
 tick_interval_seconds: 30

--- a/src/cw/dev_queue.py
+++ b/src/cw/dev_queue.py
@@ -7,12 +7,18 @@ import fcntl
 import json
 from typing import TYPE_CHECKING
 
-from cw.config import DEV_QUEUE_FILE, DEV_QUEUE_LOCK
+from cw.config import (
+    DEV_PLAN_FILE,
+    DEV_PLAN_LOCK,
+    DEV_QUEUE_FILE,
+    DEV_QUEUE_LOCK,
+)
 from cw.exceptions import CwError
-from cw.models import DevQueueStore, OrchestratorConfig, TicketTask
+from cw.models import DevQueueStore, DispatchPlan, OrchestratorConfig, TicketTask
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
 
 
 @contextlib.contextmanager
@@ -26,6 +32,50 @@ def _lock() -> Iterator[None]:
     finally:
         fcntl.flock(fd, fcntl.LOCK_UN)
         fd.close()
+
+
+@contextlib.contextmanager
+def _plan_lock() -> Iterator[None]:
+    """Acquire an exclusive file lock for the dispatch plan."""
+    DEV_PLAN_FILE.parent.mkdir(parents=True, exist_ok=True)
+    fd = DEV_PLAN_LOCK.open("w")
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        fd.close()
+
+
+def plan_path() -> Path:
+    """Return the path to the persisted dispatch plan file."""
+    return DEV_PLAN_FILE
+
+
+def save_plan(plan: DispatchPlan) -> Path:
+    """Persist a DispatchPlan to disk under the plan file lock.
+
+    Returns the path the plan was written to.
+    """
+    with _plan_lock():
+        DEV_PLAN_FILE.parent.mkdir(parents=True, exist_ok=True)
+        DEV_PLAN_FILE.write_text(plan.model_dump_json(indent=2))
+    return DEV_PLAN_FILE
+
+
+def load_plan() -> DispatchPlan | None:
+    """Load the persisted DispatchPlan, returning None if missing.
+
+    Returns None if the plan file does not exist or fails validation.
+    Does not raise on validation errors — callers should fall back to
+    enqueue order when None is returned.
+    """
+    if not DEV_PLAN_FILE.exists():
+        return None
+    try:
+        return DispatchPlan.model_validate_json(DEV_PLAN_FILE.read_text())
+    except (ValueError, OSError):
+        return None
 
 
 def load_dev_queue() -> DevQueueStore:

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from cw.cmux import get_cmux_adapter
 from cw.config import load_clients, load_orchestrator_config, load_state
-from cw.dev_queue import _lock, load_dev_queue, save_dev_queue
+from cw.dev_queue import _lock, load_dev_queue, load_plan, save_dev_queue
 from cw.events import advance_cursor, read_events, record_event
 from cw.models import (
     OrchestratorEventType,
@@ -25,15 +25,37 @@ if TYPE_CHECKING:
 _DISPATCH_CONSUMER = "dispatch"
 
 
-def _claim_next_pending(client_name: str) -> TicketTask | None:
+def _claim_next_pending(
+    client_name: str,
+    *,
+    priority_ticket_ids: list[str] | None = None,
+) -> TicketTask | None:
     """Atomically claim the next PENDING task for a client.
 
     Acquires the dev-queue file lock, loads the queue, marks the first
     PENDING task for *client_name* as RUNNING, saves, and returns it.
     Returns None if no pending task exists for the client.
+
+    If *priority_ticket_ids* is provided, prefer claiming PENDING tasks in
+    that order (only those whose ticket_id appears in the list).  Tasks not
+    referenced by the list are skipped at this stage; they will be claimed
+    by subsequent ticks once the prioritised tasks are exhausted (the
+    parameter is intentionally a *preference*, not a filter — see the
+    fallback after the priority loop).
     """
     with _lock():
         store = load_dev_queue()
+        if priority_ticket_ids:
+            for ticket_id in priority_ticket_ids:
+                for task in store.tasks:
+                    if (
+                        task.client == client_name
+                        and task.ticket_id == ticket_id
+                        and task.status == QueueItemStatus.PENDING
+                    ):
+                        task.status = QueueItemStatus.RUNNING
+                        save_dev_queue(store)
+                        return task
         for task in store.tasks:
             if task.client == client_name and task.status == QueueItemStatus.PENDING:
                 task.status = QueueItemStatus.RUNNING
@@ -45,6 +67,8 @@ def _claim_next_pending(client_name: str) -> TicketTask | None:
 def dispatch_tick(
     config: OrchestratorConfig,
     adapter: CmuxAdapter | None = None,
+    *,
+    use_plan: bool = False,
 ) -> int:
     """Run one dispatch tick.
 
@@ -61,6 +85,15 @@ def dispatch_tick(
     state = load_state()
     spawned = 0
 
+    plan_order_by_client: dict[str, list[str]] = {}
+    if use_plan:
+        plan = load_plan()
+        if plan is not None:
+            for plan_task in plan.tasks:
+                plan_order_by_client.setdefault(plan_task.client, []).append(
+                    plan_task.ticket_id,
+                )
+
     for client in clients.values():
         # Count running daemon sessions for this client
         running_count = sum(
@@ -73,8 +106,12 @@ def dispatch_tick(
 
         cap = config.per_client_max_parallel.get(client.name, 1)
 
+        priority_ids = plan_order_by_client.get(client.name)
         while running_count < cap:
-            task = _claim_next_pending(client.name)
+            task: TicketTask | None = _claim_next_pending(
+                client.name,
+                priority_ticket_ids=priority_ids,
+            )
             if task is None:
                 break
 
@@ -159,6 +196,7 @@ def run_dispatch_loop(
     max_parallel: int | None = None,
     once: bool = False,
     adapter: CmuxAdapter | None = None,
+    use_plan: bool = False,
 ) -> None:
     """Run the dispatch loop, optionally overriding per-client concurrency caps.
 
@@ -167,6 +205,9 @@ def run_dispatch_loop(
         once: If True, run a single tick and return immediately.
         adapter: Optional CmuxAdapter for testing.  Defaults to
             ``get_cmux_adapter()`` at call time.
+        use_plan: If True, load the persisted DispatchPlan and use its
+            ordering to claim tasks.  Falls back to enqueue order when no
+            plan is found (load_plan returns None).
     """
     config = load_orchestrator_config()
 
@@ -179,7 +220,7 @@ def run_dispatch_loop(
 
     while True:
         consume_completed_sessions()
-        dispatch_tick(config, adapter=resolved_adapter)
+        dispatch_tick(config, adapter=resolved_adapter, use_plan=use_plan)
 
         if once:
             return

--- a/src/cw/plan.py
+++ b/src/cw/plan.py
@@ -1,0 +1,176 @@
+"""Planner orchestration: spawn /orchestrate-plan, collect, validate, persist.
+
+The planner is a one-shot Claude session that consumes a list of pending
+TicketTasks and produces a :class:`DispatchPlan` JSON file the dispatcher
+can use to override enqueue order.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from cw.config import DEV_PLAN_OUTPUT_DIR
+from cw.dev_queue import list_tickets, save_plan
+from cw.exceptions import CwError
+from cw.models import DispatchPlan
+from cw.spawn import spawn_create_impl
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from cw.cmux import CmuxAdapter
+    from cw.models import ClientConfig, TicketTask
+
+
+_DEFAULT_TIMEOUT_SECONDS = 300
+_POLL_INTERVAL_SECONDS = 1.0
+
+
+def _format_tickets_prompt(tickets: list[TicketTask], output_path: Path) -> str:
+    """Build the prompt body for /orchestrate-plan.
+
+    The prompt instructs the planner skill where to write its JSON output
+    and supplies the pending TicketTasks as JSON for context.
+    """
+    ticket_lines: list[str] = [t.model_dump_json() for t in tickets]
+    tickets_block = "\n".join(ticket_lines)
+    return (
+        f"/orchestrate-plan {output_path}\n\n"
+        "Pending tickets (one TicketTask JSON per line):\n"
+        f"{tickets_block}\n"
+    )
+
+
+def _wait_for_plan_output(
+    output_path: Path,
+    timeout_seconds: int,
+    *,
+    poll_interval: float = _POLL_INTERVAL_SECONDS,
+) -> bool:
+    """Poll *output_path* until it exists or *timeout_seconds* elapses.
+
+    Returns True if the file appeared in time, False otherwise.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if output_path.exists() and output_path.stat().st_size > 0:
+            return True
+        time.sleep(poll_interval)
+    return output_path.exists() and output_path.stat().st_size > 0
+
+
+def _validate_and_persist(output_path: Path) -> DispatchPlan | None:
+    """Validate the JSON at *output_path* against DispatchPlan and persist.
+
+    Returns the persisted plan on success, or None on validation failure.
+    """
+    try:
+        raw = output_path.read_text()
+    except OSError:
+        return None
+    try:
+        plan = DispatchPlan.model_validate_json(raw)
+    except ValueError:
+        return None
+    save_plan(plan)
+    return plan
+
+
+class PlanResult:
+    """Outcome of a single planner invocation."""
+
+    def __init__(
+        self,
+        *,
+        plan: DispatchPlan | None,
+        session_id: str,
+        prompt_path: Path,
+        output_path: Path,
+        error: str | None = None,
+    ) -> None:
+        self.plan = plan
+        self.session_id = session_id
+        self.prompt_path = prompt_path
+        self.output_path = output_path
+        self.error = error
+
+
+def run_planner(
+    *,
+    client: ClientConfig,
+    adapter: CmuxAdapter,
+    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+    poll_interval: float = _POLL_INTERVAL_SECONDS,
+    client_filter: str | None = None,
+) -> PlanResult:
+    """Spawn the /orchestrate-plan skill and collect its DispatchPlan output.
+
+    Args:
+        client: Target client whose cmux workspace hosts the planner session.
+        adapter: cmux adapter used to spawn the session (FakeCmuxAdapter in
+            tests).
+        timeout_seconds: How long to wait for the planner to write its
+            output JSON file before giving up.
+        poll_interval: Seconds between output-path existence checks.
+        client_filter: If set, only include pending tickets for this client
+            in the planner prompt.  When None, all pending tickets across
+            all clients are included.
+
+    Returns:
+        :class:`PlanResult` describing the outcome.  When validation fails
+        or the planner times out, ``result.plan`` is None and ``result.error``
+        carries a short description.  Callers should leave the dev queue
+        untouched in those cases.
+    """
+    pending = [t for t in list_tickets(client_filter) if t.status.value == "pending"]
+    if not pending:
+        msg = "No pending tickets to plan."
+        raise CwError(msg)
+
+    correlation_id = uuid4().hex[:8]
+    DEV_PLAN_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    output_path = DEV_PLAN_OUTPUT_DIR / f"plan-{correlation_id}.json"
+    prompt_path = DEV_PLAN_OUTPUT_DIR / f"prompt-{correlation_id}.txt"
+    prompt_path.write_text(_format_tickets_prompt(pending, output_path))
+
+    session_id = spawn_create_impl(
+        client=client,
+        worktree=client.workspace_path,
+        prompt_file=prompt_path,
+        surface="split",
+        label=f"plan-{correlation_id}",
+        adapter=adapter,
+    )
+
+    appeared = _wait_for_plan_output(
+        output_path,
+        timeout_seconds=timeout_seconds,
+        poll_interval=poll_interval,
+    )
+    if not appeared:
+        return PlanResult(
+            plan=None,
+            session_id=session_id,
+            prompt_path=prompt_path,
+            output_path=output_path,
+            error=f"Timed out after {timeout_seconds}s waiting for plan output.",
+        )
+
+    plan = _validate_and_persist(output_path)
+    if plan is None:
+        return PlanResult(
+            plan=None,
+            session_id=session_id,
+            prompt_path=prompt_path,
+            output_path=output_path,
+            error="Plan output failed DispatchPlan validation.",
+        )
+
+    return PlanResult(
+        plan=plan,
+        session_id=session_id,
+        prompt_path=prompt_path,
+        output_path=output_path,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,30 @@ def tmp_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     with contextlib.suppress(AttributeError):
         monkeypatch.setattr("cw.pr_responder.STATE_DIR", state_dir)
 
+    # Dev queue paths used by cw.dev_queue
+    dev_queue_file = state_dir / "dev_queue.json"
+    dev_queue_lock = state_dir / ".dev_queue.lock"
+    monkeypatch.setattr("cw.config.DEV_QUEUE_FILE", dev_queue_file)
+    monkeypatch.setattr("cw.config.DEV_QUEUE_LOCK", dev_queue_lock)
+    with contextlib.suppress(AttributeError):
+        monkeypatch.setattr("cw.dev_queue.DEV_QUEUE_FILE", dev_queue_file)
+    with contextlib.suppress(AttributeError):
+        monkeypatch.setattr("cw.dev_queue.DEV_QUEUE_LOCK", dev_queue_lock)
+
+    # Dev plan paths used by cw.plan and cw.dev_queue
+    dev_plan_file = state_dir / "dev_plan.json"
+    dev_plan_lock = state_dir / ".dev_plan.lock"
+    dev_plan_output_dir = state_dir / "plan_output"
+    monkeypatch.setattr("cw.config.DEV_PLAN_FILE", dev_plan_file)
+    monkeypatch.setattr("cw.config.DEV_PLAN_LOCK", dev_plan_lock)
+    monkeypatch.setattr("cw.config.DEV_PLAN_OUTPUT_DIR", dev_plan_output_dir)
+    with contextlib.suppress(AttributeError):
+        monkeypatch.setattr("cw.dev_queue.DEV_PLAN_FILE", dev_plan_file)
+    with contextlib.suppress(AttributeError):
+        monkeypatch.setattr("cw.dev_queue.DEV_PLAN_LOCK", dev_plan_lock)
+    with contextlib.suppress(AttributeError):
+        monkeypatch.setattr("cw.plan.DEV_PLAN_OUTPUT_DIR", dev_plan_output_dir)
+
     return tmp_path
 
 

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -10,10 +10,19 @@ from click.testing import CliRunner
 
 from cw.cli import main
 from cw.config import load_orchestrator_config
-from cw.dev_queue import add_ticket, list_tickets, load_dev_queue, resolve_client
+from cw.dev_queue import (
+    add_ticket,
+    list_tickets,
+    load_dev_queue,
+    load_plan,
+    plan_path,
+    resolve_client,
+    save_plan,
+)
 from cw.exceptions import CwError
 from cw.models import (
     DevQueueStore,
+    DispatchPlan,
     OrchestratorConfig,
     QueueItemStatus,
     TicketTask,
@@ -33,11 +42,17 @@ def tmp_dev_queue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Redirect dev queue file and lock to tmp_path."""
     dev_queue_file = tmp_path / "dev_queue.json"
     dev_queue_lock = tmp_path / ".dev_queue.lock"
+    dev_plan_file = tmp_path / "dev_plan.json"
+    dev_plan_lock = tmp_path / ".dev_plan.lock"
 
     monkeypatch.setattr("cw.config.DEV_QUEUE_FILE", dev_queue_file)
     monkeypatch.setattr("cw.config.DEV_QUEUE_LOCK", dev_queue_lock)
     monkeypatch.setattr("cw.dev_queue.DEV_QUEUE_FILE", dev_queue_file)
     monkeypatch.setattr("cw.dev_queue.DEV_QUEUE_LOCK", dev_queue_lock)
+    monkeypatch.setattr("cw.config.DEV_PLAN_FILE", dev_plan_file)
+    monkeypatch.setattr("cw.config.DEV_PLAN_LOCK", dev_plan_lock)
+    monkeypatch.setattr("cw.dev_queue.DEV_PLAN_FILE", dev_plan_file)
+    monkeypatch.setattr("cw.dev_queue.DEV_PLAN_LOCK", dev_plan_lock)
 
     return tmp_path
 
@@ -431,3 +446,57 @@ class TestCLIDevQueueStatus:
         assert result.exit_code == 0, result.output
         assert "genhealth" in result.output
         assert "other" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# TestDispatchPlanPersistence
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchPlanPersistence:
+    """Save/load round-trip and missing-file behaviour for the dispatch plan."""
+
+    def test_load_when_missing_returns_none(self, tmp_dev_queue: Path) -> None:
+        assert load_plan() is None
+
+    def test_save_roundtrip(self, tmp_dev_queue: Path) -> None:
+        plan = DispatchPlan(
+            tasks=[
+                TicketTask(ticket_id="GEN-100", client="genhealth"),
+                TicketTask(ticket_id="GEN-101", client="genhealth"),
+            ],
+            grouping_hints={"GEN-100": "shared dependency with GEN-101"},
+        )
+        save_plan(plan)
+        loaded = load_plan()
+        assert loaded is not None
+        assert [t.ticket_id for t in loaded.tasks] == ["GEN-100", "GEN-101"]
+        assert loaded.grouping_hints == {"GEN-100": "shared dependency with GEN-101"}
+
+    def test_save_overwrites_previous_plan(self, tmp_dev_queue: Path) -> None:
+        save_plan(DispatchPlan(tasks=[TicketTask(ticket_id="X-1", client="c")]))
+        save_plan(
+            DispatchPlan(
+                tasks=[
+                    TicketTask(ticket_id="Y-1", client="c"),
+                    TicketTask(ticket_id="Y-2", client="c"),
+                ]
+            )
+        )
+        loaded = load_plan()
+        assert loaded is not None
+        assert [t.ticket_id for t in loaded.tasks] == ["Y-1", "Y-2"]
+
+    def test_load_malformed_json_returns_none(self, tmp_dev_queue: Path) -> None:
+        plan_path().parent.mkdir(parents=True, exist_ok=True)
+        plan_path().write_text("not valid json")
+        assert load_plan() is None
+
+    def test_load_invalid_schema_returns_none(self, tmp_dev_queue: Path) -> None:
+        plan_path().parent.mkdir(parents=True, exist_ok=True)
+        plan_path().write_text('{"tasks": [{"missing": "fields"}]}')
+        assert load_plan() is None
+
+    def test_plan_path_returns_configured_path(self, tmp_dev_queue: Path) -> None:
+        path = plan_path()
+        assert path == tmp_dev_queue / "dev_plan.json"

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -8,13 +8,14 @@ import pytest
 
 from cw.cmux import FakeCmuxAdapter
 from cw.config import load_state, save_state
-from cw.dev_queue import add_ticket, load_dev_queue, save_dev_queue
+from cw.dev_queue import add_ticket, load_dev_queue, save_dev_queue, save_plan
 from cw.dispatch import consume_completed_sessions, dispatch_tick
 from cw.events import record_event
 from cw.models import (
     ClientConfig,
     CwState,
     DevQueueStore,
+    DispatchPlan,
     OrchestratorConfig,
     OrchestratorEventType,
     QueueItemStatus,
@@ -55,6 +56,8 @@ def tmp_dispatch_dirs(
     events_dir.mkdir(parents=True)
     dev_queue_file = state_dir / "dev_queue.json"
     dev_queue_lock = state_dir / ".dev_queue.lock"
+    dev_plan_file = state_dir / "dev_plan.json"
+    dev_plan_lock = state_dir / ".dev_plan.lock"
 
     monkeypatch.setattr("cw.config.CONFIG_DIR", config_dir)
     monkeypatch.setattr("cw.config.STATE_DIR", state_dir)
@@ -64,11 +67,15 @@ def tmp_dispatch_dirs(
     monkeypatch.setattr("cw.config.EVENTS_DIR", events_dir)
     monkeypatch.setattr("cw.config.DEV_QUEUE_FILE", dev_queue_file)
     monkeypatch.setattr("cw.config.DEV_QUEUE_LOCK", dev_queue_lock)
+    monkeypatch.setattr("cw.config.DEV_PLAN_FILE", dev_plan_file)
+    monkeypatch.setattr("cw.config.DEV_PLAN_LOCK", dev_plan_lock)
 
     # Patch module-level imported references
     monkeypatch.setattr("cw.events.EVENTS_DIR", events_dir)
     monkeypatch.setattr("cw.dev_queue.DEV_QUEUE_FILE", dev_queue_file)
     monkeypatch.setattr("cw.dev_queue.DEV_QUEUE_LOCK", dev_queue_lock)
+    monkeypatch.setattr("cw.dev_queue.DEV_PLAN_FILE", dev_plan_file)
+    monkeypatch.setattr("cw.dev_queue.DEV_PLAN_LOCK", dev_plan_lock)
 
     return tmp_path
 
@@ -363,3 +370,92 @@ class TestDispatchTickReturnsCount:
 
         assert count == 0
         assert len(adapter.calls["spawn"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestDispatchTickWithPlan
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchTickWithPlan:
+    """use_plan=True respects DispatchPlan ordering, falls back gracefully."""
+
+    def test_use_plan_reorders_pending_claims(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        cap2_config: OrchestratorConfig,
+    ) -> None:
+        """When use_plan=True, dispatch claims tickets in plan order, not enqueue."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        # Enqueue in order A, B, C
+        add_ticket(TicketTask(ticket_id="GEN-A", client="test-client"))
+        add_ticket(TicketTask(ticket_id="GEN-B", client="test-client"))
+        add_ticket(TicketTask(ticket_id="GEN-C", client="test-client"))
+
+        # Plan reorders to C, A, B
+        save_plan(
+            DispatchPlan(
+                tasks=[
+                    TicketTask(ticket_id="GEN-C", client="test-client"),
+                    TicketTask(ticket_id="GEN-A", client="test-client"),
+                    TicketTask(ticket_id="GEN-B", client="test-client"),
+                ]
+            )
+        )
+
+        adapter = FakeCmuxAdapter()
+        # cap=2 => should claim C first, then A
+        spawned = dispatch_tick(cap2_config, adapter=adapter, use_plan=True)
+        assert spawned == 2
+
+        store = load_dev_queue()
+        running_ids = sorted(t.ticket_id for t in store.running())
+        assert running_ids == ["GEN-A", "GEN-C"]
+
+    def test_use_plan_missing_falls_back_to_enqueue_order(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """No persisted plan: dispatch falls back to enqueue order, no crash."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        add_ticket(TicketTask(ticket_id="GEN-FIRST", client="test-client"))
+        add_ticket(TicketTask(ticket_id="GEN-SECOND", client="test-client"))
+
+        adapter = FakeCmuxAdapter()
+        spawned = dispatch_tick(simple_config, adapter=adapter, use_plan=True)
+        assert spawned == 1
+
+        store = load_dev_queue()
+        running = store.running()
+        assert len(running) == 1
+        assert running[0].ticket_id == "GEN-FIRST"
+
+    def test_use_plan_drains_unplanned_after_planned(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        cap2_config: OrchestratorConfig,
+    ) -> None:
+        """Planned tickets first, then unplanned still get dispatched."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        add_ticket(TicketTask(ticket_id="GEN-A", client="test-client"))
+        add_ticket(TicketTask(ticket_id="GEN-B", client="test-client"))
+
+        # Plan only mentions B
+        save_plan(
+            DispatchPlan(tasks=[TicketTask(ticket_id="GEN-B", client="test-client")])
+        )
+
+        adapter = FakeCmuxAdapter()
+        spawned = dispatch_tick(cap2_config, adapter=adapter, use_plan=True)
+        # cap=2: claims B first (per plan), then A (fallback)
+        assert spawned == 2
+
+        store = load_dev_queue()
+        assert len(store.running()) == 2

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,295 @@
+"""Tests for cw.plan and `cw dev-queue plan` CLI command."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cw.cmux import FakeCmuxAdapter
+from cw.dev_queue import add_ticket, load_dev_queue, load_plan
+from cw.exceptions import CwError
+from cw.models import (
+    ClientConfig,
+    DispatchPlan,
+    QueueItemStatus,
+    TicketTask,
+)
+from cw.plan import run_planner
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def planner_client(tmp_path: Path) -> ClientConfig:
+    """A ClientConfig usable as the planner host."""
+    workspace = tmp_path / "workspace" / "planner-client"
+    workspace.mkdir(parents=True)
+    return ClientConfig(
+        name="planner-client",
+        workspace_path=workspace,
+        default_branch="main",
+    )
+
+
+class _ScriptedAdapter(FakeCmuxAdapter):
+    """FakeCmuxAdapter that, on spawn, immediately writes a planned JSON file.
+
+    Reads the prompt file (path appears in the cmux command argument) to
+    discover the expected output_path declared by run_planner, then writes
+    *output_payload* (string) to that path.  Mimics the production
+    /orchestrate-plan skill side-effect without invoking Claude.
+    """
+
+    def __init__(self, output_payload: str) -> None:
+        super().__init__()
+        self._payload = output_payload
+
+    def spawn(self, workspace: str, command: str, surface: str = "right") -> str:
+        ref = super().spawn(workspace, command, surface)
+        # The prompt file path appears in the command between the literal
+        # string repr quotes; recover it by looking for "/orchestrate-plan ".
+        # Easier path: re-read the prompt files in DEV_PLAN_OUTPUT_DIR.
+        from cw.config import DEV_PLAN_OUTPUT_DIR
+
+        prompts = sorted(DEV_PLAN_OUTPUT_DIR.glob("prompt-*.txt"))
+        if not prompts:
+            return ref
+        prompt_text = prompts[-1].read_text()
+        first_line = prompt_text.splitlines()[0]
+        # Format: "/orchestrate-plan <output_path>"
+        parts = first_line.split(" ", maxsplit=1)
+        if len(parts) == 2:
+            output_path = parts[1].strip()
+            from pathlib import Path
+
+            Path(output_path).write_text(self._payload)
+        return ref
+
+
+# ---------------------------------------------------------------------------
+# TestRunPlanner
+# ---------------------------------------------------------------------------
+
+
+class TestRunPlanner:
+    def test_no_pending_tickets_raises(
+        self,
+        tmp_config_dir: Path,
+        planner_client: ClientConfig,
+    ) -> None:
+        with pytest.raises(CwError, match="No pending tickets"):
+            run_planner(
+                client=planner_client,
+                adapter=FakeCmuxAdapter(),
+                timeout_seconds=1,
+            )
+
+    def test_happy_path_persists_plan(
+        self,
+        tmp_config_dir: Path,
+        planner_client: ClientConfig,
+    ) -> None:
+        add_ticket(TicketTask(ticket_id="GEN-1", client="planner-client"))
+        add_ticket(TicketTask(ticket_id="GEN-2", client="planner-client"))
+
+        plan_payload = DispatchPlan(
+            tasks=[
+                TicketTask(ticket_id="GEN-2", client="planner-client"),
+                TicketTask(ticket_id="GEN-1", client="planner-client"),
+            ],
+            grouping_hints={"GEN-2": "should run first per planner heuristic"},
+        ).model_dump_json()
+        adapter = _ScriptedAdapter(plan_payload)
+
+        result = run_planner(
+            client=planner_client,
+            adapter=adapter,
+            timeout_seconds=10,
+            poll_interval=0.05,
+        )
+
+        assert result.error is None
+        assert result.plan is not None
+        assert [t.ticket_id for t in result.plan.tasks] == ["GEN-2", "GEN-1"]
+
+        loaded = load_plan()
+        assert loaded is not None
+        assert [t.ticket_id for t in loaded.tasks] == ["GEN-2", "GEN-1"]
+
+    def test_malformed_json_returns_error_no_persist(
+        self,
+        tmp_config_dir: Path,
+        planner_client: ClientConfig,
+    ) -> None:
+        add_ticket(TicketTask(ticket_id="GEN-1", client="planner-client"))
+        adapter = _ScriptedAdapter("this is { not valid JSON")
+
+        result = run_planner(
+            client=planner_client,
+            adapter=adapter,
+            timeout_seconds=5,
+            poll_interval=0.05,
+        )
+
+        assert result.plan is None
+        assert result.error is not None
+        assert "validation" in result.error.lower()
+
+        # Plan must NOT be persisted on failure
+        assert load_plan() is None
+
+        # Queue must remain unchanged (still PENDING)
+        store = load_dev_queue()
+        assert all(t.status == QueueItemStatus.PENDING for t in store.tasks)
+
+    def test_invalid_schema_returns_error(
+        self,
+        tmp_config_dir: Path,
+        planner_client: ClientConfig,
+    ) -> None:
+        add_ticket(TicketTask(ticket_id="GEN-1", client="planner-client"))
+        # Valid JSON but missing required ticket_task fields
+        bad_payload = json.dumps({"tasks": [{"foo": "bar"}]})
+        adapter = _ScriptedAdapter(bad_payload)
+
+        result = run_planner(
+            client=planner_client,
+            adapter=adapter,
+            timeout_seconds=5,
+            poll_interval=0.05,
+        )
+
+        assert result.plan is None
+        assert result.error is not None
+        assert load_plan() is None
+
+    def test_timeout_returns_error(
+        self,
+        tmp_config_dir: Path,
+        planner_client: ClientConfig,
+    ) -> None:
+        add_ticket(TicketTask(ticket_id="GEN-1", client="planner-client"))
+        # Plain FakeCmuxAdapter never writes the output file
+        adapter = FakeCmuxAdapter()
+
+        result = run_planner(
+            client=planner_client,
+            adapter=adapter,
+            timeout_seconds=1,
+            poll_interval=0.05,
+        )
+
+        assert result.plan is None
+        assert result.error is not None
+        assert "timed out" in result.error.lower()
+        assert load_plan() is None
+
+    def test_client_filter_limits_tickets_in_prompt(
+        self,
+        tmp_config_dir: Path,
+        planner_client: ClientConfig,
+    ) -> None:
+        add_ticket(TicketTask(ticket_id="GEN-1", client="planner-client"))
+        add_ticket(TicketTask(ticket_id="OTH-1", client="other-client"))
+
+        plan_payload = DispatchPlan(
+            tasks=[TicketTask(ticket_id="GEN-1", client="planner-client")]
+        ).model_dump_json()
+        adapter = _ScriptedAdapter(plan_payload)
+
+        result = run_planner(
+            client=planner_client,
+            adapter=adapter,
+            timeout_seconds=5,
+            poll_interval=0.05,
+            client_filter="planner-client",
+        )
+
+        assert result.plan is not None
+        # Verify the prompt file only contained the filtered ticket
+        prompt_text = result.prompt_path.read_text()
+        assert "GEN-1" in prompt_text
+        assert "OTH-1" not in prompt_text
+
+
+# ---------------------------------------------------------------------------
+# TestCLIDevQueuePlan
+# ---------------------------------------------------------------------------
+
+
+class TestCLIDevQueuePlan:
+    def test_cli_plan_happy_path(
+        self,
+        tmp_config_dir: Path,
+        planner_client: ClientConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from click.testing import CliRunner
+
+        from cw.cli import main
+
+        # Register the planner client in the in-memory client config
+        clients = {planner_client.name: planner_client}
+        monkeypatch.setattr("cw.cli.load_clients", lambda: clients)
+        monkeypatch.setattr("cw.config.load_clients", lambda: clients)
+
+        add_ticket(TicketTask(ticket_id="GEN-1", client="planner-client"))
+
+        plan_payload = DispatchPlan(
+            tasks=[TicketTask(ticket_id="GEN-1", client="planner-client")]
+        ).model_dump_json()
+        adapter = _ScriptedAdapter(plan_payload)
+        monkeypatch.setattr("cw.cli.get_cmux_adapter", lambda: adapter)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["dev-queue", "plan", "--client", "planner-client", "--timeout", "5"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Plan persisted" in result.output
+
+        loaded = load_plan()
+        assert loaded is not None
+        assert [t.ticket_id for t in loaded.tasks] == ["GEN-1"]
+
+    def test_cli_plan_validation_failure_exits_nonzero(
+        self,
+        tmp_config_dir: Path,
+        planner_client: ClientConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from click.testing import CliRunner
+
+        from cw.cli import main
+
+        clients = {planner_client.name: planner_client}
+        monkeypatch.setattr("cw.cli.load_clients", lambda: clients)
+        monkeypatch.setattr("cw.config.load_clients", lambda: clients)
+
+        add_ticket(TicketTask(ticket_id="GEN-1", client="planner-client"))
+
+        adapter = _ScriptedAdapter("not valid json at all")
+        monkeypatch.setattr("cw.cli.get_cmux_adapter", lambda: adapter)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["dev-queue", "plan", "--client", "planner-client", "--timeout", "5"],
+        )
+
+        assert result.exit_code != 0
+        assert "Planner failed" in result.output
+        # Queue unchanged
+        store = load_dev_queue()
+        assert all(t.status == QueueItemStatus.PENDING for t in store.tasks)
+        # Plan not persisted
+        assert load_plan() is None


### PR DESCRIPTION
## Summary

- New ` /orchestrate-plan` skill (committed to `global-claude/skills/`) that reads pending `TicketTask` rows, enriches them with Linear context, and writes a `DispatchPlan` JSON ordering them by priority, dependencies, and scope.
- `cw dev-queue plan --client <name>` spawns a one-shot CC session via `spawn_create_impl()`, waits for the JSON output, validates with pydantic, and persists the plan. Validation failures and timeouts leave the queue untouched and log a warning.
- `cw dev-queue run --use-plan` claims tasks in the persisted plan's order; missing plan falls back to enqueue order cleanly.
- New module `src/cw/plan.py` hosts the planner orchestration (prompt formatting, output polling, validation).
- `DispatchPlan` persistence helpers added to `src/cw/dev_queue.py` (`save_plan`, `load_plan`, `plan_path`) using the same file-lock pattern as the ticket queue.

## Test plan

- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run mypy src/` — zero errors
- [x] `uv run pytest tests/ -v` — all tests pass
- [x] New `tests/test_plan.py` covers happy path (FakeCmuxAdapter produces JSON, plan persisted), timeout path, malformed JSON path (queue unchanged).
- [x] `tests/test_dev_queue.py` extended with plan save/load roundtrip and missing-plan returns None.
- [x] `tests/test_dispatch.py` extended with `use_plan=True` honors ordering and falls back to enqueue order when plan is missing.

## Notes

- Skill file lives in `global-claude/skills/orchestrate-plan.md` — already committed to that repo (symlinks into `~/.claude/skills/`). Push `global-claude` to propagate.
- Scope fits the Wave-4 handoff: ~300 lines production + ~200 lines tests.

Closes #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)