### PR TITLE
Multiplexer/state reconciliation: detect and reap phantom sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Multiplexer/state reconciliation. Phantom sessions (tmux/cmux surfaces
+  that no longer exist) are detected and reaped automatically on `cw status`,
+  `cw list`, `cw start`, and at the top of each `dispatch_tick`. Explicit
+  reconciliation is available via `cw doctor --reap`.
+- `MultiplexerAdapter.list_surfaces()` on the adapter protocol; implemented
+  for tmux, cmux (macOS), and fake backends.
+- Public `dev_queue_lock` context manager in `cw.dev_queue` for callers
+  that need load → mutate → save around the queue.
+
+### Changed
+- `start_session`'s "Launching ... surfaces" message now names the active
+  backend (tmux/cmux/fake).
+- Dev-queue `TicketTask`s associated with reaped DAEMON sessions revert
+  from RUNNING to PENDING so the dispatch loop retries them.
+- `RealCmuxAdapter._call` now normalises socket `OSError` and
+  `json.JSONDecodeError` into `CwError`, giving callers a single
+  exception type to guard against backend failures.
+
 ## [0.6.0] — 2026-04-18
 
 The multi-platform bridge. `cw` now runs natively on Linux via tmux,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `RealCmuxAdapter._call` now normalises socket `OSError` and
   `json.JSONDecodeError` into `CwError`, giving callers a single
   exception type to guard against backend failures.
+- `reconcile()` refuses to mass-reap when the adapter reports zero live
+  surfaces but the persisted state still has ACTIVE/IDLE sessions with
+  surface refs — a transient cmux/tmux outage no longer marks every
+  session COMPLETED/CRASHED. `compute_drift` stays pure; the guard
+  lives only in the side-effecting path.
+- `RealCmuxAdapter.list_surfaces` now returns an empty set on any
+  enumeration failure (including per-workspace `surface.list` errors)
+  rather than a partial set, matching the all-or-nothing protocol
+  contract expected by the reconciler.
+- `ReconcileReport` carries `phantom_session_names` alongside IDs so
+  callers no longer need to reload state to resolve names.
+- `dispatch_tick` guards the reconcile call and logs failures instead
+  of halting the dispatch loop on a reconcile error.
+- `doctor._check_reconcile` narrowed its `except Exception` to
+  `except CwError` and wraps the reconcile call itself so that an
+  unexpected failure is reported as a check result rather than
+  crashing `cw doctor --reap`.
 
 ## [0.6.0] — 2026-04-18
 

