### PR TITLE
0.6.0: multi-platform bridge (#36–#42)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.13"]
 
     steps:
@@ -21,6 +23,14 @@ jobs:
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
+
+      - name: Install tmux (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y tmux
+
+      - name: Install tmux (macOS)
+        if: runner.os == 'macOS'
+        run: brew install tmux
 
       - name: Install dependencies
         run: uv sync --dev
@@ -34,5 +44,8 @@ jobs:
       - name: Type check
         run: uv run mypy src/
 
-      - name: Test
-        run: uv run pytest tests/ -v --tb=short
+      - name: Test (unit)
+        run: uv run pytest tests/ -v --tb=short -m 'not integration'
+
+      - name: Test (tmux integration)
+        run: uv run pytest tests/ -v --tb=short -m integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,27 @@ on:
     tags: ['v*']
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
+  verify:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
+
+      - name: Install tmux (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y tmux
+
+      - name: Install tmux (macOS)
+        if: runner.os == 'macOS'
+        run: brew install tmux
+
+      - name: Install dependencies
+        run: uv sync --dev
 
       - name: Verify version matches tag
         run: |
@@ -29,6 +42,14 @@ jobs:
           uv run ruff format --check src/ tests/
           uv run mypy src/
           uv run pytest tests/ -v
+
+  release:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] — 2026-04-18
+
+The multi-platform bridge. `cw` now runs natively on Linux via tmux,
+while keeping the macOS-native cmux path unchanged. Backend choice is
+driven by a three-tier selector so CI, power users, and single-user
+preferences all have a way in.
+
+### Added
+- `cw.tmux.TmuxAdapter`: a tmux backend that wraps the `tmux` CLI via
+  `subprocess`. A workspace maps to a tmux session, a surface to a
+  pane. Raises `CwError` at instantiation time if `tmux` is not on
+  PATH (#38).
+- Three-tier backend selector in `cw.cmux.get_backend_adapter()`:
+  `CW_BACKEND` env var → `orchestrator.yaml` `backend:` field →
+  platform default (`darwin` → cmux, everything else → tmux). Setting
+  `CW_BACKEND=fake` returns a `FakeCmuxAdapter` for CI and local
+  smoke tests (#37).
+- `BackendName` enum in `cw.models`; optional `backend` field on
+  `OrchestratorConfig`.
+- `MultiplexerAdapter` protocol — the backend-neutral name the
+  protocol carries going forward. `CmuxAdapter` is a type alias kept
+  for one release (#36).
+- `cw doctor` subcommand and module — reports resolved backend,
+  binary/daemon availability, config and state file validity, and
+  version. Exits non-zero when any check fails (#41).
+- Parametrized protocol-conformance suite covering every adapter
+  class (`tests/test_adapter_protocol.py`) (#39).
+- `integration` pytest marker for end-to-end tests that shell out to
+  a real multiplexer.
+
+### Changed
+- CI matrix is now `[ubuntu-latest, macos-latest]`; tmux is installed
+  via apt/brew on the matching runner, and the tmux integration test
+  runs on both OSes (#40). Release workflow mirrors the matrix.
+
+### Migration notes
+- `from cw.cmux import CmuxAdapter, get_cmux_adapter` keeps working
+  in this release. Switch to `MultiplexerAdapter` and
+  `get_backend_adapter` before 0.7.
+- On Linux, `cw` now defaults to tmux — install `tmux` or set
+  `CW_BACKEND=cmux` (if you really want the macOS-only cmux path).
+
 ## [0.5.0] — 2026-04-18
 
 Foundations for the multi-platform bridge landing in 0.6.0. No new user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-workspace"
-version = "0.5.0"
+version = "0.6.0"
 description = "Multi-session workspace orchestrator for Claude Code"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ packages = ["src/cw"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+markers = [
+    "integration: end-to-end tests that shell out to external tools (tmux, cmux)",
+]
 
 [tool.ruff]
 target-version = "py313"

--- a/src/cw/__init__.py
+++ b/src/cw/__init__.py
@@ -1,3 +1,3 @@
 """claude-workspace: Multi-session workspace orchestrator for Claude Code."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -26,6 +26,7 @@ from cw.config import (
 from cw.daemon import run_watcher_tick
 from cw.dev_queue import add_ticket, list_tickets, resolve_client
 from cw.dispatch import run_dispatch_loop
+from cw.doctor import format_report, run_doctor
 from cw.events import advance_cursor, read_events, record_event
 from cw.exceptions import CwError
 from cw.models import (
@@ -217,6 +218,21 @@ def done(session_name: str | None, cleanup: bool, force: bool) -> None:
 def config() -> None:
     """Show current configuration."""
     show_config()
+
+
+@main.command()
+@handle_errors
+def doctor() -> None:
+    """Run environment preflight checks and print a health report.
+
+    Reports the resolved backend, backend binary/daemon availability,
+    config file locations and validity, and state file parseability.
+    Exits non-zero if any check fails so CI pipelines can gate on it.
+    """
+    report = run_doctor()
+    click.echo(format_report(report))
+    if not report.ok:
+        raise click.exceptions.Exit(1)
 
 
 @main.command(name="init")

--- a/src/cw/cmux.py
+++ b/src/cw/cmux.py
@@ -1,7 +1,10 @@
-"""cmux terminal multiplexer adapter.
+"""Terminal multiplexer adapters and factory.
 
-Platform: macOS-only for RealCmuxAdapter. All logic is testable on Linux
-via FakeCmuxAdapter injection.
+Defines the :class:`MultiplexerAdapter` protocol that every backend
+implements, plus the macOS-native :class:`RealCmuxAdapter` and the
+test-only :class:`FakeCmuxAdapter`. :func:`get_backend_adapter` is the
+one factory callers should use; legacy names (``CmuxAdapter``,
+``get_cmux_adapter``) are kept as aliases for one release.
 """
 
 from __future__ import annotations
@@ -42,8 +45,8 @@ def _find_socket() -> Path:
 
 
 @runtime_checkable
-class CmuxAdapter(Protocol):
-    """Protocol for cmux terminal multiplexer adapters."""
+class MultiplexerAdapter(Protocol):
+    """Protocol for terminal-multiplexer backends (cmux, tmux, fakes)."""
 
     def spawn(self, workspace: str, command: str, surface: str = "right") -> str:
         """Spawn a new surface in the given workspace running command.
@@ -59,6 +62,11 @@ class CmuxAdapter(Protocol):
     def identify(self) -> dict[str, Any]:
         """Return current focus context."""
         ...
+
+
+# Legacy alias. Keep for one release so downstream type hints that read
+# `from cw.cmux import CmuxAdapter` don't break mid-upgrade.
+CmuxAdapter = MultiplexerAdapter
 
 
 class RealCmuxAdapter:
@@ -167,6 +175,15 @@ class FakeCmuxAdapter:
         }
 
 
-def get_cmux_adapter() -> CmuxAdapter:
-    """Return RealCmuxAdapter on macOS. Raises CwError on other platforms."""
+def get_backend_adapter() -> MultiplexerAdapter:
+    """Return the active multiplexer adapter.
+
+    Today this is hard-coded to :class:`RealCmuxAdapter` (macOS only).
+    #37 replaces this with a 3-tier selector (env var → config →
+    platform default) and #38 plugs in :class:`TmuxAdapter` for Linux.
+    """
     return RealCmuxAdapter()
+
+
+# Legacy alias retained for one release alongside ``CmuxAdapter``.
+get_cmux_adapter = get_backend_adapter

--- a/src/cw/cmux.py
+++ b/src/cw/cmux.py
@@ -16,7 +16,10 @@ import sys
 from pathlib import Path
 from typing import Any, Protocol, cast, runtime_checkable
 
+from cw.config import load_orchestrator_config
 from cw.exceptions import CwError
+from cw.models import BackendName
+from cw.tmux import TmuxAdapter
 
 _LEGACY_HINT_PATH: Path = Path("/tmp/cmux-last-socket-path")
 
@@ -175,14 +178,49 @@ class FakeCmuxAdapter:
         }
 
 
+def _resolve_backend_name() -> BackendName:
+    """Walk the three-tier backend selector and return the chosen name.
+
+    Priority:
+    1. ``CW_BACKEND`` env var — testing / CI override, highest priority.
+    2. ``orchestrator.yaml`` ``backend:`` field — persistent user choice.
+    3. Platform default — ``darwin`` picks cmux, everything else tmux.
+    """
+    env_choice = os.environ.get("CW_BACKEND", "").strip().lower()
+    if env_choice:
+        try:
+            return BackendName(env_choice)
+        except ValueError as exc:
+            valid = ", ".join(b.value for b in BackendName)
+            msg = f"Invalid CW_BACKEND={env_choice!r}; valid values: {valid}"
+            raise CwError(msg) from exc
+
+    try:
+        config = load_orchestrator_config()
+    except Exception:  # pragma: no cover - config load shouldn't hard-fail selector
+        config = None
+    if config is not None and config.backend is not None:
+        return config.backend
+
+    return BackendName.CMUX if sys.platform == "darwin" else BackendName.TMUX
+
+
 def get_backend_adapter() -> MultiplexerAdapter:
     """Return the active multiplexer adapter.
 
-    Today this is hard-coded to :class:`RealCmuxAdapter` (macOS only).
-    #37 replaces this with a 3-tier selector (env var → config →
-    platform default) and #38 plugs in :class:`TmuxAdapter` for Linux.
+    Walks the three-tier selector (env → config → platform default).
+    On ``CW_BACKEND=fake`` returns a :class:`FakeCmuxAdapter` so CI and
+    local smoke tests can skip the real multiplexer entirely.
     """
-    return RealCmuxAdapter()
+    name = _resolve_backend_name()
+    if name is BackendName.CMUX:
+        return RealCmuxAdapter()
+    if name is BackendName.TMUX:
+        return TmuxAdapter()
+    if name is BackendName.FAKE:
+        return FakeCmuxAdapter()
+    msg = f"Unhandled backend selector: {name!r}"  # pragma: no cover - enum exhausted
+    raise CwError(msg)
 
 
 # Legacy alias retained for one release alongside ``CmuxAdapter``.

--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -1,0 +1,158 @@
+"""cw doctor preflight — report environment health in one place.
+
+When a user's environment doesn't satisfy the chosen backend (no tmux,
+cmux daemon not running, state file corrupted), every cw command fails
+deep in an adapter with a cryptic error. `cw doctor` is the one place
+to find out *what* is wrong before you start a session.
+
+Returns structured results so the CLI can format them and tests can
+assert on specific checks.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from cw import __version__
+from cw.cmux import _resolve_backend_name
+from cw.config import (
+    clients_file,
+    load_clients,
+    load_state,
+    orchestrator_config_file,
+    state_file,
+)
+from cw.dev_queue import load_dev_queue
+from cw.models import BackendName
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """One preflight check and whether it passed."""
+
+    name: str
+    ok: bool
+    detail: str
+
+
+@dataclass
+class DoctorReport:
+    """Aggregated output from :func:`run_doctor`."""
+
+    version: str
+    backend: BackendName
+    checks: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return all(c.ok for c in self.checks)
+
+
+_CMUX_SOCKET_PATH = (
+    Path.home() / "Library" / "Application Support" / "cmux" / "cmux.sock"
+)
+
+
+def _check_backend_binary(backend: BackendName) -> CheckResult:
+    """Check whether the chosen backend's binary/daemon is reachable."""
+    if backend is BackendName.TMUX:
+        path = shutil.which("tmux")
+        if path:
+            return CheckResult("tmux on PATH", ok=True, detail=path)
+        return CheckResult(
+            "tmux on PATH",
+            ok=False,
+            detail="tmux not found; install via brew/apt or set CW_BACKEND=cmux",
+        )
+    if backend is BackendName.CMUX:
+        if sys.platform != "darwin":
+            return CheckResult(
+                "cmux daemon",
+                ok=False,
+                detail=f"cmux requires macOS; running on {sys.platform}",
+            )
+        if _CMUX_SOCKET_PATH.exists():
+            return CheckResult(
+                "cmux daemon socket", ok=True, detail=str(_CMUX_SOCKET_PATH)
+            )
+        return CheckResult(
+            "cmux daemon socket",
+            ok=False,
+            detail=f"not found at {_CMUX_SOCKET_PATH}; is cmux running?",
+        )
+    # fake backend needs no binary
+    return CheckResult("fake backend (no binary required)", ok=True, detail="")
+
+
+def _check_config_file() -> CheckResult:
+    """Verify the clients.yaml exists or that no clients is acceptable."""
+    path = clients_file()
+    if not path.exists():
+        return CheckResult(
+            "clients.yaml",
+            ok=True,
+            detail=f"not yet created at {path} (run `cw init`)",
+        )
+    try:
+        load_clients()
+    except Exception as exc:
+        return CheckResult("clients.yaml", ok=False, detail=f"parse failed: {exc}")
+    return CheckResult("clients.yaml", ok=True, detail=str(path))
+
+
+def _check_orchestrator_config() -> CheckResult:
+    path = orchestrator_config_file()
+    if not path.exists():
+        return CheckResult(
+            "orchestrator.yaml",
+            ok=True,
+            detail=f"not yet created at {path} (will be generated on first use)",
+        )
+    return CheckResult("orchestrator.yaml", ok=True, detail=str(path))
+
+
+def _check_state_file() -> CheckResult:
+    path = state_file()
+    try:
+        load_state()
+    except Exception as exc:
+        return CheckResult("sessions.json", ok=False, detail=f"load failed: {exc}")
+    return CheckResult("sessions.json", ok=True, detail=str(path))
+
+
+def _check_dev_queue() -> CheckResult:
+    try:
+        load_dev_queue()
+    except Exception as exc:
+        return CheckResult("dev_queue.json", ok=False, detail=f"load failed: {exc}")
+    return CheckResult("dev_queue.json", ok=True, detail="parseable")
+
+
+def run_doctor() -> DoctorReport:
+    """Run every preflight check and return a populated report."""
+    backend = _resolve_backend_name()
+    report = DoctorReport(version=__version__, backend=backend)
+    report.checks.append(CheckResult("resolved backend", ok=True, detail=backend.value))
+    report.checks.append(_check_backend_binary(backend))
+    report.checks.append(_check_config_file())
+    report.checks.append(_check_orchestrator_config())
+    report.checks.append(_check_state_file())
+    report.checks.append(_check_dev_queue())
+    return report
+
+
+def format_report(report: DoctorReport) -> str:
+    """Render a :class:`DoctorReport` as a human-readable block."""
+    lines = [f"cw {report.version}"]
+    for check in report.checks:
+        mark = "OK" if check.ok else "FAIL"
+        line = f"  [{mark}] {check.name}"
+        if check.detail:
+            line += f" — {check.detail}"
+        lines.append(line)
+    lines.append("")
+    lines.append("status: healthy" if report.ok else "status: problems detected")
+    return "\n".join(lines)

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -166,12 +166,21 @@ class DevQueueStore(BaseModel):
         return [t for t in self.tasks if t.client == client]
 
 
+class BackendName(StrEnum):
+    """Name of a multiplexer backend cw can drive."""
+
+    CMUX = "cmux"
+    TMUX = "tmux"
+    FAKE = "fake"
+
+
 class OrchestratorConfig(BaseModel):
     """Parsed contents of orchestrator.yaml."""
 
     tick_interval_seconds: int = 30
     per_client_max_parallel: dict[str, int] = Field(default_factory=dict)
     linear_prefix_map: dict[str, str] = Field(default_factory=dict)
+    backend: BackendName | None = None
 
 
 class HookRule(BaseModel):

--- a/src/cw/tmux.py
+++ b/src/cw/tmux.py
@@ -1,0 +1,110 @@
+"""tmux multiplexer adapter.
+
+Wraps the ``tmux`` CLI via :mod:`subprocess`. A workspace maps to a tmux
+session, a surface to a tmux pane. The same three-method protocol
+(:class:`cw.cmux.MultiplexerAdapter`) that the cmux backend implements.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from typing import Any
+
+from cw.exceptions import CwError
+
+# Pane reference format returned by ``tmux split-window -P -F ...``.
+_PANE_FORMAT = "#{session_name}:#{window_index}.#{pane_index}"
+
+# Mapping from the cw-level "surface" hint to tmux's split-window flag.
+# "right" produces a horizontal split (new pane to the right); "bottom"
+# produces a vertical split. Anything else falls back to horizontal.
+_SPLIT_FLAG = {"right": "-h", "bottom": "-v"}
+
+
+class TmuxAdapter:
+    """Multiplexer adapter backed by the ``tmux`` command-line tool.
+
+    Instantiation verifies that ``tmux`` is on PATH. The adapter shells
+    out for each protocol call — no long-lived connection is held.
+    """
+
+    def __init__(self) -> None:
+        if shutil.which("tmux") is None:
+            msg = "tmux not found on PATH; install tmux or set CW_BACKEND=cmux"
+            raise CwError(msg)
+
+    def _run(
+        self,
+        args: list[str],
+        *,
+        check: bool = True,
+        capture: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run a tmux subcommand and return the completed process."""
+        return subprocess.run(
+            ["tmux", *args],
+            capture_output=capture,
+            text=True,
+            check=check,
+        )
+
+    def _ensure_session(self, workspace: str) -> None:
+        """Create the tmux session for *workspace* if it does not exist."""
+        result = self._run(["has-session", "-t", workspace], check=False)
+        if result.returncode != 0:
+            self._run(["new-session", "-d", "-s", workspace])
+
+    def spawn(self, workspace: str, command: str, surface: str = "right") -> str:
+        """Split a pane in *workspace* and run *command* inside it.
+
+        Returns the tmux pane reference (``session:window.pane``).
+        """
+        self._ensure_session(workspace)
+        split_flag = _SPLIT_FLAG.get(surface, "-h")
+        result = self._run(
+            [
+                "split-window",
+                split_flag,
+                "-t",
+                workspace,
+                "-P",
+                "-F",
+                _PANE_FORMAT,
+            ]
+        )
+        pane_ref = result.stdout.strip()
+        if not pane_ref:
+            msg = "tmux split-window returned empty pane reference"
+            raise CwError(msg)
+        # ``-l`` sends the command literally; ``Enter`` submits it.
+        self._run(["send-keys", "-t", pane_ref, "-l", command])
+        self._run(["send-keys", "-t", pane_ref, "Enter"])
+        return pane_ref
+
+    def close(self, surface_ref: str) -> None:
+        """Kill the pane identified by *surface_ref*."""
+        self._run(["kill-pane", "-t", surface_ref], check=False)
+
+    def identify(self) -> dict[str, Any]:
+        """Return the focused workspace/surface as seen by tmux.
+
+        Uses ``tmux display-message`` with a JSON format string. If tmux
+        is not attached to any session, returns an empty focus context.
+        """
+        result = self._run(
+            [
+                "display-message",
+                "-p",
+                '{"focused":{"workspace_id":"#S","surface_id":"#S:#I.#P"}}',
+            ],
+            check=False,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return {"focused": {}}
+        try:
+            parsed: dict[str, Any] = json.loads(result.stdout.strip())
+        except json.JSONDecodeError:
+            return {"focused": {}}
+        return parsed

--- a/tests/test_adapter_protocol.py
+++ b/tests/test_adapter_protocol.py
@@ -1,0 +1,100 @@
+"""Protocol conformance tests parametrized over every known adapter.
+
+Each backend must satisfy the :class:`MultiplexerAdapter` protocol —
+same method names, same arities, same basic return types. Fast to run
+(no real multiplexer required); catches drift when a backend adds an
+argument the protocol hasn't grown yet.
+"""
+
+from __future__ import annotations
+
+import inspect
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cw.cmux import FakeCmuxAdapter, MultiplexerAdapter, RealCmuxAdapter
+from cw.tmux import TmuxAdapter
+
+if TYPE_CHECKING:
+    pass
+
+
+def _instantiate(cls: type, monkeypatch: pytest.MonkeyPatch) -> MultiplexerAdapter:
+    """Return a usable instance without requiring a live backend."""
+    if cls is FakeCmuxAdapter:
+        return cls()  # type: ignore[no-any-return]
+    if cls is TmuxAdapter:
+        monkeypatch.setattr("cw.tmux.shutil.which", lambda _name: "/usr/bin/tmux")
+        return cls()  # type: ignore[no-any-return]
+    if cls is RealCmuxAdapter:
+        # Skip the macOS guard by stubbing sys.platform before __init__
+        # reads it; we're only inspecting signatures, not running spawn.
+        monkeypatch.setattr("cw.cmux.sys.platform", "darwin")
+        return cls()  # type: ignore[no-any-return]
+    msg = f"unhandled adapter class: {cls.__name__}"
+    raise AssertionError(msg)
+
+
+ADAPTER_CLASSES = [FakeCmuxAdapter, TmuxAdapter, RealCmuxAdapter]
+
+
+@pytest.mark.parametrize("adapter_cls", ADAPTER_CLASSES)
+class TestProtocolConformance:
+    def test_satisfies_runtime_protocol(
+        self, adapter_cls: type, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = _instantiate(adapter_cls, monkeypatch)
+        assert isinstance(adapter, MultiplexerAdapter)
+
+    def test_spawn_signature(self, adapter_cls: type) -> None:
+        sig = inspect.signature(adapter_cls.spawn)
+        params = list(sig.parameters.keys())
+        # self, workspace, command, surface
+        assert params[1:] == ["workspace", "command", "surface"]
+        assert sig.parameters["surface"].default == "right"
+
+    def test_close_signature(self, adapter_cls: type) -> None:
+        sig = inspect.signature(adapter_cls.close)
+        params = list(sig.parameters.keys())
+        assert params[1:] == ["surface_ref"]
+
+    def test_identify_signature(self, adapter_cls: type) -> None:
+        sig = inspect.signature(adapter_cls.identify)
+        params = list(sig.parameters.keys())
+        # self only
+        assert params == ["self"]
+
+
+class TestSpawnReturnTypesMatch:
+    """The callable adapters (Fake, Tmux) must both return a string ref.
+
+    RealCmuxAdapter.spawn needs a live socket, so it's excluded — its
+    signature is covered in the parametrized class above.
+    """
+
+    def test_fake_spawn_returns_string(self) -> None:
+        ref = FakeCmuxAdapter().spawn("ws", "claude")
+        assert isinstance(ref, str)
+        assert ref
+
+    def test_tmux_spawn_returns_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("cw.tmux.shutil.which", lambda _name: "/usr/bin/tmux")
+
+        def fake_run(
+            args: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            if "split-window" in args:
+                return subprocess.CompletedProcess(
+                    args=args, returncode=0, stdout="ws:0.1\n", stderr=""
+                )
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="", stderr=""
+            )
+
+        monkeypatch.setattr("cw.tmux.subprocess.run", fake_run)
+        adapter = TmuxAdapter()
+        ref = adapter.spawn("ws", "claude")
+        assert isinstance(ref, str)
+        assert ref == "ws:0.1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,7 @@ class TestCli:
         runner = CliRunner()
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.5.0" in result.output
+        assert "0.6.0" in result.output
 
     def test_help(self) -> None:
         runner = CliRunner()

--- a/tests/test_cmux.py
+++ b/tests/test_cmux.py
@@ -9,8 +9,18 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from cw.cmux import CmuxAdapter, FakeCmuxAdapter, RealCmuxAdapter, get_cmux_adapter
+from cw.cmux import (
+    CmuxAdapter,
+    FakeCmuxAdapter,
+    MultiplexerAdapter,
+    RealCmuxAdapter,
+    _resolve_backend_name,
+    get_backend_adapter,
+    get_cmux_adapter,
+)
 from cw.exceptions import CwError
+from cw.models import BackendName, OrchestratorConfig
+from cw.tmux import TmuxAdapter
 
 if TYPE_CHECKING:
     pass
@@ -119,11 +129,16 @@ class TestRealCmuxAdapterPlatformGuard:
         with pytest.raises(CwError, match="requires macOS"):
             RealCmuxAdapter()
 
-    def test_get_cmux_adapter_raises_on_non_macos(self) -> None:
-        """get_cmux_adapter() raises CwError on non-macOS."""
+    def test_get_cmux_adapter_raises_on_non_macos(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Forcing cmux on a non-macOS platform still raises CwError."""
         if sys.platform == "darwin":
             pytest.skip("skipping on macOS — guard not triggered")
 
+        # The default selector on Linux now returns TmuxAdapter, so force
+        # cmux via the env-var tier to exercise the platform guard.
+        monkeypatch.setenv("CW_BACKEND", "cmux")
         with pytest.raises(CwError, match="requires macOS"):
             get_cmux_adapter()
 
@@ -455,3 +470,80 @@ class TestMigration:
         state = load_state()
         # surface_ref already present — zellij_pane should be discarded
         assert state.sessions[0].surface_ref == "new-ref"
+
+
+class TestMultiplexerAdapterAlias:
+    def test_cmux_adapter_is_multiplexer_adapter(self) -> None:
+        # The legacy name must still resolve to the new protocol so any
+        # downstream `from cw.cmux import CmuxAdapter` survives this
+        # release.
+        assert CmuxAdapter is MultiplexerAdapter
+
+    def test_get_cmux_adapter_is_backend_adapter(self) -> None:
+        assert get_cmux_adapter is get_backend_adapter
+
+
+class TestResolveBackendName:
+    def test_env_var_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CW_BACKEND", "fake")
+        assert _resolve_backend_name() is BackendName.FAKE
+
+    def test_env_var_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CW_BACKEND", "TMUX")
+        assert _resolve_backend_name() is BackendName.TMUX
+
+    def test_invalid_env_var_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CW_BACKEND", "wat")
+        with pytest.raises(CwError, match="Invalid CW_BACKEND"):
+            _resolve_backend_name()
+
+    def test_config_tier(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CW_BACKEND", raising=False)
+        monkeypatch.setattr(
+            "cw.cmux.load_orchestrator_config",
+            lambda: OrchestratorConfig(backend=BackendName.TMUX),
+        )
+        assert _resolve_backend_name() is BackendName.TMUX
+
+    def test_platform_default_linux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CW_BACKEND", raising=False)
+        monkeypatch.setattr(
+            "cw.cmux.load_orchestrator_config",
+            lambda: OrchestratorConfig(backend=None),
+        )
+        monkeypatch.setattr("cw.cmux.sys.platform", "linux")
+        assert _resolve_backend_name() is BackendName.TMUX
+
+    def test_platform_default_darwin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CW_BACKEND", raising=False)
+        monkeypatch.setattr(
+            "cw.cmux.load_orchestrator_config",
+            lambda: OrchestratorConfig(backend=None),
+        )
+        monkeypatch.setattr("cw.cmux.sys.platform", "darwin")
+        assert _resolve_backend_name() is BackendName.CMUX
+
+
+class TestGetBackendAdapter:
+    def test_fake_backend_returns_fake_adapter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CW_BACKEND", "fake")
+        adapter = get_backend_adapter()
+        assert isinstance(adapter, FakeCmuxAdapter)
+
+    def test_tmux_backend_raises_without_tmux_on_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CW_BACKEND", "tmux")
+        monkeypatch.setattr("cw.tmux.shutil.which", lambda _name: None)
+        with pytest.raises(CwError, match="tmux not found"):
+            get_backend_adapter()
+
+    def test_tmux_backend_returns_tmux_adapter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CW_BACKEND", "tmux")
+        monkeypatch.setattr("cw.tmux.shutil.which", lambda _name: "/usr/bin/tmux")
+        adapter = get_backend_adapter()
+        assert isinstance(adapter, TmuxAdapter)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,108 @@
+"""Tests for cw.doctor — environment preflight checks."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from cw.cli import main
+from cw.doctor import format_report, run_doctor
+from cw.models import BackendName
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+class TestRunDoctorFakeBackend:
+    """When CW_BACKEND=fake the backend binary check is a no-op."""
+
+    def test_resolved_backend_is_fake(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        monkeypatch.setenv("CW_BACKEND", "fake")
+        report = run_doctor()
+        assert report.backend is BackendName.FAKE
+        assert report.ok
+
+    def test_report_includes_version(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        monkeypatch.setenv("CW_BACKEND", "fake")
+        report = run_doctor()
+        assert report.version
+
+
+class TestRunDoctorTmuxBackend:
+    def test_tmux_missing_is_reported_as_failure(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        monkeypatch.setenv("CW_BACKEND", "tmux")
+        monkeypatch.setattr("cw.doctor.shutil.which", lambda _name: None)
+        report = run_doctor()
+        assert not report.ok
+        failing = [c for c in report.checks if not c.ok]
+        assert any("tmux" in c.name for c in failing)
+
+    def test_tmux_on_path_passes(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        monkeypatch.setenv("CW_BACKEND", "tmux")
+        monkeypatch.setattr("cw.doctor.shutil.which", lambda _name: "/usr/bin/tmux")
+        report = run_doctor()
+        assert report.ok
+
+
+class TestRunDoctorCmuxBackend:
+    def test_cmux_non_darwin_is_reported_as_failure(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        monkeypatch.setenv("CW_BACKEND", "cmux")
+        monkeypatch.setattr("cw.doctor.sys.platform", "linux")
+        report = run_doctor()
+        assert not report.ok
+        failing = [c for c in report.checks if not c.ok]
+        assert any("cmux" in c.name for c in failing)
+
+
+class TestFormatReport:
+    def test_render_contains_ok_and_fail_markers(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        monkeypatch.setenv("CW_BACKEND", "tmux")
+        monkeypatch.setattr("cw.doctor.shutil.which", lambda _name: None)
+        report = run_doctor()
+        rendered = format_report(report)
+        assert "FAIL" in rendered
+        assert "status: problems detected" in rendered
+
+    def test_healthy_report_ends_with_healthy(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        monkeypatch.setenv("CW_BACKEND", "fake")
+        report = run_doctor()
+        rendered = format_report(report)
+        assert "status: healthy" in rendered
+
+
+class TestDoctorCli:
+    def test_cli_exit_zero_on_healthy(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        monkeypatch.setenv("CW_BACKEND", "fake")
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor"])
+        assert result.exit_code == 0
+        assert "status: healthy" in result.output
+
+    def test_cli_exit_nonzero_on_failure(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        monkeypatch.setenv("CW_BACKEND", "tmux")
+        monkeypatch.setattr("cw.doctor.shutil.which", lambda _name: None)
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor"])
+        assert result.exit_code != 0
+        assert "FAIL" in result.output

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -1,0 +1,181 @@
+"""Tests for cw.tmux - tmux multiplexer adapter."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cw.exceptions import CwError
+from cw.tmux import TmuxAdapter
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class TestInstantiationGuard:
+    def test_missing_tmux_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("cw.tmux.shutil.which", lambda _name: None)
+        with pytest.raises(CwError, match="tmux not found"):
+            TmuxAdapter()
+
+    def test_tmux_on_path_instantiates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("cw.tmux.shutil.which", lambda _name: "/usr/bin/tmux")
+        adapter = TmuxAdapter()
+        assert isinstance(adapter, TmuxAdapter)
+
+
+class TestSubprocessWiring:
+    """Verify the adapter calls tmux with the expected arguments.
+
+    These tests stub out ``subprocess.run`` so they work on any platform
+    and don't require a running tmux server.
+    """
+
+    def _make_adapter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[
+        TmuxAdapter,
+        list[list[str]],
+        Callable[..., subprocess.CompletedProcess[str]],
+    ]:
+        monkeypatch.setattr("cw.tmux.shutil.which", lambda _name: "/usr/bin/tmux")
+        adapter = TmuxAdapter()
+        calls: list[list[str]] = []
+
+        def fake_run(
+            args: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            calls.append(list(args))
+            # First call is has-session (may fail); subsequent calls succeed.
+            # Simulate the pane ref coming back from split-window -P.
+            if "split-window" in args:
+                return subprocess.CompletedProcess(
+                    args=args, returncode=0, stdout="my-ws:0.1\n", stderr=""
+                )
+            if "has-session" in args:
+                return subprocess.CompletedProcess(
+                    args=args, returncode=1, stdout="", stderr=""
+                )
+            if "display-message" in args:
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout='{"focused":{"workspace_id":"my-ws","surface_id":"my-ws:0.1"}}\n',
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="", stderr=""
+            )
+
+        monkeypatch.setattr("cw.tmux.subprocess.run", fake_run)
+        return adapter, calls, fake_run
+
+    def test_spawn_creates_session_when_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter, calls, _ = self._make_adapter(monkeypatch)
+        adapter.spawn("my-ws", "claude", "right")
+
+        has = next(c for c in calls if "has-session" in c)
+        assert "my-ws" in has
+        new = next(c for c in calls if "new-session" in c)
+        assert "my-ws" in new
+
+    def test_spawn_returns_pane_ref_and_sends_command(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter, calls, _ = self._make_adapter(monkeypatch)
+        ref = adapter.spawn("my-ws", "claude", "right")
+        assert ref == "my-ws:0.1"
+
+        send = [c for c in calls if "send-keys" in c]
+        # One call to send the literal command, one to press Enter.
+        assert len(send) == 2
+        literal = send[0]
+        assert "-l" in literal
+        assert "claude" in literal
+        enter = send[1]
+        assert "Enter" in enter
+
+    def test_spawn_maps_surface_to_split_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter, calls, _ = self._make_adapter(monkeypatch)
+        adapter.spawn("my-ws", "claude", "bottom")
+        split = next(c for c in calls if "split-window" in c)
+        assert "-v" in split
+
+    def test_close_kills_pane(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        adapter, calls, _ = self._make_adapter(monkeypatch)
+        adapter.close("my-ws:0.1")
+        kill = next(c for c in calls if "kill-pane" in c)
+        assert "my-ws:0.1" in kill
+
+    def test_identify_parses_display_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter, _calls, _ = self._make_adapter(monkeypatch)
+        result = adapter.identify()
+        assert result["focused"]["workspace_id"] == "my-ws"
+        assert result["focused"]["surface_id"] == "my-ws:0.1"
+
+    def test_identify_survives_detached_tmux(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("cw.tmux.shutil.which", lambda _name: "/usr/bin/tmux")
+        adapter = TmuxAdapter()
+
+        def fake_run(
+            args: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=1, stdout="", stderr="not attached"
+            )
+
+        monkeypatch.setattr("cw.tmux.subprocess.run", fake_run)
+        assert adapter.identify() == {"focused": {}}
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux not installed")
+class TestTmuxIntegration:
+    """End-to-end against a real tmux server on an isolated socket.
+
+    Runs in its own ``-L`` socket so it never collides with a tmux
+    session the developer has attached interactively.
+    """
+
+    def test_spawn_close_cycle(self) -> None:
+        socket_name = f"cw-test-{uuid.uuid4().hex[:8]}"
+        ws = f"cw-test-{uuid.uuid4().hex[:8]}"
+        try:
+            # Pre-flight: tmux binary is responsive.
+            subprocess.run(
+                ["tmux", "-L", socket_name, "kill-server"],
+                check=False,
+                capture_output=True,
+            )
+            adapter = TmuxAdapter()
+            # Shim _run to target the isolated socket for every call.
+            original = adapter._run
+
+            def socketed_run(
+                args: list[str], **kwargs: object
+            ) -> subprocess.CompletedProcess[str]:
+                return original(["-L", socket_name, *args], **kwargs)  # type: ignore[arg-type]
+
+            adapter._run = socketed_run  # type: ignore[method-assign]
+
+            ref = adapter.spawn(ws, "true", "right")
+            assert ref.startswith(f"{ws}:")
+            adapter.close(ref)
+        finally:
+            subprocess.run(
+                ["tmux", "-L", socket_name, "kill-server"],
+                check=False,
+                capture_output=True,
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "claude-workspace"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
**Stacked on [PR #43](https://github.com/mattwwarren/claude-workspace/pull/43) (Phase A foundations).** Once #43 merges, change the base of this PR to `main` (or rebase and push-force).

## Summary

Phase B of the multi-platform bridge plan (`/home/matthew/.claude/plans/okay-it-s-time-to-shimmering-book.md`). `cw` now runs natively on Linux via tmux while keeping the macOS-native cmux path unchanged. Backend choice is driven by a three-tier selector so CI, power users, and single-user preferences all have a way in.

- Closes #36, #37, #38, #39, #40, #41, #42

## Commits

| # | Commit | What it does |
|---|---|---|
| 36 | `refactor: rename CmuxAdapter to MultiplexerAdapter` | New protocol name. `CmuxAdapter` and `get_cmux_adapter` are aliases for one release so downstream type hints don't break. |
| 38 | `feat: TmuxAdapter` | Shells out to `tmux` via `subprocess`. Workspace↔session, surface↔pane. Raises `CwError` at instantiation when `tmux` missing. |
| 37 | `feat: three-tier backend selector` | `CW_BACKEND` env var → `orchestrator.yaml` `backend:` → platform default. `BackendName` enum in `cw.models`. |
| 39 | `test: parametrize adapter protocol conformance` | Runs four assertions against every adapter class — signature drift is caught even when a new backend lands. |
| 40 | `ci: matrix across Linux and macOS with tmux` | `[ubuntu-latest, macos-latest]` with `apt-get install tmux` / `brew install tmux`. Integration tests run on both. Mirrored in `release.yml`. |
| 41 | `feat: cw doctor preflight command` | Reports resolved backend, binary/daemon availability, config/state validity, version. Exits non-zero on any failure. |
| 42 | `release: 0.6.0` | Version bump + CHANGELOG entry. |

## Verification

- `uv run ruff check src/ tests/` — clean
- `uv run mypy src/` — clean (25 source files)
- `uv run pytest tests/ -v` — **589 passed, 1 skipped** (tmux integration — tmux not installed on dev machine)
- Pre/post test-run checksums of `~/.local/share/cw`, `~/.config/cw`, `~/.claude-workspace` — byte-identical (no state leak)
- Manual smoke on Linux: `CW_BACKEND=fake cw doctor` reports healthy, `cw --version` → `0.6.0`

## Migration notes

- `from cw.cmux import CmuxAdapter, get_cmux_adapter` still works in 0.6.0. Switch to `MultiplexerAdapter` and `get_backend_adapter` before 0.7.
- On Linux, `cw` now defaults to tmux. Install `tmux` or set `CW_BACKEND=cmux` (if you really want the macOS-only cmux path).

## Test plan

- [ ] CI green on both ubuntu-latest and macos-latest
- [ ] After merge: tag `v0.6.0` so `release.yml` fires
- [ ] Manual smoke on the developer's Mac: `cw start personal` still launches a cmux surface
- [ ] Manual smoke on Linux: `brew/apt install tmux`, then `cw start personal` launches a tmux session
- [ ] `cw doctor` on both machines prints a clean report

🤖 Generated with [Claude Code](https://claude.com/claude-code)