### PR TITLE
feat(state): add Session linkage fields, bump schema to v2

### DIFF
--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -196,13 +196,18 @@ def migrate_cw_state(raw: dict[str, Any]) -> dict[str, Any]:
     warning rather than raising a validation error.
     """
     sessions = raw.get("sessions")
+    if "sessions" in raw and not isinstance(sessions, list):
+        # Malformed payload — leave schema_version untouched so the
+        # corruption surfaces downstream rather than getting a false
+        # "fully migrated" stamp.
+        return raw
     if isinstance(sessions, list):
         for session_raw in sessions:
             if not isinstance(session_raw, dict):
                 continue
             _migrate_zellij_fields(session_raw)
             _coerce_session_origin(session_raw)
-            _migrate_v1_linkage_fields(session_raw)
+            _fill_linkage_field_defaults(session_raw)
     # Bump persisted schema_version to current after all migration steps.
     raw["schema_version"] = CW_STATE_SCHEMA_VERSION
     return raw
@@ -240,11 +245,14 @@ def _coerce_session_origin(session_raw: dict[str, Any]) -> None:
         session_raw["origin"] = SessionOrigin.USER.value
 
 
-def _migrate_v1_linkage_fields(session_raw: dict[str, Any]) -> None:
+def _fill_linkage_field_defaults(session_raw: dict[str, Any]) -> None:
     """Fill parent_session_id and worker_session_ids introduced in schema v2.
 
