### PR TITLE
chore(doctor): cleanup deferred from #55 review (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
-- `cw doctor` now exits non-zero when parent/worker linkage drift is
-  detected (stale `worker_session_ids`, mismatched `parent_session_id`,
-  or asymmetric references). Previously such states passed silently.
-  Run `cw doctor --reap` to inspect the reported drift; remediation
-  hints are included in each `linkage/*` check's detail.
+- Documenting prior behavior: since the linkage-drift detection in #68,
+  `cw doctor` reports parent/worker linkage drift (stale
+  `worker_session_ids`, mismatched `parent_session_id`, or asymmetric
+  references) as failed checks, which contribute to the overall doctor
+  exit code. Run `cw doctor` to inspect the report; remediation hints
+  are included in each `linkage/*` check's detail. `cw doctor --reap`
+  additionally reconciles phantom sessions detected via the surface
+  liveness check.
 
 ## [0.6.4] — 2026-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- `cw doctor` now exits non-zero when parent/worker linkage drift is
+  detected (stale `worker_session_ids`, mismatched `parent_session_id`,
+  or asymmetric references). Previously such states passed silently.
+  Run `cw doctor --reap` to inspect the reported drift; remediation
+  hints are included in each `linkage/*` check's detail.
+
 ## [0.6.4] — 2026-05-01
 
 Completes the dispatch-spawn fix started in 0.6.3. The earlier release

--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -159,8 +159,7 @@ def _check_linkage(state: CwState) -> list[CheckResult]:
     All three results are always returned; each is ``ok=True`` when no drift
     of that type is detected.
     """
-    # Indexes built once: O(1) membership and lookup throughout the function.
-    session_ids = {s.id for s in state.sessions}
+    # Index built once: O(1) membership (via .keys()) and lookup throughout.
     session_by_id: dict[str, Session] = {s.id: s for s in state.sessions}
 
     # --- dangling-worker: orchestrator.worker_session_ids → missing session ---
@@ -169,7 +168,7 @@ def _check_linkage(state: CwState) -> list[CheckResult]:
         " — remove the stale ID from worker_session_ids"
         for sess in state.sessions
         for wid in sess.worker_session_ids
-        if wid not in session_ids
+        if wid not in session_by_id
     ]
 
     if dangling_worker_msgs:
@@ -184,7 +183,7 @@ def _check_linkage(state: CwState) -> list[CheckResult]:
         " — clear parent_session_id or restore the parent session"
         for sess in state.sessions
         if sess.parent_session_id is not None
-        and sess.parent_session_id not in session_ids
+        and sess.parent_session_id not in session_by_id
     ]
 
     if dangling_parent_msgs:
@@ -197,8 +196,9 @@ def _check_linkage(state: CwState) -> list[CheckResult]:
     # Build a map: parent_id → {set of worker IDs that claim it as parent}
     claimed_by: dict[str, set[str]] = {}
     for sess in state.sessions:
-        if sess.parent_session_id is not None and sess.parent_session_id in session_ids:
-            claimed_by.setdefault(sess.parent_session_id, set()).add(sess.id)
+        parent_id = sess.parent_session_id
+        if parent_id is not None and parent_id in session_by_id:
+            claimed_by.setdefault(parent_id, set()).add(sess.id)
 
     # Forward check: orchestrator lists a worker, but worker doesn't claim it back.
     # Workers already caught as dangling are skipped (wid not in session_by_id).

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -664,8 +664,8 @@ def _mk_session(
 class TestCheckLinkageDirect:
     """Direct tests of _check_linkage(state) — bypass state-file roundtrip."""
 
-    def test_clean_state_returns_three_ok_results(self, tmp_path: Path) -> None:
-        """Empty state and well-linked state both produce all-ok results."""
+    def test_empty_state_returns_three_ok_results(self) -> None:
+        """Empty state produces three named ok results."""
         from cw.doctor import _check_linkage
         from cw.models import CwState
 
@@ -678,7 +678,11 @@ class TestCheckLinkageDirect:
             "linkage/asymmetric",
         }
 
-        # Bidirectional valid linkage also clean.
+    def test_clean_bidirectional_linkage_passes(self, tmp_path: Path) -> None:
+        """Orchestrator and worker referencing each other produce all-ok."""
+        from cw.doctor import _check_linkage
+        from cw.models import CwState
+
         state = CwState(
             sessions=[
                 _mk_session("orch", tmp_path, worker_session_ids=["w1"]),
@@ -703,6 +707,9 @@ class TestCheckLinkageDirect:
         assert "orch" in dw.detail
         assert "ghost" in dw.detail
         # Other two checks remain clean — drift is isolated to dangling-worker.
+        # asymmetric stays ok because the forward check skips ghost workers
+        # via `session_by_id.get(wid)` returning None (no session to inspect
+        # for back-reference), so the missing-back-reference path never fires.
         assert results["linkage/dangling-parent"].ok
         assert results["linkage/asymmetric"].ok
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
     import pytest
 
-    from cw.models import ClientConfig
+    from cw.models import ClientConfig, Session
 
 
 class TestRunDoctorFakeBackend:
@@ -292,12 +292,13 @@ class TestCheckLinkageHealthy:
 class TestCheckLinkageDanglingWorker:
     """Dangling worker: orchestrator lists a worker ID not in state."""
 
-    def test_dangling_worker_flagged(
+    def test_dangling_worker_flagged_with_remediation_hint(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
     ) -> None:
+        """Single dangling worker: flag both IDs and surface remediation hint."""
         from cw.config import save_state
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
@@ -322,35 +323,7 @@ class TestCheckLinkageDanglingWorker:
         assert not dw.ok
         assert "orch-1" in dw.detail
         assert "worker-gone" in dw.detail
-
-    def test_dangling_worker_includes_remediation_hint(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        tmp_config_dir: Path,
-        sample_client: ClientConfig,
-    ) -> None:
-        from cw.config import save_state
-        from cw.models import CwState, Session, SessionPurpose, SessionStatus
-
-        monkeypatch.setenv("CW_BACKEND", "fake")
-        save_state(
-            CwState(
-                sessions=[
-                    Session(
-                        id="orch-2",
-                        name="client/impl",
-                        client="client",
-                        purpose=SessionPurpose.IMPL,
-                        status=SessionStatus.ACTIVE,
-                        workspace_path=sample_client.workspace_path,
-                        worker_session_ids=["missing-id"],
-                    ),
-                ]
-            )
-        )
-        report = run_doctor()
-        dw = next(c for c in report.checks if c.name == "linkage/dangling-worker")
-        assert not dw.ok
+        # Remediation hint is included alongside the IDs.
         assert "remove" in dw.detail.lower() or "worker_session_ids" in dw.detail
 
     def test_multiple_dangling_workers_all_listed(
@@ -382,6 +355,7 @@ class TestCheckLinkageDanglingWorker:
         report = run_doctor()
         dw = next(c for c in report.checks if c.name == "linkage/dangling-worker")
         assert not dw.ok
+        assert "orch-multi" in dw.detail
         assert "gone-a" in dw.detail
         assert "gone-b" in dw.detail
         assert "gone-c" in dw.detail
@@ -390,12 +364,13 @@ class TestCheckLinkageDanglingWorker:
 class TestCheckLinkageDanglingParent:
     """Dangling parent: worker's parent_session_id is not in state."""
 
