### PR TITLE
feat(auto_dev_result): extend contract with no_op status + schema_version 2

### DIFF
--- a/docs/headless-contract.md
+++ b/docs/headless-contract.md
@@ -86,7 +86,7 @@ The skill emits **exactly one** sentinel block per invocation. If the parser fin
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "ticket_id": "GEN-1234",
   "status": "shipped",
   "stage_reached": "stage5_post_create",
@@ -127,7 +127,7 @@ The skill emits **exactly one** sentinel block per invocation. If the parser fin
 
 | Field | Type | Notes |
 |---|---|---|
-| `schema_version` | int | Currently `1`. Bump rules in §8. |
+| `schema_version` | int | Currently `2` (legacy `1` still accepted during the rollout window). Bump rules in §8. |
 | `ticket_id` | string | Linear ID, or synthetic for free-text invocations. |
 | `status` | string enum | See §4. |
 | `stage_reached` | string enum | Pipeline-stage marker. Closed set: `stage1_plan`, `stage2_impl`, `stage3_review`, `stage4a_merge_gate`, `stage4b_pr_create`, `stage5_post_create`. Producer and parser must keep this list in lockstep — adding a stage is a `schema_version` bump (see §8). |
@@ -167,6 +167,7 @@ The `status` field is a closed set. Consumers MUST treat unknown statuses as a p
 | `scope_exceeded` | `--scope-limit small` rejected a Large ticket before impl started. |
 | `forbidden_area` | `--forbidden` constraint matched a planned file; ticket rejected before impl started. |
 | `blocked` | Unrecoverable error mid-pipeline; see `blocker` field for details. |
+| `no_op` | Pre-flight detected the ticket already satisfied (or otherwise not work-bearing); no plan, no branch, no PR. Introduced at `schema_version=2`. Rationale: terse, neutral wording — does not presume the cause (already-merged dupe, invalid ticket, code already covers it). The actor (skill / cw) decides what to do via `next_actions` (typically `close_issue_as_completed`). |
 
 ### 4.2 `blocker.reason` (when `status = "blocked"`)
 
@@ -192,8 +193,9 @@ Advisory only. cw acts on these without parsing prose.
 | `user_approve_plan` | `status = plan_pending_approval` | Notify user that a large-scope plan is in Linear awaiting approval. |
 | `user_approve_review` | `status = review_pending_approval` | Notify user that a branch is pushed for review. |
 | `resolve_merge_gate` | `status = merge_gate_blocked` | Notify user that the prior pipeline PR must merge first. The user then manually re-invokes `/auto-dev` for this ticket; no automatic re-dispatch exists. |
+| `close_issue_as_completed` | `status = no_op` | Close the ticket as already completed (the work was a no-op because the system is already in the desired state). Consumer chooses how to close — Linear "Done", GitHub `gh issue close --reason completed`, etc. |
 
-Empty list for terminal-reject (`scope_exceeded`, `forbidden_area`, `blocked`). For `shipped`, `next_actions` always contains `wait_for_ci`.
+Empty list for terminal-reject (`scope_exceeded`, `forbidden_area`, `blocked`). For `shipped`, `next_actions` always contains `wait_for_ci`. `next_actions` is otherwise an open vocabulary — parsers MUST pass unknown actions through unchanged (do not act on them, do not reject the payload).
 
 ---
 
@@ -265,9 +267,16 @@ Until then, cw must treat all non-terminal exits as fully manual recovery: the u
 
 ## 8. Versioning
 
-`schema_version: 1` is the current contract.
+`schema_version: 2` is the current contract. Parsers also accept `schema_version: 1` during the rollout window (the skill upgrades after this; old worker emissions still in flight must keep parsing).
 
-**Bump to 2 required when:**
+**Version history:**
+
+| Version | Changes |
+|---|---|
+| 1 | Initial contract. |
+| 2 | Added `no_op` status (§4.1) and `close_issue_as_completed` advisory action (§4.3). v1-tagged payloads with `status=no_op` are rejected as `validation_failed`. |
+
+**Bump required when:**
 - Any field is removed or renamed.
 - Any existing field's type or semantics change.
 - A new value is added to a closed enum (`status`, `stage_reached`).
@@ -278,7 +287,9 @@ Until then, cw must treat all non-terminal exits as fully manual recovery: the u
 - A new `next_actions` entry is added (parsers already treat unknown actions as advisory).
 - A new `blocker.reason` value is added (open enum — see §4.2).
 
