### PR TITLE
feat(dispatch): parent linkage + --headless for daemon-spawned workers

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -926,10 +926,28 @@ def dev_queue_status(client: str | None) -> None:
     default=False,
     help="Respect the persisted DispatchPlan ordering when claiming tasks.",
 )
+@click.option(
+    "--parent",
+    default=None,
+    help=(
+        "Orchestrator session ID. Spawned workers are linked back via "
+        "parent_session_id + worker_session_ids."
+    ),
+)
 @handle_errors
-def dev_queue_run(max_parallel: int | None, once: bool, use_plan: bool) -> None:
+def dev_queue_run(
+    max_parallel: int | None,
+    once: bool,
+    use_plan: bool,
+    parent: str | None,
+) -> None:
     """Run the dispatch loop, spawning sessions for pending tickets."""
-    run_dispatch_loop(max_parallel=max_parallel, once=once, use_plan=use_plan)
+    run_dispatch_loop(
+        max_parallel=max_parallel,
+        once=once,
+        use_plan=use_plan,
+        parent=parent,
+    )
 
 
 _PLAN_DEFAULT_TIMEOUT = 300

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -72,6 +72,7 @@ def dispatch_tick(
     adapter: CmuxAdapter | None = None,
     *,
     use_plan: bool = False,
+    parent: str | None = None,
 ) -> int:
     """Run one dispatch tick.
 
@@ -79,6 +80,16 @@ def dispatch_tick(
     sessions are currently ACTIVE or IDLE and compare against the
     per-client cap from *config*.  If below the cap, claim one pending
     task and spawn a Claude session for it.
+
+    Args:
+        config: Orchestrator config (per-client caps, tick interval).
+        adapter: Optional CmuxAdapter for testing.
+        use_plan: If True, respect the persisted DispatchPlan ordering.
+        parent: Optional parent session ID. When set, every spawned
+            worker is linked to it (``parent_session_id`` +
+            bidirectional ``worker_session_ids``) so ``cw orchestrate
+            workers`` can list dispatched workers as first-class
+            sessions.
 
     Returns:
         Number of sessions spawned during this tick.
@@ -134,10 +145,11 @@ def dispatch_tick(
             session_id = spawn_create_impl(
                 client=client,
                 worktree=worktree_path,
-                prompt=f"/auto-dev {task.ticket_id}",
+                prompt=f"/auto-dev {task.ticket_id} --headless",
                 surface="split",
                 label=label,
                 adapter=resolved_adapter,
+                parent=parent,
             )
 
             record_event(
@@ -205,6 +217,7 @@ def run_dispatch_loop(
     once: bool = False,
     adapter: CmuxAdapter | None = None,
     use_plan: bool = False,
+    parent: str | None = None,
 ) -> None:
     """Run the dispatch loop, optionally overriding per-client concurrency caps.
 
