### PR TITLE
feat: parse <<<AUTO_DEV_RESULT sentinel + persist on Session (#57)

### DIFF
--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -1,0 +1,359 @@
+"""Parser for the ``<<<AUTO_DEV_RESULT`` sentinel block.
+
+The headless ``/auto-dev`` skill emits a sentinel-delimited JSON block as the
+final lines of stdout summarizing the pipeline outcome. ``cw`` parses that
+block to persist a structured view on the worker Session.
+
+Spec: ``docs/headless-contract.md`` (§3 framing, §4 enum, §5 health, §6
+failure modes).
+
+Public surface:
+
+- :class:`AutoDevResult` and its nested models (Pydantic).
+- :func:`parse_stdout` — accepts raw stdout, returns either a parsed
+  ``AutoDevResult`` or a synthetic ``BlockedResult`` describing why the
+  payload was unusable. Never raises on malformed input.
+- :func:`extract_block` — low-level helper that locates the LAST sentinel
+  pair and returns the inner JSON text (no parsing).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, ValidationError, model_validator
+
+_log = logging.getLogger(__name__)
+
+SUPPORTED_SCHEMA_VERSION = 1
+
+_OPEN_SENTINEL = "<<<AUTO_DEV_RESULT"
+_CLOSE_SENTINEL = "AUTO_DEV_RESULT>>>"
+# A "complete" block runs from a line containing the open sentinel to a
+# subsequent line containing only the close sentinel. We take the LAST such
+# block per §3.1 — narrative above the real block may legitimately quote
+# the literal sentinel string (e.g., this docstring).
+_BLOCK_RE = re.compile(
+    r"<<<AUTO_DEV_RESULT\s*\n(.*?)\nAUTO_DEV_RESULT>>>",
+    re.DOTALL,
+)
+
+# Keep the last-N-lines payload bounded so synthetic blocker details don't
+# bloat the persisted state file. 40 lines is enough to capture a typical
+# pre-crash traceback without dragging in megabytes of pane scrollback.
+_TAIL_LINES = 40
+
+
+Status = Literal[
+    "shipped",
+    "plan_pending_approval",
+    "review_pending_approval",
+    "merge_gate_blocked",
+    "scope_exceeded",
+    "forbidden_area",
+    "blocked",
+]
+StageReached = Literal[
+    "stage1_plan",
+    "stage2_impl",
+    "stage3_review",
+    "stage4a_merge_gate",
+    "stage4b_pr_create",
+    "stage5_post_create",
+]
+ScopeTier = Literal["small", "large"]
+PlanSource = Literal["linear_existing", "generated", "free_text"]
+
+
+class Scope(BaseModel):
+    tier: ScopeTier
+    files: int
+    lines_estimate: int
+    lines_actual: int | None = None
+    forbidden_touched: bool
+
+
+class PrInfo(BaseModel):
+    number: int
+    url: str
+    auto_merge: bool
+    base: str
+
+
+class Review(BaseModel):
+    must_fix_initial: int
+    should_fix: int
+    fix_cycles_used: int
+
+
+class Health(BaseModel):
+    lowest_agent_confidence: Literal["HIGH", "MEDIUM", "LOW"]
+    any_incomplete_risk: bool
+    shortcuts: list[str] = Field(default_factory=list)
+    recommendation: Literal["PROCEED", "EXIT_FOR_HUMAN_REVIEW"]
+    downgrade_applied: bool = False
+    fix_loop_escalated: bool = False
+
+
+class Blocker(BaseModel):
+    """Either an emitted blocker (``status=blocked``) or a synthetic one.
+
+    ``reason`` is intentionally typed as ``str`` (open enum per §4.2). The
+    producer may add new reasons without a schema bump; consumers surface
+    unknown reasons verbatim.
+    """
+
+    stage: str
+    reason: str
+    details: str = ""
+
+
+_TERMINAL_REJECT_STATUSES: frozenset[Status] = frozenset(
+    {"scope_exceeded", "forbidden_area", "blocked"},
+)
+_PRE_BRANCH_STATUSES: frozenset[Status] = frozenset(
+    {"plan_pending_approval", "scope_exceeded", "forbidden_area"},
+)
+
+
+class AutoDevResult(BaseModel):
+    """Parsed sentinel block. All cross-field invariants from §3-§5 enforced."""
+
+    schema_version: Literal[1]
+    ticket_id: str
+    status: Status
+    stage_reached: StageReached
+    scope: Scope
+    plan_source: PlanSource
+    branch: str | None = None
+    worktree_path: str | None = None
+    fork_point_sha: str | None = None
+    commits: list[str] = Field(default_factory=list)
+    pr: PrInfo | None = None
+    review: Review
+    health: Health
+    friction_highlights: list[str] = Field(default_factory=list)
+    blocker: Blocker | None = None
+    next_actions: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _check_invariants(self) -> AutoDevResult:
+        # §3.3 pr: non-null iff status == shipped
+        if self.status == "shipped" and self.pr is None:
+            msg = "pr must be non-null when status is 'shipped'"
+            raise ValueError(msg)
+        if self.status != "shipped" and self.pr is not None:
+            msg = f"pr must be null when status is {self.status!r}"
+            raise ValueError(msg)
+
+        # §3.3 blocker: non-null iff status == blocked
+        if self.status == "blocked" and self.blocker is None:
+            msg = "blocker must be non-null when status is 'blocked'"
+            raise ValueError(msg)
+        if self.status != "blocked" and self.blocker is not None:
+            msg = f"blocker must be null when status is {self.status!r}"
+            raise ValueError(msg)
+
+        # §4.3 next_actions: wait_for_ci iff shipped
+        wait_present = "wait_for_ci" in self.next_actions
+        if self.status == "shipped" and not wait_present:
+            msg = (
+                "'wait_for_ci' must be present in next_actions when status is 'shipped'"
+            )
+            raise ValueError(msg)
+        if self.status != "shipped" and wait_present:
+            msg = (
+                f"'wait_for_ci' must not appear in next_actions "
+                f"when status is {self.status!r}"
+            )
+            raise ValueError(msg)
+
+        # §5.1 downgrade_applied implies review_pending_approval + small
+        if self.health.downgrade_applied and (
+            self.status != "review_pending_approval" or self.scope.tier != "small"
+        ):
+            msg = (
+                "health.downgrade_applied=true requires "
+                "status='review_pending_approval' and scope.tier='small'"
+            )
+            raise ValueError(msg)
+
+        # §4.1 merge_gate_blocked is small-scope only
+        if self.status == "merge_gate_blocked" and self.scope.tier != "small":
+            msg = "merge_gate_blocked requires scope.tier='small'"
+            raise ValueError(msg)
+
+        # §3.3 pre-branch statuses must have branch=None
+        if self.status in _PRE_BRANCH_STATUSES and self.branch is not None:
+            msg = f"branch must be null when status is {self.status!r}"
+            raise ValueError(msg)
+
+        # §3.3 lines_actual is None iff exited before impl (stage1_plan)
+        exited_pre_impl = self.stage_reached == "stage1_plan"
+        if exited_pre_impl and self.scope.lines_actual is not None:
+            msg = "scope.lines_actual must be null when stage_reached='stage1_plan'"
+            raise ValueError(msg)
+        if not exited_pre_impl and self.scope.lines_actual is None:
+            msg = (
+                "scope.lines_actual must be non-null when "
+                f"stage_reached={self.stage_reached!r}"
+            )
+            raise ValueError(msg)
+
+        # §4.3 terminal-reject statuses have empty next_actions
+        if self.status in _TERMINAL_REJECT_STATUSES and self.next_actions:
+            msg = (
+                f"next_actions must be empty for terminal-reject status "
+                f"{self.status!r}, got {self.next_actions!r}"
+            )
+            raise ValueError(msg)
+
+        return self
+
+
+class BlockedResult(BaseModel):
+    """Synthetic result for §6 failure modes (parser-side blockers).
+
+    Distinct from a producer-emitted ``AutoDevResult`` with ``status=blocked``:
+    a ``BlockedResult`` indicates that the parser could not extract a valid
+    sentinel payload at all. cw should treat these the same as a real
+    ``blocked`` outcome — surface to user, do not auto-route.
+    """
+
+    status: Literal["blocked"] = "blocked"
+    blocker: Blocker
+
+
+def _tail(text: str, lines: int = _TAIL_LINES) -> str:
+    return "\n".join(text.splitlines()[-lines:])
+
+
+def extract_block(text: str) -> str | None:
+    """Return the JSON text inside the LAST complete sentinel pair, or None.
+
+    Does not parse the JSON. Returns None if no complete pair is found —
+    callers must distinguish "no opening sentinel at all" from "opening
+    present but no close" themselves if they care (see :func:`parse_stdout`).
+    """
+    matches = list(_BLOCK_RE.finditer(text))
+    if not matches:
+        return None
+    return matches[-1].group(1)
+
+
+def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
+    """Parse a worker's stdout and return either the result or a synthetic blocker.
+
+    Handles all six §6 failure modes by returning a :class:`BlockedResult`
+    rather than raising. Callers can branch on ``isinstance(result,
+    AutoDevResult)`` or check ``result.status``.
+    """
+    # §6 (6) multi-block detection comes first: even if the LAST block is
+    # well-formed, the contract says exactly one per invocation.
+    matches = list(_BLOCK_RE.finditer(text))
+    if len(matches) > 1:
+        last_payload = matches[-1].group(1)
+        return BlockedResult(
+            blocker=Blocker(
+                stage="unknown",
+                reason="multiple_result_blocks",
+                details=f"count={len(matches)}; last_block={last_payload}",
+            ),
+        )
+
+    if not matches:
+        # §6 (1) no sentinel, or §6 (2) opening without close. We don't
+        # distinguish — both indicate the skill failed before/during the
+        # emit step.
+        if _OPEN_SENTINEL in text:
+            reason = "no_result_emitted"
+            details = f"opening sentinel present, close missing; tail:\n{_tail(text)}"
+        else:
+            reason = "no_result_emitted"
+            details = f"no sentinel block in stdout; tail:\n{_tail(text)}"
+        return BlockedResult(
+            blocker=Blocker(stage="unknown", reason=reason, details=details),
+        )
+
+    raw_block = matches[0].group(1)
+
+    # §6 (3) JSON does not parse.
+    try:
+        payload: Any = json.loads(raw_block)
+    except json.JSONDecodeError as exc:
+        _log.warning("auto-dev sentinel block did not parse as JSON: %s", exc)
+        return BlockedResult(
+            blocker=Blocker(
+                stage="unknown",
+                reason="no_result_emitted",
+                details=f"sentinel block JSON parse failed ({exc}); raw:\n{raw_block}",
+            ),
+        )
+
+    if not isinstance(payload, dict):
+        type_name = type(payload).__name__
+        return BlockedResult(
+            blocker=Blocker(
+                stage="unknown",
+                reason="no_result_emitted",
+                details=f"sentinel block was not a JSON object (got {type_name})",
+            ),
+        )
+
+    # §6 (4) schema_version higher than supported, and the related case where
+    # the field is missing or non-int. Pre-validate before handing to Pydantic
+    # so the caller gets a structured surface instead of a ValidationError.
+    raw_version = payload.get("schema_version")
+    if not isinstance(raw_version, int) or raw_version != SUPPORTED_SCHEMA_VERSION:
+        _log.warning(
+            "auto-dev sentinel schema_version=%r unsupported (parser supports %d)",
+            raw_version,
+            SUPPORTED_SCHEMA_VERSION,
+        )
+        return BlockedResult(
+            blocker=Blocker(
+                stage="unknown",
+                reason="schema_version_unsupported",
+                details=(
+                    f"got schema_version={raw_version!r}, "
+                    f"parser supports {SUPPORTED_SCHEMA_VERSION}"
+                ),
+            ),
+        )
+
+    # §6 (5) unknown status — short-circuit before Pydantic raises a
+    # ValidationError on the closed Literal.
+    raw_status = payload.get("status")
+    if raw_status not in {
+        "shipped",
+        "plan_pending_approval",
+        "review_pending_approval",
+        "merge_gate_blocked",
+        "scope_exceeded",
+        "forbidden_area",
+        "blocked",
+    }:
+        return BlockedResult(
+            blocker=Blocker(
+                stage="unknown",
+                reason="status_unknown",
+                details=(
+                    f"got status={raw_status!r}; surface verbatim, do not auto-route"
+                ),
+            ),
+        )
+
+    try:
+        return AutoDevResult.model_validate(payload)
+    except ValidationError as exc:
+        _log.warning("auto-dev sentinel failed model validation: %s", exc)
+        return BlockedResult(
+            blocker=Blocker(
+                stage="unknown",
+                reason="validation_failed",
+                details=f"{exc}",
+            ),
+        )

--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -208,6 +208,7 @@ def migrate_cw_state(raw: dict[str, Any]) -> dict[str, Any]:
             _migrate_zellij_fields(session_raw)
             _coerce_session_origin(session_raw)
             _fill_linkage_field_defaults(session_raw)
+            _fill_last_result_default(session_raw)
     # Bump persisted schema_version to current after all migration steps.
     raw["schema_version"] = CW_STATE_SCHEMA_VERSION
     return raw
@@ -258,6 +259,17 @@ def _fill_linkage_field_defaults(session_raw: dict[str, Any]) -> None:
         session_raw["parent_session_id"] = None
     if "worker_session_ids" not in session_raw:
         session_raw["worker_session_ids"] = []
+
+
+def _fill_last_result_default(session_raw: dict[str, Any]) -> None:
+    """Fill last_result introduced in schema v3.
+
+    Idempotent like the linkage defaults helper. Sessions that pre-date the
+    headless auto-dev parser have no last_result on disk; setting None
+    explicitly keeps the on-disk shape stable across re-saves.
+    """
+    if "last_result" not in session_raw:
+        session_raw["last_result"] = None
 
 
 def save_state(state: CwState) -> None:

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -6,8 +6,9 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
+from cw.auto_dev_result import AutoDevResult, parse_stdout
 from cw.cmux import get_cmux_adapter
-from cw.config import load_clients, load_orchestrator_config, load_state
+from cw.config import load_clients, load_orchestrator_config, load_state, save_state
 from cw.dev_queue import dev_queue_lock, load_dev_queue, load_plan, save_dev_queue
 from cw.events import advance_cursor, read_events, record_event
 from cw.models import (
@@ -205,10 +206,49 @@ def consume_completed_sessions() -> int:
         if completed:
             save_dev_queue(store)
 
+    # Persist sentinel-block summaries on Sessions whose completion event
+    # carried captured stdout. Producer side (worker stdout capture) is
+    # gated on the orchestrator P1.A wiring; this consumer is forward-
+    # compatible with events that lack a ``stdout`` payload.
+    for event in events:
+        session_id = event.payload.get("session_id")
+        stdout = event.payload.get("stdout")
+        if isinstance(session_id, str) and isinstance(stdout, str):
+            persist_last_result(session_id, stdout)
+
     # Advance cursor to the last event processed
     advance_cursor(_DISPATCH_CONSUMER, events[-1].id)
 
     return completed
+
+
+def persist_last_result(session_id: str, stdout: str) -> bool:
+    """Parse *stdout* and write the result onto the matching Session.
+
+    Returns True if a session was updated, False if no match or if parsing
+    yielded nothing actionable. Never raises — parser failures surface as
+    a synthetic blocker dict on ``Session.last_result`` so post-hoc
+    inspection still has something to look at.
+    """
+    parsed = parse_stdout(stdout)
+    state = load_state()
+    target = None
+    for session in state.sessions:
+        if session.id == session_id:
+            target = session
+            break
+    if target is None:
+        _log.warning(
+            "persist_last_result: session %s not found in state",
+            session_id,
+        )
+        return False
+    if isinstance(parsed, AutoDevResult):
+        target.last_result = parsed.model_dump(mode="json")
+    else:
+        target.last_result = parsed.model_dump(mode="json")
+    save_state(state)
+    return True
 
 
 def run_dispatch_loop(

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -45,7 +45,7 @@ class QueueItemStatus(StrEnum):
 # Schema versions for persisted state. Bump when making a breaking change
 # to the on-disk layout; add a migration in `cw.config.migrate_cw_state`
 # or `cw.dev_queue.migrate_dev_queue` to handle older versions.
-CW_STATE_SCHEMA_VERSION = 2
+CW_STATE_SCHEMA_VERSION = 3
 DEV_QUEUE_SCHEMA_VERSION = 1
 
 
@@ -221,6 +221,13 @@ class Session(BaseModel):
     completed_at: datetime | None = None
     parent_session_id: str | None = None
     worker_session_ids: list[str] = Field(default_factory=list)
+    # Sentinel-block summary parsed from a headless /auto-dev worker's stdout
+    # at completion time. ``None`` for any session that didn't run headless or
+    # whose stdout could not be parsed. Stored as a raw dict (rather than the
+    # AutoDevResult Pydantic model) so the persisted state file remains
+    # readable when the result schema bumps independently of cw's CW_STATE
+    # schema. See ``cw.auto_dev_result`` for the parser.
+    last_result: dict[str, Any] | None = None
 
 
 DEFAULT_AUTO_PURPOSES: list[SessionPurpose] = [

--- a/tests/test_auto_dev_result.py
+++ b/tests/test_auto_dev_result.py
@@ -1,0 +1,491 @@
+"""Tests for cw.auto_dev_result - sentinel block parser + invariants."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from cw.auto_dev_result import (
+    AutoDevResult,
+    BlockedResult,
+    extract_block,
+    parse_stdout,
+)
+
+# ---------------------------------------------------------------------------
+# Payload helpers — keep round-trippable shapes for each terminal status.
+# ---------------------------------------------------------------------------
+
+
+def _shipped_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "ticket_id": "GEN-1234",
+        "status": "shipped",
+        "stage_reached": "stage5_post_create",
+        "scope": {
+            "tier": "small",
+            "files": 3,
+            "lines_estimate": 42,
+            "lines_actual": 47,
+            "forbidden_touched": False,
+        },
+        "plan_source": "linear_existing",
+        "branch": "dev/gen-1234-fix-login",
+        "worktree_path": "/tmp/wt/gen-1234",
+        "fork_point_sha": "abc1234",
+        "commits": ["sha1", "sha2"],
+        "pr": {
+            "number": 42,
+            "url": "https://github.com/foo/bar/pull/42",
+            "auto_merge": True,
+            "base": "main",
+        },
+        "review": {"must_fix_initial": 0, "should_fix": 1, "fix_cycles_used": 0},
+        "health": {
+            "lowest_agent_confidence": "MEDIUM",
+            "any_incomplete_risk": False,
+            "shortcuts": [],
+            "recommendation": "PROCEED",
+            "downgrade_applied": False,
+            "fix_loop_escalated": False,
+        },
+        "friction_highlights": [],
+        "blocker": None,
+        "next_actions": ["wait_for_ci"],
+    }
+
+
+def _plan_pending_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "ticket_id": "GEN-2",
+        "status": "plan_pending_approval",
+        "stage_reached": "stage1_plan",
+        "scope": {
+            "tier": "large",
+            "files": 25,
+            "lines_estimate": 1200,
+            "lines_actual": None,
+            "forbidden_touched": False,
+        },
+        "plan_source": "generated",
+        "branch": None,
+        "worktree_path": None,
+        "fork_point_sha": None,
+        "commits": [],
+        "pr": None,
+        "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+        "health": {
+            "lowest_agent_confidence": "HIGH",
+            "any_incomplete_risk": False,
+            "shortcuts": [],
+            "recommendation": "PROCEED",
+            "downgrade_applied": False,
+            "fix_loop_escalated": False,
+        },
+        "friction_highlights": [],
+        "blocker": None,
+        "next_actions": ["user_approve_plan"],
+    }
+
+
+def _review_pending_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "ticket_id": "GEN-3",
+        "status": "review_pending_approval",
+        "stage_reached": "stage3_review",
+        "scope": {
+            "tier": "large",
+            "files": 12,
+            "lines_estimate": 600,
+            "lines_actual": 580,
+            "forbidden_touched": False,
+        },
+        "plan_source": "linear_existing",
+        "branch": "dev/gen-3",
+        "worktree_path": "/tmp/wt/gen-3",
+        "fork_point_sha": "def456",
+        "commits": ["c1"],
+        "pr": None,
+        "review": {"must_fix_initial": 2, "should_fix": 0, "fix_cycles_used": 1},
+        "health": {
+            "lowest_agent_confidence": "MEDIUM",
+            "any_incomplete_risk": False,
+            "shortcuts": [],
+            "recommendation": "PROCEED",
+            "downgrade_applied": False,
+            "fix_loop_escalated": False,
+        },
+        "friction_highlights": [],
+        "blocker": None,
+        "next_actions": ["user_approve_review"],
+    }
+
+
+def _merge_gate_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "ticket_id": "GEN-4",
+        "status": "merge_gate_blocked",
+        "stage_reached": "stage4a_merge_gate",
+        "scope": {
+            "tier": "small",
+            "files": 2,
+            "lines_estimate": 20,
+            "lines_actual": 18,
+            "forbidden_touched": False,
+        },
+        "plan_source": "linear_existing",
+        "branch": "dev/gen-4",
+        "worktree_path": "/tmp/wt/gen-4",
+        "fork_point_sha": "fff",
+        "commits": ["c1"],
+        "pr": None,
+        "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+        "health": {
+            "lowest_agent_confidence": "HIGH",
+            "any_incomplete_risk": False,
+            "shortcuts": [],
+            "recommendation": "PROCEED",
+            "downgrade_applied": False,
+            "fix_loop_escalated": False,
+        },
+        "friction_highlights": [],
+        "blocker": None,
+        "next_actions": ["resolve_merge_gate"],
+    }
+
+
+def _scope_exceeded_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "ticket_id": "GEN-5",
+        "status": "scope_exceeded",
+        "stage_reached": "stage1_plan",
+        "scope": {
+            "tier": "large",
+            "files": 30,
+            "lines_estimate": 2000,
+            "lines_actual": None,
+            "forbidden_touched": False,
+        },
+        "plan_source": "generated",
+        "branch": None,
+        "worktree_path": None,
+        "fork_point_sha": None,
+        "commits": [],
+        "pr": None,
+        "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+        "health": {
+            "lowest_agent_confidence": "HIGH",
+            "any_incomplete_risk": False,
+            "shortcuts": [],
+            "recommendation": "PROCEED",
+            "downgrade_applied": False,
+            "fix_loop_escalated": False,
+        },
+        "friction_highlights": [],
+        "blocker": None,
+        "next_actions": [],
+    }
+
+
+def _forbidden_area_payload() -> dict[str, Any]:
+    p = _scope_exceeded_payload()
+    p["ticket_id"] = "GEN-6"
+    p["status"] = "forbidden_area"
+    p["scope"]["tier"] = "small"
+    p["scope"]["files"] = 5
+    p["scope"]["lines_estimate"] = 100
+    p["scope"]["forbidden_touched"] = True
+    return p
+
+
+def _blocked_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "ticket_id": "GEN-7",
+        "status": "blocked",
+        "stage_reached": "stage2_impl",
+        "scope": {
+            "tier": "small",
+            "files": 4,
+            "lines_estimate": 80,
+            "lines_actual": 60,
+            "forbidden_touched": False,
+        },
+        "plan_source": "linear_existing",
+        "branch": "dev/gen-7",
+        "worktree_path": "/tmp/wt/gen-7",
+        "fork_point_sha": "aaa",
+        "commits": ["c1"],
+        "pr": None,
+        "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+        "health": {
+            "lowest_agent_confidence": "LOW",
+            "any_incomplete_risk": True,
+            "shortcuts": ["skipped lint"],
+            "recommendation": "EXIT_FOR_HUMAN_REVIEW",
+            "downgrade_applied": False,
+            "fix_loop_escalated": False,
+        },
+        "friction_highlights": ["impl agent reported BLOCK"],
+        "blocker": {
+            "stage": "stage2_impl",
+            "reason": "impl_failed",
+            "details": "tests failed twice",
+        },
+        "next_actions": [],
+    }
+
+
+def _wrap_sentinel(payload: dict[str, Any]) -> str:
+    body = json.dumps(payload)
+    return f"some narrative\n<<<AUTO_DEV_RESULT\n{body}\nAUTO_DEV_RESULT>>>\n"
+
+
+# ---------------------------------------------------------------------------
+# Status round-trips
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload_factory",
+    [
+        _shipped_payload,
+        _plan_pending_payload,
+        _review_pending_payload,
+        _merge_gate_payload,
+        _scope_exceeded_payload,
+        _forbidden_area_payload,
+        _blocked_payload,
+    ],
+)
+class TestStatusRoundTrips:
+    def test_parses_clean(self, payload_factory: Any) -> None:
+        result = parse_stdout(_wrap_sentinel(payload_factory()))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == payload_factory()["status"]
+
+    def test_round_trip_preserves_status(self, payload_factory: Any) -> None:
+        payload = payload_factory()
+        result = parse_stdout(_wrap_sentinel(payload))
+        assert isinstance(result, AutoDevResult)
+        # model_dump round-trip preserves the status enum
+        dumped = result.model_dump(mode="json")
+        assert dumped["status"] == payload["status"]
+
+
+# ---------------------------------------------------------------------------
+# §6 Failure modes
+# ---------------------------------------------------------------------------
+
+
+class TestSentinelFailureModes:
+    def test_no_sentinel_at_all(self) -> None:
+        result = parse_stdout("just narrative, no block here\n")
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "no_result_emitted"
+
+    def test_open_sentinel_no_close(self) -> None:
+        text = '<<<AUTO_DEV_RESULT\n{"schema_version": 1\n... crashed mid-emit'
+        result = parse_stdout(text)
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "no_result_emitted"
+        assert "opening sentinel present" in result.blocker.details
+
+    def test_malformed_json(self) -> None:
+        text = "<<<AUTO_DEV_RESULT\n{not json,,,}\nAUTO_DEV_RESULT>>>\n"
+        result = parse_stdout(text)
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "no_result_emitted"
+        assert "JSON parse failed" in result.blocker.details
+
+    def test_unsupported_schema_version(self) -> None:
+        payload = _shipped_payload()
+        payload["schema_version"] = 99
+        result = parse_stdout(_wrap_sentinel(payload))
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "schema_version_unsupported"
+
+    def test_missing_schema_version(self) -> None:
+        payload = _shipped_payload()
+        del payload["schema_version"]
+        result = parse_stdout(_wrap_sentinel(payload))
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "schema_version_unsupported"
+
+    def test_unknown_status(self) -> None:
+        payload = _shipped_payload()
+        payload["status"] = "exploded"
+        result = parse_stdout(_wrap_sentinel(payload))
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "status_unknown"
+        assert "exploded" in result.blocker.details
+
+    def test_multiple_blocks(self) -> None:
+        text = (
+            _wrap_sentinel(_shipped_payload())
+            + "extra noise\n"
+            + _wrap_sentinel(_plan_pending_payload())
+        )
+        result = parse_stdout(text)
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "multiple_result_blocks"
+        assert "count=2" in result.blocker.details
+
+    def test_top_level_not_an_object(self) -> None:
+        text = "<<<AUTO_DEV_RESULT\n[1, 2, 3]\nAUTO_DEV_RESULT>>>\n"
+        result = parse_stdout(text)
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "no_result_emitted"
+
+    def test_validation_failure_surfaces_blocked(self) -> None:
+        # Invariant violation: shipped without pr → ValidationError → blocked.
+        payload = _shipped_payload()
+        payload["pr"] = None
+        result = parse_stdout(_wrap_sentinel(payload))
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "validation_failed"
+
+
+# ---------------------------------------------------------------------------
+# Sentinel framing edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSentinelFraming:
+    def test_extra_noise_before_and_after(self) -> None:
+        text = (
+            "lots of pre-noise\n"
+            "more lines\n" + _wrap_sentinel(_shipped_payload()) + "trailing CI url\n"
+        )
+        result = parse_stdout(text)
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "shipped"
+
+    def test_extract_block_returns_none_when_absent(self) -> None:
+        assert extract_block("nothing here") is None
+
+    def test_extract_block_returns_inner_text(self) -> None:
+        text = _wrap_sentinel(_shipped_payload())
+        inner = extract_block(text)
+        assert inner is not None
+        assert json.loads(inner)["status"] == "shipped"
+
+    def test_narrative_quoting_sentinel_doesnt_break_parse(self) -> None:
+        # If narrative happens to mention the literal sentinel string but
+        # without a complete pair, it must not be extracted.
+        text = "the agent said: <<<AUTO_DEV_RESULT is the sentinel\n" + _wrap_sentinel(
+            _shipped_payload()
+        )
+        result = parse_stdout(text)
+        assert isinstance(result, AutoDevResult)
+
+
+# ---------------------------------------------------------------------------
+# Cross-field invariants (per the owner's comment + §3-§5)
+# ---------------------------------------------------------------------------
+
+
+class TestInvariants:
+    def test_shipped_requires_pr(self) -> None:
+        p = _shipped_payload()
+        p["pr"] = None
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_non_shipped_rejects_pr(self) -> None:
+        p = _plan_pending_payload()
+        p["pr"] = {
+            "number": 1,
+            "url": "x",
+            "auto_merge": True,
+            "base": "main",
+        }
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_blocked_requires_blocker(self) -> None:
+        p = _blocked_payload()
+        p["blocker"] = None
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_non_blocked_rejects_blocker(self) -> None:
+        p = _shipped_payload()
+        p["blocker"] = {"stage": "x", "reason": "y", "details": ""}
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_shipped_requires_wait_for_ci(self) -> None:
+        p = _shipped_payload()
+        p["next_actions"] = []
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_non_shipped_rejects_wait_for_ci(self) -> None:
+        p = _plan_pending_payload()
+        p["next_actions"] = ["wait_for_ci"]
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_downgrade_applied_requires_review_pending_small(self) -> None:
+        # downgrade=True on a shipped payload (which is also small) is
+        # rejected because the status must be review_pending_approval.
+        p = _shipped_payload()
+        p["health"]["downgrade_applied"] = True
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_downgrade_applied_accepted_on_review_pending_small(self) -> None:
+        p = _review_pending_payload()
+        p["scope"]["tier"] = "small"
+        p["health"]["downgrade_applied"] = True
+        # large→small swap also needs lines_actual present; already set
+        result = AutoDevResult.model_validate(p)
+        assert result.health.downgrade_applied is True
+
+    def test_merge_gate_blocked_requires_small(self) -> None:
+        p = _merge_gate_payload()
+        p["scope"]["tier"] = "large"
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_pre_branch_status_rejects_branch(self) -> None:
+        p = _plan_pending_payload()
+        p["branch"] = "dev/sneak"
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_stage1_plan_requires_lines_actual_null(self) -> None:
+        p = _plan_pending_payload()
+        p["scope"]["lines_actual"] = 50
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_post_impl_requires_lines_actual_present(self) -> None:
+        p = _shipped_payload()
+        p["scope"]["lines_actual"] = None
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_terminal_reject_rejects_next_actions(self) -> None:
+        p = _scope_exceeded_payload()
+        p["next_actions"] = ["something"]
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_blocker_reason_is_open_enum(self) -> None:
+        # The producer can emit reasons we've never seen; consumers must
+        # accept them rather than forcing a closed Literal.
+        p = _blocked_payload()
+        p["blocker"]["reason"] = "future_unknown_reason"
+        result = AutoDevResult.model_validate(p)
+        assert result.blocker is not None
+        assert result.blocker.reason == "future_unknown_reason"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -685,6 +685,38 @@ class TestMigrateCwState:
         migrated = migrate_cw_state(raw)
         assert migrated["schema_version"] == CW_STATE_SCHEMA_VERSION
 
