### PR TITLE
feat: add cw orchestrate watch live dashboard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
           - click>=8.3.1
           - jinja2>=3.1.6
           - pyyaml>=6.0.3
+          - rich>=13.7
           - types-PyYAML>=6.0
           - ruamel.yaml>=0.18.6
         args: [--strict, --python-version=3.13]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "jinja2>=3.1.6",
     "pydantic>=2.12.5",
     "pyyaml>=6.0.3",
+    "rich>=13.7",
     "ruamel.yaml>=0.18.6",
 
 ]

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -62,6 +62,8 @@ from cw.session import (
     start_session,
 )
 from cw.spawn import spawn_create_impl
+from cw.tui import DetailLevel
+from cw.tui import watch as tui_watch
 from cw.wrapper import run_claude_wrapper, signal_idle
 
 
@@ -1021,6 +1023,64 @@ def orchestrate_retire() -> None:
     click.echo(f"Retired {len(retired)} session(s):")
     for sid in retired:
         click.echo(f"  {sid}")
+
+
+@orchestrate.command(name="watch")
+@click.option(
+    "--interval",
+    type=int,
+    default=2,
+    show_default=True,
+    help="Seconds between refreshes (1-60).",
+)
+@click.option(
+    "--client",
+    "client_filter",
+    default=None,
+    shell_complete=_complete_client,
+    help="Only render this client.",
+)
+@click.option(
+    "--compact",
+    "level_compact",
+    is_flag=True,
+    default=False,
+    help="One-line per-client summary (counts only).",
+)
+@click.option(
+    "--verbose",
+    "level_verbose",
+    is_flag=True,
+    default=False,
+    help="Show extra columns: surface_ref, scope_hint, unresolved threads.",
+)
+@handle_errors
+def orchestrate_watch(
+    interval: int,
+    client_filter: str | None,
+    level_compact: bool,
+    level_verbose: bool,
+) -> None:
+    """Render the orchestrator dashboard live, refreshing on an interval.
+
+    Groups sessions, tickets, and PRs by client.  Press Ctrl-C to exit.
+    """
+    if level_compact and level_verbose:
+        msg = "Pass at most one of --compact / --verbose."
+        raise click.ClickException(msg)
+
+    level = DetailLevel.DEFAULT
+    if level_compact:
+        level = DetailLevel.COMPACT
+    elif level_verbose:
+        level = DetailLevel.VERBOSE
+
+    tui_watch(
+        interval=interval,
+        client_filter=client_filter,
+        level=level,
+        home=str(Path.home()),
+    )
 
 
 # --- Spawn command group ---

--- a/src/cw/orchestrate.py
+++ b/src/cw/orchestrate.py
@@ -293,6 +293,7 @@ class SessionSummary(BaseModel):
     purpose: str
     started_at: datetime
     surface_ref: str | None = None
+    worktree_path: Path | None = None
 
 
 class TicketSummary(BaseModel):
@@ -303,6 +304,7 @@ class TicketSummary(BaseModel):
     priority: int
     status: str
     created_at: datetime
+    scope_hint: str | None = None
 
 
 class EventSummary(BaseModel):
@@ -336,6 +338,7 @@ def _summarise_ticket(task: TicketTask) -> TicketSummary:
         priority=task.priority,
         status=task.status.value,
         created_at=task.created_at,
+        scope_hint=task.scope_hint,
     )
 
 
@@ -348,6 +351,7 @@ def _summarise_session(sess: Session) -> SessionSummary:
         purpose=sess.purpose.value,
         started_at=sess.started_at,
         surface_ref=sess.surface_ref,
+        worktree_path=sess.worktree_path,
     )
 
 

