### PR TITLE
ci+test(cmux): park real-cmux nightly, replace with mock-daemon wire tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,35 +27,41 @@ jobs:
           brew tap manaflow-ai/cmux
           brew install --cask cmux
 
-      - name: Start cmux daemon
+      - name: Diagnose cmux install
         run: |
-          # cmux expects its socket at ~/Library/Application Support/cmux/cmux.sock
-          # TODO: confirm the actual daemon launch command (e.g. `cmux daemon &`)
+          # Self-documenting diagnostics so future failures don't require
+          # spelunking through closed Actions logs.
+          echo "## which cmux"
+          which cmux || true
+          echo "## cmux --help"
+          cmux --help 2>&1 || true
+          echo "## /Applications/cmux.app contents"
+          ls -la /Applications/cmux.app/Contents/MacOS/ 2>&1 || true
+          echo "## cask info"
+          brew info --cask cmux 2>&1 | head -40 || true
+
+      - name: Launch cmux app (spawns daemon)
+        run: |
+          # The cmux cask installs a GUI .app; the daemon (and its unix
+          # socket) come up when the bundle is launched. `-g` keeps it
+          # background so CI doesn't try to bring a window forward.
           mkdir -p "$HOME/Library/Application Support/cmux"
-          cmux daemon &
-          DAEMON_PID=$!
-          echo "DAEMON_PID=$DAEMON_PID" >> "$GITHUB_ENV"
-          for _ in $(seq 1 20); do
+          open -ga cmux
+          for _ in $(seq 1 30); do
             if [ -S "$HOME/Library/Application Support/cmux/cmux.sock" ]; then
-              # Verify daemon is still alive after socket appears.
-              if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
-                echo "::error::cmux daemon exited after socket appeared"
-                exit 1
-              fi
-              echo "cmux socket ready (pid=$DAEMON_PID)"
+              echo "cmux socket ready"
               exit 0
             fi
-            sleep 0.5
+            sleep 1
           done
-          echo "::error::cmux socket never appeared"
+          echo "::error::cmux socket never appeared after 30s"
           exit 1
 
-      - name: Stop cmux daemon
+      - name: Stop cmux app
         if: always()
         run: |
-          if [ -n "${DAEMON_PID:-}" ]; then
-            kill "$DAEMON_PID" 2>/dev/null || true
-          fi
+          osascript -e 'tell application "cmux" to quit' 2>/dev/null || true
+          pkill -x cmux 2>/dev/null || true
 
       - name: Test (cmux integration)
         run: uv run pytest tests/ -v --tb=short -m cmux


### PR DESCRIPTION
## Summary

Originally a quick fix for the nightly cmux integration job. Iteration revealed hosted GitHub macOS runners can't actually launch cmux: the daemon dies during init (socket appears, then RPC connections fail with \`Broken pipe\`). Cmux is a GUI \`.app\` and the runner's stripped-down desktop session won't carry it. Pivoted to a mock-daemon approach.

### What changed

- **Park the nightly behind \`workflow_dispatch\` only.** Cron schedule removed. The install/launch wiring (\`brew tap manaflow-ai/cmux\`, \`lsregister -f /Applications/cmux.app\`, \`cmux <path>\` for daemon spawn) is preserved with comments so a future self-hosted macOS runner can flip the schedule back on without redoing this discovery work.
- **\`tests/test_cmux_wire.py\`** — threaded \`AF_UNIX\` server speaks cmux's JSON-RPC envelope. \`RealCmuxAdapter\` runs against it through real socket I/O. Three tests pin the wire format: full \`spawn()\` round-trip, \`list_surfaces\` aggregation, daemon-error propagation as \`CwError\`. Runs on the regular matrix (Linux + macOS), no GUI required.
- **\`cmux\` pytest marker repurposed** — was \"requires a live cmux daemon\"; now flags the wire-format tests. Marker doesn't exclude from default runs, so CI picks them up automatically.

### Failure trail (for the next person poking at this)

| Run | Approach | Failure |
|-----|----------|---------|
| 25318104275 | \`cmux daemon &\` | \"Socket not found\" — \`daemon\` is a client subcommand |
| 25318255048 | \`open -ga cmux\` | \"Unable to find application named 'cmux'\" — LaunchServices unindexed |
| 25318344296 | \`cmux <path>\` | Same LaunchServices miss via the CLI's internal launcher |
| 25318537122 | + \`lsregister -f\` | Socket appears, then \`Broken pipe (errno 32)\` — daemon dies during GUI init |

### Test plan

- [ ] CI green — three new tests in \`pytest -m 'not integration'\`
- [ ] \`pytest -m cmux\` selects only the wire tests, runs on Linux

🤖 Shipped via /prep-pr