### PR TITLE
fix(state): use atomic writes for JSON state files (#46)

### DIFF
--- a/src/cw/atomic.py
+++ b/src/cw/atomic.py
@@ -1,0 +1,44 @@
+"""Atomic file writing utilities.
+
+State files in ``cw`` are read without a lock (``load_dev_queue``,
+``load_state``, etc.). Writers previously used ``Path.write_text``, which
+opens with ``O_TRUNC`` and can expose an empty or partial file to any
+concurrent reader. ``atomic_write_text`` writes to a sibling temp file
+and atomically renames it into place so readers always observe either
+the prior complete file or the new complete file.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    """Write *text* to *path* atomically via a unique temp file + ``os.replace``.
+
+    The temp file is created with ``mkstemp`` in the same directory as
+    *path* so the final rename stays on one filesystem. A unique temp
+    name per call is required because concurrent writers (possible when
+    the outer lock is advisory or absent) would otherwise race on a
+    shared temp name and one ``os.replace`` would fail with ``ENOENT``.
+    """
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        os.replace(tmp_name, path)
+    except BaseException:
+        # Remove the temp file if the rename didn't consume it.
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp_name)
+        raise

--- a/src/cw/atomic.py
+++ b/src/cw/atomic.py
@@ -34,7 +34,7 @@ def atomic_write_text(path: Path, text: str) -> None:
         dir=str(path.parent),
     )
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(text)
         os.replace(tmp_name, path)
     except BaseException:

--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -15,6 +15,7 @@ import yaml
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 
+from cw.atomic import atomic_write_text
 from cw.exceptions import CwError
 from cw.models import (
     DEFAULT_AUTO_PURPOSES,
@@ -236,9 +237,9 @@ def _coerce_session_origin(session_raw: dict[str, Any]) -> None:
 
 
 def save_state(state: CwState) -> None:
-    """Persist session state to disk."""
+    """Persist session state to disk atomically."""
     state_dir().mkdir(parents=True, exist_ok=True)
-    state_file().write_text(state.model_dump_json(indent=2))
+    atomic_write_text(state_file(), state.model_dump_json(indent=2))
 
 
 def load_orchestrator_config() -> OrchestratorConfig:

--- a/src/cw/daemon.py
+++ b/src/cw/daemon.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
+from cw.atomic import atomic_write_text
 from cw.config import (
     load_clients,
     load_orchestrator_config,
@@ -90,11 +91,11 @@ def _load_snapshot(client_name: str) -> WatcherSnapshot:
 
 
 def _save_snapshot(client_name: str, snapshot: WatcherSnapshot) -> None:
-    """Persist a WatcherSnapshot for a client."""
+    """Persist a WatcherSnapshot for a client atomically."""
     watcher_dir = pr_watcher_dir()
     watcher_dir.mkdir(parents=True, exist_ok=True)
     path = watcher_dir / f"{client_name}.json"
-    path.write_text(snapshot.model_dump_json(indent=2))
+    atomic_write_text(path, snapshot.model_dump_json(indent=2))
 
 
 def _load_throttle() -> ThrottleStore:
@@ -106,10 +107,10 @@ def _load_throttle() -> ThrottleStore:
 
 
 def _save_throttle(store: ThrottleStore) -> None:
-    """Persist the global ThrottleStore."""
+    """Persist the global ThrottleStore atomically."""
     state_dir().mkdir(parents=True, exist_ok=True)
     path = state_dir() / "pr_dispatch_throttle.json"
-    path.write_text(store.model_dump_json(indent=2))
+    atomic_write_text(path, store.model_dump_json(indent=2))
 
 
 def _load_monitor_files() -> list[dict[str, Any]]:

--- a/src/cw/dev_queue.py
+++ b/src/cw/dev_queue.py
@@ -7,6 +7,7 @@ import fcntl
 import json
 from typing import TYPE_CHECKING
 
+from cw.atomic import atomic_write_text
 from cw.config import (
     dev_plan_file,
     dev_plan_lock,
@@ -60,7 +61,7 @@ def save_plan(plan: DispatchPlan) -> Path:
     with _plan_lock():
         path = dev_plan_file()
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(plan.model_dump_json(indent=2))
+        atomic_write_text(path, plan.model_dump_json(indent=2))
     return path
 
 
@@ -90,10 +91,10 @@ def load_dev_queue() -> DevQueueStore:
 
 
 def save_dev_queue(store: DevQueueStore) -> None:
-    """Persist the dev queue to disk."""
+    """Persist the dev queue to disk atomically."""
     path = dev_queue_file()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(store.model_dump_json(indent=2))
+    atomic_write_text(path, store.model_dump_json(indent=2))
 
 
 def add_ticket(task: TicketTask) -> None:

--- a/src/cw/events.py
+++ b/src/cw/events.py
@@ -8,6 +8,7 @@ import json
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from cw.atomic import atomic_write_text
 from cw.config import events_dir
 from cw.models import OrchestratorEvent, OrchestratorEventType
 
@@ -97,7 +98,7 @@ def advance_cursor(consumer: str, event_id: str) -> None:
         "cursor": event_id,
         "updated_at": datetime.now(UTC).isoformat(),
     }
-    path.write_text(json.dumps(data))
+    atomic_write_text(path, json.dumps(data))
 
 
 def read_events(

--- a/src/cw/pr_responder.py
+++ b/src/cw/pr_responder.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
+from cw.atomic import atomic_write_text
 from cw.cmux import get_cmux_adapter
 from cw.config import load_clients, load_state, save_state, state_dir
 from cw.events import advance_cursor, read_events
@@ -58,10 +59,10 @@ def load_dispatch_record() -> PRDispatchRecord:
 
 
 def save_dispatch_record(record: PRDispatchRecord) -> None:
-    """Persist PRDispatchRecord to the state directory."""
+    """Persist PRDispatchRecord to the state directory atomically."""
     state_dir().mkdir(parents=True, exist_ok=True)
     path = state_dir() / _DISPATCH_FILE_NAME
-    path.write_text(record.model_dump_json(indent=2))
+    atomic_write_text(path, record.model_dump_json(indent=2))
 
 
 def _is_session_active(session_id: str, state: CwState) -> bool:

--- a/src/cw/queue.py
+++ b/src/cw/queue.py
@@ -8,6 +8,7 @@ import json
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from cw.atomic import atomic_write_text
 from cw.config import queues_dir
 from cw.history import EventType, HistoryEvent, record_event
 from cw.models import QueueItem, QueueItemStatus, QueueStore, TaskSpec
@@ -51,10 +52,10 @@ def load_queue(client: str) -> QueueStore:
 
 
 def save_queue(client: str, store: QueueStore) -> None:
-    """Persist a client's queue to disk."""
+    """Persist a client's queue to disk atomically."""
     path = _queue_path(client)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(store.model_dump_json(indent=2))
+    atomic_write_text(path, store.model_dump_json(indent=2))
 
 
 def add_item(client: str, task: TaskSpec) -> QueueItem:

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from typing import TYPE_CHECKING
 
 import pytest
@@ -17,6 +18,7 @@ from cw.dev_queue import (
     load_plan,
     plan_path,
     resolve_client,
+    save_dev_queue,
     save_plan,
 )
 from cw.exceptions import CwError
@@ -496,3 +498,106 @@ class TestDispatchPlanPersistence:
     def test_plan_path_returns_configured_path(self, tmp_dev_queue: Path) -> None:
         path = plan_path()
         assert path == tmp_dev_queue / "dev_plan.json"
+
+
+# ---------------------------------------------------------------------------
+# TestConcurrentAccess
+# ---------------------------------------------------------------------------
+
+
+_RACE_WRITER_COUNT = 4
+_RACE_READER_COUNT = 4
+_RACE_DURATION_SECONDS = 0.4
+_RACE_SEED_TICKETS = 40
+
+
+class TestConcurrentAccess:
+    """Concurrent writers + readers must never observe a partial JSON file."""
+
+    def test_reader_never_sees_partial_write(self, tmp_dev_queue: Path) -> None:
+        # Seed enough tasks that the serialized file is large enough for a
+        # truncating writer to race a reader mid-flight.
+        for i in range(_RACE_SEED_TICKETS):
+            add_ticket(TicketTask(ticket_id=f"GEN-{i}", client="genhealth"))
+
+        stop = threading.Event()
+        reader_errors: list[BaseException] = []
+
+        def writer() -> None:
+            while not stop.is_set():
+                store = load_dev_queue()
+                save_dev_queue(store)
+
+        def reader() -> None:
+            while not stop.is_set():
+                try:
+                    load_dev_queue()
+                except (
+                    ValueError,
+                    OSError,
+                ) as exc:  # ValueError covers json.JSONDecodeError
+                    reader_errors.append(exc)
+
+        threads = [
+            threading.Thread(target=writer, daemon=True)
+            for _ in range(_RACE_WRITER_COUNT)
+        ] + [
+            threading.Thread(target=reader, daemon=True)
+            for _ in range(_RACE_READER_COUNT)
+        ]
+        for t in threads:
+            t.start()
+        time.sleep(_RACE_DURATION_SECONDS)
+        stop.set()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert not reader_errors, (
+            f"Reader observed {len(reader_errors)} partial writes: {reader_errors[:3]}"
+        )
+
+    def test_save_plan_reader_never_sees_partial_write(
+        self, tmp_dev_queue: Path
+    ) -> None:
+        seed = DispatchPlan(
+            tasks=[
+                TicketTask(ticket_id=f"GEN-{i}", client="genhealth")
+                for i in range(_RACE_SEED_TICKETS)
+            ]
+        )
+        save_plan(seed)
+
+        stop = threading.Event()
+        reader_errors: list[BaseException] = []
+
+        def writer() -> None:
+            while not stop.is_set():
+                save_plan(seed)
+
+        def reader() -> None:
+            while not stop.is_set():
+                try:
+                    load_plan()
+                except (ValueError, OSError) as exc:
+                    reader_errors.append(exc)
+
+        threads = [
+            threading.Thread(target=writer, daemon=True)
+            for _ in range(_RACE_WRITER_COUNT)
+        ] + [
+            threading.Thread(target=reader, daemon=True)
+            for _ in range(_RACE_READER_COUNT)
+        ]
+        for t in threads:
+            t.start()
+        time.sleep(_RACE_DURATION_SECONDS)
+        stop.set()
+        for t in threads:
+            t.join(timeout=5)
+
+        # load_plan() swallows parse errors and returns None — so instead
+        # assert that load_plan kept returning the expected populated plan
+        # (no intermittent None from half-written files).
+        assert not reader_errors, (
+            f"Reader observed {len(reader_errors)} partial writes: {reader_errors[:3]}"
+        )

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -574,10 +574,14 @@ class TestConcurrentAccess:
             while not stop.is_set():
                 save_plan(seed)
 
+        # load_plan() intentionally swallows parse errors and returns
+        # None, so the reader thread must call the validator directly
+        # to expose partial-write observations.
         def reader() -> None:
+            path = plan_path()
             while not stop.is_set():
                 try:
-                    load_plan()
+                    DispatchPlan.model_validate_json(path.read_text())
                 except (ValueError, OSError) as exc:
                     reader_errors.append(exc)
 
@@ -595,9 +599,6 @@ class TestConcurrentAccess:
         for t in threads:
             t.join(timeout=5)
 
-        # load_plan() swallows parse errors and returns None — so instead
-        # assert that load_plan kept returning the expected populated plan
-        # (no intermittent None from half-written files).
         assert not reader_errors, (
             f"Reader observed {len(reader_errors)} partial writes: {reader_errors[:3]}"
         )


### PR DESCRIPTION
## Summary

Fixes #46. `save_dev_queue` and several other JSON state writers called `path.write_text(...)`, which opens the file with `O_TRUNC` and exposes an empty/partial file to any concurrent reader. Since readers (`load_dev_queue`, `load_state`, etc.) intentionally don't take the writer lock, they would intermittently fail mid-write with `JSONDecodeError`.

- Add `src/cw/atomic.py` with `atomic_write_text(path, text)` — writes to a unique temp file (`tempfile.mkstemp` so concurrent writers don't race on a shared temp name) then `os.replace` into place.
- Apply at every JSON state write site in the package:
  - `dev_queue.py`: `save_plan`, `save_dev_queue`
  - `config.py`: `save_state`
  - `queue.py`: `save_queue`
  - `daemon.py`: `_save_snapshot`, `_save_throttle`
  - `events.py`: `advance_cursor`
  - `pr_responder.py`: `save_dispatch_record`
- Append-only JSONL writes (inbox, history) are intentionally left alone.

## Test plan

- [x] New `TestConcurrentAccess` class in `tests/test_dev_queue.py` — 4 writer + 4 reader threads running for 0.4s, asserts no parse error escapes a reader.
- [x] Verified tests FAIL against the unfixed code (5/5 runs) and PASS with the atomic fix.
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest tests/` — 592/592 pass

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)