+    def test_v2_to_v3_fills_last_result_default(self) -> None:
+        raw = {
+            "schema_version": 2,
+            "sessions": [
+                {
+                    "id": "s1",
+                    "parent_session_id": None,
+                    "worker_session_ids": [],
+                }
+            ],
+        }
+        migrated = migrate_cw_state(raw)
+        session = migrated["sessions"][0]
+        assert session["last_result"] is None
+        assert migrated["schema_version"] == CW_STATE_SCHEMA_VERSION
+
+    def test_v3_last_result_preserved_idempotently(self) -> None:
+        existing = {"schema_version": 1, "status": "shipped"}
+        raw = {
+            "schema_version": 3,
+            "sessions": [
+                {
+                    "id": "s1",
+                    "parent_session_id": None,
+                    "worker_session_ids": [],
+                    "last_result": existing,
+                }
+            ],
+        }
+        migrated = migrate_cw_state(raw)
+        assert migrated["sessions"][0]["last_result"] == existing
+
     def test_non_list_sessions_does_not_bump_version(self) -> None:
         # Malformed payload: sessions is not a list. The corruption must NOT
         # be certified as fully migrated — schema_version stays unchanged so

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -9,7 +10,11 @@ import pytest
 from cw.cmux import FakeCmuxAdapter
 from cw.config import load_state, save_state
 from cw.dev_queue import add_ticket, load_dev_queue, save_dev_queue, save_plan