--- a/docs/superpowers/plans/2026-04-19-multiplexer-state-reconciliation.md
+++ b/docs/superpowers/plans/2026-04-19-multiplexer-state-reconciliation.md
@@ -1,0 +1,1462 @@
+# Multiplexer/State Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect when `sessions.json` has drifted from live multiplexer reality (tmux server death, cmux surface closure) and reconcile phantom sessions — marking them COMPLETED+CRASHED and reverting their dev-queue tickets to PENDING — via both cheap passive checks on read paths and an explicit `cw doctor --reap` command.
+
+**Architecture:** Extend the `MultiplexerAdapter` protocol with an additive `list_surfaces()` method that returns the set of live surface refs for tmux/cmux/fake backends. A new `cw.reconcile` module computes a drift report (phantom sessions whose `surface_ref` is not in `list_surfaces()`) and applies it under the state lock — flipping phantoms to `COMPLETED`/`CRASHED`, recording `SESSION_COMPLETED` events with `crashed: true`, and reverting their `RUNNING` `TicketTask`s to `PENDING`. Passive reconciliation runs in `_check_and_mark_dead_sessions` (already a stub in `cli.py`), covering `cw status` and `cw list`. Active reconciliation runs at the top of `dispatch_tick`, ahead of `consume_completed_sessions`. Explicit reconciliation lands as `cw doctor --reap`. `cw start`'s existing "existing active session" short-circuit inherits passive reconciliation by calling the same helper before deciding to resume.
+
+**Tech Stack:** Python 3.12+, Pydantic, Click, pytest, uv. Follows existing cw patterns: Protocol-typed adapters, file-locked state access, Pydantic models, fcntl locks, `FakeCmuxAdapter` for test injection.
+
+---
+
+## File Structure
+
+**Files to create:**
+- `src/cw/reconcile.py` — reconciliation logic (`ReconcileReport`, `compute_drift`, `reconcile`)
+- `tests/test_reconcile.py` — unit tests for the reconcile module
+
+**Files to modify:**
+- `src/cw/cmux.py` — add `list_surfaces` to the `MultiplexerAdapter` Protocol; implement on `RealCmuxAdapter` (via `workspace.list` + `surface.list`) and `FakeCmuxAdapter` (in-memory set).
+- `src/cw/tmux.py` — implement `list_surfaces` via `tmux list-panes -a -F <_PANE_FORMAT>`.
+- `src/cw/cli.py` — flesh out `_check_and_mark_dead_sessions` (currently a stub at line ~350) to call `reconcile`; add `--reap` flag to `cw doctor`; use backend-aware surface-launching message.
+- `src/cw/doctor.py` — add `run_doctor(reap: bool = False)` option that also runs reconciliation and reports reaped sessions.
+- `src/cw/dispatch.py` — call `reconcile` at the top of each `dispatch_tick` (before `consume_completed_sessions`).
+- `src/cw/session.py` — (1) backend-aware "Launching X surfaces" message at line ~221; (2) `start_session` passes through the reconciled state when checking for `existing` session.
+- `tests/test_cmux.py` — `FakeCmuxAdapter.list_surfaces` behaviour test.
+- `tests/test_tmux.py` — `TmuxAdapter.list_surfaces` parsing test (mocked subprocess).
+- `tests/test_cli.py` — `_display_status` / `cw status` now reports reaped sessions; `cw doctor --reap`.
+- `tests/test_dispatch.py` — `dispatch_tick` reconciles before claiming.
+- `tests/test_session.py` — backend-aware launching message.
+
+**Responsibility boundaries:**
+- `cw.reconcile` owns: drift computation, state mutation under lock, event recording, ticket-task revert. Pure logic; never calls the adapter directly except through a single `list_surfaces()` hop.
+- `cw.cmux` / `cw.tmux` own: adapter implementation detail. They know *how* to list surfaces; they don't know *why*.
+- `cw.cli` / `cw.doctor` / `cw.dispatch` own: *when* to invoke reconciliation. They are the three call sites (passive, explicit, active).
+
+---
+
+## Task 1: Extend MultiplexerAdapter protocol with `list_surfaces`
+
+**Why first:** every subsequent task consumes this method. Get the protocol pinned down before anything else reads/mutates state based on it.
+
+**Files:**
+- Modify: `src/cw/cmux.py:50-67` (Protocol), `src/cw/cmux.py:148-178` (FakeCmuxAdapter)
+- Test: `tests/test_cmux.py`
+
+- [ ] **Step 1: Write the failing test for `FakeCmuxAdapter.list_surfaces`**
+
+Append to `tests/test_cmux.py`:
+
+```python
+def test_fake_adapter_list_surfaces_tracks_spawn_and_close() -> None:
+    """FakeCmuxAdapter tracks live surfaces via spawn/close."""
+    adapter = FakeCmuxAdapter()
+
+    assert adapter.list_surfaces() == set()
+
+    ref1 = adapter.spawn("ws-1", "echo hi")
+    ref2 = adapter.spawn("ws-1", "echo bye")
+    assert adapter.list_surfaces() == {ref1, ref2}
+
+    adapter.close(ref1)
+    assert adapter.list_surfaces() == {ref2}
+
+
+def test_fake_adapter_close_unknown_ref_is_noop() -> None:
+    """Closing a surface we never spawned must not raise."""
+    adapter = FakeCmuxAdapter()
+    adapter.close("never-spawned")  # must not raise
+    assert adapter.list_surfaces() == set()
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `uv run pytest tests/test_cmux.py::test_fake_adapter_list_surfaces_tracks_spawn_and_close tests/test_cmux.py::test_fake_adapter_close_unknown_ref_is_noop -v`
+Expected: FAIL with `AttributeError: 'FakeCmuxAdapter' object has no attribute 'list_surfaces'`
+
+- [ ] **Step 3: Extend Protocol and FakeCmuxAdapter**
+
+Edit `src/cw/cmux.py`. In the `MultiplexerAdapter` Protocol (around line 50), add after `identify`:
+
+```python
+    def list_surfaces(self) -> set[str]:
+        """Return the set of surface refs currently known to the backend.
+
+        Used by reconciliation to detect phantom sessions: any surface_ref
+        in cw state that is *not* in this set is assumed dead. Implementers
+        should return an empty set if the multiplexer server is unreachable,
+        so callers cannot accidentally interpret "server down" as "all
+        surfaces still alive".
+        """
+        ...
+```
+
+In `FakeCmuxAdapter.__init__`, add a live-set after `self.calls`:
+
+```python
+        self._live: set[str] = set()
+```
+
+In `FakeCmuxAdapter.spawn`, after computing `ref`:
+
+```python
+        self._live.add(ref)
+```
+
+In `FakeCmuxAdapter.close`, replace with:
+
+```python
+    def close(self, surface_ref: str) -> None:
+        """Record call and drop from live set (idempotent)."""
+        self.calls["close"].append((surface_ref,))
+        self._live.discard(surface_ref)
+```
+
+Append new method:
+
+```python
+    def list_surfaces(self) -> set[str]:
+        """Return the current in-memory live-surface set (copy)."""
+        self.calls.setdefault("list_surfaces", []).append(())
+        return set(self._live)
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_cmux.py -v`
+Expected: PASS, no previously-passing tests regress.
+
+- [ ] **Step 5: Run full quality gate**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/ && uv run pytest tests/test_cmux.py -v`
+Expected: zero violations, zero errors, all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cw/cmux.py tests/test_cmux.py
+git commit -m "feat(cmux): add list_surfaces to MultiplexerAdapter protocol"
+```
+
+---
+
+## Task 2: Implement `list_surfaces` on `TmuxAdapter`
+
+**Files:**
+- Modify: `src/cw/tmux.py`
+- Test: `tests/test_tmux.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_tmux.py`:
+
+```python
+def test_tmux_list_surfaces_parses_pane_refs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_surfaces parses `tmux list-panes -a -F` output into a set."""
+    import subprocess
+    from cw.tmux import TmuxAdapter
+
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/tmux")
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        assert cmd[:4] == ["tmux", "list-panes", "-a", "-F"]
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout="cw-client-a:0.0\ncw-client-a:0.1\ncw-client-b:1.0\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    adapter = TmuxAdapter()
+
+    assert adapter.list_surfaces() == {
+        "cw-client-a:0.0",
+        "cw-client-a:0.1",
+        "cw-client-b:1.0",
+    }
+
+
+def test_tmux_list_surfaces_returns_empty_on_server_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If tmux server is not running, list-panes returns non-zero; we return empty."""
+    import subprocess
+    from cw.tmux import TmuxAdapter
+
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/tmux")
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=1,
+            stdout="",
+            stderr="no server running on /tmp/tmux-1000/default\n",
+        )
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    adapter = TmuxAdapter()
+    assert adapter.list_surfaces() == set()
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `uv run pytest tests/test_tmux.py::test_tmux_list_surfaces_parses_pane_refs -v`
+Expected: FAIL with `AttributeError: 'TmuxAdapter' object has no attribute 'list_surfaces'`
+
+- [ ] **Step 3: Implement `list_surfaces` on TmuxAdapter**
+
+Edit `src/cw/tmux.py`. After `identify` (~line 110), append:
+
+```python
+    def list_surfaces(self) -> set[str]:
+        """Return the set of live tmux pane refs across all sessions.
+
+        Empty set when the tmux server is not running — callers in
+        reconciliation rely on this invariant to avoid false positives.
+        """
+        result = self._run(
+            ["list-panes", "-a", "-F", _PANE_FORMAT],
+            check=False,
+        )
+        if result.returncode != 0 or not result.stdout:
+            return set()
+        return {line for line in result.stdout.strip().splitlines() if line}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_tmux.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full quality gate**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/ && uv run pytest tests/test_tmux.py -v`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cw/tmux.py tests/test_tmux.py
+git commit -m "feat(tmux): implement list_surfaces via list-panes -a"
+```
+
+---
+
+## Task 3: Implement `list_surfaces` on `RealCmuxAdapter`
+
+**Why last among adapter tasks:** macOS-only, can't be integration-tested in CI. Unit-test the call-shape via a monkeypatched `_call`.
+
+**Files:**
+- Modify: `src/cw/cmux.py:75-145` (RealCmuxAdapter)
+- Test: `tests/test_cmux.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_cmux.py`:
+
+```python
+def test_real_cmux_list_surfaces_aggregates_across_workspaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """list_surfaces calls workspace.list then surface.list for each workspace."""
+    import sys
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    from cw.cmux import RealCmuxAdapter
+
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_call(self, method, params):  # noqa: ANN001, ANN202
+        calls.append((method, dict(params)))
+        if method == "workspace.list":
+            return {"workspaces": [
+                {"id": "ws-a", "title": "client-a"},
+                {"id": "ws-b", "title": "client-b"},
+            ]}
+        if method == "surface.list":
+            ws_id = params["workspace_id"]
+            if ws_id == "ws-a":
+                return {"surfaces": [{"id": "surf-a1"}, {"id": "surf-a2"}]}
+            return {"surfaces": [{"id": "surf-b1"}]}
+        raise AssertionError(f"unexpected call: {method}")
+
+    monkeypatch.setattr(RealCmuxAdapter, "_call", fake_call)
+    adapter = RealCmuxAdapter(socket_path=Path("/tmp/fake.sock"))
+
+    assert adapter.list_surfaces() == {"surf-a1", "surf-a2", "surf-b1"}
+    assert calls[0][0] == "workspace.list"
+    assert {c[1]["workspace_id"] for c in calls if c[0] == "surface.list"} == {
+        "ws-a", "ws-b",
+    }
+
+
+def test_real_cmux_list_surfaces_returns_empty_on_socket_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the cmux socket is down, return empty set instead of raising."""
+    import sys
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    from cw.cmux import RealCmuxAdapter
+    from cw.exceptions import CwError
+
+    def fake_call(self, method, params):  # noqa: ANN001, ANN202
+        raise CwError("connection refused")
+
+    monkeypatch.setattr(RealCmuxAdapter, "_call", fake_call)
+    adapter = RealCmuxAdapter(socket_path=Path("/tmp/fake.sock"))
+    assert adapter.list_surfaces() == set()
+```
+
+Also make sure the test file already imports `Path`; if not, add `from pathlib import Path` and `import pytest` at the top (check existing imports first and only add what's missing).
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `uv run pytest tests/test_cmux.py::test_real_cmux_list_surfaces_aggregates_across_workspaces -v`
+Expected: FAIL with `AttributeError` on `list_surfaces`.
+
+- [ ] **Step 3: Implement `list_surfaces` on RealCmuxAdapter**
+
+Edit `src/cw/cmux.py`. After `identify` in `RealCmuxAdapter` (~line 145), append:
+
+```python
+    def list_surfaces(self) -> set[str]:
+        """Return the set of live cmux surface IDs across all workspaces.
+
+        Returns an empty set if the cmux socket is unreachable — the
+        reconciler uses that as a "can't tell" signal and leaves state
+        untouched (see :mod:`cw.reconcile`).
+        """
+        try:
+            workspaces_raw = self._call("workspace.list", {})
+        except CwError:
+            return set()
+        workspaces: list[dict[str, Any]] = workspaces_raw.get("workspaces", [])
+        live: set[str] = set()
+        for ws in workspaces:
+            ws_id = ws.get("id")
+            if not ws_id:
+                continue
+            try:
+                resp = self._call("surface.list", {"workspace_id": ws_id})
+            except CwError:
+                continue
+            for surf in resp.get("surfaces", []):
+                surf_id = surf.get("id")
+                if surf_id:
+                    live.add(surf_id)
+        return live
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_cmux.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full quality gate**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/ && uv run pytest tests/test_cmux.py -v`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cw/cmux.py tests/test_cmux.py
+git commit -m "feat(cmux): implement list_surfaces on RealCmuxAdapter"
+```
+
+---
+
+## Task 4: Create `cw.reconcile` module — pure drift computation
+
+**Why split from apply:** drift computation is pure and easy to test. The write half (under lock, mutating state and dev-queue) is harder and lives in the next task. Keep them separable so tests can assert the "what changed" without the side effects.
+
+**Files:**
+- Create: `src/cw/reconcile.py`
+- Create: `tests/test_reconcile.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_reconcile.py`:
+
+```python
+"""Unit tests for cw.reconcile."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from cw.cmux import FakeCmuxAdapter
+from cw.models import (
+    ClientConfig,
+    CwState,
+    Session,
+    SessionPurpose,
+    SessionStatus,
+)
+from cw.reconcile import compute_drift
+
+
+def _mk_session(
+    sid: str,
+    surface_ref: str | None,
+    status: SessionStatus = SessionStatus.ACTIVE,
+) -> Session:
+    return Session(
+        id=sid,
+        name=f"client-a/{sid}",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        status=status,
+        workspace_path=ClientConfig(
+            name="client-a", workspace_path="/tmp/ws"
+        ).workspace_path,
+        surface_ref=surface_ref,
+        started_at=datetime(2026, 4, 19, tzinfo=UTC),
+    )
+
+
+def test_compute_drift_empty_state_returns_empty_report() -> None:
+    adapter = FakeCmuxAdapter()
+    state = CwState()
+    report = compute_drift(state, adapter)
+    assert report.phantom_session_ids == []
+
+
+def test_compute_drift_flags_active_session_with_missing_surface() -> None:
+    adapter = FakeCmuxAdapter()  # no surfaces
+    state = CwState(sessions=[_mk_session("s1", "missing-ref")])
+    report = compute_drift(state, adapter)
+    assert report.phantom_session_ids == ["s1"]
+
+
+def test_compute_drift_ignores_backgrounded_completed_and_refless() -> None:
+    adapter = FakeCmuxAdapter()
+    state = CwState(sessions=[
+        _mk_session("s-bg", "ref1", status=SessionStatus.BACKGROUNDED),
+        _mk_session("s-done", "ref2", status=SessionStatus.COMPLETED),
+        _mk_session("s-noref", None, status=SessionStatus.ACTIVE),
+    ])
+    report = compute_drift(state, adapter)
+    assert report.phantom_session_ids == []
+
+
+def test_compute_drift_respects_live_set() -> None:
+    adapter = FakeCmuxAdapter()
+    live_ref = adapter.spawn("ws", "echo hi")  # registers in live set
+    state = CwState(sessions=[
+        _mk_session("alive", live_ref),
+        _mk_session("dead", "gone"),
+    ])
+    report = compute_drift(state, adapter)
+    assert report.phantom_session_ids == ["dead"]
+
+
+def test_compute_drift_empty_live_set_from_adapter_is_reconciled(
+    monkeypatch,
+) -> None:
+    """Adapters return empty on backend outage. That's 'no surfaces alive' —
+    so everything ACTIVE/IDLE with a surface_ref is phantom. The reconciler
+    trusts the adapter; callers who want "don't touch state when backend is
+    down" must guard before calling.
+    """
+    adapter = FakeCmuxAdapter()
+    state = CwState(sessions=[
+        _mk_session("s1", "r1"),
+        _mk_session("s2", "r2", status=SessionStatus.IDLE),
+    ])
+    report = compute_drift(state, adapter)
+    assert set(report.phantom_session_ids) == {"s1", "s2"}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `uv run pytest tests/test_reconcile.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'cw.reconcile'`
+
+- [ ] **Step 3: Create the module**
+
+Create `src/cw/reconcile.py`:
+
+```python
+"""Reconcile cw session state with live multiplexer surfaces.
+
+The authoritative view of what is running lives in the multiplexer
+(tmux/cmux/fake). :func:`compute_drift` compares ``sessions.json`` against
+that view and returns a :class:`ReconcileReport` naming the sessions that
+have gone phantom — active/idle rows whose ``surface_ref`` no longer maps
+to any live surface. :func:`reconcile` (Task 5) applies the report under
+the state lock.
+
+The split is deliberate: ``compute_drift`` is pure and testable in
+isolation; ``reconcile`` does the side-effecting work (state mutation,
+event emission, dev-queue revert).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from cw.models import SessionStatus
+
+if TYPE_CHECKING:
+    from cw.cmux import MultiplexerAdapter
+    from cw.models import CwState
+
+
+# Only these two statuses imply "the multiplexer should have a surface".
+# BACKGROUNDED sessions intentionally have no pane (that's the whole point);
+# COMPLETED is terminal. Both are ignored by reconciliation.
+_LIVE_STATUSES: frozenset[SessionStatus] = frozenset({
+    SessionStatus.ACTIVE,
+    SessionStatus.IDLE,
+})
+
+
+@dataclass(frozen=True)
+class ReconcileReport:
+    """What reconciliation would do / did.
+
+    ``phantom_session_ids`` — sessions whose ``surface_ref`` is not in the
+    live set. Ordered by the original order in ``state.sessions``.
+    ``reverted_ticket_ids`` — ticket IDs whose TicketTasks got reverted
+    from RUNNING to PENDING. Populated by :func:`reconcile`, empty after
+    :func:`compute_drift`.
+    """
+
+    phantom_session_ids: list[str] = field(default_factory=list)
+    reverted_ticket_ids: list[str] = field(default_factory=list)
+
+
+def compute_drift(state: CwState, adapter: MultiplexerAdapter) -> ReconcileReport:
+    """Return a report naming sessions whose surface is no longer live.
+
+    An ACTIVE or IDLE session is phantom when:
+    - it has a ``surface_ref`` (None means it was never spawned), AND
+    - that ref is not in ``adapter.list_surfaces()``.
+
+    This function does not mutate state.
+    """
+    live = adapter.list_surfaces()
+    phantoms: list[str] = []
+    for session in state.sessions:
+        if session.status not in _LIVE_STATUSES:
+            continue
+        if session.surface_ref is None:
+            continue
+        if session.surface_ref not in live:
+            phantoms.append(session.id)
+    return ReconcileReport(phantom_session_ids=phantoms)
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_reconcile.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full quality gate**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/ && uv run pytest tests/test_reconcile.py -v`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cw/reconcile.py tests/test_reconcile.py
+git commit -m "feat(reconcile): add compute_drift pure drift computation"
+```
+
+---
+
+## Task 5: Implement `reconcile` — apply drift under lock, revert tickets
+
+**Files:**
+- Modify: `src/cw/reconcile.py`
+- Modify: `tests/test_reconcile.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_reconcile.py`:
+
+```python
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cw.config import save_state, load_state
+from cw.dev_queue import load_dev_queue, save_dev_queue
+from cw.models import (
+    CompletionReason,
+    DevQueueStore,
+    QueueItemStatus,
+    SessionOrigin,
+    TicketTask,
+)
+from cw.reconcile import reconcile
+
+
+def test_reconcile_marks_phantom_completed_crashed(
+    tmp_config_dir: Path,  # noqa: ARG001 -- autouse redirects state paths
+) -> None:
+    """reconcile flips phantom sessions to COMPLETED/CRASHED and persists."""
+    state = CwState(sessions=[_mk_session("s1", "missing-ref")])
+    save_state(state)
+
+    adapter = FakeCmuxAdapter()  # empty live set → s1 is phantom
+    report = reconcile(adapter)
+
+    assert report.phantom_session_ids == ["s1"]
+    reloaded = load_state()
+    s1 = reloaded.find_by_name_or_id("s1")
+    assert s1 is not None
+    assert s1.status == SessionStatus.COMPLETED
+    assert s1.completed_reason == CompletionReason.CRASHED
+    assert s1.completed_at is not None
+
+
+def test_reconcile_reverts_daemon_session_ticket_to_pending(
+    tmp_config_dir: Path,  # noqa: ARG001
+) -> None:
+    """When a DAEMON session for a ticket is phantom, revert its task."""
+    sess = _mk_session("sess-daemon", "dead-ref")
+    sess.origin = SessionOrigin.DAEMON
+    sess.name = "client-a/auto-dev/TKT-1"
+    save_state(CwState(sessions=[sess]))
+
+    task = TicketTask(
+        ticket_id="TKT-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    report = reconcile(FakeCmuxAdapter())
+
+    assert "TKT-1" in report.reverted_ticket_ids
+    queue = load_dev_queue()
+    assert queue.tasks[0].status == QueueItemStatus.PENDING
+
+
+def test_reconcile_noop_when_no_phantoms(
+    tmp_config_dir: Path,  # noqa: ARG001
+) -> None:
+    adapter = FakeCmuxAdapter()
+    live_ref = adapter.spawn("ws", "echo")
+    sess = _mk_session("alive", live_ref)
+    save_state(CwState(sessions=[sess]))
+
+    report = reconcile(adapter)
+    assert report.phantom_session_ids == []
+    assert report.reverted_ticket_ids == []
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `uv run pytest tests/test_reconcile.py -v`
+Expected: FAIL with `ImportError: cannot import name 'reconcile' from 'cw.reconcile'`.
+
+- [ ] **Step 3: Implement `reconcile`**
+
+Edit `src/cw/reconcile.py`. Extend imports at the top:
+
+```python
+from datetime import UTC, datetime
+
+from cw.config import load_state, save_state
+from cw.dev_queue import _lock as _dev_queue_lock
+from cw.dev_queue import load_dev_queue, save_dev_queue
+from cw.events import record_event
+from cw.models import (
+    CompletionReason,
+    OrchestratorEventType,
+    QueueItemStatus,
+    SessionOrigin,
+    SessionStatus,
+)
+```
+
+Append to the module:
+
+```python
+# Daemon session names follow "client/auto-dev/<ticket-id>" (see
+# src/cw/dispatch.py::dispatch_tick where the label is constructed).
+_AUTO_DEV_LABEL_PREFIX = "auto-dev/"
+
+
+def _ticket_id_for_session(session_name: str) -> str | None:
+    """Extract the ticket id from a daemon session name, or None."""
+    _, _, tail = session_name.partition("/")
+    if tail.startswith(_AUTO_DEV_LABEL_PREFIX):
+        return tail[len(_AUTO_DEV_LABEL_PREFIX) :]
+    return None
+
+
+def reconcile(adapter: MultiplexerAdapter) -> ReconcileReport:
+    """Apply drift reconciliation against the persisted state.
+
+    Flips phantom ACTIVE/IDLE sessions to COMPLETED with
+    ``completed_reason = CRASHED``, emits a ``SESSION_COMPLETED`` event
+    with ``crashed: True``, and reverts any RUNNING TicketTask whose
+    ticket-id can be recovered from the session name back to PENDING so
+    the dispatch loop will retry.
+    """
+    state = load_state()
+    drift = compute_drift(state, adapter)
+    if not drift.phantom_session_ids:
+        return drift
+
+    phantom_set = set(drift.phantom_session_ids)
+    now = datetime.now(UTC)
+    reverted: list[str] = []
+
+    ticket_ids_to_revert: list[str] = []
+    for session in state.sessions:
+        if session.id not in phantom_set:
+            continue
+        session.status = SessionStatus.COMPLETED
+        session.completed_reason = CompletionReason.CRASHED
+        session.completed_at = now
+        if session.origin is SessionOrigin.DAEMON:
+            ticket_id = _ticket_id_for_session(session.name)
+            if ticket_id:
+                ticket_ids_to_revert.append(ticket_id)
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {
+                "session_id": session.id,
+                "session_name": session.name,
+                "client": session.client,
+                "crashed": True,
+            },
+        )
+
+    save_state(state)
+
+    if ticket_ids_to_revert:
+        with _dev_queue_lock():
+            store = load_dev_queue()
+            for task in store.tasks:
+                if (
+                    task.ticket_id in ticket_ids_to_revert
+                    and task.status == QueueItemStatus.RUNNING
+                ):
+                    task.status = QueueItemStatus.PENDING
+                    reverted.append(task.ticket_id)
+            if reverted:
+                save_dev_queue(store)
+
+    return ReconcileReport(
+        phantom_session_ids=drift.phantom_session_ids,
+        reverted_ticket_ids=reverted,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_reconcile.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full quality gate**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/ && uv run pytest tests/test_reconcile.py -v`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cw/reconcile.py tests/test_reconcile.py
+git commit -m "feat(reconcile): apply drift and revert phantom tickets"
+```
+
+---
+
+## Task 6: Wire passive reconciliation into `cw status` / `cw list`
+
+**Context:** `cli.py:350-356` has `_check_and_mark_dead_sessions` as a stub with TODO. It's already called from `_display_status`. Replace the stub with a call into `reconcile`, display any reaped session names, and have `_display_sessions` call it too.
+
+**Files:**
+- Modify: `src/cw/cli.py` (stub function + `_display_sessions`)
+- Test: `tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_cli.py`:
+
+```python
+def test_display_status_reconciles_phantom_active_sessions(
+    tmp_config_dir,  # noqa: ANN001, ARG001
+    sample_client,  # noqa: ANN001
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """`cw status` reports and reaps sessions with missing surfaces."""
+    from click.testing import CliRunner
+    from cw.cli import main
+    from cw.config import load_state, save_state
+    from cw.models import CwState, Session, SessionPurpose, SessionStatus
+    from cw.cmux import FakeCmuxAdapter
+
+    save_state(CwState(sessions=[
+        Session(
+            id="phantom1",
+            name="client-a/impl",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=sample_client.workspace_path,
+            surface_ref="gone",
+        ),
+    ]))
+
+    # Force cli.py to use a fresh FakeCmuxAdapter so list_surfaces is empty.
+    monkeypatch.setattr("cw.cli.get_cmux_adapter", FakeCmuxAdapter)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["status"])
+    assert result.exit_code == 0
+    assert "Reaped phantom session" in result.output
+    assert "client-a/impl" in result.output
+
+    reloaded = load_state()
+    reaped = reloaded.find_by_name_or_id("phantom1")
+    assert reaped is not None
+    assert reaped.status == SessionStatus.COMPLETED
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `uv run pytest tests/test_cli.py::test_display_status_reconciles_phantom_active_sessions -v`
+Expected: FAIL (currently the stub returns `[]`; message not emitted).
+
+- [ ] **Step 3: Replace the stub**
+
+Edit `src/cw/cli.py`. At the top, add to the existing `cw.reconcile` import (or create one):
+
+```python
+from cw.reconcile import reconcile
+```
+
+Replace `_check_and_mark_dead_sessions` (~line 350-356) with:
+
+```python
+def _check_and_mark_dead_sessions(_state: CwState) -> list[str]:
+    """Reconcile state with the live multiplexer and return reaped session names.
+
+    Cheap passive reconciliation: called from every read path (``cw status``,
+    ``cw list``, ``cw start``). The reconciler is idempotent and returns an
+    empty list when nothing changed. When the adapter cannot reach its
+    backend (empty live set from ``list_surfaces``), everything active with
+    a surface_ref gets flagged — that is the intended behaviour: we treat
+    "backend unreachable" as "nothing running".
+    """
+    try:
+        adapter = get_cmux_adapter()
+    except CwError:
+        return []
+    report = reconcile(adapter)
+    if not report.phantom_session_ids:
+        return []
+    # load_state() again after reconcile so we can name the reaped sessions.
+    reloaded = load_state()
+    names: list[str] = []
+    for sid in report.phantom_session_ids:
+        sess = reloaded.find_by_name_or_id(sid)
+        if sess is not None:
+            names.append(sess.name)
+    return names
+```
+
+Update `_display_status` (~line 359) to print the list of names instead of the old per-session line. Change:
+
+```python
+    dead = _check_and_mark_dead_sessions(state)
+    for s in dead:
+        click.echo(f"Detected crashed session: {s.name} (crashed)")
+```
+
+to:
+
+```python
+    dead = _check_and_mark_dead_sessions(state)
+    for name in dead:
+        click.echo(f"Reaped phantom session: {name}")
+    if dead:
+        # State mutated, reload so active/backgrounded lists reflect truth.
+        state = load_state()
+```
+
+Add the same reconcile call at the top of `_display_sessions` (~line 323). Immediately after `state = load_state()`:
+
+```python
+    dead = _check_and_mark_dead_sessions(state)
+    for name in dead:
+        click.echo(f"Reaped phantom session: {name}")
+    if dead:
+        state = load_state()
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_cli.py -v`
+Expected: PASS. Also re-run any existing tests for `_display_status` and verify they still pass — the old "Detected crashed session:" message is replaced; if any existing test asserted on that string, update it to "Reaped phantom session:".
+
+- [ ] **Step 5: Run full quality gate**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/ && uv run pytest tests/test_cli.py -v`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cw/cli.py tests/test_cli.py
+git commit -m "feat(cli): reconcile phantom sessions on status/list read"
+```
+
+---
+
+## Task 7: Passive reconciliation guard in `cw start`
+
+**Context:** `start_session` (`src/cw/session.py:194-204`) checks `state.find_session(...)` for an existing ACTIVE/BACKGROUNDED session. If that "active" record is phantom (the tmux pane died), cw skips spawning and wrongly says "Session already active". Reconcile first.
+
+**Files:**
+- Modify: `src/cw/session.py`
+- Test: `tests/test_session.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_session.py`:
+
+```python
+def test_start_session_reaps_phantom_before_existing_check(
+    tmp_config_dir,  # noqa: ANN001, ARG001
+    sample_client,  # noqa: ANN001
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """If the 'existing active' session is phantom, start_session reaps and spawns fresh."""
+    from cw.cmux import FakeCmuxAdapter
+    from cw.config import init_client, load_state, save_state
+    from cw.models import CwState, Session, SessionPurpose, SessionStatus
+    from cw.session import start_session
+
+    init_client(
+        sample_client.name,
+        sample_client.workspace_path,
+        default_branch="main",
+    )
+
+    save_state(CwState(sessions=[
+        Session(
+            id="phantom",
+            name=f"{sample_client.name}/impl",
+            client=sample_client.name,
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=sample_client.workspace_path,
+            surface_ref="gone-ref",
+        ),
+    ]))
+
+    adapter = FakeCmuxAdapter()  # empty live set
+    start_session(sample_client.name, "impl", adapter=adapter)
+
+    reloaded = load_state()
+    # Phantom got reaped
+    phantom = reloaded.find_by_name_or_id("phantom")
+    assert phantom is not None
+    assert phantom.status == SessionStatus.COMPLETED
+    # New sessions spawned (at least one spawn call)
+    assert len(adapter.calls["spawn"]) >= 1
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `uv run pytest tests/test_session.py::test_start_session_reaps_phantom_before_existing_check -v`
+Expected: FAIL — `start_session` short-circuits on the phantom ACTIVE session and never spawns.
+
+- [ ] **Step 3: Call reconcile in start_session**
+
+Edit `src/cw/session.py`. Add to imports at the top:
+
+```python
+from cw.reconcile import reconcile
+```
+
+In `start_session`, immediately after `state = load_state()` (~line 173), insert:
+
+```python
+    # Reap phantom sessions so we don't short-circuit on a dead "active" row.
+    reconcile(adapter)
+    state = load_state()
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_session.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full quality gate**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/ && uv run pytest tests/test_session.py -v`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cw/session.py tests/test_session.py
+git commit -m "feat(session): reconcile phantoms before start's existing-session check"
+```
+
+---
+
+## Task 8: Active reconciliation in `dispatch_tick`
+
+**Context:** `dispatch_tick` counts `running_count` from sessions currently ACTIVE/IDLE. If phantoms inflate that count, new tickets never get claimed. Call reconcile at the top of the tick, before counting.
+
+**Files:**
+- Modify: `src/cw/dispatch.py`
+- Test: `tests/test_dispatch.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_dispatch.py`:
+
+```python
+def test_dispatch_tick_reconciles_phantoms_before_counting(
+    tmp_config_dir,  # noqa: ANN001, ARG001
+    sample_client,  # noqa: ANN001
+) -> None:
+    """Phantom DAEMON sessions do not block new dispatch."""
+    from cw.cmux import FakeCmuxAdapter
+    from cw.config import init_client, save_state, load_state
+    from cw.dev_queue import save_dev_queue
+    from cw.dispatch import dispatch_tick
+    from cw.models import (
+        CwState,
+        DevQueueStore,
+        OrchestratorConfig,
+        QueueItemStatus,
+        Session,
+        SessionOrigin,
+        SessionPurpose,
+        SessionStatus,
+        TicketTask,
+    )
+
+    init_client(
+        sample_client.name,
+        sample_client.workspace_path,
+        default_branch="main",
+    )
+
+    # Cap = 1, one ACTIVE phantom DAEMON session for the same client,
+    # and one PENDING ticket. Without reconciliation, running_count == 1
+    # would equal the cap and dispatch would spawn nothing.
+    save_state(CwState(sessions=[
+        Session(
+            id="phantom-daemon",
+            name=f"{sample_client.name}/auto-dev/TKT-OLD",
+            client=sample_client.name,
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+            workspace_path=sample_client.workspace_path,
+            surface_ref="dead",
+        ),
+    ]))
+    save_dev_queue(DevQueueStore(tasks=[
+        TicketTask(
+            ticket_id="TKT-OLD",
+            client=sample_client.name,
+            status=QueueItemStatus.RUNNING,
+        ),
+        TicketTask(
+            ticket_id="TKT-NEW",
+            client=sample_client.name,
+            status=QueueItemStatus.PENDING,
+        ),
+    ]))
+
+    adapter = FakeCmuxAdapter()
+    config = OrchestratorConfig(per_client_max_parallel={sample_client.name: 1})
+
+    spawned = dispatch_tick(config, adapter=adapter)
+    assert spawned == 1
+
+    # TKT-OLD reverted-then-maybe-reclaimed; TKT-NEW was also pending.
+    # Either order is acceptable, but at least one must now be RUNNING
+    # and the phantom must be marked COMPLETED.
+    reloaded = load_state()
+    assert reloaded.find_by_name_or_id("phantom-daemon").status == SessionStatus.COMPLETED
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `uv run pytest tests/test_dispatch.py::test_dispatch_tick_reconciles_phantoms_before_counting -v`
+Expected: FAIL — `spawned == 0` because the phantom inflates `running_count`.
+
+- [ ] **Step 3: Call reconcile in dispatch_tick**
+
+Edit `src/cw/dispatch.py`. Add to imports:
+
+```python
+from cw.reconcile import reconcile
+```
+
+At the top of `dispatch_tick` (~line 83), after `resolved_adapter = adapter or get_cmux_adapter()`, add:
+
+```python
+    reconcile(resolved_adapter)
+```
+
+And at the top of `run_dispatch_loop` body (~line 221-223), ensure reconcile runs each tick (it will, via `dispatch_tick`). No change needed there.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_dispatch.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full quality gate**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/ && uv run pytest tests/test_dispatch.py -v`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cw/dispatch.py tests/test_dispatch.py
+git commit -m "feat(dispatch): reconcile phantoms at start of each dispatch_tick"
+```
+
+---
+
+## Task 9: Explicit reconciliation via `cw doctor --reap`
+
+**Files:**
+- Modify: `src/cw/doctor.py`, `src/cw/cli.py`
+- Test: `tests/test_doctor.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_doctor.py`:
+
+```python
+def test_run_doctor_reap_flag_reconciles_and_reports(
+    tmp_config_dir,  # noqa: ANN001, ARG001
+    sample_client,  # noqa: ANN001
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """run_doctor(reap=True) invokes reconcile and reports reaped sessions."""
+    from cw.cmux import FakeCmuxAdapter
+    from cw.config import save_state, load_state
+    from cw.doctor import run_doctor
+    from cw.models import CwState, Session, SessionPurpose, SessionStatus
+
+    save_state(CwState(sessions=[
+        Session(
+            id="phantom",
+            name="client-a/impl",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=sample_client.workspace_path,
+            surface_ref="gone",
+        ),
+    ]))
+    monkeypatch.setattr("cw.doctor.get_cmux_adapter", FakeCmuxAdapter)
+
+    report = run_doctor(reap=True)
+    reap_checks = [c for c in report.checks if c.name == "reconciliation"]
+    assert len(reap_checks) == 1
+    assert reap_checks[0].ok is True
+    assert "phantom" in reap_checks[0].detail or "client-a/impl" in reap_checks[0].detail
+
+    reloaded = load_state()
+    phantom = reloaded.find_by_name_or_id("phantom")
+    assert phantom is not None
+    assert phantom.status == SessionStatus.COMPLETED
+
+
+def test_cw_doctor_cli_reap_flag(
+    tmp_config_dir,  # noqa: ANN001, ARG001
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """The CLI `cw doctor --reap` forwards the flag."""
+    from click.testing import CliRunner
+    from cw.cli import main
+    from cw.cmux import FakeCmuxAdapter
+
+    monkeypatch.setattr("cw.doctor.get_cmux_adapter", FakeCmuxAdapter)
+    runner = CliRunner()
+    result = runner.invoke(main, ["doctor", "--reap"])
+    assert result.exit_code == 0
+    assert "reconciliation" in result.output
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `uv run pytest tests/test_doctor.py -v`
+Expected: FAIL — `run_doctor` does not accept `reap`; CLI has no `--reap`.
+
+- [ ] **Step 3: Implement the flag**
+
+Edit `src/cw/doctor.py`. Add imports:
+
+```python
+from cw.cmux import get_cmux_adapter
+from cw.reconcile import reconcile
+```
+
+Change signature of `run_doctor`:
+
+```python
+def run_doctor(*, reap: bool = False) -> DoctorReport:
+    """Run every preflight check and return a populated report.
+
+    When *reap* is True, also run multiplexer/state reconciliation and
+    append a ``reconciliation`` check summarising the number of reaped
+    sessions and reverted tickets.
+    """
+    backend = _resolve_backend_name()
+    report = DoctorReport(version=__version__, backend=backend)
+    report.checks.append(CheckResult("resolved backend", ok=True, detail=backend.value))
+    report.checks.append(_check_backend_binary(backend))
+    report.checks.append(_check_config_file())
+    report.checks.append(_check_orchestrator_config())
+    report.checks.append(_check_state_file())
+    report.checks.append(_check_dev_queue())
+    if reap:
+        report.checks.append(_check_reconcile())
+    return report
+
+
+def _check_reconcile() -> CheckResult:
+    """Run reconciliation and describe the outcome as a check result."""
+    try:
+        adapter = get_cmux_adapter()
+    except Exception as exc:  # noqa: BLE001 -- backend may be unreachable
+        return CheckResult(
+            "reconciliation",
+            ok=False,
+            detail=f"adapter unavailable: {exc}",
+        )
+    reconcile_report = reconcile(adapter)
+    reaped = len(reconcile_report.phantom_session_ids)
+    reverted = len(reconcile_report.reverted_ticket_ids)
+    if reaped == 0 and reverted == 0:
+        return CheckResult("reconciliation", ok=True, detail="no phantoms")
+    return CheckResult(
+        "reconciliation",
+        ok=True,
+        detail=(
+            f"reaped {reaped} session(s), reverted {reverted} ticket(s); "
+            f"ids: {reconcile_report.phantom_session_ids}"
+        ),
+    )
+```
+
+Edit `src/cw/cli.py`. Update the `doctor` command:
+
+```python
+@main.command()
+@click.option(
+    "--reap",
+    is_flag=True,
+    help="Also reconcile state with the live multiplexer and reap phantoms.",
+)
+@handle_errors
+def doctor(reap: bool) -> None:
+    """Run environment preflight checks and print a health report.
+
+    Reports the resolved backend, backend binary/daemon availability,
+    config file locations and validity, and state file parseability.
+    With ``--reap`` also reconciles cw's session state with the live
+    multiplexer, marking phantom sessions COMPLETED and reverting their
+    tickets to PENDING. Exits non-zero if any check fails.
+    """
+    report = run_doctor(reap=reap)
+    click.echo(format_report(report))
+    if not report.ok:
+        raise click.exceptions.Exit(1)
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_doctor.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full quality gate**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/ && uv run pytest tests/test_doctor.py tests/test_cli.py -v`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cw/doctor.py src/cw/cli.py tests/test_doctor.py
+git commit -m "feat(doctor): add --reap flag for explicit reconciliation"
+```
+
+---
+
+## Task 10: Backend-aware surface-launching message
+
+**Files:**
+- Modify: `src/cw/session.py:221`
+- Test: `tests/test_session.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_session.py`:
+
+```python
+def test_start_session_launch_message_names_backend(
+    tmp_config_dir,  # noqa: ANN001, ARG001
+    sample_client,  # noqa: ANN001
+    capsys,  # noqa: ANN001
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """The 'Launching X surfaces...' message names the backend in use."""
+    from cw.cmux import FakeCmuxAdapter
+    from cw.config import init_client
+    from cw.models import BackendName
+    from cw.session import start_session
+
+    init_client(
+        sample_client.name,
+        sample_client.workspace_path,
+        default_branch="main",
+    )
+    monkeypatch.setattr("cw.session._resolve_backend_name", lambda: BackendName.TMUX)
+
+    start_session(sample_client.name, "impl", adapter=FakeCmuxAdapter())
+    out = capsys.readouterr().out
+    assert "Launching tmux surfaces" in out
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `uv run pytest tests/test_session.py::test_start_session_launch_message_names_backend -v`
+Expected: FAIL — message is hardcoded to "cmux".
+
+- [ ] **Step 3: Make message backend-aware**
+
+Edit `src/cw/session.py`. Add import at the top:
+
+```python
+from cw.cmux import _resolve_backend_name
+```
+
+Replace line ~221:
+
+```python
+    click.echo(f"Launching cmux surfaces for {client_name}...")
+```
+
+with:
+
+```python
+    backend = _resolve_backend_name()
+    click.echo(f"Launching {backend.value} surfaces for {client_name}...")
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_session.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full quality gate**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/ && uv run pytest tests/ -v`
+Expected: all 541+ tests pass (existing) plus the new ones. Zero ruff/mypy issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cw/session.py tests/test_session.py
+git commit -m "feat(session): use backend-aware surface-launching message"
+```
+
+---
+
+## Task 11: End-to-end smoke test and CHANGELOG
+
+**Context:** Final sanity pass. Run the whole suite, exercise the new `cw doctor --reap` path manually against a fake backend, and document.
+
+**Files:**
+- Modify: `CHANGELOG.md` (if present; otherwise skip)
+- No new code — this task is all verification.
+
+- [ ] **Step 1: Run the full quality gate on the whole tree**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/ && uv run pytest tests/ -v --cov=cw`
+Expected: zero ruff violations, zero mypy errors, 100% pass rate. Coverage on `src/cw/reconcile.py` should be ≥95%.
+
+- [ ] **Step 2: Smoke the CLI with the fake backend**
+
+Run:
+
+```bash
+CW_BACKEND=fake uv run cw doctor --reap
+```
+
+Expected: output ends with `status: healthy`, a line `[OK] reconciliation — no phantoms` is present, exit code 0.
+
+- [ ] **Step 3: Update CHANGELOG.md**
+
+If `CHANGELOG.md` exists at the repo root, prepend a new section (check the existing format first and follow it exactly). Suggested content:
+
+```markdown
+## Unreleased
+
+### Added
+- Multiplexer/state reconciliation. Phantom sessions (tmux/cmux surfaces
+  that no longer exist) are detected and reaped automatically on `cw status`,
+  `cw list`, `cw start`, and at the top of each `dispatch_tick`. Explicit
+  reconciliation is available via `cw doctor --reap`.
+- `MultiplexerAdapter.list_surfaces()` on the adapter protocol; implemented
+  for tmux, cmux (macOS), and fake backends.
+
+### Changed
+- `start_session`'s "Launching ... surfaces" message now names the active
+  backend (tmux/cmux/fake).
+- Dev-queue `TicketTask`s associated with reaped DAEMON sessions revert
+  from RUNNING to PENDING so the dispatch loop retries them.
+```
+
+If no `CHANGELOG.md` exists, skip this step.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md  # only if step 3 made changes
+git commit -m "docs: note multiplexer state reconciliation in changelog" \
+    --allow-empty
+```
+
+Use `--allow-empty` only if step 3 was skipped so the pipeline still ends with a commit. Otherwise drop it.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- (1) Reconciliation primitive → Tasks 4-5 (`cw.reconcile` module with `compute_drift` + `reconcile`).
+- (2a) On-read reconciliation → Task 6 (`_check_and_mark_dead_sessions` replaces stub; wired into `_display_status` and `_display_sessions`) and Task 7 (`start_session`).
+- (2b) On-write reconciliation → Task 8 (`dispatch_tick`).
+- (2c) Explicit command → Task 9 (`cw doctor --reap`).
+- (3) State transition → phantoms flip to `COMPLETED` with `CompletionReason.CRASHED`; no new enum needed (CRASHED already exists).
+- (4) Dev-queue coupling policy → **revert RUNNING TicketTask to PENDING** so the dispatch loop retries. Task 5 implements; Task 8 verifies end-to-end.
+- (5) Backend-aware launch message → Task 10.
+
+**Non-goals honoured:**
+- No background daemon added.
+- Protocol extension is strictly additive (one new method, no renames, no removals). `CmuxAdapter` alias retained.
+
+**Placeholder scan:** no TBDs. Every code step ships concrete code.
+
+**Type consistency check:**
+- `ReconcileReport.phantom_session_ids: list[str]` (session IDs) — consumed by `cli._check_and_mark_dead_sessions` which translates IDs to names via `find_by_name_or_id`. Consistent.
+- `reconcile(adapter)` signature is stable across Tasks 5, 6, 7, 8, 9.
+- `list_surfaces() -> set[str]` signature matches between Protocol (Task 1), TmuxAdapter (Task 2), RealCmuxAdapter (Task 3), and FakeCmuxAdapter (Task 1).
+- `CompletionReason.CRASHED` already exists in `models.py` — no enum changes needed.

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -32,7 +32,6 @@ from cw.exceptions import CwError
 from cw.models import (
     ClientConfig,
     CompletionReason,
-    CwState,
     OrchestratorEventType,
     QueueItem,
     QueueItemStatus,
@@ -324,7 +323,7 @@ def _display_sessions() -> None:
     """Display all tracked sessions."""
     state = load_state()
 
-    dead = _check_and_mark_dead_sessions(state)
+    dead = _check_and_mark_dead_sessions()
     for name in dead:
         click.echo(f"Reaped phantom session: {name}")
     if dead:
@@ -353,7 +352,7 @@ def _display_sessions() -> None:
         click.echo(f"{s.client:<18} {s.purpose:<10} {s.status:<14} {s.id:<10} {since}")
 
 
-def _check_and_mark_dead_sessions(_state: CwState) -> list[str]:
+def _check_and_mark_dead_sessions() -> list[str]:
     """Reconcile state with the live multiplexer and return reaped session names.
 
     Cheap passive reconciliation: called from every read path (``cw status``,
@@ -385,7 +384,7 @@ def _display_status() -> None:
     state = load_state()
     clients = load_clients()
 
-    dead = _check_and_mark_dead_sessions(state)
+    dead = _check_and_mark_dead_sessions()
     for name in dead:
         click.echo(f"Reaped phantom session: {name}")
     if dead:

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -364,26 +364,17 @@ def _check_and_mark_dead_sessions() -> list[str]:
 
     Cheap passive reconciliation: called from every read path (``cw status``,
     ``cw list``, ``cw start``). The reconciler is idempotent and returns an
-    empty list when nothing changed. When the adapter cannot reach its
-    backend (empty live set from ``list_surfaces``), everything active with
-    a surface_ref gets flagged — that is the intended behaviour: we treat
-    "backend unreachable" as "nothing running".
+    empty list when nothing changed. :func:`cw.reconcile.reconcile` refuses
+    to mass-reap when the adapter reports an empty live set while active
+    sessions still have surface refs (backend-outage guard), so this helper
+    is safe to run on every read path.
     """
     try:
         adapter = get_cmux_adapter()
     except CwError:
         return []
     report = reconcile(adapter)
-    if not report.phantom_session_ids:
-        return []
-    # load_state() again after reconcile so we can name the reaped sessions.
-    reloaded = load_state()
-    names: list[str] = []
-    for sid in report.phantom_session_ids:
-        sess = reloaded.find_by_name_or_id(sid)
-        if sess is not None:
-            names.append(sess.name)
-    return names
+    return list(report.phantom_session_names)
 
 
 def _display_status() -> None:

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -36,7 +36,6 @@ from cw.models import (
     OrchestratorEventType,
     QueueItem,
     QueueItemStatus,
-    Session,
     SessionPurpose,
     SessionStatus,
     TaskSpec,
@@ -55,6 +54,7 @@ from cw.queue import (
     peek_next,
     remove_item,
 )
+from cw.reconcile import reconcile
 from cw.session import (
     background_all_sessions,
     background_session,
@@ -324,6 +324,12 @@ def _display_sessions() -> None:
     """Display all tracked sessions."""
     state = load_state()
 
+    dead = _check_and_mark_dead_sessions(state)
+    for name in dead:
+        click.echo(f"Reaped phantom session: {name}")
+    if dead:
+        state = load_state()
+
     if not state.sessions:
         click.echo("No sessions tracked.")
         return
@@ -347,13 +353,31 @@ def _display_sessions() -> None:
         click.echo(f"{s.client:<18} {s.purpose:<10} {s.status:<14} {s.id:<10} {since}")
 
 
-def _check_and_mark_dead_sessions(_state: CwState) -> list[Session]:
-    """Check active sessions for dead surfaces, mark them COMPLETED.
+def _check_and_mark_dead_sessions(_state: CwState) -> list[str]:
+    """Reconcile state with the live multiplexer and return reaped session names.
 
-    Currently a stub — cmux health check will be implemented in a follow-up
-    ticket once the cmux surface liveness API is determined.
+    Cheap passive reconciliation: called from every read path (``cw status``,
+    ``cw list``, ``cw start``). The reconciler is idempotent and returns an
+    empty list when nothing changed. When the adapter cannot reach its
+    backend (empty live set from ``list_surfaces``), everything active with
+    a surface_ref gets flagged — that is the intended behaviour: we treat
+    "backend unreachable" as "nothing running".
     """
-    return []
+    try:
+        adapter = get_cmux_adapter()
+    except CwError:
+        return []
+    report = reconcile(adapter)
+    if not report.phantom_session_ids:
+        return []
+    # load_state() again after reconcile so we can name the reaped sessions.
+    reloaded = load_state()
+    names: list[str] = []
+    for sid in report.phantom_session_ids:
+        sess = reloaded.find_by_name_or_id(sid)
+        if sess is not None:
+            names.append(sess.name)
+    return names
 
 
 def _display_status() -> None:
@@ -362,8 +386,11 @@ def _display_status() -> None:
     clients = load_clients()
 
     dead = _check_and_mark_dead_sessions(state)
-    for s in dead:
-        click.echo(f"Detected crashed session: {s.name} (crashed)")
+    for name in dead:
+        click.echo(f"Reaped phantom session: {name}")
+    if dead:
+        # State mutated, reload so active/backgrounded lists reflect truth.
+        state = load_state()
 
     active = state.active_sessions()
     idled = state.idled_sessions()

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -220,15 +220,22 @@ def config() -> None:
 
 
 @main.command()
+@click.option(
+    "--reap",
+    is_flag=True,
+    help="Also reconcile state with the live multiplexer and reap phantoms.",
+)
 @handle_errors
-def doctor() -> None:
+def doctor(reap: bool) -> None:
     """Run environment preflight checks and print a health report.
 
     Reports the resolved backend, backend binary/daemon availability,
     config file locations and validity, and state file parseability.
-    Exits non-zero if any check fails so CI pipelines can gate on it.
+    With ``--reap`` also reconciles cw's session state with the live
+    multiplexer, marking phantom sessions COMPLETED and reverting their
+    tickets to PENDING. Exits non-zero if any check fails.
     """
-    report = run_doctor()
+    report = run_doctor(reap=reap)
     click.echo(format_report(report))
     if not report.ok:
         raise click.exceptions.Exit(1)

--- a/src/cw/cmux.py
+++ b/src/cw/cmux.py
@@ -156,13 +156,31 @@ class RealCmuxAdapter:
         return self._call("system.identify", {})
 
     def list_surfaces(self) -> set[str]:
-        """Return the set of live surface refs from cmux.
+        """Return the set of live cmux surface IDs across all workspaces.
 
-        Stub implementation — full reconciliation query added in Task 3.
-        Returns empty set on any error so callers treat "server down" as
-        "no surfaces alive" rather than "all surfaces still alive".
+        Returns an empty set if the cmux socket is unreachable — the
+        reconciler uses that as a "can't tell" signal and leaves state
+        untouched (see :mod:`cw.reconcile`).
         """
-        return set()
+        try:
+            workspaces_raw = self._call("workspace.list", {})
+        except CwError:
+            return set()
+        workspaces: list[dict[str, Any]] = workspaces_raw.get("workspaces", [])
+        live: set[str] = set()
+        for ws in workspaces:
+            ws_id = ws.get("id")
+            if not ws_id:
+                continue
+            try:
+                resp = self._call("surface.list", {"workspace_id": ws_id})
+            except CwError:
+                continue
+            for surf in resp.get("surfaces", []):
+                surf_id = surf.get("id")
+                if surf_id:
+                    live.add(surf_id)
+        return live
 
 
 class FakeCmuxAdapter:

--- a/src/cw/cmux.py
+++ b/src/cw/cmux.py
@@ -97,22 +97,35 @@ class RealCmuxAdapter:
         self._counter: int = 0
 
     def _call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
-        """Send a JSON-RPC request and return the result dict."""
+        """Send a JSON-RPC request and return the result dict.
+
+        All failure modes — socket unreachable, short read, malformed JSON,
+        daemon-reported error — are normalised to ``CwError`` so callers can
+        rely on a single exception type.
+        """
         self._counter += 1
         req = json.dumps({"id": self._counter, "method": method, "params": params})
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
-            sock.connect(str(self._socket_path))
-            sock.sendall((req + "\n").encode())
-            response = b""
-            while not response.endswith(b"\n"):
-                chunk = sock.recv(4096)
-                if not chunk:
-                    break
-                response += chunk
+            try:
+                sock.connect(str(self._socket_path))
+                sock.sendall((req + "\n").encode())
+                response = b""
+                while not response.endswith(b"\n"):
+                    chunk = sock.recv(4096)
+                    if not chunk:
+                        break
+                    response += chunk
+            except OSError as exc:
+                msg = f"cmux socket error at {self._socket_path}: {exc}"
+                raise CwError(msg) from exc
         finally:
             sock.close()
-        raw: dict[str, Any] = json.loads(response.decode().strip())
+        try:
+            raw: dict[str, Any] = json.loads(response.decode().strip())
+        except json.JSONDecodeError as exc:
+            msg = f"cmux returned malformed JSON: {exc}"
+            raise CwError(msg) from exc
         if not raw.get("ok", True):
             err: dict[str, Any] = raw.get("error", {})
             msg = f"cmux error {err.get('code', 'unknown')}: {err.get('message', '')}"

--- a/src/cw/cmux.py
+++ b/src/cw/cmux.py
@@ -158,7 +158,7 @@ class RealCmuxAdapter:
     def list_surfaces(self) -> set[str]:
         """Return the set of live surface refs from cmux.
 
-        Stub implementation — full reconciliation query added in Task 2.
+        Stub implementation — full reconciliation query added in Task 3.
         Returns empty set on any error so callers treat "server down" as
         "no surfaces alive" rather than "all surfaces still alive".
         """
@@ -174,6 +174,7 @@ class FakeCmuxAdapter:
             "spawn": [],
             "close": [],
             "identify": [],
+            "list_surfaces": [],
         }
         self._live: set[str] = set()
 
@@ -202,7 +203,7 @@ class FakeCmuxAdapter:
 
     def list_surfaces(self) -> set[str]:
         """Return the current in-memory live-surface set (copy)."""
-        self.calls.setdefault("list_surfaces", []).append(())
+        self.calls["list_surfaces"].append(())
         return set(self._live)
 
 

--- a/src/cw/cmux.py
+++ b/src/cw/cmux.py
@@ -66,6 +66,17 @@ class MultiplexerAdapter(Protocol):
         """Return current focus context."""
         ...
 
+    def list_surfaces(self) -> set[str]:
+        """Return the set of surface refs currently known to the backend.
+
+        Used by reconciliation to detect phantom sessions: any surface_ref
+        in cw state that is *not* in this set is assumed dead. Implementers
+        should return an empty set if the multiplexer server is unreachable,
+        so callers cannot accidentally interpret "server down" as "all
+        surfaces still alive".
+        """
+        ...
+
 
 # Legacy alias. Keep for one release so downstream type hints that read
 # `from cw.cmux import CmuxAdapter` don't break mid-upgrade.
@@ -144,6 +155,15 @@ class RealCmuxAdapter:
         """Return current focus context from system.identify."""
         return self._call("system.identify", {})
 
+    def list_surfaces(self) -> set[str]:
+        """Return the set of live surface refs from cmux.
+
+        Stub implementation — full reconciliation query added in Task 2.
+        Returns empty set on any error so callers treat "server down" as
+        "no surfaces alive" rather than "all surfaces still alive".
+        """
+        return set()
+
 
 class FakeCmuxAdapter:
     """In-memory adapter for testing. Records all calls; no real I/O."""
@@ -155,17 +175,20 @@ class FakeCmuxAdapter:
             "close": [],
             "identify": [],
         }
+        self._live: set[str] = set()
 
     def spawn(self, workspace: str, command: str, surface: str = "right") -> str:
         """Record call and return a deterministic fake surface ref."""
         self._counter += 1
         ref = f"fake-pane-{self._counter}"
         self.calls["spawn"].append((workspace, command, surface))
+        self._live.add(ref)
         return ref
 
     def close(self, surface_ref: str) -> None:
-        """Record call."""
+        """Record call and drop from live set (idempotent)."""
         self.calls["close"].append((surface_ref,))
+        self._live.discard(surface_ref)
 
     def identify(self) -> dict[str, Any]:
         """Record call and return stub focus context."""
@@ -176,6 +199,11 @@ class FakeCmuxAdapter:
                 "surface_id": "fake-pane-1",
             }
         }
+
+    def list_surfaces(self) -> set[str]:
+        """Return the current in-memory live-surface set (copy)."""
+        self.calls.setdefault("list_surfaces", []).append(())
+        return set(self._live)
 
 
 def _resolve_backend_name() -> BackendName:

--- a/src/cw/cmux.py
+++ b/src/cw/cmux.py
@@ -70,10 +70,13 @@ class MultiplexerAdapter(Protocol):
         """Return the set of surface refs currently known to the backend.
 
         Used by reconciliation to detect phantom sessions: any surface_ref
-        in cw state that is *not* in this set is assumed dead. Implementers
-        should return an empty set if the multiplexer server is unreachable,
-        so callers cannot accidentally interpret "server down" as "all
-        surfaces still alive".
+        in cw state that is *not* in this set is assumed dead. The contract
+        is all-or-nothing — return a complete live set, or an empty set
+        if the backend is unreachable or only partially enumerable.
+        Partial results would cause selective false-positive reaping, so
+        implementers must not return a subset. ``cw.reconcile`` treats an
+        empty result as "possibly unreachable" and refuses to touch state
+        when any known session still has a surface_ref.
         """
         ...
 
@@ -171,28 +174,27 @@ class RealCmuxAdapter:
     def list_surfaces(self) -> set[str]:
         """Return the set of live cmux surface IDs across all workspaces.
 
-        Returns an empty set if the cmux socket is unreachable — the
-        reconciler uses that as a "can't tell" signal and leaves state
-        untouched (see :mod:`cw.reconcile`).
+        Returns an empty set on any enumeration failure (socket down,
+        ``workspace.list`` errors, or any ``surface.list`` call fails).
+        Partial results would let the reconciler falsely flag surfaces
+        from the failing workspace as phantom while preserving the rest,
+        so the adapter gives an all-or-nothing answer.
         """
         try:
             workspaces_raw = self._call("workspace.list", {})
+            workspaces: list[dict[str, Any]] = workspaces_raw.get("workspaces", [])
+            live: set[str] = set()
+            for ws in workspaces:
+                ws_id = ws.get("id")
+                if not ws_id:
+                    continue
+                resp = self._call("surface.list", {"workspace_id": ws_id})
+                for surf in resp.get("surfaces", []):
+                    surf_id = surf.get("id")
+                    if surf_id:
+                        live.add(surf_id)
         except CwError:
             return set()
-        workspaces: list[dict[str, Any]] = workspaces_raw.get("workspaces", [])
-        live: set[str] = set()
-        for ws in workspaces:
-            ws_id = ws.get("id")
-            if not ws_id:
-                continue
-            try:
-                resp = self._call("surface.list", {"workspace_id": ws_id})
-            except CwError:
-                continue
-            for surf in resp.get("surfaces", []):
-                surf_id = surf.get("id")
-                if surf_id:
-                    live.add(surf_id)
         return live
 
 

--- a/src/cw/dev_queue.py
+++ b/src/cw/dev_queue.py
@@ -12,7 +12,9 @@ from cw.config import (
     dev_plan_file,
     dev_plan_lock,
     dev_queue_file,
-    dev_queue_lock,
+)
+from cw.config import (
+    dev_queue_lock as _dev_queue_lock_file,
 )
 from cw.exceptions import CwError
 from cw.models import DevQueueStore, DispatchPlan, OrchestratorConfig, TicketTask
@@ -26,13 +28,19 @@ if TYPE_CHECKING:
 def _lock() -> Iterator[None]:
     """Acquire an exclusive file lock for the dev queue."""
     dev_queue_file().parent.mkdir(parents=True, exist_ok=True)
-    fd = dev_queue_lock().open("w")
+    fd = _dev_queue_lock_file().open("w")
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
         yield
     finally:
         fcntl.flock(fd, fcntl.LOCK_UN)
         fd.close()
+
+
+# Public alias for callers that need the dev-queue lock directly (e.g. the
+# reconciler, which needs load → mutate → save around a RUNNING→PENDING
+# revert). Prefer higher-level helpers like ``add_ticket`` when available.
+dev_queue_lock = _lock
 
 
 @contextlib.contextmanager

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from cw.cmux import get_cmux_adapter
 from cw.config import load_clients, load_orchestrator_config, load_state
-from cw.dev_queue import _lock, load_dev_queue, load_plan, save_dev_queue
+from cw.dev_queue import dev_queue_lock, load_dev_queue, load_plan, save_dev_queue
 from cw.events import advance_cursor, read_events, record_event
 from cw.models import (
     OrchestratorEventType,
@@ -44,7 +44,7 @@ def _claim_next_pending(
     parameter is intentionally a *preference*, not a filter — see the
     fallback after the priority loop).
     """
-    with _lock():
+    with dev_queue_lock():
         store = load_dev_queue()
         if priority_ticket_ids:
             for ticket_id in priority_ticket_ids:
@@ -170,7 +170,7 @@ def consume_completed_sessions() -> int:
         return 0
 
     completed = 0
-    with _lock():
+    with dev_queue_lock():
         store = load_dev_queue()
         for event in events:
             ticket_id = event.payload.get("ticket_id")

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -15,6 +15,7 @@ from cw.models import (
     SessionOrigin,
     SessionStatus,
 )
+from cw.reconcile import reconcile
 from cw.spawn import spawn_create_impl
 from cw.worktree import worktree_path_for
 
@@ -81,6 +82,7 @@ def dispatch_tick(
         Number of sessions spawned during this tick.
     """
     resolved_adapter = adapter or get_cmux_adapter()
+    reconcile(resolved_adapter)
     clients = load_clients()
     state = load_state()
     spawned = 0

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import TYPE_CHECKING
 
@@ -15,7 +16,7 @@ from cw.models import (
     SessionOrigin,
     SessionStatus,
 )
-from cw.reconcile import reconcile
+from cw.reconcile import AUTO_DEV_LABEL_PREFIX, reconcile
 from cw.spawn import spawn_create_impl
 from cw.worktree import worktree_path_for
 
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
     from cw.models import OrchestratorConfig, TicketTask
 
 _DISPATCH_CONSUMER = "dispatch"
+_log = logging.getLogger(__name__)
 
 
 def _claim_next_pending(
@@ -82,7 +84,10 @@ def dispatch_tick(
         Number of sessions spawned during this tick.
     """
     resolved_adapter = adapter or get_cmux_adapter()
-    reconcile(resolved_adapter)
+    try:
+        reconcile(resolved_adapter)
+    except Exception:
+        _log.exception("reconcile failed during dispatch_tick; continuing")
     clients = load_clients()
     state = load_state()
     spawned = 0
@@ -117,14 +122,14 @@ def dispatch_tick(
             if task is None:
                 break
 
-            branch = f"auto-dev/{task.ticket_id}"
+            branch = f"{AUTO_DEV_LABEL_PREFIX}{task.ticket_id}"
             worktree_path = worktree_path_for(client, branch)
             worktree_path.mkdir(parents=True, exist_ok=True)
 
             prompt_path = worktree_path / ".cw-prompt.txt"
             prompt_path.write_text(f"/auto-dev {task.ticket_id}")
 
-            label = f"auto-dev/{task.ticket_id}"
+            label = f"{AUTO_DEV_LABEL_PREFIX}{task.ticket_id}"
             session_id = spawn_create_impl(
                 client=client,
                 worktree=worktree_path,

--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -26,6 +26,7 @@ from cw.config import (
     state_file,
 )
 from cw.dev_queue import load_dev_queue
+from cw.exceptions import CwError
 from cw.models import BackendName
 from cw.reconcile import reconcile
 
@@ -136,13 +137,20 @@ def _check_reconcile() -> CheckResult:
     """Run reconciliation and describe the outcome as a check result."""
     try:
         adapter = get_cmux_adapter()
-    except Exception as exc:
+    except CwError as exc:
         return CheckResult(
             "reconciliation",
             ok=False,
             detail=f"adapter unavailable: {exc}",
         )
-    reconcile_report = reconcile(adapter)
+    try:
+        reconcile_report = reconcile(adapter)
+    except CwError as exc:
+        return CheckResult(
+            "reconciliation",
+            ok=False,
+            detail=f"reconcile failed: {exc}",
+        )
     reaped = len(reconcile_report.phantom_session_ids)
     reverted = len(reconcile_report.reverted_ticket_ids)
     if reaped == 0 and reverted == 0:

--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from cw import __version__
-from cw.cmux import _resolve_backend_name
+from cw.cmux import _resolve_backend_name, get_cmux_adapter
 from cw.config import (
     clients_file,
     load_clients,
@@ -27,6 +27,7 @@ from cw.config import (
 )
 from cw.dev_queue import load_dev_queue
 from cw.models import BackendName
+from cw.reconcile import reconcile
 
 
 @dataclass(frozen=True)
@@ -131,8 +132,38 @@ def _check_dev_queue() -> CheckResult:
     return CheckResult("dev_queue.json", ok=True, detail="parseable")
 
 
-def run_doctor() -> DoctorReport:
-    """Run every preflight check and return a populated report."""
+def _check_reconcile() -> CheckResult:
+    """Run reconciliation and describe the outcome as a check result."""
+    try:
+        adapter = get_cmux_adapter()
+    except Exception as exc:
+        return CheckResult(
+            "reconciliation",
+            ok=False,
+            detail=f"adapter unavailable: {exc}",
+        )
+    reconcile_report = reconcile(adapter)
+    reaped = len(reconcile_report.phantom_session_ids)
+    reverted = len(reconcile_report.reverted_ticket_ids)
+    if reaped == 0 and reverted == 0:
+        return CheckResult("reconciliation", ok=True, detail="no phantoms")
+    return CheckResult(
+        "reconciliation",
+        ok=True,
+        detail=(
+            f"reaped {reaped} session(s), reverted {reverted} ticket(s); "
+            f"ids: {reconcile_report.phantom_session_ids}"
+        ),
+    )
+
+
+def run_doctor(*, reap: bool = False) -> DoctorReport:
+    """Run every preflight check and return a populated report.
+
+    When *reap* is True, also run multiplexer/state reconciliation and
+    append a ``reconciliation`` check summarising the number of reaped
+    sessions and reverted tickets.
+    """
     backend = _resolve_backend_name()
     report = DoctorReport(version=__version__, backend=backend)
     report.checks.append(CheckResult("resolved backend", ok=True, detail=backend.value))
@@ -141,6 +172,8 @@ def run_doctor() -> DoctorReport:
     report.checks.append(_check_orchestrator_config())
     report.checks.append(_check_state_file())
     report.checks.append(_check_dev_queue())
+    if reap:
+        report.checks.append(_check_reconcile())
     return report
 
 

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -1,0 +1,71 @@
+"""Reconcile cw session state with live multiplexer surfaces.
+
+The authoritative view of what is running lives in the multiplexer
+(tmux/cmux/fake). :func:`compute_drift` compares ``sessions.json`` against
+that view and returns a :class:`ReconcileReport` naming the sessions that
+have gone phantom — active/idle rows whose ``surface_ref`` no longer maps
+to any live surface. :func:`reconcile` (Task 5) applies the report under
+the state lock.
+
+The split is deliberate: ``compute_drift`` is pure and testable in
+isolation; ``reconcile`` does the side-effecting work (state mutation,
+event emission, dev-queue revert).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from cw.models import SessionStatus
+
+if TYPE_CHECKING:
+    from cw.cmux import MultiplexerAdapter
+    from cw.models import CwState
+
+
+# Only these two statuses imply "the multiplexer should have a surface".
+# BACKGROUNDED sessions intentionally have no pane (that's the whole point);
+# COMPLETED is terminal. Both are ignored by reconciliation.
+_LIVE_STATUSES: frozenset[SessionStatus] = frozenset(
+    {
+        SessionStatus.ACTIVE,
+        SessionStatus.IDLE,
+    }
+)
+
+
+@dataclass(frozen=True)
+class ReconcileReport:
+    """What reconciliation would do / did.
+
+    ``phantom_session_ids`` — sessions whose ``surface_ref`` is not in the
+    live set. Ordered by the original order in ``state.sessions``.
+    ``reverted_ticket_ids`` — ticket IDs whose TicketTasks got reverted
+    from RUNNING to PENDING. Populated by :func:`reconcile`, empty after
+    :func:`compute_drift`.
+    """
+
+    phantom_session_ids: list[str] = field(default_factory=list)
+    reverted_ticket_ids: list[str] = field(default_factory=list)
+
+
+def compute_drift(state: CwState, adapter: MultiplexerAdapter) -> ReconcileReport:
+    """Return a report naming sessions whose surface is no longer live.
+
+    An ACTIVE or IDLE session is phantom when:
+    - it has a ``surface_ref`` (None means it was never spawned), AND
+    - that ref is not in ``adapter.list_surfaces()``.
+
+    This function does not mutate state.
+    """
+    live = adapter.list_surfaces()
+    phantoms: list[str] = []
+    for session in state.sessions:
+        if session.status not in _LIVE_STATUSES:
+            continue
+        if session.surface_ref is None:
+            continue
+        if session.surface_ref not in live:
+            phantoms.append(session.id)
+    return ReconcileReport(phantom_session_ids=phantoms)

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -15,9 +15,20 @@ event emission, dev-queue revert).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from cw.models import SessionStatus
+from cw.config import load_state, save_state
+from cw.dev_queue import _lock as _dev_queue_lock
+from cw.dev_queue import load_dev_queue, save_dev_queue
+from cw.events import record_event
+from cw.models import (
+    CompletionReason,
+    OrchestratorEventType,
+    QueueItemStatus,
+    SessionOrigin,
+    SessionStatus,
+)
 
 if TYPE_CHECKING:
     from cw.cmux import MultiplexerAdapter
@@ -69,3 +80,76 @@ def compute_drift(state: CwState, adapter: MultiplexerAdapter) -> ReconcileRepor
         if session.surface_ref not in live:
             phantoms.append(session.id)
     return ReconcileReport(phantom_session_ids=phantoms)
+
+
+# Daemon session names follow "client/auto-dev/<ticket-id>" (see
+# src/cw/dispatch.py::dispatch_tick where the label is constructed).
+_AUTO_DEV_LABEL_PREFIX = "auto-dev/"
+
+
+def _ticket_id_for_session(session_name: str) -> str | None:
+    """Extract the ticket id from a daemon session name, or None."""
+    _, _, tail = session_name.partition("/")
+    if tail.startswith(_AUTO_DEV_LABEL_PREFIX):
+        return tail[len(_AUTO_DEV_LABEL_PREFIX) :]
+    return None
+
+
+def reconcile(adapter: MultiplexerAdapter) -> ReconcileReport:
+    """Apply drift reconciliation against the persisted state.
+
+    Flips phantom ACTIVE/IDLE sessions to COMPLETED with
+    ``completed_reason = CRASHED``, emits a ``SESSION_COMPLETED`` event
+    with ``crashed: True``, and reverts any RUNNING TicketTask whose
+    ticket-id can be recovered from the session name back to PENDING so
+    the dispatch loop will retry.
+    """
+    state = load_state()
+    drift = compute_drift(state, adapter)
+    if not drift.phantom_session_ids:
+        return drift
+
+    phantom_set = set(drift.phantom_session_ids)
+    now = datetime.now(UTC)
+
+    ticket_ids_to_revert: list[str] = []
+    for session in state.sessions:
+        if session.id not in phantom_set:
+            continue
+        session.status = SessionStatus.COMPLETED
+        session.completed_reason = CompletionReason.CRASHED
+        session.completed_at = now
+        if session.origin is SessionOrigin.DAEMON:
+            ticket_id = _ticket_id_for_session(session.name)
+            if ticket_id:
+                ticket_ids_to_revert.append(ticket_id)
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {
+                "session_id": session.id,
+                "session_name": session.name,
+                "client": session.client,
+                "crashed": True,
+            },
+        )
+
+    save_state(state)
+
+    reverted: list[str] = []
+    if ticket_ids_to_revert:
+        with _dev_queue_lock():
+            store = load_dev_queue()
+            for task in store.tasks:
+                if (
+                    task.ticket_id in ticket_ids_to_revert
+                    and task.status == QueueItemStatus.RUNNING
+                ):
+                    task.status = QueueItemStatus.PENDING
+                    reverted.append(task.ticket_id)
+            if reverted:
+                save_dev_queue(store)
+
+    return ReconcileReport(
+        phantom_session_ids=drift.phantom_session_ids,
+        reverted_ticket_ids=reverted,
+    )

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -4,12 +4,26 @@ The authoritative view of what is running lives in the multiplexer
 (tmux/cmux/fake). :func:`compute_drift` compares ``sessions.json`` against
 that view and returns a :class:`ReconcileReport` naming the sessions that
 have gone phantom — active/idle rows whose ``surface_ref`` no longer maps
-to any live surface. :func:`reconcile` (Task 5) applies the report under
-the state lock.
+to any live surface. :func:`reconcile` applies the report.
 
 The split is deliberate: ``compute_drift`` is pure and testable in
 isolation; ``reconcile`` does the side-effecting work (state mutation,
 event emission, dev-queue revert).
+
+Transient-outage safety: ``reconcile`` refuses to mutate state when the
+adapter reports *zero* live surfaces but the persisted state still
+contains ACTIVE/IDLE sessions with surface refs. A temporary multiplexer
+hiccup would otherwise irreversibly mark every session as CRASHED.
+``compute_drift`` stays pure and does not apply this guard — callers that
+want drift-without-side-effects still get the full phantom list.
+
+Race note: ``reconcile`` does ``load_state → mutate → save_state`` without
+a dedicated ``sessions.json`` file lock. This matches every other
+``save_state`` call site in the codebase (``cw.session``, ``cw.cli``, …);
+a unified state lock is a larger refactor tracked separately. In
+practice the race window is the in-memory mutation between load and save,
+and concurrent writers are rare in the single-user model this tool
+targets.
 """
 
 from __future__ import annotations
@@ -34,6 +48,14 @@ if TYPE_CHECKING:
     from cw.models import CwState
 
 
+# Session-name prefix for DAEMON sessions spawned by the dispatch loop. The
+# full name is ``<client>/<AUTO_DEV_LABEL_PREFIX><ticket_id>``; reconciliation
+# uses it to recover the ticket id when reverting phantom tickets. Defined
+# here (not in ``cw.dispatch``) to avoid a circular import — ``cw.dispatch``
+# imports :func:`reconcile` from this module.
+AUTO_DEV_LABEL_PREFIX = "auto-dev/"
+
+
 # Only these two statuses imply "the multiplexer should have a surface".
 # BACKGROUNDED sessions intentionally have no pane (that's the whole point);
 # COMPLETED is terminal. Both are ignored by reconciliation.
@@ -51,12 +73,16 @@ class ReconcileReport:
 
     ``phantom_session_ids`` — sessions whose ``surface_ref`` is not in the
     live set. Ordered by the original order in ``state.sessions``.
+    ``phantom_session_names`` — session names in the same order as
+    ``phantom_session_ids``. Populated by :func:`reconcile`; empty after
+    :func:`compute_drift`.
     ``reverted_ticket_ids`` — ticket IDs whose TicketTasks got reverted
-    from RUNNING to PENDING. Populated by :func:`reconcile`, empty after
+    from RUNNING to PENDING. Populated by :func:`reconcile`; empty after
     :func:`compute_drift`.
     """
 
     phantom_session_ids: list[str] = field(default_factory=list)
+    phantom_session_names: list[str] = field(default_factory=list)
     reverted_ticket_ids: list[str] = field(default_factory=list)
 
 
@@ -67,7 +93,9 @@ def compute_drift(state: CwState, adapter: MultiplexerAdapter) -> ReconcileRepor
     - it has a ``surface_ref`` (None means it was never spawned), AND
     - that ref is not in ``adapter.list_surfaces()``.
 
-    This function does not mutate state.
+    This function does not mutate state. It also does not distinguish
+    "backend reports zero live surfaces" from "backend is unreachable";
+    that guard lives in :func:`reconcile`.
     """
     live = adapter.list_surfaces()
     phantoms: list[str] = []
@@ -81,17 +109,28 @@ def compute_drift(state: CwState, adapter: MultiplexerAdapter) -> ReconcileRepor
     return ReconcileReport(phantom_session_ids=phantoms)
 
 
-# Daemon session names follow "client/auto-dev/<ticket-id>" (see
-# src/cw/dispatch.py::dispatch_tick where the label is constructed).
-_AUTO_DEV_LABEL_PREFIX = "auto-dev/"
-
-
 def _ticket_id_for_session(session_name: str) -> str | None:
     """Extract the ticket id from a daemon session name, or None."""
     _, _, tail = session_name.partition("/")
-    if tail.startswith(_AUTO_DEV_LABEL_PREFIX):
-        return tail[len(_AUTO_DEV_LABEL_PREFIX) :]
+    if tail.startswith(AUTO_DEV_LABEL_PREFIX):
+        return tail[len(AUTO_DEV_LABEL_PREFIX) :]
     return None
+
+
+def _looks_like_backend_outage(state: CwState, live: set[str]) -> bool:
+    """True when the empty ``live`` set is almost certainly a backend outage.
+
+    If the adapter returned an empty set *and* the persisted state has at
+    least one ACTIVE/IDLE session that was once given a surface_ref, we
+    assume the multiplexer is unreachable rather than "somehow every
+    session died at once". Aborting here is the difference between a
+    5-second cmux restart and permanent data loss.
+    """
+    if live:
+        return False
+    return any(
+        s.surface_ref is not None and s.status in _LIVE_STATUSES for s in state.sessions
+    )
 
 
 def reconcile(adapter: MultiplexerAdapter) -> ReconcileReport:
@@ -103,6 +142,10 @@ def reconcile(adapter: MultiplexerAdapter) -> ReconcileReport:
     ticket-id can be recovered from the session name back to PENDING so
     the dispatch loop will retry.
 
+    Returns an empty report without mutating state when
+    :func:`_looks_like_backend_outage` matches — a transient multiplexer
+    restart must not trigger mass-reaping.
+
     Partial-failure note: state and the dev queue are separate files. If
     ``save_state`` succeeds but the subsequent dev-queue update raises,
     the session will be COMPLETED while its TicketTask stays RUNNING.
@@ -112,6 +155,10 @@ def reconcile(adapter: MultiplexerAdapter) -> ReconcileReport:
     tradeoff for a file-based, single-user tool.
     """
     state = load_state()
+    live = adapter.list_surfaces()
+    if _looks_like_backend_outage(state, live):
+        return ReconcileReport()
+
     drift = compute_drift(state, adapter)
     if not drift.phantom_session_ids:
         return drift
@@ -121,12 +168,14 @@ def reconcile(adapter: MultiplexerAdapter) -> ReconcileReport:
 
     ticket_ids_to_revert: list[str] = []
     pending_events: list[dict[str, object]] = []
+    phantom_names: list[str] = []
     for session in state.sessions:
         if session.id not in phantom_set:
             continue
         session.status = SessionStatus.COMPLETED
         session.completed_reason = CompletionReason.CRASHED
         session.completed_at = now
+        phantom_names.append(session.name)
         if session.origin is SessionOrigin.DAEMON:
             ticket_id = _ticket_id_for_session(session.name)
             if ticket_id:
@@ -160,5 +209,6 @@ def reconcile(adapter: MultiplexerAdapter) -> ReconcileReport:
 
     return ReconcileReport(
         phantom_session_ids=drift.phantom_session_ids,
+        phantom_session_names=phantom_names,
         reverted_ticket_ids=reverted,
     )

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -19,8 +19,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from cw.config import load_state, save_state
-from cw.dev_queue import _lock as _dev_queue_lock
-from cw.dev_queue import load_dev_queue, save_dev_queue
+from cw.dev_queue import dev_queue_lock, load_dev_queue, save_dev_queue
 from cw.events import record_event
 from cw.models import (
     CompletionReason,
@@ -103,6 +102,14 @@ def reconcile(adapter: MultiplexerAdapter) -> ReconcileReport:
     with ``crashed: True``, and reverts any RUNNING TicketTask whose
     ticket-id can be recovered from the session name back to PENDING so
     the dispatch loop will retry.
+
+    Partial-failure note: state and the dev queue are separate files. If
+    ``save_state`` succeeds but the subsequent dev-queue update raises,
+    the session will be COMPLETED while its TicketTask stays RUNNING.
+    The next ``reconcile()`` call will not pick this up because the
+    session is no longer ACTIVE/IDLE — so a stranded RUNNING task can
+    only be recovered by explicit operator action. This is an acceptable
+    tradeoff for a file-based, single-user tool.
     """
     state = load_state()
     drift = compute_drift(state, adapter)
@@ -113,6 +120,7 @@ def reconcile(adapter: MultiplexerAdapter) -> ReconcileReport:
     now = datetime.now(UTC)
 
     ticket_ids_to_revert: list[str] = []
+    pending_events: list[dict[str, object]] = []
     for session in state.sessions:
         if session.id not in phantom_set:
             continue
@@ -123,21 +131,22 @@ def reconcile(adapter: MultiplexerAdapter) -> ReconcileReport:
             ticket_id = _ticket_id_for_session(session.name)
             if ticket_id:
                 ticket_ids_to_revert.append(ticket_id)
-        record_event(
-            OrchestratorEventType.SESSION_COMPLETED,
+        pending_events.append(
             {
                 "session_id": session.id,
                 "session_name": session.name,
                 "client": session.client,
                 "crashed": True,
-            },
+            }
         )
 
     save_state(state)
+    for payload in pending_events:
+        record_event(OrchestratorEventType.SESSION_COMPLETED, payload)
 
     reverted: list[str] = []
     if ticket_ids_to_revert:
-        with _dev_queue_lock():
+        with dev_queue_lock():
             store = load_dev_queue()
             for task in store.tasks:
                 if (

--- a/src/cw/session.py
+++ b/src/cw/session.py
@@ -26,6 +26,7 @@ from cw.models import (
     SessionStatus,
 )
 from cw.prompts import build_session_context, get_purpose_prompt
+from cw.reconcile import reconcile
 from cw.worktree import create_worktree, remove_worktree
 
 # Purposes that receive worktree cwd (impl works on the feature branch,
@@ -170,6 +171,10 @@ def start_session(
         adapter = get_cmux_adapter()
 
     client = get_client(client_name)
+    state = load_state()
+
+    # Reap phantom sessions so we don't short-circuit on a dead "active" row.
+    reconcile(adapter)
     state = load_state()
 
     # Auto-resolve worktree for worktree-mode clients

--- a/src/cw/session.py
+++ b/src/cw/session.py
@@ -13,7 +13,7 @@ import click
 if TYPE_CHECKING:
     from pathlib import Path
 
-from cw.cmux import CmuxAdapter, get_cmux_adapter
+from cw.cmux import CmuxAdapter, _resolve_backend_name, get_cmux_adapter
 from cw.config import get_client, load_state, save_state
 from cw.exceptions import CwError
 from cw.handoff import extract_resumption_prompt, find_latest_handoff
@@ -222,8 +222,9 @@ def start_session(
     for s in all_sessions.values():
         click.echo(f"  {s.name}")
 
-    # Spawn cmux surfaces for all purposes
-    click.echo(f"Launching cmux surfaces for {client_name}...")
+    # Spawn surfaces for all purposes
+    backend = _resolve_backend_name()
+    click.echo(f"Launching {backend.value} surfaces for {client_name}...")
     for purpose_str, session in all_sessions.items():
         pane_cmd = panes[purpose_str]["claude_cmd"]
         _spawn_session_surface(client, session, pane_cmd, adapter)

--- a/src/cw/tmux.py
+++ b/src/cw/tmux.py
@@ -110,10 +110,15 @@ class TmuxAdapter:
         return parsed
 
     def list_surfaces(self) -> set[str]:
-        """Return the set of live pane refs from tmux.
+        """Return the set of live tmux pane refs across all sessions.
 
-        Stub implementation — full reconciliation query added in Task 2.
-        Returns empty set on any error so callers treat "tmux unreachable"
-        as "no surfaces alive" rather than "all surfaces still alive".
+        Empty set when the tmux server is not running — callers in
+        reconciliation rely on this invariant to avoid false positives.
         """
-        return set()
+        result = self._run(
+            ["list-panes", "-a", "-F", _PANE_FORMAT],
+            check=False,
+        )
+        if result.returncode != 0 or not result.stdout:
+            return set()
+        return {line for line in result.stdout.strip().splitlines() if line}

--- a/src/cw/tmux.py
+++ b/src/cw/tmux.py
@@ -108,3 +108,12 @@ class TmuxAdapter:
         except json.JSONDecodeError:
             return {"focused": {}}
         return parsed
+
+    def list_surfaces(self) -> set[str]:
+        """Return the set of live pane refs from tmux.
+
+        Stub implementation — full reconciliation query added in Task 3.
+        Returns empty set on any error so callers treat "tmux unreachable"
+        as "no surfaces alive" rather than "all surfaces still alive".
+        """
+        return set()

--- a/src/cw/tmux.py
+++ b/src/cw/tmux.py
@@ -112,7 +112,7 @@ class TmuxAdapter:
     def list_surfaces(self) -> set[str]:
         """Return the set of live pane refs from tmux.
 
-        Stub implementation — full reconciliation query added in Task 3.
+        Stub implementation — full reconciliation query added in Task 2.
         Returns empty set on any error so callers treat "tmux unreachable"
         as "no surfaces alive" rather than "all surfaces still alive".
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -397,7 +397,14 @@ class TestShowStatus:
         """_check_and_mark_dead_sessions reaps sessions whose surface is gone."""
         from cw.cmux import FakeCmuxAdapter
 
-        monkeypatch.setattr("cw.cli.get_cmux_adapter", FakeCmuxAdapter)
+        def _adapter_with_decoy() -> FakeCmuxAdapter:
+            # Non-empty live set prevents reconcile's outage guard from
+            # refusing to mutate state (see cw.reconcile._looks_like_backend_outage).
+            a = FakeCmuxAdapter()
+            a.spawn("decoy-ws", "echo")
+            return a
+
+        monkeypatch.setattr("cw.cli.get_cmux_adapter", _adapter_with_decoy)
         clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
         clients_file.write_text(
             f"clients:\n"
@@ -789,8 +796,14 @@ def test_display_status_reconciles_phantom_active_sessions(
         )
     )
 
-    # Force cli.py to use a fresh FakeCmuxAdapter so list_surfaces is empty.
-    monkeypatch.setattr("cw.cli.get_cmux_adapter", FakeCmuxAdapter)
+    # Non-empty live set prevents the outage guard from aborting reconcile;
+    # the "gone" surface_ref still isn't in the set so phantom1 is reaped.
+    def _adapter_with_decoy() -> FakeCmuxAdapter:
+        a = FakeCmuxAdapter()
+        a.spawn("decoy-ws", "echo")
+        return a
+
+    monkeypatch.setattr("cw.cli.get_cmux_adapter", _adapter_with_decoy)
 
     runner = CliRunner()
     result = runner.invoke(main, ["status"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -363,9 +363,12 @@ class TestShowStatus:
         self,
         tmp_config_dir: Path,
         sample_state: CwState,
+        monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
-        mock_cmux_adapter: object,
     ) -> None:
+        from cw.cmux import FakeCmuxAdapter
+
+        monkeypatch.setattr("cw.cli.get_cmux_adapter", FakeCmuxAdapter)
         clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
         clients_file.write_text(
             "clients:\n"
@@ -384,14 +387,17 @@ class TestShowStatus:
         assert "Active sessions:    1" in output
         assert "Backgrounded:       1" in output
 
-    def test_check_dead_sessions_stub_returns_empty(
+    def test_check_dead_sessions_reaps_phantom_with_surface_ref(
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: object,
+        monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """_check_and_mark_dead_sessions is stubbed — always returns empty list."""
+        """_check_and_mark_dead_sessions reaps sessions whose surface is gone."""
+        from cw.cmux import FakeCmuxAdapter
+
+        monkeypatch.setattr("cw.cli.get_cmux_adapter", FakeCmuxAdapter)
         clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
         clients_file.write_text(
             f"clients:\n"
@@ -417,10 +423,10 @@ class TestShowStatus:
         _display_status()
 
         output = capsys.readouterr().out
-        # Stub never detects crashes — session stays active
-        assert "Active sessions:    1" in output
+        # Real reconciler detects missing surface — session is reaped
+        assert "Reaped phantom session: test-client/impl" in output
         updated = load_state()
-        assert updated.sessions[0].status == SessionStatus.ACTIVE
+        assert updated.sessions[0].status == SessionStatus.COMPLETED
 
 
 class TestBgNotifyCli:
@@ -755,3 +761,44 @@ class TestQueueFailCli:
                 ["queue", "fail", "my-client", "bad-id"],
             )
             assert result.exit_code != 0
+
+
+def test_display_status_reconciles_phantom_active_sessions(
+    tmp_config_dir: Path,
+    sample_client: ClientConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`cw status` reports and reaps sessions with missing surfaces."""
+    from cw.cmux import FakeCmuxAdapter
+    from cw.config import load_state, save_state
+    from cw.models import CwState, Session, SessionPurpose, SessionStatus
+
+    save_state(
+        CwState(
+            sessions=[
+                Session(
+                    id="phantom1",
+                    name="client-a/impl",
+                    client="client-a",
+                    purpose=SessionPurpose.IMPL,
+                    status=SessionStatus.ACTIVE,
+                    workspace_path=sample_client.workspace_path,
+                    surface_ref="gone",
+                ),
+            ]
+        )
+    )
+
+    # Force cli.py to use a fresh FakeCmuxAdapter so list_surfaces is empty.
+    monkeypatch.setattr("cw.cli.get_cmux_adapter", FakeCmuxAdapter)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["status"])
+    assert result.exit_code == 0
+    assert "Reaped phantom session" in result.output
+    assert "client-a/impl" in result.output
+
+    reloaded = load_state()
+    reaped = reloaded.find_by_name_or_id("phantom1")
+    assert reaped is not None
+    assert reaped.status == SessionStatus.COMPLETED

--- a/tests/test_cmux.py
+++ b/tests/test_cmux.py
@@ -547,3 +547,24 @@ class TestGetBackendAdapter:
         monkeypatch.setattr("cw.tmux.shutil.which", lambda _name: "/usr/bin/tmux")
         adapter = get_backend_adapter()
         assert isinstance(adapter, TmuxAdapter)
+
+
+def test_fake_adapter_list_surfaces_tracks_spawn_and_close() -> None:
+    """FakeCmuxAdapter tracks live surfaces via spawn/close."""
+    adapter = FakeCmuxAdapter()
+
+    assert adapter.list_surfaces() == set()
+
+    ref1 = adapter.spawn("ws-1", "echo hi")
+    ref2 = adapter.spawn("ws-1", "echo bye")
+    assert adapter.list_surfaces() == {ref1, ref2}
+
+    adapter.close(ref1)
+    assert adapter.list_surfaces() == {ref2}
+
+
+def test_fake_adapter_close_unknown_ref_is_noop() -> None:
+    """Closing a surface we never spawned must not raise."""
+    adapter = FakeCmuxAdapter()
+    adapter.close("never-spawned")  # must not raise
+    assert adapter.list_surfaces() == set()

--- a/tests/test_cmux.py
+++ b/tests/test_cmux.py
@@ -568,3 +568,65 @@ def test_fake_adapter_close_unknown_ref_is_noop() -> None:
     adapter = FakeCmuxAdapter()
     adapter.close("never-spawned")  # must not raise
     assert adapter.list_surfaces() == set()
+
+
+def test_real_cmux_list_surfaces_aggregates_across_workspaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """list_surfaces calls workspace.list then surface.list for each workspace."""
+    import sys
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    from cw.cmux import RealCmuxAdapter
+
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_call(
+        self: object, method: str, params: dict[str, object]
+    ) -> dict[str, object]:
+        calls.append((method, dict(params)))
+        if method == "workspace.list":
+            return {
+                "workspaces": [
+                    {"id": "ws-a", "title": "client-a"},
+                    {"id": "ws-b", "title": "client-b"},
+                ]
+            }
+        if method == "surface.list":
+            ws_id = params["workspace_id"]
+            if ws_id == "ws-a":
+                return {"surfaces": [{"id": "surf-a1"}, {"id": "surf-a2"}]}
+            return {"surfaces": [{"id": "surf-b1"}]}
+        raise AssertionError(f"unexpected call: {method}")
+
+    monkeypatch.setattr(RealCmuxAdapter, "_call", fake_call)
+    adapter = RealCmuxAdapter(socket_path=Path("/tmp/fake.sock"))
+
+    assert adapter.list_surfaces() == {"surf-a1", "surf-a2", "surf-b1"}
+    assert calls[0][0] == "workspace.list"
+    assert {c[1]["workspace_id"] for c in calls if c[0] == "surface.list"} == {
+        "ws-a",
+        "ws-b",
+    }
+
+
+def test_real_cmux_list_surfaces_returns_empty_on_socket_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the cmux socket is down, return empty set instead of raising."""
+    import sys
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    from cw.cmux import RealCmuxAdapter
+    from cw.exceptions import CwError
+
+    def fake_call(
+        self: object, method: str, params: dict[str, object]
+    ) -> dict[str, object]:
+        raise CwError("connection refused")
+
+    monkeypatch.setattr(RealCmuxAdapter, "_call", fake_call)
+    adapter = RealCmuxAdapter(socket_path=Path("/tmp/fake.sock"))
+    assert adapter.list_surfaces() == set()

--- a/tests/test_cmux.py
+++ b/tests/test_cmux.py
@@ -630,3 +630,92 @@ def test_real_cmux_list_surfaces_returns_empty_on_socket_error(
     monkeypatch.setattr(RealCmuxAdapter, "_call", fake_call)
     adapter = RealCmuxAdapter(socket_path=Path("/tmp/fake.sock"))
     assert adapter.list_surfaces() == set()
+
+
+def test_real_cmux_list_surfaces_skips_workspace_on_surface_list_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One workspace failing surface.list does not abort aggregation."""
+    import sys
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    from cw.cmux import RealCmuxAdapter
+    from cw.exceptions import CwError
+
+    def fake_call(
+        self: object, method: str, params: dict[str, object]
+    ) -> dict[str, object]:
+        if method == "workspace.list":
+            return {
+                "workspaces": [
+                    {"id": "ws-ok", "title": "a"},
+                    {"id": "ws-broken", "title": "b"},
+                ]
+            }
+        if method == "surface.list":
+            if params["workspace_id"] == "ws-broken":
+                raise CwError("permission denied")
+            return {"surfaces": [{"id": "surf-ok"}]}
+        raise AssertionError(f"unexpected call: {method}")
+
+    monkeypatch.setattr(RealCmuxAdapter, "_call", fake_call)
+    adapter = RealCmuxAdapter(socket_path=Path("/tmp/fake.sock"))
+
+    assert adapter.list_surfaces() == {"surf-ok"}
+
+
+def test_real_cmux_call_translates_os_error_to_cwerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_call converts socket OSError into CwError; callers get one exception type."""
+    import socket as socket_module
+    import sys
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    from cw.cmux import RealCmuxAdapter
+    from cw.exceptions import CwError
+
+    def fake_connect(self: socket_module.socket, address: object) -> None:
+        raise ConnectionRefusedError("no such file")
+
+    monkeypatch.setattr(socket_module.socket, "connect", fake_connect)
+    adapter = RealCmuxAdapter(socket_path=Path("/tmp/nonexistent.sock"))
+
+    with pytest.raises(CwError, match="cmux socket error"):
+        adapter._call("whatever", {})
+
+
+def test_real_cmux_call_translates_json_decode_error_to_cwerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_call converts malformed JSON response into CwError."""
+    import sys
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    from cw.cmux import RealCmuxAdapter
+    from cw.exceptions import CwError
+
+    class FakeSock:
+        def connect(self, address: object) -> None:
+            return None
+
+        def sendall(self, data: bytes) -> None:
+            return None
+
+        def recv(self, bufsize: int) -> bytes:
+            return b"not json\n"
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "socket.socket",
+        lambda *_args: FakeSock(),  # type: ignore[misc]
+    )
+    adapter = RealCmuxAdapter(socket_path=Path("/tmp/fake.sock"))
+
+    with pytest.raises(CwError, match="malformed JSON"):
+        adapter._call("whatever", {})

--- a/tests/test_cmux.py
+++ b/tests/test_cmux.py
@@ -632,10 +632,15 @@ def test_real_cmux_list_surfaces_returns_empty_on_socket_error(
     assert adapter.list_surfaces() == set()
 
 
-def test_real_cmux_list_surfaces_skips_workspace_on_surface_list_error(
+def test_real_cmux_list_surfaces_aborts_on_surface_list_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """One workspace failing surface.list does not abort aggregation."""
+    """A per-workspace surface.list failure collapses the whole result to empty.
+
+    Partial enumeration would let the reconciler falsely treat surfaces in
+    the failing workspace as phantom while preserving the rest, so the
+    adapter must return all-or-nothing.
+    """
     import sys
 
     monkeypatch.setattr(sys, "platform", "darwin")
@@ -662,7 +667,7 @@ def test_real_cmux_list_surfaces_skips_workspace_on_surface_list_error(
     monkeypatch.setattr(RealCmuxAdapter, "_call", fake_call)
     adapter = RealCmuxAdapter(socket_path=Path("/tmp/fake.sock"))
 
-    assert adapter.list_surfaces() == {"surf-ok"}
+    assert adapter.list_surfaces() == set()
 
 
 def test_real_cmux_call_translates_os_error_to_cwerror(
@@ -713,6 +718,8 @@ def test_real_cmux_call_translates_json_decode_error_to_cwerror(
 
     monkeypatch.setattr(
         "socket.socket",
+        # FakeSock mimics the socket.socket protocol structurally; mypy
+        # cannot see that and flags the return type as incompatible.
         lambda *_args: FakeSock(),  # type: ignore[misc]
     )
     adapter = RealCmuxAdapter(socket_path=Path("/tmp/fake.sock"))

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -420,3 +420,63 @@ class TestDispatchTickWithPlan:
 
         store = load_dev_queue()
         assert len(store.running()) == 2
+
+
+# ---------------------------------------------------------------------------
+# TestDispatchTickReconcilePhantoms
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_tick_reconciles_phantoms_before_counting(
+    tmp_dispatch_dirs: Path,
+    sample_client_config: ClientConfig,
+    simple_config: OrchestratorConfig,
+) -> None:
+    """Phantom DAEMON sessions do not block new dispatch."""
+    _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+    # Cap = 1, one ACTIVE phantom DAEMON session for the same client,
+    # and one PENDING ticket. Without reconciliation, running_count == 1
+    # would equal the cap and dispatch would spawn nothing.
+    save_state(
+        CwState(
+            sessions=[
+                Session(
+                    id="phantom-daemon",
+                    name=f"{sample_client_config.name}/auto-dev/TKT-OLD",
+                    client=sample_client_config.name,
+                    purpose=SessionPurpose.IMPL,
+                    origin=SessionOrigin.DAEMON,
+                    status=SessionStatus.ACTIVE,
+                    workspace_path=sample_client_config.workspace_path,
+                    surface_ref="dead",
+                ),
+            ]
+        )
+    )
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="TKT-OLD",
+                    client=sample_client_config.name,
+                    status=QueueItemStatus.RUNNING,
+                ),
+                TicketTask(
+                    ticket_id="TKT-NEW",
+                    client=sample_client_config.name,
+                    status=QueueItemStatus.PENDING,
+                ),
+            ]
+        )
+    )
+
+    adapter = FakeCmuxAdapter()
+
+    spawned = dispatch_tick(simple_config, adapter=adapter)
+    assert spawned == 1
+
+    reloaded = load_state()
+    phantom = reloaded.find_by_name_or_id("phantom-daemon")
+    assert phantom is not None
+    assert phantom.status == SessionStatus.COMPLETED

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -472,6 +472,9 @@ def test_dispatch_tick_reconciles_phantoms_before_counting(
     )
 
     adapter = FakeCmuxAdapter()
+    # Non-empty live set bypasses reconcile's outage guard; "dead" ref still
+    # isn't live so the phantom is reaped as intended.
+    adapter.spawn("decoy-ws", "echo")
 
     spawned = dispatch_tick(simple_config, adapter=adapter)
     assert spawned == 1

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 
     import pytest
 
+    from cw.models import ClientConfig
+
 
 class TestRunDoctorFakeBackend:
     """When CW_BACKEND=fake the backend binary check is a no-op."""
@@ -106,3 +108,61 @@ class TestDoctorCli:
         result = runner.invoke(main, ["doctor"])
         assert result.exit_code != 0
         assert "FAIL" in result.output
+
+
+def test_run_doctor_reap_flag_reconciles_and_reports(
+    tmp_config_dir: Path,
+    sample_client: ClientConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_doctor(reap=True) invokes reconcile and reports reaped sessions."""
+    from cw.cmux import FakeCmuxAdapter
+    from cw.config import load_state, save_state
+    from cw.doctor import run_doctor
+    from cw.models import CwState, Session, SessionPurpose, SessionStatus
+
+    save_state(
+        CwState(
+            sessions=[
+                Session(
+                    id="phantom",
+                    name="client-a/impl",
+                    client="client-a",
+                    purpose=SessionPurpose.IMPL,
+                    status=SessionStatus.ACTIVE,
+                    workspace_path=sample_client.workspace_path,
+                    surface_ref="gone",
+                ),
+            ]
+        )
+    )
+    monkeypatch.setattr("cw.doctor.get_cmux_adapter", FakeCmuxAdapter)
+
+    report = run_doctor(reap=True)
+    reap_checks = [c for c in report.checks if c.name == "reconciliation"]
+    assert len(reap_checks) == 1
+    assert reap_checks[0].ok is True
+    detail = reap_checks[0].detail
+    assert "phantom" in detail or "client-a/impl" in detail
+
+    reloaded = load_state()
+    phantom = reloaded.find_by_name_or_id("phantom")
+    assert phantom is not None
+    assert phantom.status == SessionStatus.COMPLETED
+
+
+def test_cw_doctor_cli_reap_flag(
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CLI `cw doctor --reap` forwards the flag."""
+    from click.testing import CliRunner
+
+    from cw.cli import main
+    from cw.cmux import FakeCmuxAdapter
+
+    monkeypatch.setattr("cw.doctor.get_cmux_adapter", FakeCmuxAdapter)
+    runner = CliRunner()
+    result = runner.invoke(main, ["doctor", "--reap"])
+    assert result.exit_code == 0
+    assert "reconciliation" in result.output

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -136,7 +136,15 @@ def test_run_doctor_reap_flag_reconciles_and_reports(
             ]
         )
     )
-    monkeypatch.setattr("cw.doctor.get_cmux_adapter", FakeCmuxAdapter)
+
+    def _adapter_with_decoy() -> FakeCmuxAdapter:
+        # Non-empty live set bypasses reconcile's outage guard; "gone" still
+        # isn't live so phantom is still reaped.
+        a = FakeCmuxAdapter()
+        a.spawn("decoy-ws", "echo")
+        return a
+
+    monkeypatch.setattr("cw.doctor.get_cmux_adapter", _adapter_with_decoy)
 
     report = run_doctor(reap=True)
     reap_checks = [c for c in report.checks if c.name == "reconciliation"]
@@ -159,9 +167,10 @@ def test_cw_doctor_cli_reap_flag(
     from click.testing import CliRunner
 
     from cw.cli import main
-    from cw.cmux import FakeCmuxAdapter
 
-    monkeypatch.setattr("cw.doctor.get_cmux_adapter", FakeCmuxAdapter)
+    # Force fake backend so the binary/socket check passes on every platform
+    # (macOS default is cmux, whose socket does not exist in CI).
+    monkeypatch.setenv("CW_BACKEND", "fake")
     runner = CliRunner()
     result = runner.invoke(main, ["doctor", "--reap"])
     assert result.exit_code == 0

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -3,16 +3,24 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 
 from cw.cmux import FakeCmuxAdapter
+from cw.config import load_state, save_state
+from cw.dev_queue import load_dev_queue, save_dev_queue
 from cw.models import (
     ClientConfig,
+    CompletionReason,
     CwState,
+    DevQueueStore,
+    QueueItemStatus,
     Session,
+    SessionOrigin,
     SessionPurpose,
     SessionStatus,
+    TicketTask,
 )
-from cw.reconcile import compute_drift
+from cw.reconcile import compute_drift, reconcile
 
 
 def _mk_session(
@@ -89,3 +97,58 @@ def test_compute_drift_empty_live_set_from_adapter_is_reconciled() -> None:
     )
     report = compute_drift(state, adapter)
     assert set(report.phantom_session_ids) == {"s1", "s2"}
+
+
+def test_reconcile_marks_phantom_completed_crashed(
+    tmp_config_dir: Path,
+) -> None:
+    """reconcile flips phantom sessions to COMPLETED/CRASHED and persists."""
+    state = CwState(sessions=[_mk_session("s1", "missing-ref")])
+    save_state(state)
+
+    adapter = FakeCmuxAdapter()  # empty live set → s1 is phantom
+    report = reconcile(adapter)
+
+    assert report.phantom_session_ids == ["s1"]
+    reloaded = load_state()
+    s1 = reloaded.find_by_name_or_id("s1")
+    assert s1 is not None
+    assert s1.status == SessionStatus.COMPLETED
+    assert s1.completed_reason == CompletionReason.CRASHED
+    assert s1.completed_at is not None
+
+
+def test_reconcile_reverts_daemon_session_ticket_to_pending(
+    tmp_config_dir: Path,
+) -> None:
+    """When a DAEMON session for a ticket is phantom, revert its task."""
+    sess = _mk_session("sess-daemon", "dead-ref")
+    sess.origin = SessionOrigin.DAEMON
+    sess.name = "client-a/auto-dev/TKT-1"
+    save_state(CwState(sessions=[sess]))
+
+    task = TicketTask(
+        ticket_id="TKT-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    report = reconcile(FakeCmuxAdapter())
+
+    assert "TKT-1" in report.reverted_ticket_ids
+    queue = load_dev_queue()
+    assert queue.tasks[0].status == QueueItemStatus.PENDING
+
+
+def test_reconcile_noop_when_no_phantoms(
+    tmp_config_dir: Path,
+) -> None:
+    adapter = FakeCmuxAdapter()
+    live_ref = adapter.spawn("ws", "echo")
+    sess = _mk_session("alive", live_ref)
+    save_state(CwState(sessions=[sess]))
+
+    report = reconcile(adapter)
+    assert report.phantom_session_ids == []
+    assert report.reverted_ticket_ids == []

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,0 +1,91 @@
+"""Unit tests for cw.reconcile."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from cw.cmux import FakeCmuxAdapter
+from cw.models import (
+    ClientConfig,
+    CwState,
+    Session,
+    SessionPurpose,
+    SessionStatus,
+)
+from cw.reconcile import compute_drift
+
+
+def _mk_session(
+    sid: str,
+    surface_ref: str | None,
+    status: SessionStatus = SessionStatus.ACTIVE,
+) -> Session:
+    return Session(
+        id=sid,
+        name=f"client-a/{sid}",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        status=status,
+        workspace_path=ClientConfig(
+            name="client-a", workspace_path="/tmp/ws"
+        ).workspace_path,
+        surface_ref=surface_ref,
+        started_at=datetime(2026, 4, 19, tzinfo=UTC),
+    )
+
+
+def test_compute_drift_empty_state_returns_empty_report() -> None:
+    adapter = FakeCmuxAdapter()
+    state = CwState()
+    report = compute_drift(state, adapter)
+    assert report.phantom_session_ids == []
+
+
+def test_compute_drift_flags_active_session_with_missing_surface() -> None:
+    adapter = FakeCmuxAdapter()  # no surfaces
+    state = CwState(sessions=[_mk_session("s1", "missing-ref")])
+    report = compute_drift(state, adapter)
+    assert report.phantom_session_ids == ["s1"]
+
+
+def test_compute_drift_ignores_backgrounded_completed_and_refless() -> None:
+    adapter = FakeCmuxAdapter()
+    state = CwState(
+        sessions=[
+            _mk_session("s-bg", "ref1", status=SessionStatus.BACKGROUNDED),
+            _mk_session("s-done", "ref2", status=SessionStatus.COMPLETED),
+            _mk_session("s-noref", None, status=SessionStatus.ACTIVE),
+        ]
+    )
+    report = compute_drift(state, adapter)
+    assert report.phantom_session_ids == []
+
+
+def test_compute_drift_respects_live_set() -> None:
+    adapter = FakeCmuxAdapter()
+    live_ref = adapter.spawn("ws", "echo hi")  # registers in live set
+    state = CwState(
+        sessions=[
+            _mk_session("alive", live_ref),
+            _mk_session("dead", "gone"),
+        ]
+    )
+    report = compute_drift(state, adapter)
+    assert report.phantom_session_ids == ["dead"]
+
+
+def test_compute_drift_empty_live_set_from_adapter_is_reconciled() -> None:
+    """Adapters return empty on backend outage. That's 'no surfaces alive' —
+    so everything ACTIVE/IDLE with a surface_ref is phantom. The reconciler
+    trusts the adapter; callers who want "don't touch state when backend is
+    down" must guard before calling.
+    """
+    adapter = FakeCmuxAdapter()
+    state = CwState(
+        sessions=[
+            _mk_session("s1", "r1"),
+            _mk_session("s2", "r2", status=SessionStatus.IDLE),
+        ]
+    )
+    report = compute_drift(state, adapter)
+    assert set(report.phantom_session_ids) == {"s1", "s2"}

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -116,6 +116,7 @@ def test_reconcile_marks_phantom_completed_crashed(
     assert s1.status == SessionStatus.COMPLETED
     assert s1.completed_reason == CompletionReason.CRASHED
     assert s1.completed_at is not None
+    assert report.reverted_ticket_ids == []
 
 
 def test_reconcile_reverts_daemon_session_ticket_to_pending(

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -106,10 +106,12 @@ def test_reconcile_marks_phantom_completed_crashed(
     state = CwState(sessions=[_mk_session("s1", "missing-ref")])
     save_state(state)
 
-    adapter = FakeCmuxAdapter()  # empty live set → s1 is phantom
+    adapter = FakeCmuxAdapter()
+    adapter.spawn("ws", "echo decoy")  # keep live set non-empty to bypass outage guard
     report = reconcile(adapter)
 
     assert report.phantom_session_ids == ["s1"]
+    assert report.phantom_session_names == ["client-a/s1"]
     reloaded = load_state()
     s1 = reloaded.find_by_name_or_id("s1")
     assert s1 is not None
@@ -135,7 +137,9 @@ def test_reconcile_reverts_daemon_session_ticket_to_pending(
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
-    report = reconcile(FakeCmuxAdapter())
+    adapter = FakeCmuxAdapter()
+    adapter.spawn("ws", "echo decoy")  # non-empty live set bypasses outage guard
+    report = reconcile(adapter)
 
     assert "TKT-1" in report.reverted_ticket_ids
     queue = load_dev_queue()
@@ -153,3 +157,34 @@ def test_reconcile_noop_when_no_phantoms(
     report = reconcile(adapter)
     assert report.phantom_session_ids == []
     assert report.reverted_ticket_ids == []
+
+
+def test_reconcile_refuses_to_mass_reap_on_empty_live_set(
+    tmp_config_dir: Path,
+) -> None:
+    """Transient backend outage: adapter returns empty, reconcile must abort.
+
+    Without this guard, a 5-second cmux/tmux restart during `cw status`
+    would mark every ACTIVE session COMPLETED+CRASHED irreversibly.
+    """
+    state = CwState(
+        sessions=[
+            _mk_session("s1", "r1"),
+            _mk_session("s2", "r2", status=SessionStatus.IDLE),
+        ]
+    )
+    save_state(state)
+
+    adapter = FakeCmuxAdapter()  # empty live set simulates backend outage
+    report = reconcile(adapter)
+
+    assert report.phantom_session_ids == []
+    assert report.phantom_session_names == []
+    assert report.reverted_ticket_ids == []
+
+    reloaded = load_state()
+    for sid in ("s1", "s2"):
+        s = reloaded.find_by_name_or_id(sid)
+        assert s is not None
+        assert s.status in {SessionStatus.ACTIVE, SessionStatus.IDLE}
+        assert s.completed_reason is None

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1205,6 +1205,50 @@ class TestBackgroundNotify:
         assert "No active idea session" in output
 
 
+def test_start_session_reaps_phantom_before_existing_check(
+    tmp_config_dir: Path,
+    sample_client: ClientConfig,
+) -> None:
+    """Phantom ACTIVE session is reaped; start_session then spawns fresh sessions.
+
+    Reconciliation runs before the existing-session check so a dead "active"
+    row doesn't cause start_session to short-circuit.
+    """
+    clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
+    clients_file.write_text(
+        f"clients:\n"
+        f"  {sample_client.name}:\n"
+        f"    workspace_path: {sample_client.workspace_path}\n"
+    )
+
+    save_state(
+        CwState(
+            sessions=[
+                Session(
+                    id="phantom",
+                    name=f"{sample_client.name}/impl",
+                    client=sample_client.name,
+                    purpose=SessionPurpose.IMPL,
+                    status=SessionStatus.ACTIVE,
+                    workspace_path=sample_client.workspace_path,
+                    surface_ref="gone-ref",
+                ),
+            ]
+        )
+    )
+
+    adapter = FakeCmuxAdapter()  # empty live set
+    start_session(sample_client.name, "impl", adapter=adapter)
+
+    reloaded = load_state()
+    # Phantom got reaped
+    phantom = reloaded.find_by_name_or_id("phantom")
+    assert phantom is not None
+    assert phantom.status == SessionStatus.COMPLETED
+    # New sessions spawned (at least one spawn call)
+    assert len(adapter.calls["spawn"]) >= 1
+
+
 class TestBackgroundAllSessions:
     def test_backgrounds_all_active(
         self,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1249,6 +1249,28 @@ def test_start_session_reaps_phantom_before_existing_check(
     assert len(adapter.calls["spawn"]) >= 1
 
 
+def test_start_session_launch_message_names_backend(
+    tmp_config_dir: Path,
+    sample_client: ClientConfig,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 'Launching X surfaces...' message names the backend in use."""
+    from cw.models import BackendName
+
+    clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
+    clients_file.write_text(
+        f"clients:\n"
+        f"  test-client:\n"
+        f"    workspace_path: {sample_client.workspace_path}\n"
+    )
+    monkeypatch.setattr("cw.session._resolve_backend_name", lambda: BackendName.TMUX)
+
+    start_session(sample_client.name, "impl", adapter=FakeCmuxAdapter())
+    out = capsys.readouterr().out
+    assert "Launching tmux surfaces" in out
+
+
 class TestBackgroundAllSessions:
     def test_backgrounds_all_active(
         self,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1237,7 +1237,10 @@ def test_start_session_reaps_phantom_before_existing_check(
         )
     )
 
-    adapter = FakeCmuxAdapter()  # empty live set
+    adapter = FakeCmuxAdapter()
+    # Non-empty live set bypasses reconcile's outage guard; "gone-ref" still
+    # isn't live so the phantom is still reaped.
+    adapter.spawn("decoy-ws", "echo")
     start_session(sample_client.name, "impl", adapter=adapter)
 
     reloaded = load_state()
@@ -1245,8 +1248,8 @@ def test_start_session_reaps_phantom_before_existing_check(
     phantom = reloaded.find_by_name_or_id("phantom")
     assert phantom is not None
     assert phantom.status == SessionStatus.COMPLETED
-    # New sessions spawned (at least one spawn call)
-    assert len(adapter.calls["spawn"]) >= 1
+    # New sessions spawned: at least one for impl beyond the decoy
+    assert len(adapter.calls["spawn"]) >= 2
 
 
 def test_start_session_launch_message_names_backend(

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -182,6 +182,25 @@ def test_tmux_list_surfaces_returns_empty_on_server_down(
     assert adapter.list_surfaces() == set()
 
 
+def test_tmux_list_surfaces_returns_empty_when_no_panes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Running tmux server with zero panes: returncode 0, stdout empty → empty set."""
+    monkeypatch.setattr("cw.tmux.shutil.which", lambda _: "/usr/bin/tmux")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+    monkeypatch.setattr("cw.tmux.subprocess.run", fake_run)
+    adapter = TmuxAdapter()
+    assert adapter.list_surfaces() == set()
+
+
 @pytest.mark.integration
 @pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux not installed")
 class TestTmuxIntegration:

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -140,6 +140,48 @@ class TestSubprocessWiring:
         assert adapter.identify() == {"focused": {}}
 
 
+def test_tmux_list_surfaces_parses_pane_refs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_surfaces parses `tmux list-panes -a -F` output into a set."""
+    monkeypatch.setattr("cw.tmux.shutil.which", lambda _: "/usr/bin/tmux")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert cmd[:4] == ["tmux", "list-panes", "-a", "-F"]
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout="cw-client-a:0.0\ncw-client-a:0.1\ncw-client-b:1.0\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr("cw.tmux.subprocess.run", fake_run)
+    adapter = TmuxAdapter()
+
+    assert adapter.list_surfaces() == {
+        "cw-client-a:0.0",
+        "cw-client-a:0.1",
+        "cw-client-b:1.0",
+    }
+
+
+def test_tmux_list_surfaces_returns_empty_on_server_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If tmux server is not running, list-panes returns non-zero; we return empty."""
+    monkeypatch.setattr("cw.tmux.shutil.which", lambda _: "/usr/bin/tmux")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=1,
+            stdout="",
+            stderr="no server running on /tmp/tmux-1000/default\n",
+        )
+
+    monkeypatch.setattr("cw.tmux.subprocess.run", fake_run)
+    adapter = TmuxAdapter()
+    assert adapter.list_surfaces() == set()
+
+
 @pytest.mark.integration
 @pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux not installed")
 class TestTmuxIntegration:


### PR DESCRIPTION
## Summary

Fixes the phantom-session bug where `sessions.json` drifts from multiplexer reality: when tmux dies (machine sleep/restart) or cmux surfaces close, cw keeps reporting dead sessions as ACTIVE/IDLE — blocking new dispatch and lying in `cw status`.

- **New:** `MultiplexerAdapter.list_surfaces()` on the adapter protocol, implemented for tmux/cmux/fake.
- **New:** `cw.reconcile` module — `compute_drift` (pure) identifies phantoms, `reconcile` (side-effecting) marks them COMPLETED/CRASHED, emits SESSION_COMPLETED events with `crashed: true`, and reverts stranded RUNNING TicketTasks to PENDING.
- **New:** Passive reconciliation in `cw status`, `cw list`, and `cw start`; active reconciliation at the top of each `dispatch_tick`; explicit via `cw doctor --reap`.
- **Bonus fix:** `RealCmuxAdapter._call` now normalises `OSError` and `json.JSONDecodeError` to `CwError`, making the "return empty set on unreachable backend" contract actually work in production.
- **Bonus fix:** `start_session`'s "Launching cmux surfaces" message now names the active backend (cmux/tmux/fake).
- **Refactor:** `cw.dev_queue._lock` → public `dev_queue_lock` context manager; `dispatch.py` and `reconcile.py` both use the public name.

Plan: `docs/superpowers/plans/2026-04-19-multiplexer-state-reconciliation.md`.

## Test Plan

- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run mypy src/` — zero errors
- [x] `uv run pytest tests/` — 620 passed (was 592; +28 new tests)
- [x] Coverage on `src/cw/reconcile.py` — 97%
- [x] Smoke: `CW_BACKEND=fake cw doctor --reap` exits 0 and reports reconciliation check
- [x] Real-world smoke on the developer machine: reaped 8 phantom sessions + reverted 2 stranded tickets, reproducing the originally reported bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)