### PR TITLE
fix(session): harden start_session parent edge cases (#64)

### DIFF
--- a/src/cw/session.py
+++ b/src/cw/session.py
@@ -23,6 +23,7 @@ from cw.models import (
     CompletionReason,
     CwState,
     Session,
+    SessionPurpose,
     SessionStatus,
 )
 from cw.prompts import build_session_context, get_purpose_prompt
@@ -179,6 +180,24 @@ def start_session(
     reconcile(adapter)
     state = load_state()
 
+    # Validate parent session FIRST so a bad ID always errors, even when
+    # a short-circuit would otherwise fire — and BEFORE worktree creation
+    # so a bad --parent on a worktree-mode client doesn't orphan an on-disk
+    # worktree.
+    parent_session: Session | None = None
+    if parent is not None:
+        parent_session = state.find_by_name_or_id(parent)
+        if parent_session is None:
+            msg = f"Parent session not found: {parent}"
+            raise CwError(msg)
+        # --parent links the impl session to the parent. If the client
+        # config excludes 'impl' from auto_purposes there's nothing to link.
+        if SessionPurpose.IMPL not in client.auto_purposes:
+            msg = (
+                "--parent requires the client config to include 'impl' in auto_purposes"
+            )
+            raise CwError(msg)
+
     # Auto-resolve worktree for worktree-mode clients
     worktree_path: Path | None = None
     worktree_branch: str | None = worktree
@@ -197,15 +216,6 @@ def start_session(
         click.echo(f"Creating worktree for branch '{worktree}'...")
         worktree_path = create_worktree(client, worktree)
         click.echo(f"Worktree ready: {worktree_path}")
-
-    # Validate parent session FIRST so a bad ID always errors, even when
-    # a short-circuit would otherwise fire.
-    parent_session: Session | None = None
-    if parent is not None:
-        parent_session = state.find_by_name_or_id(parent)
-        if parent_session is None:
-            msg = f"Parent session not found: {parent}"
-            raise CwError(msg)
 
     # Check for existing backgrounded session
     existing = state.find_session(client_name, purpose)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1660,3 +1660,74 @@ class TestStartSessionParentLinkage:
             start_session(
                 "test-client", "impl", parent="bad-id", adapter=mock_cmux_adapter
             )
+
+    def test_parent_validation_runs_before_backgrounded_short_circuit(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_cmux_adapter: FakeCmuxAdapter,
+    ) -> None:
+        """Bad parent ID raises CwError even when a backgrounded session would
+        short-circuit (resume path)."""
+        self._write_clients_file(tmp_config_dir, sample_client)
+
+        # Pre-create a backgrounded impl session that would normally trigger
+        # the resume_session short-circuit path.
+        existing_impl = Session(
+            id="existing-impl-bg-sc",
+            name="test-client/impl",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.BACKGROUNDED,
+            workspace_path=sample_client.workspace_path,
+        )
+        save_state(CwState(sessions=[existing_impl]))
+
+        # Bad parent ID must error BEFORE resume_session is invoked.
+        with pytest.raises(CwError, match="Parent session not found: bad-id"):
+            start_session(
+                "test-client", "impl", parent="bad-id", adapter=mock_cmux_adapter
+            )
+
+        # Existing session must remain BACKGROUNDED — short-circuit never ran.
+        state = load_state()
+        assert len(state.sessions) == 1
+        assert state.sessions[0].status == SessionStatus.BACKGROUNDED
+
+    def test_parent_requires_impl_in_auto_purposes(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_cmux_adapter: FakeCmuxAdapter,
+    ) -> None:
+        """--parent raises CwError when client.auto_purposes excludes 'impl'."""
+        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
+        clients_file.write_text(
+            f"clients:\n"
+            f"  test-client:\n"
+            f"    workspace_path: {sample_client.workspace_path}\n"
+            f"    auto_purposes: [idea, debt]\n"
+        )
+
+        parent_session = Session(
+            id="parent06",
+            name="test-client/debt",
+            client="test-client",
+            purpose=SessionPurpose.DEBT,
+            status=SessionStatus.ACTIVE,
+            workspace_path=sample_client.workspace_path,
+        )
+        save_state(CwState(sessions=[parent_session]))
+
+        err_match = "--parent requires the client config to include 'impl'"
+        with pytest.raises(CwError, match=err_match):
+            start_session(
+                "test-client", "impl", parent="parent06", adapter=mock_cmux_adapter
+            )
+
+        # No new sessions created and parent unchanged.
+        state = load_state()
+        assert len(state.sessions) == 1
+        updated_parent = state.find_by_name_or_id("parent06")
+        assert updated_parent is not None
+        assert updated_parent.worker_session_ids == []

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1731,3 +1731,42 @@ class TestStartSessionParentLinkage:
         updated_parent = state.find_by_name_or_id("parent06")
         assert updated_parent is not None
         assert updated_parent.worker_session_ids == []
+
+    def test_parent_validation_runs_before_worktree_creation(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_cmux_adapter: FakeCmuxAdapter,
+    ) -> None:
+        """Bad --parent on a worktree-mode client must error BEFORE
+        create_worktree runs, so no on-disk worktree is orphaned.
+
+        Pins Item 2's stated motivation: a regression that re-orders parent
+        validation back below worktree creation would call create_worktree
+        and leave an orphaned worktree on disk before the validation error
+        fires. This spy catches that regression.
+        """
+        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
+        clients_file.write_text(
+            f"clients:\n"
+            f"  test-client:\n"
+            f"    workspace_path: {sample_client.workspace_path}\n"
+            f"    branch: main\n"
+        )
+
+        create_worktree_calls: list[tuple[object, ...]] = []
+
+        def spy_create_worktree(*args: object, **kwargs: object) -> Path:
+            create_worktree_calls.append(args)
+            msg = "create_worktree should not have been called"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr("cw.session.create_worktree", spy_create_worktree)
+
+        with pytest.raises(CwError, match="Parent session not found: bad-id"):
+            start_session(
+                "test-client", "impl", parent="bad-id", adapter=mock_cmux_adapter
+            )
+
+        assert create_worktree_calls == []


### PR DESCRIPTION
## Summary

Three deferred SHOULD_FIX items from PR #53 review:

- **Item 1** ✓ Replace `KeyError` with a clean `CwError` when `--parent` is used and the client config excludes `impl` from `auto_purposes`. Guard fires before any side effects.
- **Item 2** ✓ Move parent validation above the worktree creation block (option A). A bad `--parent` on a worktree-mode client used to create the worktree on disk and then orphan it when validation raised; now the validation runs first.
- **Item 3** ✓ Add `test_parent_validation_runs_before_backgrounded_short_circuit`. The original test only covered the ACTIVE branch; the BACKGROUNDED short-circuit (which calls `resume_session` and returns) had no equivalent.

Plus, in response to review feedback: added `test_parent_validation_runs_before_worktree_creation` — Item 2's stated motivation. Configures a worktree-mode client, spies on `create_worktree` to raise on call, supplies `--parent bad-id`, asserts the bad-parent error fires before `create_worktree` is ever invoked. Pins the regression vector.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest tests/` — 685/685 pass
- [x] `TestStartSessionParentLinkage` class: 11 tests, all pass

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)