-When bumping, update this doc, `commands/auto-dev.md`, and the cw parser in lockstep. The skill SHOULD coordinate rollout so it does not emit a higher `schema_version` than deployed parsers support; this is a deployment-process concern (no in-band negotiation mechanism exists today). Parsers MUST defensively reject unknown `schema_version` values per §6 (4).
+**Cross-version status compatibility:** A status introduced at version N is invalid under any `schema_version < N`. Parsers MUST reject mismatched payloads (e.g., v1 + `no_op` → `validation_failed`).
+
+When bumping, update this doc, `commands/auto-dev.md`, and the cw parser in lockstep. **Order matters:** the parser must accept the new version BEFORE the skill emits it, otherwise in-flight emissions land in deployed parsers that don't recognize them. Parsers MUST defensively reject unknown `schema_version` values per §6 (4).
 
 ---
 

--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -28,7 +28,9 @@ from pydantic import BaseModel, Field, ValidationError, model_validator
 
 _log = logging.getLogger(__name__)
 
-SUPPORTED_SCHEMA_VERSION = 1
+# v1 is the legacy shape; v2 adds the `no_op` status. Both are accepted during
+# the rollout window — see docs/headless-contract.md §8.
+SUPPORTED_SCHEMA_VERSIONS: frozenset[int] = frozenset({1, 2})
 
 _OPEN_SENTINEL = "<<<AUTO_DEV_RESULT"
 _CLOSE_SENTINEL = "AUTO_DEV_RESULT>>>"
@@ -55,7 +57,12 @@ Status = Literal[
     "scope_exceeded",
     "forbidden_area",
     "blocked",
+    "no_op",
 ]
+# Statuses introduced after v1. Emitting one under schema_version=1 is a
+# producer bug — it would silently degrade for downstream tools that key off
+# the version field.
+_V2_STATUSES: frozenset[str] = frozenset({"no_op"})
 StageReached = Literal[
     "stage1_plan",
     "stage2_impl",
@@ -115,14 +122,14 @@ _TERMINAL_REJECT_STATUSES: frozenset[Status] = frozenset(
     {"scope_exceeded", "forbidden_area", "blocked"},
 )
 _PRE_BRANCH_STATUSES: frozenset[Status] = frozenset(
-    {"plan_pending_approval", "scope_exceeded", "forbidden_area"},
+    {"plan_pending_approval", "scope_exceeded", "forbidden_area", "no_op"},
 )
 
 
 class AutoDevResult(BaseModel):
     """Parsed sentinel block. All cross-field invariants from §3-§5 enforced."""
 
-    schema_version: Literal[1]
+    schema_version: Literal[1, 2]
     ticket_id: str
     status: Status
     stage_reached: StageReached
@@ -141,6 +148,15 @@ class AutoDevResult(BaseModel):
 
     @model_validator(mode="after")
     def _check_invariants(self) -> AutoDevResult:
+        # §8 status/version compat: v2-introduced statuses cannot ride on a
+        # v1-tagged payload.
+        if self.schema_version < 2 and self.status in _V2_STATUSES:
+            msg = (
+                f"status={self.status!r} requires schema_version>=2, "
+                f"got {self.schema_version}"
+            )
+            raise ValueError(msg)
+
         # §3.3 pr: non-null iff status == shipped
         if self.status == "shipped" and self.pr is None:
             msg = "pr must be non-null when status is 'shipped'"
@@ -307,11 +323,11 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
     # the field is missing or non-int. Pre-validate before handing to Pydantic
     # so the caller gets a structured surface instead of a ValidationError.
     raw_version = payload.get("schema_version")
-    if not isinstance(raw_version, int) or raw_version != SUPPORTED_SCHEMA_VERSION:
+    if not isinstance(raw_version, int) or raw_version not in SUPPORTED_SCHEMA_VERSIONS:
         _log.warning(
-            "auto-dev sentinel schema_version=%r unsupported (parser supports %d)",
+            "auto-dev sentinel schema_version=%r unsupported (parser supports %s)",
             raw_version,
-            SUPPORTED_SCHEMA_VERSION,
+            sorted(SUPPORTED_SCHEMA_VERSIONS),
         )
         return BlockedResult(
             blocker=Blocker(
@@ -319,7 +335,7 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
                 reason="schema_version_unsupported",
                 details=(
                     f"got schema_version={raw_version!r}, "
-                    f"parser supports {SUPPORTED_SCHEMA_VERSION}"
+                    f"parser supports {sorted(SUPPORTED_SCHEMA_VERSIONS)}"
                 ),
             ),
         )
@@ -335,6 +351,7 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
         "scope_exceeded",
         "forbidden_area",
         "blocked",
+        "no_op",
     }:
         return BlockedResult(
             blocker=Blocker(

--- a/tests/test_auto_dev_result.py
+++ b/tests/test_auto_dev_result.py
@@ -206,6 +206,40 @@ def _forbidden_area_payload() -> dict[str, Any]:
     return p
 
 
+def _no_op_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "ticket_id": "GEN-8",
+        "status": "no_op",
+        "stage_reached": "stage1_plan",
+        "scope": {
+            "tier": "small",
+            "files": 0,
+            "lines_estimate": 0,
+            "lines_actual": None,
+            "forbidden_touched": False,
+        },
+        "plan_source": "linear_existing",
+        "branch": None,
+        "worktree_path": None,
+        "fork_point_sha": None,
+        "commits": [],
+        "pr": None,
+        "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+        "health": {
+            "lowest_agent_confidence": "HIGH",
+            "any_incomplete_risk": False,
+            "shortcuts": [],
+            "recommendation": "PROCEED",
+            "downgrade_applied": False,
+            "fix_loop_escalated": False,
+        },
+        "friction_highlights": [],
+        "blocker": None,
+        "next_actions": ["close_issue_as_completed"],
+    }
+
+
 def _blocked_payload() -> dict[str, Any]:
     return {
         "schema_version": 1,
@@ -264,6 +298,7 @@ def _wrap_sentinel(payload: dict[str, Any]) -> str:
         _scope_exceeded_payload,
         _forbidden_area_payload,
         _blocked_payload,
+        _no_op_payload,
     ],
 )
 class TestStatusRoundTrips:
