### PR TITLE
fix(dispatch): include ticket_id in session.completed events (#94)

### DIFF
--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -16,7 +16,7 @@ from cw.models import (
     SessionOrigin,
     SessionStatus,
 )
-from cw.reconcile import AUTO_DEV_LABEL_PREFIX, reconcile
+from cw.reconcile import AUTO_DEV_LABEL_PREFIX, reconcile, ticket_id_for_session
 from cw.spawn import spawn_create_impl
 from cw.worktree import create_worktree
 
@@ -180,6 +180,14 @@ def consume_completed_sessions() -> int:
         store = load_dev_queue()
         for event in events:
             ticket_id = event.payload.get("ticket_id")
+            if not ticket_id:
+                # Fallback: recover ticket_id from the session_name for events
+                # produced before the reconciler emitted ticket_id explicitly.
+                # Drains historical RUNNING tasks whose completion events
+                # predate the producer-side fix.
+                session_name = event.payload.get("session_name")
+                if isinstance(session_name, str):
+                    ticket_id = ticket_id_for_session(session_name)
             if not ticket_id:
                 continue
             for task in store.tasks:

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -109,7 +109,7 @@ def compute_drift(state: CwState, adapter: MultiplexerAdapter) -> ReconcileRepor
     return ReconcileReport(phantom_session_ids=phantoms)
 
 
-def _ticket_id_for_session(session_name: str) -> str | None:
+def ticket_id_for_session(session_name: str) -> str | None:
     """Extract the ticket id from a daemon session name, or None."""
     _, _, tail = session_name.partition("/")
     if tail.startswith(AUTO_DEV_LABEL_PREFIX):
@@ -176,18 +176,18 @@ def reconcile(adapter: MultiplexerAdapter) -> ReconcileReport:
         session.completed_reason = CompletionReason.CRASHED
         session.completed_at = now
         phantom_names.append(session.name)
-        if session.origin is SessionOrigin.DAEMON:
-            ticket_id = _ticket_id_for_session(session.name)
-            if ticket_id:
-                ticket_ids_to_revert.append(ticket_id)
-        pending_events.append(
-            {
-                "session_id": session.id,
-                "session_name": session.name,
-                "client": session.client,
-                "crashed": True,
-            }
-        )
+        ticket_id = ticket_id_for_session(session.name)
+        if ticket_id and session.origin is SessionOrigin.DAEMON:
+            ticket_ids_to_revert.append(ticket_id)
+        payload: dict[str, object] = {
+            "session_id": session.id,
+            "session_name": session.name,
+            "client": session.client,
+            "crashed": True,
+        }
+        if ticket_id:
+            payload["ticket_id"] = ticket_id
+        pending_events.append(payload)
 
     save_state(state)
     for payload in pending_events:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -249,6 +249,40 @@ class TestConsumeCompletesTasks:
         completed = consume_completed_sessions()
         assert completed == 0
 
+    def test_consume_recovers_ticket_id_from_session_name(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """Events without explicit ticket_id are recovered from session_name.
+
+        Drains historical RUNNING tasks whose completion events predate the
+        producer-side fix — see GitHub issue #94.
+        """
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        task = TicketTask(
+            ticket_id="GEN-700",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {
+                "session_id": "abc123",
+                "session_name": "test-client/auto-dev/GEN-700",
+                "client": "test-client",
+                "crashed": True,
+            },
+        )
+
+        completed = consume_completed_sessions()
+        assert completed == 1
+        assert load_dev_queue().tasks[0].status == QueueItemStatus.COMPLETED
+
     def test_consume_advances_cursor(
         self,
         tmp_dispatch_dirs: Path,

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -8,11 +8,13 @@ from pathlib import Path
 from cw.cmux import FakeCmuxAdapter
 from cw.config import load_state, save_state
 from cw.dev_queue import load_dev_queue, save_dev_queue
+from cw.events import read_events
 from cw.models import (
     ClientConfig,
     CompletionReason,
     CwState,
     DevQueueStore,
+    OrchestratorEventType,
     QueueItemStatus,
     Session,
     SessionOrigin,
@@ -144,6 +146,15 @@ def test_reconcile_reverts_daemon_session_ticket_to_pending(
     assert "TKT-1" in report.reverted_ticket_ids
     queue = load_dev_queue()
     assert queue.tasks[0].status == QueueItemStatus.PENDING
+
+    # The emitted SESSION_COMPLETED event must carry ticket_id so the
+    # dispatch consumer can mark queue tasks COMPLETED downstream.
+    events = read_events(
+        consumer="test-reconcile-emits-ticket-id",
+        event_types=[OrchestratorEventType.SESSION_COMPLETED],
+    )
+    assert len(events) == 1
+    assert events[0].payload.get("ticket_id") == "TKT-1"
 
 
 def test_reconcile_noop_when_no_phantoms(


### PR DESCRIPTION
## Summary

- fix(dispatch): include ticket_id in session.completed events (#94)

Fixes #94.

The reconciler emitted `SESSION_COMPLETED` events without `ticket_id`, so `consume_completed_sessions` skipped every event and dev-queue tasks stayed `RUNNING` forever — concurrency-cap accounting progressively starves slots.

**Producer fix** (`src/cw/reconcile.py`): include `ticket_id` in the emitted payload whenever the session name parses as auto-dev. Mirrors what `session.spawned` already does.

**Consumer fix** (`src/cw/dispatch.py`): fall back to parsing `ticket_id` from `session_name` when the payload lacks it. Drains historical RUNNING tasks whose completion events predate the producer-side fix — no manual queue surgery needed.

`ticket_id_for_session` is now public (renamed from `_ticket_id_for_session`) so dispatch can share the parsing helper rather than duplicating the prefix logic.

## Test plan

- [x] ruff check — zero violations
- [x] mypy — zero type errors
- [x] pytest — 686/686 pass
- [x] New test: reconciler test asserts `ticket_id` lands in emitted payload
- [x] New test: dispatch test covers the consumer-side fallback path

## Out of scope

The issue's secondary observation (success-path session `68f85630` had no `SESSION_COMPLETED` event at all) is a distinct emission gap on the merge path. `orchestrate._close_session` also omits `ticket_id` for the same reason — both belong to a separate followup since fixing the payload doesn't help when the event isn't emitted in the first place.

🤖 Shipped via /prep-pr + project /ship-it