### PR TITLE
fix(session): remove dual save_state in start_session (#63)

### DIFF
--- a/src/cw/session.py
+++ b/src/cw/session.py
@@ -248,7 +248,6 @@ def start_session(
         impl_session.parent_session_id = parent_session.id
         parent_session.worker_session_ids.append(impl_session.id)
 
-    save_state(state)
     panes = _build_pane_args(all_sessions, client=client)
 
     for s in all_sessions.values():
@@ -261,6 +260,9 @@ def start_session(
         pane_cmd = panes[purpose_str]["claude_cmd"]
         _spawn_session_surface(client, session, pane_cmd, adapter)
 
+    # Single end-to-end persist: state hits disk only after every surface
+    # has been spawned. If any spawn raises, on-disk state is unchanged
+    # (no partial-success window where sessions exist without surface_ref).
     save_state(state)
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1274,6 +1274,45 @@ def test_start_session_launch_message_names_backend(
     assert "Launching tmux surfaces" in out
 
 
+def test_start_session_spawn_failure_leaves_state_unchanged(
+    tmp_config_dir: Path,
+    sample_client: ClientConfig,
+) -> None:
+    """If spawn raises mid-loop, on-disk state is unchanged from pre-call.
+
+    Pins the invariant from issue #63: state persists once at the end after
+    every surface has been spawned. Partial-success window (sessions linked
+    on disk without surface_ref) must not exist.
+    """
+    clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
+    clients_file.write_text(
+        f"clients:\n"
+        f"  test-client:\n"
+        f"    workspace_path: {sample_client.workspace_path}\n"
+    )
+
+    # Snapshot pre-call state file (empty initially).
+    pre_state = load_state()
+    pre_session_count = len(pre_state.sessions)
+
+    # Adapter that fails on the second spawn — first one succeeds, then boom.
+    class FlakyAdapter(FakeCmuxAdapter):
+        def spawn(self, workspace: str, command: str, surface: str = "right") -> str:
+            if len(self.calls["spawn"]) >= 1:
+                msg = "simulated spawn failure"
+                raise CwError(msg)
+            return super().spawn(workspace, command, surface)
+
+    adapter = FlakyAdapter()
+
+    with pytest.raises(CwError, match="simulated spawn failure"):
+        start_session("test-client", "impl", adapter=adapter)
+
+    # Post-call: state file must be unchanged (no partial sessions persisted).
+    post_state = load_state()
+    assert len(post_state.sessions) == pre_session_count
+
+
 class TestBackgroundAllSessions:
     def test_backgrounds_all_active(
         self,


### PR DESCRIPTION
## Summary

- Drop the first `save_state(state)` call in `start_session`. Persist once at the end after every surface has been spawned.
- The original justification (zellij `exec` race) no longer applies under cmux/tmux.
- Eliminates the partial-success window where on-disk state held linked sessions with no `surface_ref`.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest tests/ -v` — 679/679 pass
- [x] New test `test_start_session_spawn_failure_leaves_state_unchanged` injects a flaky adapter and pins the new invariant.

## Reviewer notes

- Bonus finding (from SysAdmin review): removing the first `save_state` also closes a narrow reconcile race where a daemon tick between the two saves could observe sessions whose surfaces were not yet visible to the multiplexer.
- The orphaned-multiplexer-surface case on partial spawn is pre-existing and out of scope here.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)