-    Idempotent: if the fields are already present they are left untouched,
-    so a v2 file round-trips without modification.
+    Runs unconditionally and is idempotent: if the fields are already present
+    they are left untouched, so a v2 file round-trips without modification.
+    The canonical source of truth for these defaults is the Session Pydantic
+    model; this helper exists only to ensure the on-disk file gets the keys
+    explicitly so re-saves don't lose them.
     """
     if "parent_session_id" not in session_raw:
         session_raw["parent_session_id"] = None

--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -18,6 +18,7 @@ from ruamel.yaml.comments import CommentedMap
 from cw.atomic import atomic_write_text
 from cw.exceptions import CwError
 from cw.models import (
+    CW_STATE_SCHEMA_VERSION,
     DEFAULT_AUTO_PURPOSES,
     ClientConfig,
     CwState,
@@ -201,6 +202,9 @@ def migrate_cw_state(raw: dict[str, Any]) -> dict[str, Any]:
                 continue
             _migrate_zellij_fields(session_raw)
             _coerce_session_origin(session_raw)
+            _migrate_v1_linkage_fields(session_raw)
+    # Bump persisted schema_version to current after all migration steps.
+    raw["schema_version"] = CW_STATE_SCHEMA_VERSION
     return raw
 
 
@@ -234,6 +238,18 @@ def _coerce_session_origin(session_raw: dict[str, Any]) -> None:
             origin,
         )
         session_raw["origin"] = SessionOrigin.USER.value
+
+
+def _migrate_v1_linkage_fields(session_raw: dict[str, Any]) -> None:
+    """Fill parent_session_id and worker_session_ids introduced in schema v2.
+
+    Idempotent: if the fields are already present they are left untouched,
+    so a v2 file round-trips without modification.
+    """
+    if "parent_session_id" not in session_raw:
+        session_raw["parent_session_id"] = None
+    if "worker_session_ids" not in session_raw:
+        session_raw["worker_session_ids"] = []
 
 
 def save_state(state: CwState) -> None:

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -45,7 +45,7 @@ class QueueItemStatus(StrEnum):
 # Schema versions for persisted state. Bump when making a breaking change
 # to the on-disk layout; add a migration in `cw.config.migrate_cw_state`
 # or `cw.dev_queue.migrate_dev_queue` to handle older versions.
-CW_STATE_SCHEMA_VERSION = 1
+CW_STATE_SCHEMA_VERSION = 2
 DEV_QUEUE_SCHEMA_VERSION = 1
 
 
@@ -219,6 +219,8 @@ class Session(BaseModel):
     resumed_at: datetime | None = None
     completed_reason: CompletionReason | None = None
     completed_at: datetime | None = None
+    parent_session_id: str | None = None
+    worker_session_ids: list[str] = Field(default_factory=list)
 
 
 DEFAULT_AUTO_PURPOSES: list[SessionPurpose] = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -670,3 +670,25 @@ class TestMigrateCwState:
         assert session["parent_session_id"] is None
         assert session["worker_session_ids"] == []
         assert migrated["schema_version"] == CW_STATE_SCHEMA_VERSION
+
+    def test_no_sessions_key_still_bumps_schema_version(self) -> None:
+        # A state with no sessions key at all is legitimately empty; schema
+        # version should still be stamped so re-saves are at current version.
+        raw: dict[str, int] = {"schema_version": 1}
+        migrated = migrate_cw_state(raw)
+        assert migrated["schema_version"] == CW_STATE_SCHEMA_VERSION
+
+    def test_missing_schema_version_gets_stamped(self) -> None:
+        # A file without schema_version (very old or hand-crafted) should be
+        # stamped with the current version after migration runs.
+        raw = {"sessions": [{"id": "s1"}]}
+        migrated = migrate_cw_state(raw)
+        assert migrated["schema_version"] == CW_STATE_SCHEMA_VERSION
+
+    def test_non_list_sessions_does_not_bump_version(self) -> None:
+        # Malformed payload: sessions is not a list. The corruption must NOT
+        # be certified as fully migrated — schema_version stays unchanged so
+        # the problem surfaces downstream.
+        raw = {"schema_version": 1, "sessions": "oops"}
+        migrated = migrate_cw_state(raw)
+        assert migrated["schema_version"] == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -617,3 +617,56 @@ class TestMigrateCwState:
         )
         state = load_state()
         assert state.sessions[0].origin == SessionOrigin.USER
+
+    def test_v1_to_v2_fills_linkage_fields(self) -> None:
+        raw = {
+            "schema_version": 1,
+            "sessions": [{"id": "s1"}],
+        }
+        migrated = migrate_cw_state(raw)
+        session = migrated["sessions"][0]
+        assert session["parent_session_id"] is None
+        assert session["worker_session_ids"] == []
+        assert migrated["schema_version"] == CW_STATE_SCHEMA_VERSION
+
+    def test_v2_file_is_idempotent(self) -> None:
+        raw = {
+            "schema_version": 2,
+            "sessions": [
+                {
+                    "id": "s1",
+                    "parent_session_id": "root0001",
+                    "worker_session_ids": ["abc123"],
+                }
+            ],
+        }
+        migrated = migrate_cw_state(raw)
+        session = migrated["sessions"][0]
+        assert session["parent_session_id"] == "root0001"
+        assert session["worker_session_ids"] == ["abc123"]
+        assert migrated["schema_version"] == CW_STATE_SCHEMA_VERSION
+
+    def test_multiple_sessions_all_get_linkage_fields(self) -> None:
+        raw = {
+            "schema_version": 1,
+            "sessions": [{"id": "s1"}, {"id": "s2"}, {"id": "s3"}],
+        }
+        migrated = migrate_cw_state(raw)
+        for session in migrated["sessions"]:
+            assert session["parent_session_id"] is None
+            assert session["worker_session_ids"] == []
+
+    def test_v1_zellij_and_linkage_both_migrate(self) -> None:
+        raw = {
+            "schema_version": 1,
+            "sessions": [{"id": "s1", "zellij_pane": "0:1.0"}],
+        }
+        migrated = migrate_cw_state(raw)
+        session = migrated["sessions"][0]
+        # Zellij armor ran
+        assert session["surface_ref"] == "0:1.0"
+        assert "zellij_pane" not in session
+        # Linkage fields filled
+        assert session["parent_session_id"] is None
+        assert session["worker_session_ids"] == []
+        assert migrated["schema_version"] == CW_STATE_SCHEMA_VERSION

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -358,6 +358,64 @@ class TestCwState:
         assert s.idle_at is None
 
 
+class TestSessionLinkageFields:
+    def test_defaults_are_none_and_empty(self) -> None:
+        s = Session(
+            name="c/impl",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            workspace_path=Path("/dev/null"),
+        )
+        assert s.parent_session_id is None
+        assert s.worker_session_ids == []
+
+    def test_worker_session_ids_instances_are_independent(self) -> None:
+        s1 = Session(
+            name="c/impl",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            workspace_path=Path("/dev/null"),
+        )
+        s2 = Session(
+            name="c/idea",
+            client="c",
+            purpose=SessionPurpose.IDEA,
+            workspace_path=Path("/dev/null"),
+        )
+        s1.worker_session_ids.append("abc123")
+        assert s2.worker_session_ids == []
+
+    def test_linkage_fields_populated_round_trip(self) -> None:
+        s = Session(
+            id="parent01",
+            name="c/impl",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            workspace_path=Path("/dev/null"),
+            parent_session_id="root0001",
+            worker_session_ids=["abc123", "def456"],
+        )
+        json_str = s.model_dump_json()
+        restored = Session.model_validate_json(json_str)
+        assert restored.parent_session_id == "root0001"
+        assert restored.worker_session_ids == ["abc123", "def456"]
+        assert restored == s
+
+    def test_default_linkage_fields_round_trip(self) -> None:
+        s = Session(
+            id="solo0001",
+            name="c/impl",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            workspace_path=Path("/dev/null"),
+        )
+        json_str = s.model_dump_json()
+        restored = Session.model_validate_json(json_str)
+        assert restored.parent_session_id is None
+        assert restored.worker_session_ids == []
+        assert restored == s
+
+
 class TestCompletionReason:
     def test_enum_values(self) -> None:
         assert CompletionReason.USER.value == "user"


### PR DESCRIPTION
## Summary

- feat(state): add Session linkage fields, bump schema to v2
- fix(state): guard schema_version bump on non-list sessions, rename helper

Closes #52

## Test plan

- [x] ruff check — zero violations
- [x] mypy — zero type errors
- [x] pytest — 632 passed, 0 failures
- [x] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it