### PR TITLE
fix(worktree): tighten slugify_branch to claude's worktree charset

### DIFF
--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -32,11 +32,14 @@ _WORKSPACE_HASH_CHARS = 8
 
 
 def slugify_branch(branch: str) -> str:
-    """Convert a branch name to a filesystem-safe slug.
+    """Convert a branch name to a worktree-safe slug.
 
-    Slashes become hyphens: ``feat/search`` -> ``feat-search``.
+    Collapses any run of disallowed characters into a single hyphen, then
+    strips leading/trailing hyphens. The allowed charset (``[A-Za-z0-9._-]``)
+    matches ``claude -w``'s worktree-name validator — anything outside this
+    set (path separators, ``#``, spaces, unicode) becomes ``-``.
     """
-    return re.sub(r"[/\\]+", "-", branch).strip("-")
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", branch).strip("-")
 
 
 def _git_dir(client: ClientConfig) -> Path:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -36,6 +36,28 @@ class TestSlugifyBranch:
     def test_trailing_slash_stripped(self) -> None:
         assert slugify_branch("feat/") == "feat"
 
+    def test_hash_replaced(self) -> None:
+        # Regression: GitHub issue ids like "#7" used to leak through and
+        # break `claude -w` worktree path validation (issue #83). The double
+        # hyphen is fine — claude's segment validator allows `-`; readability
+        # is the lesser concern.
+        assert slugify_branch("auto-dev-#7") == "auto-dev--7"
+
+    def test_hash_run_collapses(self) -> None:
+        assert slugify_branch("auto-dev-##7") == "auto-dev--7"
+
+    def test_leading_hash_stripped(self) -> None:
+        assert slugify_branch("#7") == "7"
+
+    def test_spaces_replaced(self) -> None:
+        assert slugify_branch("feat search bar") == "feat-search-bar"
+
+    def test_unicode_replaced(self) -> None:
+        assert slugify_branch("feat-café") == "feat-caf"
+
+    def test_dots_and_underscores_preserved(self) -> None:
+        assert slugify_branch("v1.2_beta") == "v1.2_beta"
+
 
 class TestGitDir:
     def test_legacy_client(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Fixes dispatch failure for GitHub-issue tickets (e.g. `#7`) — `claude -w` rejects worktree paths containing `#` because its segment validator only allows `[A-Za-z0-9._-]+`.
- Replaces the slash-only regex in `slugify_branch` with a charset-deny pattern matching claude's validator. `#`, spaces, unicode → `-`.

## Test plan
- [x] Regression: `slugify_branch("auto-dev-#7") == "auto-dev--7"` (valid claude segment)
- [x] Existing slash/backslash behavior preserved
- [x] Unicode, spaces, leading-hash cases covered
- [x] Full suite (750 tests), `ruff`/`mypy` clean

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)