### PR TITLE
fix(worktree): bound default path length to cmux 64-char cap (#47)

### DIFF
--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -2,16 +2,25 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from cw.exceptions import WorktreeError
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from cw.models import ClientConfig
+
+
+# cmux rejects worktree names longer than this; the full path is treated
+# as the name. Any default layout that would exceed this limit falls
+# back to a hash-derived short base under ~/.cw/wt/ so path length stays
+# bounded regardless of client name or workspace nesting depth.
+_WORKTREE_NAME_CAP = 64
+_HASH_BASE_SEGMENTS = (".cw", "wt")
+_WORKSPACE_HASH_CHARS = 8
 
 
 def slugify_branch(branch: str) -> str:
@@ -43,10 +52,33 @@ def resolve_worktree_base(client: ClientConfig) -> Path:
     return ws.parent / ".worktrees" / ws.name
 
 
+def _hashed_worktree_base(client: ClientConfig) -> Path:
+    """Return a short hash-derived worktree base for a client.
+
+    Used as a fallback when the default sibling layout would exceed
+    ``_WORKTREE_NAME_CAP``. Hash is stable per git directory so repeat
+    invocations resolve to the same location.
+    """
+    git_dir = _git_dir(client)
+    digest = hashlib.sha256(str(git_dir).encode("utf-8")).hexdigest()
+    return Path.home().joinpath(*_HASH_BASE_SEGMENTS, digest[:_WORKSPACE_HASH_CHARS])
+
+
 def worktree_path_for(client: ClientConfig, branch: str) -> Path:
-    """Return the full worktree path for a branch."""
+    """Return the full worktree path for a branch.
+
+    Falls back to a hash-derived short base under ``~/.cw/wt/`` when the
+    default layout would produce a path longer than cmux's 64-char
+    worktree-name cap. An explicit ``client.worktree_base`` is always
+    honoured, even if it produces a path over the cap — user choice
+    wins over the safety net.
+    """
+    slug = slugify_branch(branch)
     base = resolve_worktree_base(client)
-    return base / slugify_branch(branch)
+    candidate = base / slug
+    if client.worktree_base is not None or len(str(candidate)) <= _WORKTREE_NAME_CAP:
+        return candidate
+    return _hashed_worktree_base(client) / slug
 
 
 def _run_git(

--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -14,12 +14,19 @@ if TYPE_CHECKING:
     from cw.models import ClientConfig
 
 
-# cmux rejects worktree names longer than this; the full path is treated
-# as the name. Any default layout that would exceed this limit falls
-# back to a hash-derived short base under ~/.cw/wt/ so path length stays
-# bounded regardless of client name or workspace nesting depth.
+# cmux rejects worktree names longer than 64 chars with:
+#   "Invalid worktree name: must be 64 characters or fewer (got N)"
+# The full ``claude -w <path>`` argument is what cmux measures. When the
+# default ``<ws.parent>/.worktrees/<ws.name>/<slug>`` layout would exceed
+# this cap, fall back to a hash-derived short base under ``~/.cw/wt/``
+# so path length stays bounded regardless of client name or workspace
+# nesting depth.
 _WORKTREE_NAME_CAP = 64
 _HASH_BASE_SEGMENTS = (".cw", "wt")
+# 8 hex chars = 32 bits. For a single-user tool with a handful of
+# clients the collision probability is negligible; raising this value
+# pushes the hashed base closer to _WORKTREE_NAME_CAP and reduces
+# headroom for the branch slug, so increase with care.
 _WORKSPACE_HASH_CHARS = 8
 
 
@@ -56,10 +63,12 @@ def _hashed_worktree_base(client: ClientConfig) -> Path:
     """Return a short hash-derived worktree base for a client.
 
     Used as a fallback when the default sibling layout would exceed
-    ``_WORKTREE_NAME_CAP``. Hash is stable per git directory so repeat
-    invocations resolve to the same location.
+    ``_WORKTREE_NAME_CAP``. The hash seeds from the *resolved* git
+    directory so symlinks and non-canonical paths collapse to the
+    same digest — ``create_worktree`` and ``remove_worktree`` must
+    agree on the location across invocations.
     """
-    git_dir = _git_dir(client)
+    git_dir = _git_dir(client).resolve()
     digest = hashlib.sha256(str(git_dir).encode("utf-8")).hexdigest()
     return Path.home().joinpath(*_HASH_BASE_SEGMENTS, digest[:_WORKSPACE_HASH_CHARS])
 

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -109,6 +109,20 @@ class TestWorktreePathFor:
         result = worktree_path_for(client, "main")
         assert result == Path("/p/.worktrees/r/main")
 
+    def test_hashed_fallback_is_stable_across_calls(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """create_worktree and remove_worktree must compute the same path
+        for the same client; the hash fallback must be deterministic."""
+        monkeypatch.setattr(Path, "home", lambda: Path("/home/u"))
+        ws = Path("/home/matthew/workspace/companies/infini-player")
+        client = ClientConfig(name="infini-player", workspace_path=ws)
+
+        first = worktree_path_for(client, "auto-dev/1")
+        second = worktree_path_for(client, "auto-dev/1")
+        assert first == second
+
     def test_client_override_used_even_when_long(self) -> None:
         """An explicit ``worktree_base`` is respected even if it makes the
         resulting path exceed the cap — user choice wins over our fallback."""

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
@@ -16,8 +17,6 @@ from cw.worktree import (
 )
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     import pytest
 
 
@@ -78,6 +77,49 @@ class TestWorktreePathFor:
         )
         result = worktree_path_for(client, "feat/search")
         assert result == tmp_path / "wt" / "feat-search"
+
+    def test_long_default_path_falls_back_to_hashed_base(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If the default worktree path would exceed cmux's 64-char cap,
+        fall back to a short hash-based base under ``~/.cw/wt/``."""
+        monkeypatch.setattr(Path, "home", lambda: Path("/home/u"))
+
+        # Mimic the failing real-world case from the bug report: a long
+        # workspace parent + a longish repo name.
+        ws = Path("/home/matthew/workspace/companies/infini-player")
+        client = ClientConfig(name="infini-player", workspace_path=ws)
+
+        result = worktree_path_for(client, "auto-dev/1")
+
+        # Must be under cmux's 64-char cap.
+        assert len(str(result)) <= 64, (
+            f"worktree path length {len(str(result))} exceeds cmux cap 64: {result}"
+        )
+        # Must be under the hash-based fallback root, not the sibling default.
+        assert str(result).startswith("/home/u/.cw/wt/")
+        # Branch slug preserved at the tail.
+        assert result.name == "auto-dev-1"
+
+    def test_short_default_path_unchanged(self) -> None:
+        """Short default paths keep the sibling-directory layout."""
+        ws = Path("/p/r")
+        client = ClientConfig(name="r", workspace_path=ws)
+        result = worktree_path_for(client, "main")
+        assert result == Path("/p/.worktrees/r/main")
+
+    def test_client_override_used_even_when_long(self) -> None:
+        """An explicit ``worktree_base`` is respected even if it makes the
+        resulting path exceed the cap — user choice wins over our fallback."""
+        override = Path("/this/is/a/deliberately/long/override/path/from/the/user")
+        client = ClientConfig(
+            name="test",
+            workspace_path=Path("/ws"),
+            worktree_base=override,
+        )
+        result = worktree_path_for(client, "feat/x")
+        assert result == override / "feat-x"
 
 
 class TestCreateWorktree:


### PR DESCRIPTION
## Summary

Fixes #47. `dispatch` spawns `claude -w <path>`; cmux treats the full path as the worktree name and rejects anything over 64 chars with `Invalid worktree name: must be 64 characters or fewer (got N)`. Any client whose workspace sits a few directories deep or has a longer repo name hits the cap immediately — the reported case `~/workspace/companies/.worktrees/infini-player/auto-dev-1` = 69 chars failed on every dispatch.

- `src/cw/worktree.py`: when the default `<ws.parent>/.worktrees/<ws.name>/<slug>` layout would exceed the cap, fall back to a hash-derived short base at `~/.cw/wt/<sha256[:8]>/<slug>`.
- Hash seeds from `_git_dir(client).resolve()` so symlinks and non-canonical paths collapse to the same digest — `create_worktree`/`remove_worktree` must agree on the location.
- `client.worktree_base` overrides remain authoritative, even when they push the path over the cap (user choice > safety net).

## Upgrade note

Existing `Session.worktree_path` records on disk point at the pre-fix (long) sibling path. After upgrade, for any session that was dispatched before this fix, `remove_worktree` will resolve the new (hashed) path, not find it, and silently no-op — leaving the old worktree on disk. One-time hazard; users with stale long-path worktrees should clean them up manually.

## Test plan

- [x] `TestWorktreePathFor::test_long_default_path_falls_back_to_hashed_base` — exact 69-char path from the bug. Verified to FAIL before the fix, PASS after.
- [x] `test_short_default_path_unchanged` — regression guard for the sibling layout.
- [x] `test_hashed_fallback_is_stable_across_calls` — guards the create/remove contract against symlink/hash instability.
- [x] `test_client_override_used_even_when_long` — user override still wins.
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest tests/` — 596/596 pass

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)