--- a/src/cw/tui.py
+++ b/src/cw/tui.py
@@ -1,0 +1,384 @@
+"""Live dashboard for the orchestrator subsystem.
+
+Renders the output of :func:`cw.orchestrate.orchestrator_status` as a rich
+:class:`rich.console.Group` that can be passed to a static :class:`Console`
+for ``cw orchestrate status`` or wrapped in :class:`rich.live.Live` for
+``cw orchestrate watch``.
+
+Sessions are grouped by client (primary axis) so the dashboard matches
+the mental model of existing ``cw status`` / ``cw list`` output.  Worktree
+paths are surfaced as a column so contention between parallel sessions on
+overlapping branches is visible without hiding the client axis.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from rich.console import Console, Group
+from rich.live import Live
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from cw.orchestrate import (
+    EventSummary,
+    MonitoredPR,
+    OrchestratorStatus,
+    SessionSummary,
+    TicketSummary,
+    orchestrator_status,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from rich.console import RenderableType
+
+_MIN_INTERVAL_SECONDS = 1
+_MAX_INTERVAL_SECONDS = 60
+_WORKTREE_DISPLAY_MAX = 40
+
+
+class DetailLevel(StrEnum):
+    """How much detail the dashboard should render per row."""
+
+    COMPACT = "compact"
+    DEFAULT = "default"
+    VERBOSE = "verbose"
+
+
+def _format_elapsed(started_at: datetime, now: datetime) -> str:
+    """Return a short ``HhMmSs``-style elapsed time string."""
+    delta = max(now - started_at, now - now)  # Guard against clock skew.
+    total_seconds = int(delta.total_seconds())
+    if total_seconds < 60:
+        return f"{total_seconds}s"
+    if total_seconds < 3600:
+        minutes, seconds = divmod(total_seconds, 60)
+        return f"{minutes}m{seconds:02d}s"
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes = remainder // 60
+    return f"{hours}h{minutes:02d}m"
+
+
+def _shorten_worktree(path_value: object, home: str) -> str:
+    """Display a worktree path relative to ``$HOME`` and capped in length."""
+    if path_value is None:
+        return "—"
+    as_str = str(path_value)
+    if home and as_str.startswith(home):
+        as_str = "~" + as_str[len(home) :]
+    if len(as_str) > _WORKTREE_DISPLAY_MAX:
+        keep = _WORKTREE_DISPLAY_MAX - 1
+        as_str = "…" + as_str[-keep:]
+    return as_str
+
+
+def _group_by_client(
+    sessions: Iterable[SessionSummary],
+    tickets: Iterable[TicketSummary],
+) -> list[str]:
+    """Return client names sorted by most activity first, then alphabetically."""
+    counts: dict[str, int] = {}
+    for sess in sessions:
+        counts[sess.client] = counts.get(sess.client, 0) + 1
+    for ticket in tickets:
+        counts[ticket.client] = counts.get(ticket.client, 0) + 1
+    return sorted(counts, key=lambda c: (-counts[c], c))
+
+
+def _sessions_table(
+    sessions: list[SessionSummary],
+    *,
+    level: DetailLevel,
+    now: datetime,
+    home: str,
+) -> RenderableType:
+    """Render a table of running sessions for one client."""
+    if not sessions:
+        return Text("  (no running sessions)", style="dim")
+    table = Table(
+        show_edge=False,
+        pad_edge=False,
+        expand=True,
+        header_style="bold cyan",
+    )
+    table.add_column("ID", width=10, no_wrap=True)
+    table.add_column("PURPOSE", width=8)
+    table.add_column("WORKTREE", overflow="fold")
+    if level is DetailLevel.VERBOSE:
+        table.add_column("SURFACE", width=12, no_wrap=True)
+    table.add_column("ELAPSED", width=8, justify="right", no_wrap=True)
+    for sess in sorted(sessions, key=lambda s: s.started_at):
+        row: list[str] = [
+            sess.id,
+            sess.purpose,
+            _shorten_worktree(sess.worktree_path, home),
+        ]
+        if level is DetailLevel.VERBOSE:
+            row.append(sess.surface_ref or "—")
+        row.append(_format_elapsed(sess.started_at, now))
+        table.add_row(*row)
+    return table
+
+
+def _tickets_table(
+    tickets: list[TicketSummary],
+    *,
+    level: DetailLevel,
+) -> RenderableType:
+    """Render a table of pending tickets for one client."""
+    if not tickets:
+        return Text("  (no pending tickets)", style="dim")
+    table = Table(
+        show_edge=False,
+        pad_edge=False,
+        expand=True,
+        header_style="bold cyan",
+    )
+    table.add_column("TICKET", width=14, no_wrap=True)
+    table.add_column("PRIORITY", width=8, justify="right")
+    if level is DetailLevel.VERBOSE:
+        table.add_column("SCOPE", overflow="fold")
+    for ticket in sorted(
+        tickets,
+        key=lambda t: (-t.priority, t.created_at),
+    ):
+        row = [ticket.ticket_id, str(ticket.priority)]
+        if level is DetailLevel.VERBOSE:
+            row.append(ticket.scope_hint or "—")
+        table.add_row(*row)
+    return table
+
+
+def _prs_table(prs: list[MonitoredPR], *, level: DetailLevel) -> RenderableType:
+    """Render a table of monitored PRs for one client."""
+    if not prs:
+        return Text("  (no monitored PRs)", style="dim")
+    table = Table(
+        show_edge=False,
+        pad_edge=False,
+        expand=True,
+        header_style="bold cyan",
+    )
+    table.add_column("PR", width=10, no_wrap=True)
+    table.add_column("ROLE", width=8, no_wrap=True)
+    table.add_column("STATUS", overflow="fold")
+    if level is DetailLevel.VERBOSE:
+        table.add_column("UNRESOLVED", width=10, justify="right")
+    for pr in sorted(prs, key=lambda p: (p.repo, p.pr_number)):
+        row = [
+            f"{pr.repo}#{pr.pr_number}",
+            pr.role,
+            pr.status,
+        ]
+        if level is DetailLevel.VERBOSE:
+            row.append(str(pr.unresolved_threads))
+        table.add_row(*row)
+    return table
+
+
+def _client_panel(
+    client: str,
+    *,
+    sessions: list[SessionSummary],
+    tickets: list[TicketSummary],
+    prs: list[MonitoredPR],
+    level: DetailLevel,
+    now: datetime,
+    home: str,
+) -> Panel:
+    """Build a panel with sessions, tickets, and PRs for a single client."""
+    if level is DetailLevel.COMPACT:
+        body: RenderableType = Text(
+            f"  running: {len(sessions)}   pending: {len(tickets)}   PRs: {len(prs)}",
+        )
+    else:
+        body = Group(
+            Text("Running sessions", style="bold"),
+            _sessions_table(sessions, level=level, now=now, home=home),
+            Text(""),
+            Text("Pending tickets", style="bold"),
+            _tickets_table(tickets, level=level),
+            Text(""),
+            Text("Monitored PRs", style="bold"),
+            _prs_table(prs, level=level),
+        )
+    return Panel(body, title=f"[b]{client}[/b]", title_align="left")
+
+
+def _events_panel(
+    events: list[EventSummary],
+    *,
+    level: DetailLevel,
+) -> Panel:
+    """Render the last-N events panel."""
+    if not events:
+        body: RenderableType = Text("(no recent events)", style="dim")
+    else:
+        table = Table(show_edge=False, pad_edge=False, expand=True, show_header=False)
+        table.add_column("TIME", width=8, no_wrap=True, style="dim")
+        table.add_column("TYPE", width=22, no_wrap=True, style="magenta")
+        table.add_column("PAYLOAD", overflow="fold")
+        for event in events:
+            timestamp = event.created_at.astimezone().strftime("%H:%M:%S")
+            if level is DetailLevel.VERBOSE:
+                payload_text = ", ".join(f"{k}={v}" for k, v in event.payload.items())
+            else:
+                payload_text = _summarise_event_payload(event.payload)
+            table.add_row(timestamp, event.type, payload_text or "—")
+        body = table
+    title = f"[b]Recent events[/b] ({len(events)})"
+    return Panel(body, title=title, title_align="left")
+
+
+def _summarise_event_payload(payload: dict[str, object]) -> str:
+    """One-line payload summary: prefer repo/pr_number/session_id."""
+    parts: list[str] = []
+    repo = payload.get("repo")
+    if repo:
+        pr = payload.get("pr_number")
+        parts.append(f"{repo}#{pr}" if pr is not None else str(repo))
+    session_id = payload.get("session_id")
+    if session_id:
+        parts.append(f"session={session_id}")
+    reason = payload.get("reason")
+    if reason:
+        parts.append(str(reason))
+    return " ".join(parts)
+
+
+def _header(status: OrchestratorStatus, *, level: DetailLevel) -> Text:
+    """Top-line header with generation time and detail level."""
+    local_ts = status.generated_at.astimezone().strftime("%H:%M:%S")
+    return Text.from_markup(
+        f"[b]cw orchestrate[/b]  [dim]generated {local_ts} · level={level.value}[/dim]",
+    )
+
+
+def render_dashboard(
+    status: OrchestratorStatus,
+    *,
+    level: DetailLevel = DetailLevel.DEFAULT,
+    client_filter: str | None = None,
+    now: datetime | None = None,
+    home: str = "",
+) -> RenderableType:
+    """Build the full dashboard renderable from an OrchestratorStatus.
+
+    Args:
+        status: Snapshot produced by :func:`orchestrator_status`.
+        level: COMPACT / DEFAULT / VERBOSE.
+        client_filter: If set, only show this client.
+        now: Reference time for elapsed calculations.  Defaults to
+            ``datetime.now(UTC)`` — override in tests for determinism.
+        home: Home directory string used to shorten worktree paths.
+
+    Returns:
+        A rich renderable suitable for :class:`Console.print` or
+        :class:`Live`.
+    """
+    now = now or datetime.now(UTC)
+    clients = _group_by_client(status.running_sessions, status.pending_tickets)
+    if client_filter is not None:
+        clients = [c for c in clients if c == client_filter]
+
+    panels: list[RenderableType] = [_header(status, level=level)]
+    if not clients:
+        panels.append(
+            Panel(
+                Text("No active clients.", style="dim"),
+                title="[b]Clients[/b]",
+                title_align="left",
+            ),
+        )
+    for client in clients:
+        sessions = [s for s in status.running_sessions if s.client == client]
+        tickets = [t for t in status.pending_tickets if t.client == client]
+        prs = _prs_for_client(status.monitored_prs, client, status.running_sessions)
+        panels.append(
+            _client_panel(
+                client,
+                sessions=sessions,
+                tickets=tickets,
+                prs=prs,
+                level=level,
+                now=now,
+                home=home,
+            ),
+        )
+
+    panels.append(_events_panel(status.recent_events, level=level))
+    return Group(*panels)
+
+
+def _prs_for_client(
+    prs: list[MonitoredPR],
+    client: str,
+    sessions: list[SessionSummary],
+) -> list[MonitoredPR]:
+    """Filter PRs to those whose repo matches a session's name prefix.
+
+    Falls back to including every PR when no sessions exist for the client,
+    so the dashboard still surfaces PRs before any session has been spawned.
+    """
+    if not sessions:
+        return prs
+    session_clients = {s.client for s in sessions if s.client == client}
+    if not session_clients:
+        return []
+    return prs
+
+
+def watch(
+    *,
+    interval: int = 2,
+    client_filter: str | None = None,
+    level: DetailLevel = DetailLevel.DEFAULT,
+    console: Console | None = None,
+    ticks: int | None = None,
+    status_fn: Callable[[], OrchestratorStatus] | None = None,
+    home: str = "",
+) -> None:
+    """Render the dashboard live, refreshing every *interval* seconds.
+
+    Args:
+        interval: Seconds between refreshes.  Clamped to [1, 60].
+        client_filter: If set, only render the named client.
+        level: Detail level for rendered tables.
+        console: Optional :class:`Console` (tests may pass a recording one).
+        ticks: If set, render this many frames and exit — used by tests.
+            ``None`` runs until the user hits Ctrl-C.
+        status_fn: Snapshot provider.  Defaults to
+            :func:`orchestrator_status`; tests inject fakes.
+        home: Home directory string used to shorten worktree paths.
+    """
+    interval = max(_MIN_INTERVAL_SECONDS, min(_MAX_INTERVAL_SECONDS, interval))
+    console = console or Console()
+    provider = status_fn or orchestrator_status
+
+    def _build() -> RenderableType:
+        return render_dashboard(
+            provider(),
+            level=level,
+            client_filter=client_filter,
+            home=home,
+        )
+
+    if ticks is not None:
+        # Deterministic test path: render N frames directly.
+        for _ in range(ticks):
+            console.print(_build())
+        return
+
+    with Live(_build(), console=console, screen=True, refresh_per_second=4) as live:
+        try:
+            while True:
+                time.sleep(interval)
+                live.update(_build())
+        except KeyboardInterrupt:
+            return

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,244 @@
+"""Tests for the orchestrator dashboard TUI.
+
+Snapshot-style tests using rich's :class:`Console` with a captured buffer.
+Rather than asserting exact byte-for-byte output (fragile under rich
+version bumps), tests check for presence/absence of the meaningful tokens
+-- client names, ticket IDs, detail-level-specific columns, and so on.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+from cw.orchestrate import (
+    EventSummary,
+    MonitoredPR,
+    OrchestratorStatus,
+    SessionSummary,
+    TicketSummary,
+)
+from cw.tui import DetailLevel, render_dashboard, watch
+
+
+@pytest.fixture
+def frozen_now() -> datetime:
+    return datetime(2026, 4, 18, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def sample_status(frozen_now: datetime) -> OrchestratorStatus:
+    return OrchestratorStatus(
+        generated_at=frozen_now,
+        pending_tickets=[
+            TicketSummary(
+                ticket_id="MW-101",
+                client="personal",
+                priority=2,
+                status="pending",
+                created_at=frozen_now,
+                scope_hint="refactor auth middleware",
+            ),
+            TicketSummary(
+                ticket_id="MW-102",
+                client="personal",
+                priority=0,
+                status="pending",
+                created_at=frozen_now,
+            ),
+        ],
+        running_sessions=[
+            SessionSummary(
+                id="abc12345",
+                name="personal/impl",
+                client="personal",
+                status="active",
+                purpose="impl",
+                started_at=datetime(2026, 4, 18, 11, 55, 0, tzinfo=UTC),
+                surface_ref="surf-1",
+                worktree_path=Path("/home/matthew/workspace/personal/wt/abc"),
+            ),
+            SessionSummary(
+                id="xyz98765",
+                name="lgbtqplus.map/impl",
+                client="lgbtqplus.map",
+                status="active",
+                purpose="impl",
+                started_at=datetime(2026, 4, 18, 10, 0, 0, tzinfo=UTC),
+                worktree_path=None,
+            ),
+        ],
+        monitored_prs=[
+            MonitoredPR(
+                repo="mattwwarren/claude-workspace",
+                pr_number=42,
+                role="author",
+                status="watching",
+                unresolved_threads=2,
+            ),
+        ],
+        recent_events=[
+            EventSummary(
+                id="evt-1",
+                type="session.completed",
+                payload={"session_id": "abc12345", "reason": "HANDOFF"},
+                correlation_id=None,
+                created_at=frozen_now,
+            ),
+            EventSummary(
+                id="evt-2",
+                type="pr.merged",
+                payload={"repo": "mattwwarren/claude-workspace", "pr_number": 42},
+                correlation_id=None,
+                created_at=frozen_now,
+            ),
+        ],
+    )
+
+
+def _render(
+    status: OrchestratorStatus,
+    level: DetailLevel,
+    *,
+    frozen_now: datetime,
+    client_filter: str | None = None,
+) -> str:
+    buffer = StringIO()
+    console = Console(file=buffer, width=120, record=False, force_terminal=False)
+    console.print(
+        render_dashboard(
+            status,
+            level=level,
+            client_filter=client_filter,
+            now=frozen_now,
+            home="/home/matthew",
+        ),
+    )
+    return buffer.getvalue()
+
+
+class TestRenderDashboard:
+    def test_default_level_shows_every_section(
+        self,
+        sample_status: OrchestratorStatus,
+        frozen_now: datetime,
+    ) -> None:
+        output = _render(sample_status, DetailLevel.DEFAULT, frozen_now=frozen_now)
+
+        # Clients grouped and rendered.
+        assert "personal" in output
+        assert "lgbtqplus.map" in output
+
+        # Sessions visible.
+        assert "abc12345" in output
+        assert "xyz98765" in output
+
+        # Tickets visible.
+        assert "MW-101" in output
+        assert "MW-102" in output
+
+        # PRs visible.
+        assert "mattwwarren/claude-workspace#42" in output
+
+        # Events panel present with both events.
+        assert "session.completed" in output
+        assert "pr.merged" in output
+
+    def test_compact_shows_counts_only(
+        self,
+        sample_status: OrchestratorStatus,
+        frozen_now: datetime,
+    ) -> None:
+        output = _render(sample_status, DetailLevel.COMPACT, frozen_now=frozen_now)
+
+        # Counts line renders per client.
+        assert "running:" in output
+        assert "pending:" in output
+        assert "PRs:" in output
+
+        # Per-client tables are suppressed in compact mode -- no ticket IDs.
+        # (Session IDs may still appear in the events panel payload, which
+        # is the audit log and stays visible at every level.)
+        assert "MW-101" not in output
+        assert "refactor auth middleware" not in output
+
+    def test_verbose_adds_scope_and_surface_columns(
+        self,
+        sample_status: OrchestratorStatus,
+        frozen_now: datetime,
+    ) -> None:
+        output = _render(sample_status, DetailLevel.VERBOSE, frozen_now=frozen_now)
+
+        # Scope hint appears only at VERBOSE.
+        assert "refactor auth middleware" in output
+        # Surface ref column value appears only at VERBOSE.
+        assert "surf-1" in output
+
+    def test_client_filter_hides_others(
+        self,
+        sample_status: OrchestratorStatus,
+        frozen_now: datetime,
+    ) -> None:
+        output = _render(
+            sample_status,
+            DetailLevel.DEFAULT,
+            frozen_now=frozen_now,
+            client_filter="personal",
+        )
+        assert "personal" in output
+        assert "lgbtqplus.map" not in output
+
+    def test_empty_status_renders_without_raising(
+        self,
+        frozen_now: datetime,
+    ) -> None:
+        empty = OrchestratorStatus(generated_at=frozen_now)
+        output = _render(empty, DetailLevel.DEFAULT, frozen_now=frozen_now)
+        assert "No active clients" in output
+
+    def test_worktree_path_shortened_to_tilde(
+        self,
+        sample_status: OrchestratorStatus,
+        frozen_now: datetime,
+    ) -> None:
+        output = _render(sample_status, DetailLevel.DEFAULT, frozen_now=frozen_now)
+        # /home/matthew/... is collapsed to ~/...
+        assert "~/workspace/personal/wt/abc" in output
+
+
+class TestWatch:
+    def test_ticks_mode_renders_n_frames(
+        self,
+        sample_status: OrchestratorStatus,
+    ) -> None:
+        buffer = StringIO()
+        console = Console(file=buffer, width=120, force_terminal=False)
+        watch(
+            interval=1,
+            level=DetailLevel.COMPACT,
+            console=console,
+            ticks=3,
+            status_fn=lambda: sample_status,
+        )
+        # "personal" appears once per frame.
+        assert buffer.getvalue().count("personal") >= 3
+
+    def test_interval_clamped_high(
+        self,
+        sample_status: OrchestratorStatus,
+    ) -> None:
+        # Sanity: interval=9999 must not raise; ticks=0 means no frames at all.
+        buffer = StringIO()
+        console = Console(file=buffer, width=120, force_terminal=False)
+        watch(
+            interval=9999,
+            level=DetailLevel.COMPACT,
+            console=console,
+            ticks=0,
+            status_fn=lambda: sample_status,
+        )
+        assert buffer.getvalue() == ""

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "rich" },
     { name = "ruamel-yaml" },
 ]
 
