### PR TITLE
release: 0.8.1 — fix dev-queue tasks stuck RUNNING (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.1] — 2026-05-04
+
+Patch release — fixes a queue-accounting bug introduced in 0.8.0 that
+caused every `cw dev-queue` task to stay `RUNNING` forever.
+
+### Fixed
+- **`session.completed` events now carry `ticket_id`** (#94, #95). The
+  reconciler emitted `SESSION_COMPLETED` without the `ticket_id` field,
+  so `consume_completed_sessions` skipped every event and dev-queue
+  tasks never transitioned to `COMPLETED`. Concurrency-cap accounting
+  treated stranded `RUNNING` tasks as live, progressively starving
+  available slots until the queue would refuse to dispatch anything new.
+  - **Producer side:** the reconciler now includes `ticket_id` in the
+    emitted payload whenever the session name parses as auto-dev,
+    mirroring what `session.spawned` already does.
+  - **Consumer side:** `consume_completed_sessions` falls back to
+    parsing `ticket_id` from `session_name` when the payload lacks it.
+    Drains historical `RUNNING` tasks whose completion events predate
+    the producer-side fix — no manual queue-file surgery needed.
+- `ticket_id_for_session` is now public (renamed from
+  `_ticket_id_for_session`) so dispatch and reconcile share the parsing
+  helper rather than duplicating the prefix logic.
+
 ## [0.8.0] — 2026-05-04
 
 First release of the **0.8.0 milestone** — substrate for autonomous

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-workspace"
-version = "0.8.0"
+version = "0.8.1"
 description = "Multi-session workspace orchestrator for Claude Code"
 readme = "README.md"
 authors = [

--- a/src/cw/__init__.py
+++ b/src/cw/__init__.py
@@ -1,3 +1,3 @@
 """claude-workspace: Multi-session workspace orchestrator for Claude Code."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,7 @@ class TestCli:
         runner = CliRunner()
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.8.0" in result.output
+        assert "0.8.1" in result.output
 
     def test_help(self) -> None:
         runner = CliRunner()

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,7 @@ wheels = [
 
 [[package]]
 name = "claude-workspace"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Patch release on top of 0.8.0. Ships the fix from #95.

**Bug:** every `cw dev-queue` task stayed `RUNNING` forever. The reconciler emitted `session.completed` events without `ticket_id`, so the dispatch consumer skipped every one and queue tasks never transitioned to `COMPLETED`. Concurrency-cap accounting treated stranded tasks as live, progressively starving slots.

**Fix (already merged in #95):** producer-side, the reconciler includes `ticket_id` in the payload when the session name parses as auto-dev. Consumer-side, `consume_completed_sessions` falls back to parsing `ticket_id` from `session_name` so historical events drain without manual queue surgery.

This PR is the version bump + CHANGELOG entry only — no code changes.

## Bumped

- `pyproject.toml`: 0.8.0 → 0.8.1
- `src/cw/__init__.py`: `__version__`
- `tests/test_cli.py`: `test_version`
- `CHANGELOG.md`: new `[0.8.1]` section
- `uv.lock`: regenerated

## Test plan

- [x] ruff check — zero violations
- [x] mypy — zero type errors
- [x] pytest — 751/751 pass
- [ ] After merge: tag `v0.8.1` on the merge commit and push

🤖 Cut via auto-dev follow-up