-from cw.dispatch import consume_completed_sessions, dispatch_tick
+from cw.dispatch import (
+    consume_completed_sessions,
+    dispatch_tick,
+    persist_last_result,
+)
 from cw.events import record_event
 from cw.models import (
     ClientConfig,
@@ -28,7 +33,6 @@ from cw.models import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
 
 
 # ---------------------------------------------------------------------------
@@ -345,6 +349,69 @@ class TestConsumeCompletesTasks:
         # Second consume: cursor advanced, no new events
         completed2 = consume_completed_sessions()
         assert completed2 == 0
+
+
+class TestPersistLastResult:
+    @staticmethod
+    def _seed_session(session_id: str = "sess0001") -> Session:
+        s = Session(
+            id=session_id,
+            name="test-client/impl",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            workspace_path=Path("/tmp/wt"),
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+        )
+        save_state(CwState(sessions=[s]))
+        return s
+
+    def test_persists_parsed_result(self, tmp_dispatch_dirs: Path) -> None:
+        self._seed_session("sess0001")
+        stdout = (
+            "narrative\n"
+            "<<<AUTO_DEV_RESULT\n"
+            '{"schema_version": 1, "ticket_id": "GEN-1", "status": "shipped",'
+            ' "stage_reached": "stage5_post_create",'
+            ' "scope": {"tier": "small", "files": 1, "lines_estimate": 5,'
+            ' "lines_actual": 5, "forbidden_touched": false},'
+            ' "plan_source": "linear_existing", "branch": "dev/gen-1",'
+            ' "worktree_path": "/tmp/wt", "fork_point_sha": "abc",'
+            ' "commits": ["c1"],'
+            ' "pr": {"number": 1, "url": "https://example.com",'
+            ' "auto_merge": true, "base": "main"},'
+            ' "review": {"must_fix_initial": 0, "should_fix": 0,'
+            ' "fix_cycles_used": 0},'
+            ' "health": {"lowest_agent_confidence": "HIGH",'
+            ' "any_incomplete_risk": false, "shortcuts": [],'
+            ' "recommendation": "PROCEED", "downgrade_applied": false,'
+            ' "fix_loop_escalated": false},'
+            ' "friction_highlights": [], "blocker": null,'
+            ' "next_actions": ["wait_for_ci"]}\n'
+            "AUTO_DEV_RESULT>>>\n"
+        )
+        assert persist_last_result("sess0001", stdout) is True
+        state = load_state()
+        assert state.sessions[0].last_result is not None
+        assert state.sessions[0].last_result["status"] == "shipped"
+
+    def test_persists_blocked_for_missing_sentinel(
+        self,
+        tmp_dispatch_dirs: Path,
+    ) -> None:
+        self._seed_session("sess0002")
+        assert persist_last_result("sess0002", "no sentinel here\n") is True
+        state = load_state()
+        assert state.sessions[0].last_result is not None
+        assert state.sessions[0].last_result["status"] == "blocked"
+        assert state.sessions[0].last_result["blocker"]["reason"] == "no_result_emitted"
+
+    def test_returns_false_when_session_missing(
+        self,
+        tmp_dispatch_dirs: Path,
+    ) -> None:
+        save_state(CwState(sessions=[]))
+        assert persist_last_result("nope0000", "anything") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -416,6 +416,29 @@ class TestSessionLinkageFields:
         assert restored == s
 
 
+class TestSessionLastResult:
+    def test_default_is_none(self) -> None:
+        s = Session(
+            name="c/impl",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            workspace_path=Path("/dev/null"),
+        )
+        assert s.last_result is None
+
+    def test_round_trip_preserves_dict(self) -> None:
+        payload = {"schema_version": 1, "status": "shipped", "ticket_id": "X"}
+        s = Session(
+            name="c/impl",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            workspace_path=Path("/dev/null"),
+            last_result=payload,
+        )
+        restored = Session.model_validate_json(s.model_dump_json())
+        assert restored.last_result == payload
+
+
 class TestCompletionReason:
     def test_enum_values(self) -> None:
         assert CompletionReason.USER.value == "user"


### PR DESCRIPTION
Closes #57.

## Summary

- New `cw/auto_dev_result.py` — Pydantic model + sentinel pre-parser for the structured output emitted by `/auto-dev --headless`.
- `Session.last_result: dict | None` with schema bump 2→3 and migration step.
- `dispatch.persist_last_result` wired into `consume_completed_sessions` (forward-compatible with P1.A wiring; no adapter capture added here).

## Invariants enforced (per the owner's comment on #57)

Closed-enum `Literal`s on `status`, `stage_reached`, `scope.tier`, `plan_source`, and the `health` enums. `blocker.reason` stays an open `str` per §4.2.

Cross-field model validators:
- `pr` non-null iff `status == shipped`
- `blocker` non-null iff `status == blocked`
- `wait_for_ci ∈ next_actions` iff `status == shipped`
- `health.downgrade_applied = true` ⇒ `status == review_pending_approval` AND `scope.tier == small`
- `merge_gate_blocked` ⇒ `scope.tier == small`
- pre-branch statuses (`plan_pending_approval`, `scope_exceeded`, `forbidden_area`) ⇒ `branch is None`
- `scope.lines_actual is None` iff `stage_reached == stage1_plan`
- terminal-reject statuses (`scope_exceeded`, `forbidden_area`, `blocked`) ⇒ `next_actions == []`

## §6 failure modes

Each maps to a synthetic `BlockedResult` (parser never raises): missing sentinel, half-open block, malformed JSON, unsupported `schema_version`, unknown `status`, multiple blocks, non-object top level. `details` carries enough context (last 40 lines of stdout, raw payload, validation error) to drive post-hoc human triage.

## Persistence

`Session.last_result` is typed as `dict | None` rather than `AutoDevResult` so the persisted state file can survive independent bumps of the result schema without forcing a `cw` schema bump.

`persist_last_result(session_id, stdout)` is invoked from `consume_completed_sessions` when an event payload carries `stdout`. Producer side (capturing pane stdout when a worker session transitions to COMPLETED) is left to issue A wiring per the issue body.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest tests/ -v` — 738 passing
- [x] All 7 `status` round-trips (parametrized)
- [x] All §6 failure modes covered (no sentinel, half-open, malformed JSON, unsupported version, missing version, unknown status, multi-block, non-object payload, validation failure)
- [x] All 8 cross-field invariants asserted (positive + negative cases)
- [x] Migration v2→v3 fills `last_result: None`; v3 round-trip preserves payloads
- [x] Dispatch hook: parsed-result persisted, blocked-result persisted, missing-session no-op

## Out of scope

- Adapter pane-output capture (issue A wiring)
- Acting on the parsed result (issue C)
- Resume from prior `last_result` (issue D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)