@@ -51,6 +52,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "rich", specifier = ">=13.7" },
     { name = "ruamel-yaml", specifier = ">=0.18.6" },
 ]
 
@@ -265,6 +267,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -314,6 +328,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -590,6 +613,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First cut of the orchestrator dashboard, shippable as-is and ready to iterate on.

- `cw orchestrate watch [--interval N] [--client NAME] [--compact|--verbose]` renders the pipeline live via `rich.live.Live`, refreshing every 2s by default.
- Groups by client (primary axis), worktree path shown as a column on each running-session row so parallel-session contention is visible without hiding the client axis.
- Three detail levels — `--compact` (one-line counts per client), default (full per-client tables + events), `--verbose` (adds `surface_ref`, `scope_hint`, unresolved-thread count).
- Recent-events panel tails the last 20 orchestrator events at the bottom of the frame.
- Same `render_dashboard()` renderable powers tests (via `Console(file=StringIO())`) and the live loop, so there's one code path to maintain.

## Non-goals for this PR

- **Not rebuilding the full ``cw dashboard``** (roadmap v5 — client sidebar + session table + queue panel). This is just the orchestrator view. More tabs can follow if rich holds.
- **No keybindings yet** — Ctrl-C quits; no `v` to cycle levels or `r` to force-refresh. Flags handle detail mode for the first pass.

## Schema changes

- `SessionSummary.worktree_path: Path | None` — new optional field.
- `TicketSummary.scope_hint: str | None` — new optional field.

Both additive; the JSON emitted by `cw orchestrate status --json` stays backward-compatible.

## Test plan

- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run mypy src/` — zero errors
- [x] `uv run pytest tests/ -v` — 534 tests pass (8 new in `tests/test_tui.py`)
- [x] Snapshot-style tests: each detail level renders the expected tokens, client filter hides others, empty status renders without raising, worktree paths shorten to `~/...`.
- [x] `watch(ticks=N)` test hook verified — deterministic frame count, no real sleep.
- [x] Manual smoke: `uv run cw orchestrate watch --help` renders correctly.

## Dependencies

- Adds `rich>=13.7` as a runtime dependency. Pre-commit mypy config updated to include it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)