@@ -216,6 +229,9 @@ def run_dispatch_loop(
         use_plan: If True, load the persisted DispatchPlan and use its
             ordering to claim tasks.  Falls back to enqueue order when no
             plan is found (load_plan returns None).
+        parent: Optional orchestrator session ID. Threaded into each
+            dispatch tick so spawned workers are linked back to the
+            caller's session.
     """
     config = load_orchestrator_config()
 
@@ -228,7 +244,12 @@ def run_dispatch_loop(
 
     while True:
         consume_completed_sessions()
-        dispatch_tick(config, adapter=resolved_adapter, use_plan=use_plan)
+        dispatch_tick(
+            config,
+            adapter=resolved_adapter,
+            use_plan=use_plan,
+            parent=parent,
+        )
 
         if once:
             return

--- a/src/cw/spawn.py
+++ b/src/cw/spawn.py
@@ -6,6 +6,7 @@ import shlex
 from typing import TYPE_CHECKING
 
 from cw.config import load_state, save_state
+from cw.exceptions import CwError
 from cw.models import Session, SessionOrigin, SessionPurpose
 
 if TYPE_CHECKING:
@@ -23,6 +24,7 @@ def spawn_create_impl(
     surface: str,
     label: str | None,
     adapter: CmuxAdapter,
+    parent: str | None = None,
 ) -> str:
     """Create a daemon-spawned session.
 
@@ -35,7 +37,21 @@ def spawn_create_impl(
     *name* and creates a nested worktree at a path cw cannot track. The
     worktree is established by the caller (``create_worktree`` / the
     interactive start path) and we just ``cd`` the spawned shell into it.
+
+    When *parent* is supplied, write bidirectional linkage in the same
+    state save: ``sess.parent_session_id = parent.id`` and append
+    ``sess.id`` to ``parent.worker_session_ids``. Raises :class:`CwError`
+    if the parent session is not in state.
     """
+    state = load_state()
+
+    parent_session: Session | None = None
+    if parent is not None:
+        parent_session = state.find_by_name_or_id(parent)
+        if parent_session is None:
+            msg = f"Parent session not found: {parent}"
+            raise CwError(msg)
+
     workspace = client.cmux_workspace or client.name
     cwd = shlex.quote(str(worktree))
     command = f"cd {cwd} && claude --print {prompt!r}"
@@ -52,7 +68,10 @@ def spawn_create_impl(
         surface_ref=surface_ref,
     )
 
-    state = load_state()
+    if parent_session is not None:
+        sess.parent_session_id = parent_session.id
+        parent_session.worker_session_ids.append(sess.id)
+
     state.sessions.append(sess)
     save_state(state)
     return sess.id

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -136,6 +136,86 @@ class TestDispatchTickSpawnsSession:
         # Adapter should have been called
         assert len(adapter.calls["spawn"]) == 1
 
+    def test_dispatch_tick_appends_headless_flag(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """dispatch_tick spawns auto-dev with the --headless flag.
+
+        Workers spawned via cw dev-queue must run headless so their
+        machine-readable AUTO_DEV_RESULT block is parseable by the
+        orchestrator.
+        """
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        add_ticket(TicketTask(ticket_id="GEN-300", client="test-client"))
+
+        adapter = FakeCmuxAdapter()
+        dispatch_tick(simple_config, adapter=adapter)
+
+        assert len(adapter.calls["spawn"]) == 1
+        _workspace, command, _surface = adapter.calls["spawn"][0]
+        assert "/auto-dev GEN-300 --headless" in command
+
+    def test_dispatch_tick_links_workers_to_parent(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        cap2_config: OrchestratorConfig,
+    ) -> None:
+        """dispatch_tick with parent= writes bidirectional linkage on every worker."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        # Seed an orchestrator session as the parent.
+        parent_workspace = tmp_dispatch_dirs / "workspace" / "orch"
+        parent_workspace.mkdir(parents=True)
+        parent = Session(
+            name="orch/impl",
+            client="orch",
+            purpose=SessionPurpose.IMPL,
+            workspace_path=parent_workspace,
+        )
+        state = load_state()
+        state.sessions.append(parent)
+        save_state(state)
+
+        for i in range(2):
+            add_ticket(TicketTask(ticket_id=f"GEN-{i}", client="test-client"))
+
+        adapter = FakeCmuxAdapter()
+        spawned = dispatch_tick(cap2_config, adapter=adapter, parent=parent.id)
+        assert spawned == 2
+
+        state = load_state()
+        workers = [s for s in state.sessions if s.origin == SessionOrigin.DAEMON]
+        assert len(workers) == 2
+        for w in workers:
+            assert w.parent_session_id == parent.id
+
+        refreshed_parent = state.find_by_name_or_id(parent.id)
+        assert refreshed_parent is not None
+        worker_ids = {w.id for w in workers}
+        assert worker_ids.issubset(set(refreshed_parent.worker_session_ids))
+
+    def test_dispatch_tick_no_parent_leaves_linkage_empty(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """Direct CLI run (no orchestrator): parent=None → no linkage, no error."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        add_ticket(TicketTask(ticket_id="GEN-400", client="test-client"))
+
+        adapter = FakeCmuxAdapter()
+        dispatch_tick(simple_config, adapter=adapter)  # parent omitted
+
+        state = load_state()
+        worker = state.sessions[0]
+        assert worker.parent_session_id is None
+        assert worker.worker_session_ids == []
+
 
 # ---------------------------------------------------------------------------
 # TestPerClientCapRespected

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -204,6 +204,77 @@ class TestSpawnCreate:
         # FakeCmuxAdapter returns "fake-pane-1" for first spawn call
         assert state.sessions[0].surface_ref == "fake-pane-1"
 
+    def test_parent_linkage_writes_both_directions(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn create with parent: worker.parent_session_id set and parent's
+        worker_session_ids list contains the new worker id (single state save).
+        """
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        adapter = FakeCmuxAdapter()
+        worktree = tmp_path / "worktree"
+        worktree.mkdir(parents=True)
+
+        # Seed a parent orchestrator session in state.
+        parent_workspace = tmp_path / "workspace" / "orch"
+        parent_workspace.mkdir(parents=True)
+        parent = Session(
+            name="orch/impl",
+            client="orch",
+            purpose=SessionPurpose.IMPL,
+            workspace_path=parent_workspace,
+        )
+        state = load_state()
+        state.sessions.append(parent)
+        save_state(state)
+
+        worker_id = spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt="/auto-dev GEN-9 --headless",
+            surface="split",
+            label="auto-dev-GEN-9",
+            adapter=adapter,
+            parent=parent.id,
+        )
+
+        state = load_state()
+        worker = state.find_by_name_or_id(worker_id)
+        assert worker is not None
+        assert worker.parent_session_id == parent.id
+        refreshed_parent = state.find_by_name_or_id(parent.id)
+        assert refreshed_parent is not None
+        assert worker_id in refreshed_parent.worker_session_ids
+
+    def test_parent_not_found_raises(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn create with bogus parent ID: CwError, no session created, no spawn."""
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        adapter = FakeCmuxAdapter()
+        worktree = tmp_path / "worktree"
+        worktree.mkdir(parents=True)
+
+        with pytest.raises(CwError, match="Parent session not found"):
+            spawn_create_impl(
+                client=client,
+                worktree=worktree,
+                prompt="/auto-dev GEN-9 --headless",
+                surface="split",
+                label=None,
+                adapter=adapter,
+                parent="does-not-exist",
+            )
+
+        # No worker session persisted, no surface spawned.
+        state = load_state()
+        assert state.sessions == []
+        assert adapter.calls["spawn"] == []
+
 
 class TestSpawnClose:
     """Tests for the spawn close business logic."""


### PR DESCRIPTION
Closes #56.

## Summary
- `spawn_create_impl`: optional `parent` kwarg writes bidirectional linkage (`parent_session_id` on worker, append to `parent.worker_session_ids`) under a single state save. Missing parent raises `CwError` before any surface is spawned.
- `dispatch_tick` / `run_dispatch_loop`: thread `parent` through to the spawn call; dispatched prompt now includes `--headless` so workers emit a parseable `AUTO_DEV_RESULT` block.
- `cw dev-queue run --parent <id>`: orchestrator session can hand its id down so dispatched workers become first-class linked sessions visible to `cw orchestrate workers` (#54).

Backwards compatible: every new param defaults to `None` / unchanged behavior.

## Test plan
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest tests/` — 690 pass
- [ ] Manual: `cw dev-queue run --parent <orch-id> --once` populates `worker_session_ids` on the orch session and `parent_session_id` on each worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)