@@ -312,6 +347,16 @@ class TestSentinelFailureModes:
         result = parse_stdout(_wrap_sentinel(payload))
         assert isinstance(result, BlockedResult)
         assert result.blocker.reason == "schema_version_unsupported"
+
+    def test_schema_v2_accepted(self) -> None:
+        # A v1-shape payload should round-trip cleanly under schema_version=2;
+        # the only v2-exclusive surface is the no_op status, but every other
+        # field is unchanged.
+        payload = _shipped_payload()
+        payload["schema_version"] = 2
+        result = parse_stdout(_wrap_sentinel(payload))
+        assert isinstance(result, AutoDevResult)
+        assert result.schema_version == 2
 
     def test_missing_schema_version(self) -> None:
         payload = _shipped_payload()
@@ -478,6 +523,30 @@ class TestInvariants:
     def test_terminal_reject_rejects_next_actions(self) -> None:
         p = _scope_exceeded_payload()
         p["next_actions"] = ["something"]
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_no_op_rejected_at_schema_v1(self) -> None:
+        # Per §8: new status values only valid at the version that introduced
+        # them. A v1-tagged payload with status=no_op is a producer bug —
+        # surface as validation_failed rather than silently accepting.
+        p = _no_op_payload()
+        p["schema_version"] = 1
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "validation_failed"
+
+    def test_no_op_rejects_branch(self) -> None:
+        # no_op is a pre-branch status — emitting a branch is a contract
+        # violation.
+        p = _no_op_payload()
+        p["branch"] = "dev/sneak"
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_no_op_rejects_pr(self) -> None:
+        p = _no_op_payload()
+        p["pr"] = {"number": 1, "url": "x", "auto_merge": True, "base": "main"}
         with pytest.raises(ValidationError):
             AutoDevResult.model_validate(p)
 


### PR DESCRIPTION
## Summary
- Adds the `no_op` status (and `close_issue_as_completed` advisory action) so the skill can cleanly signal "ticket already satisfied" instead of misclassifying it as a system block.
- Bumps supported `schema_version` to `{1, 2}` — v1-tagged payloads with `no_op` are rejected as `validation_failed` rather than silently coerced.
- Updates `docs/headless-contract.md` §3.3, §4.1, §4.3, §8 atomically (producer/consumer/spec triangle stays consistent).

## Rationale for `no_op` (over `already_satisfied`)
Terse, neutral, doesn't presume the cause — works for already-merged duplicates, invalid tickets, or "code already covers it" outcomes. Action-of-record is in `next_actions`.

## Cross-repo coordination
**This must land before [global-claude#7](https://github.com/mattwwarren/global-claude/issues/7).** Skill-first would push a v2 emission into a v1-only parser, which would fall through to §6's `status_unknown` branch and synthesize a fake block — exactly the noise problem this fixes.

## Test plan
- [x] Round-trip: `no_op` payload parses cleanly under `schema_version=2`
- [x] Failure mode: v1-tagged payload with `no_op` → `BlockedResult` with `reason=validation_failed`
- [x] v2 acceptance: existing v1-shape payload tagged `schema_version=2` round-trips
- [x] Pre-branch invariants: `no_op` rejects `branch` and `pr`
- [x] Full suite passes (744 tests), `ruff`/`mypy` clean

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)