### PR TITLE
release: 0.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-workspace"
-version = "0.6.0"
+version = "0.6.1"
 description = "Multi-session workspace orchestrator for Claude Code"
 readme = "README.md"
 authors = [

--- a/src/cw/__init__.py
+++ b/src/cw/__init__.py
@@ -1,3 +1,3 @@
 """claude-workspace: Multi-session workspace orchestrator for Claude Code."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,7 @@ class TestCli:
         runner = CliRunner()
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.6.0" in result.output
+        assert "0.6.1" in result.output
 
     def test_help(self) -> None:
         runner = CliRunner()

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "claude-workspace"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Bug-fix release bundling two recent PRs.

- #48 / #46 — atomic writes for JSON state files. Fixes intermittent `JSONDecodeError` in `dev_queue` and other state loaders when a concurrent writer truncates the file mid-read. Applied to `dev_queue`, `state`, `queue`, `daemon`, `events`, and `pr_responder`.
- #49 / #47 — bound default worktree path to cmux's 64-char cap. When `<ws.parent>/.worktrees/<ws.name>/<slug>` would exceed the cap, fall back to `~/.cw/wt/<sha256[:8]>/<slug>`. Hash seeds from the resolved git dir for symlink-stable behaviour. `client.worktree_base` overrides remain authoritative.

## Version bumps

- `pyproject.toml`: 0.6.0 → 0.6.1
- `src/cw/__init__.py`: `__version__` → "0.6.1"
- `uv.lock`: regenerated
- `tests/test_cli.py::test_version`: asserts new string

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest tests/` — 596/596 pass (local)

CI must pass before merging, then tag `v0.6.1` fires the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)