-    def test_dangling_parent_flagged(
+    def test_dangling_parent_flagged_with_remediation_hint(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
     ) -> None:
+        """Single dangling parent: flag both IDs and surface remediation hint."""
         from cw.config import save_state
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
@@ -420,35 +395,7 @@ class TestCheckLinkageDanglingParent:
         assert not dp.ok
         assert "worker-orphan" in dp.detail
         assert "orch-gone" in dp.detail
-
-    def test_dangling_parent_includes_remediation_hint(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        tmp_config_dir: Path,
-        sample_client: ClientConfig,
-    ) -> None:
-        from cw.config import save_state
-        from cw.models import CwState, Session, SessionPurpose, SessionStatus
-
-        monkeypatch.setenv("CW_BACKEND", "fake")
-        save_state(
-            CwState(
-                sessions=[
-                    Session(
-                        id="worker-x",
-                        name="client/impl",
-                        client="client",
-                        purpose=SessionPurpose.IMPL,
-                        status=SessionStatus.ACTIVE,
-                        workspace_path=sample_client.workspace_path,
-                        parent_session_id="no-such-parent",
-                    ),
-                ]
-            )
-        )
-        report = run_doctor()
-        dp = next(c for c in report.checks if c.name == "linkage/dangling-parent")
-        assert not dp.ok
+        # Remediation hint is included alongside the IDs.
         hint_words = {"parent_session_id", "restore", "clear"}
         assert any(w in dp.detail for w in hint_words)
 
@@ -685,3 +632,117 @@ class TestCheckLinkageIndependence:
         # Linkage dangling-worker is not ok
         dw = next(c for c in report.checks if c.name == "linkage/dangling-worker")
         assert not dw.ok
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for _check_linkage (no run_doctor / state-file roundtrip)
+# ---------------------------------------------------------------------------
+
+
+def _mk_session(
+    sid: str,
+    workspace_path: Path,
+    *,
+    parent_session_id: str | None = None,
+    worker_session_ids: list[str] | None = None,
+) -> Session:
+    """Build a minimal Session for linkage testing."""
+    from cw.models import Session, SessionPurpose, SessionStatus
+
+    return Session(
+        id=sid,
+        name=f"client/{sid}",
+        client="client",
+        purpose=SessionPurpose.IMPL,
+        status=SessionStatus.ACTIVE,
+        workspace_path=workspace_path,
+        parent_session_id=parent_session_id,
+        worker_session_ids=worker_session_ids or [],
+    )
+
+
+class TestCheckLinkageDirect:
+    """Direct tests of _check_linkage(state) — bypass state-file roundtrip."""
+
+    def test_clean_state_returns_three_ok_results(self, tmp_path: Path) -> None:
+        """Empty state and well-linked state both produce all-ok results."""
+        from cw.doctor import _check_linkage
+        from cw.models import CwState
+
+        results = _check_linkage(CwState(sessions=[]))
+        assert len(results) == 3
+        assert all(r.ok for r in results)
+        assert {r.name for r in results} == {
+            "linkage/dangling-worker",
+            "linkage/dangling-parent",
+            "linkage/asymmetric",
+        }
+
+        # Bidirectional valid linkage also clean.
+        state = CwState(
+            sessions=[
+                _mk_session("orch", tmp_path, worker_session_ids=["w1"]),
+                _mk_session("w1", tmp_path, parent_session_id="orch"),
+            ]
+        )
+        results = _check_linkage(state)
+        assert all(r.ok for r in results)
+
+    def test_dangling_worker_detected(self, tmp_path: Path) -> None:
+        from cw.doctor import _check_linkage
+        from cw.models import CwState
+
+        state = CwState(
+            sessions=[
+                _mk_session("orch", tmp_path, worker_session_ids=["ghost"]),
+            ]
+        )
+        results = {r.name: r for r in _check_linkage(state)}
+        dw = results["linkage/dangling-worker"]
+        assert not dw.ok
+        assert "orch" in dw.detail
+        assert "ghost" in dw.detail
+        # Other two checks remain clean — drift is isolated to dangling-worker.
+        assert results["linkage/dangling-parent"].ok
+        assert results["linkage/asymmetric"].ok
+
+    def test_dangling_parent_detected(self, tmp_path: Path) -> None:
+        from cw.doctor import _check_linkage
+        from cw.models import CwState
+
+        state = CwState(
+            sessions=[
+                _mk_session("worker", tmp_path, parent_session_id="ghost-parent"),
+            ]
+        )
+        results = {r.name: r for r in _check_linkage(state)}
+        dp = results["linkage/dangling-parent"]
+        assert not dp.ok
+        assert "worker" in dp.detail
+        assert "ghost-parent" in dp.detail
+        assert results["linkage/dangling-worker"].ok
+        assert results["linkage/asymmetric"].ok
+
+    def test_multiple_danglers_all_listed(self, tmp_path: Path) -> None:
+        """Mixed drift: multiple dangling workers and parents in one state."""
+        from cw.doctor import _check_linkage
+        from cw.models import CwState
+
+        state = CwState(
+            sessions=[
+                _mk_session("orch", tmp_path, worker_session_ids=["gone-1", "gone-2"]),
+                _mk_session("worker-a", tmp_path, parent_session_id="ghost-a"),
+                _mk_session("worker-b", tmp_path, parent_session_id="ghost-b"),
+            ]
+        )
+        results = {r.name: r for r in _check_linkage(state)}
+        dw = results["linkage/dangling-worker"]
+        dp = results["linkage/dangling-parent"]
+        assert not dw.ok
+        assert "gone-1" in dw.detail
+        assert "gone-2" in dw.detail
+        assert not dp.ok
+        assert "ghost-a" in dp.detail
+        assert "ghost-b" in dp.detail
+        assert "worker-a" in dp.detail
+        assert "worker-b" in dp.detail


### PR DESCRIPTION
## Summary

Implements 5 of 8 items from #67 (3 skipped per triage):

- **Item 1** ✓ Drop redundant `session_ids` set in `_check_linkage`; use `session_by_id` keys for membership.
- **Item 3** ✓ Add `"orch-multi" in dw.detail` assertion to `test_multiple_dangling_workers_all_listed` for symmetry with the single-ID sibling.
- **Item 6** ✓ Merge sibling tests (`_flagged` + `_includes_remediation_hint` pairs for both worker and parent danglers).
- **Item 7** ✓ Add CHANGELOG `[Unreleased]` entry documenting that linkage drift contributes to `cw doctor` exit code (originally introduced in #68).
- **Item 8** ✓ Add `TestCheckLinkageDirect` class with 4 cases: empty state, clean bidirectional linkage, dangling-worker isolation, dangling-parent isolation, multi-dangler.

Skipped:
- **Item 2** (`_check_state_file` two-jobs concern) — debatable design call.
- **Item 4** (severity-tier refactor) — out of scope, larger architectural change.
- **Item 5** (`orchestrator_workers` DRY) — architectural review concluded keep-as-is.

## Review feedback addressed

- CHANGELOG rewritten: `--reap` is for reconciliation, not inspection. Plain `cw doctor` is the inspection path; `--reap` reconciles phantoms.
- Split `test_clean_state_returns_three_ok_results` into two distinct tests (empty state vs. clean bidirectional linkage) so a failure in one doesn't hide the other.
- Added a comment in `test_dangling_worker_detected` explaining why asymmetric stays clean (forward check skips workers absent from `session_by_id`).

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest tests/` — 682/682 pass

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)