### PR TITLE
ci: enforce mypy --strict, gate coverage at 88%, scaffold cmux nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,4 @@ jobs:
         with:
           name: coverage-xml
           path: coverage.xml
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,17 @@ jobs:
         run: uv run ruff format --check src/ tests/
 
       - name: Type check
-        run: uv run mypy src/
+        run: uv run mypy --strict src/
 
-      - name: Test (unit)
-        run: uv run pytest tests/ -v --tb=short -m 'not integration'
+      - name: Test (unit) with coverage
+        run: uv run pytest tests/ -v --tb=short -m 'not integration' --cov=cw --cov-report=term --cov-report=xml --cov-fail-under=88
 
       - name: Test (tmux integration)
         run: uv run pytest tests/ -v --tb=short -m integration
+
+      - name: Upload coverage artifact
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: coverage-xml
+          path: coverage.xml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,15 +33,29 @@ jobs:
           # TODO: confirm the actual daemon launch command (e.g. `cmux daemon &`)
           mkdir -p "$HOME/Library/Application Support/cmux"
           cmux daemon &
+          DAEMON_PID=$!
+          echo "DAEMON_PID=$DAEMON_PID" >> "$GITHUB_ENV"
           for _ in $(seq 1 20); do
             if [ -S "$HOME/Library/Application Support/cmux/cmux.sock" ]; then
-              echo "cmux socket ready"
+              # Verify daemon is still alive after socket appears.
+              if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+                echo "::error::cmux daemon exited after socket appeared"
+                exit 1
+              fi
+              echo "cmux socket ready (pid=$DAEMON_PID)"
               exit 0
             fi
             sleep 0.5
           done
           echo "::error::cmux socket never appeared"
           exit 1
+
+      - name: Stop cmux daemon
+        if: always()
+        run: |
+          if [ -n "${DAEMON_PID:-}" ]; then
+            kill "$DAEMON_PID" 2>/dev/null || true
+          fi
 
       - name: Test (cmux integration)
         run: uv run pytest tests/ -v --tb=short -m cmux

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,57 @@
+name: Nightly (cmux integration)
+
+on:
+  schedule:
+    # 09:00 UTC daily (~02:00 PT / ~05:00 ET) — off peak
+    - cron: "0 9 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  cmux-integration:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
+
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Install cmux
+        run: |
+          brew tap manaflow-ai/cmux
+          brew install --cask cmux
+
+      - name: Start cmux daemon
+        run: |
+          # cmux expects its socket at ~/Library/Application Support/cmux/cmux.sock
+          # TODO: confirm the actual daemon launch command (e.g. `cmux daemon &`)
+          mkdir -p "$HOME/Library/Application Support/cmux"
+          cmux daemon &
+          for _ in $(seq 1 20); do
+            if [ -S "$HOME/Library/Application Support/cmux/cmux.sock" ]; then
+              echo "cmux socket ready"
+              exit 0
+            fi
+            sleep 0.5
+          done
+          echo "::error::cmux socket never appeared"
+          exit 1
+
+      - name: Test (cmux integration)
+        run: uv run pytest tests/ -v --tb=short -m cmux
+
+      - name: Upload cmux logs on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: cmux-logs
+          path: |
+            ~/Library/Logs/cmux/**
+            ~/Library/Application Support/cmux/**/*.log
+          if-no-files-found: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ testpaths = ["tests"]
 pythonpath = ["src"]
 markers = [
     "integration: end-to-end tests that shell out to external tools (tmux, cmux)",
+    "cmux: requires a live cmux daemon (macOS only); run nightly via .github/workflows/nightly.yml",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

- ci: tighten review fixes — error on missing coverage.xml, track cmux daemon PID
- Merge remote-tracking branch 'origin/main' into worktree-elegant-discovering-hamming
- ci: enforce mypy --strict, gate coverage at 88%, scaffold cmux nightly

Tightens CI guardrails so quality regressions can't silently land:
- `mypy --strict` in CI (was lax; pre-commit was already strict, so CI was the looser end)
- `pytest --cov-fail-under=88` (current actual: 91%; small headroom for flux — easy to ratchet up later)
- coverage.xml uploaded as artifact (Linux leg only; `if-no-files-found: error` so a missing file hard-fails)
- new `cmux` pytest marker for daemon-backed tests
- new nightly workflow (`workflows/nightly.yml`) installs cmux via `brew tap manaflow-ai/cmux && brew install --cask cmux`, launches the daemon, runs `pytest -m cmux`. No `@pytest.mark.cmux` tests exist yet — scaffold first, fill in tests as the daemon-launch + binary-path details get confirmed by the first nightly run.

## Test plan

- [ ] CI green on this PR (mypy strict + coverage gate exercising themselves)
- [ ] Manually trigger nightly workflow via `workflow_dispatch` after merge to surface real cmux install/launch path
- [ ] Update `docs/INSTALL.md:13` and `.claude/commands/install-cw.md:26` (stale `cmuxio/cmux` URL — separate PR)

## Branch protection follow-up

After merge, `main` should require status checks `test (ubuntu-latest, 3.13)` and `test (macos-latest, 3.13)` (now bundle the coverage gate). Do not require the nightly job — schedule-triggered jobs don't run on PRs.

🤖 Shipped via /prep-pr + project /ship-it