### PR TITLE
fix(dispatch): match completion events on session_id, skip crashed (#97)

### DIFF
--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -153,6 +153,22 @@ def dispatch_tick(
                 parent=parent,
             )
 
+            # Stamp session_id on the queued task so the completion consumer
+            # can match SESSION_COMPLETED events to the correct (current)
+            # session and reject stale events from prior crashed sessions
+            # for the same ticket. See GitHub issue #97.
+            with dev_queue_lock():
+                store = load_dev_queue()
+                for stored_task in store.tasks:
+                    if (
+                        stored_task.ticket_id == task.ticket_id
+                        and stored_task.client == client.name
+                        and stored_task.status == QueueItemStatus.RUNNING
+                    ):
+                        stored_task.session_id = session_id
+                        break
+                save_dev_queue(store)
+
             record_event(
                 OrchestratorEventType.SESSION_SPAWNED,
                 {
@@ -192,6 +208,17 @@ def consume_completed_sessions() -> int:
     with dev_queue_lock():
         store = load_dev_queue()
         for event in events:
+            # Crashed events are emitted by reconcile only. For DAEMON
+            # sessions reconcile has already reverted the task
+            # RUNNING → PENDING; marking the task COMPLETED here would
+            # shadow that revert and (worse) match the next freshly-
+            # respawned RUNNING task for the same ticket_id, falsely
+            # retiring a still-running session. For non-DAEMON crashed
+            # sessions reconcile does not touch the queue, so a blanket
+            # skip is conservative-safe (no queue task is expected to
+            # match anyway). See GitHub issue #97.
+            if event.payload.get("crashed"):
+                continue
             ticket_id = event.payload.get("ticket_id")
             if not ticket_id:
                 # Fallback: recover ticket_id from the session_name for events
@@ -203,14 +230,26 @@ def consume_completed_sessions() -> int:
                     ticket_id = ticket_id_for_session(session_name)
             if not ticket_id:
                 continue
+            event_session_id = event.payload.get("session_id")
             for task in store.tasks:
+                if task.ticket_id != ticket_id:
+                    continue
+                if task.status != QueueItemStatus.RUNNING:
+                    continue
+                # Disambiguate stale events: when the event carries a
+                # session_id and the task has been stamped with one, they
+                # must agree. Either side missing a session_id falls back to
+                # ticket_id-only matching for backward compatibility with
+                # legacy tasks/events that predate the field.
                 if (
-                    task.ticket_id == ticket_id
-                    and task.status == QueueItemStatus.RUNNING
+                    isinstance(event_session_id, str)
+                    and task.session_id is not None
+                    and task.session_id != event_session_id
                 ):
-                    task.status = QueueItemStatus.COMPLETED
-                    completed += 1
-                    break
+                    continue
+                task.status = QueueItemStatus.COMPLETED
+                completed += 1
+                break
         if completed:
             save_dev_queue(store)
 

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -138,6 +138,13 @@ class TicketTask(BaseModel):
     scope_hint: str | None = None
     status: QueueItemStatus = QueueItemStatus.PENDING
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    # Stamped by dispatch_tick after spawn_create_impl returns; cleared on
+    # reconcile revert. Used by consume_completed_sessions to disambiguate
+    # SESSION_COMPLETED events from old (crashed) sessions that share a
+    # ticket_id with a freshly-respawned task. None for legacy tasks
+    # persisted before this field existed — consumer falls back to
+    # ticket_id-only matching in that case.
+    session_id: str | None = None
 
 
 class DispatchPlan(BaseModel):

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -203,6 +203,11 @@ def reconcile(adapter: MultiplexerAdapter) -> ReconcileReport:
                     and task.status == QueueItemStatus.RUNNING
                 ):
                     task.status = QueueItemStatus.PENDING
+                    # Drop the stamp from the prior (now-crashed) session so
+                    # the next dispatch_tick can re-stamp with the freshly
+                    # spawned session_id without a window where the task
+                    # carries a stale id. See GitHub issue #97.
+                    task.session_id = None
                     reverted.append(task.ticket_id)
             if reverted:
                 save_dev_queue(store)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -202,6 +202,33 @@ class TestDispatchTickSpawnsSession:
         worker_ids = {w.id for w in workers}
         assert worker_ids.issubset(set(refreshed_parent.worker_session_ids))
 
+    def test_dispatch_tick_stamps_session_id_on_task(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """After spawn, the task carries the session_id from the spawner.
+
+        The completion consumer relies on this stamp to disambiguate
+        SESSION_COMPLETED events when an older session for the same ticket
+        crashed and was respawned. See GitHub issue #97.
+        """
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        add_ticket(TicketTask(ticket_id="GEN-STAMP", client="test-client"))
+
+        adapter = FakeCmuxAdapter()
+        dispatch_tick(simple_config, adapter=adapter)
+
+        store = load_dev_queue()
+        running = store.running()
+        assert len(running) == 1
+        assert running[0].session_id is not None
+        # The stamped session_id must match the spawned session in state.
+        spawned_state = load_state()
+        assert len(spawned_state.sessions) == 1
+        assert running[0].session_id == spawned_state.sessions[0].id
+
     def test_dispatch_tick_no_parent_leaves_linkage_empty(
         self,
         tmp_dispatch_dirs: Path,
@@ -342,7 +369,9 @@ class TestConsumeCompletesTasks:
         """Events without explicit ticket_id are recovered from session_name.
 
         Drains historical RUNNING tasks whose completion events predate the
-        producer-side fix — see GitHub issue #94.
+        producer-side fix — see GitHub issue #94. Only non-crashed events go
+        through this path; crashed events are skipped (see
+        ``test_consume_skips_crashed_events``).
         """
         _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
 
@@ -359,7 +388,173 @@ class TestConsumeCompletesTasks:
                 "session_id": "abc123",
                 "session_name": "test-client/auto-dev/GEN-700",
                 "client": "test-client",
+            },
+        )
+
+        completed = consume_completed_sessions()
+        assert completed == 1
+        assert load_dev_queue().tasks[0].status == QueueItemStatus.COMPLETED
+
+    def test_consume_skips_crashed_events(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """crashed: true events must not mark tasks COMPLETED.
+
+        Reconcile is the authoritative actor for crashed sessions — it
+        reverts the task RUNNING → PENDING. The consumer must be a no-op
+        for these events; otherwise it shadows reconcile's revert and
+        falsely matches a freshly-respawned task with the same ticket_id.
+        See GitHub issue #97.
+        """
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        task = TicketTask(
+            ticket_id="GEN-CRASH",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {
+                "ticket_id": "GEN-CRASH",
+                "session_id": "old-session",
+                "client": "test-client",
                 "crashed": True,
+            },
+        )
+
+        completed = consume_completed_sessions()
+        assert completed == 0
+        assert load_dev_queue().tasks[0].status == QueueItemStatus.RUNNING
+
+    def test_consume_skips_crashed_events_via_session_name_fallback(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """Crashed events are skipped before the session_name fallback runs.
+
+        Belt-and-suspenders: even if a crashed event lacks ticket_id and
+        only carries session_name, it must not be drained.
+        """
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        task = TicketTask(
+            ticket_id="GEN-CRASH-FB",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {
+                "session_id": "old-session",
+                "session_name": "test-client/auto-dev/GEN-CRASH-FB",
+                "client": "test-client",
+                "crashed": True,
+            },
+        )
+
+        completed = consume_completed_sessions()
+        assert completed == 0
+        assert load_dev_queue().tasks[0].status == QueueItemStatus.RUNNING
+
+    def test_consume_rejects_event_with_mismatched_session_id(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """A SESSION_COMPLETED event from an old session does not match a
+        respawn that already has a fresh session_id stamped on the task.
+
+        This guards the second failure mode in GitHub issue #97: stale
+        non-crashed events carrying an older session_id must not falsely
+        complete a freshly-respawned task.
+        """
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        task = TicketTask(
+            ticket_id="GEN-STALE",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+            session_id="new-session",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {
+                "ticket_id": "GEN-STALE",
+                "session_id": "old-session",
+                "client": "test-client",
+            },
+        )
+
+        completed = consume_completed_sessions()
+        assert completed == 0
+        assert load_dev_queue().tasks[0].status == QueueItemStatus.RUNNING
+
+    def test_consume_completes_when_session_id_matches(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """Matching session_id on event and task completes the task."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        task = TicketTask(
+            ticket_id="GEN-MATCH",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+            session_id="current-session",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {
+                "ticket_id": "GEN-MATCH",
+                "session_id": "current-session",
+                "client": "test-client",
+            },
+        )
+
+        completed = consume_completed_sessions()
+        assert completed == 1
+        assert load_dev_queue().tasks[0].status == QueueItemStatus.COMPLETED
+
+    def test_consume_falls_back_to_ticket_id_when_task_has_no_session_id(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """Legacy tasks without session_id still match by ticket_id alone."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        # Task predates the session_id field — session_id stays None.
+        task = TicketTask(
+            ticket_id="GEN-LEGACY",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {
+                "ticket_id": "GEN-LEGACY",
+                "session_id": "any-session",
+                "client": "test-client",
             },
         )
 
@@ -667,3 +862,94 @@ def test_dispatch_tick_reconciles_phantoms_before_counting(
     phantom = reloaded.find_by_name_or_id("phantom-daemon")
     assert phantom is not None
     assert phantom.status == SessionStatus.COMPLETED
+
+
+def test_crash_revert_respawn_rejects_old_event_completes_new(
+    tmp_dispatch_dirs: Path,
+    sample_client_config: ClientConfig,
+    simple_config: OrchestratorConfig,
+) -> None:
+    """End-to-end: crash → reconcile revert → respawn → consumer disambiguates.
+
+    Composes the three actors into the exact failure mode from GitHub
+    issue #97:
+
+    1. Task RUNNING with session_id="old-session" (phantom DAEMON session
+       in state).
+    2. dispatch_tick triggers reconcile, which reverts the task to
+       PENDING and clears session_id, then claims it again and stamps
+       the freshly-spawned session_id.
+    3. The reconcile-emitted SESSION_COMPLETED event (session_id="old",
+       crashed=True) is consumed and SKIPPED by the crashed guard — the
+       newly-RUNNING task stays RUNNING.
+    4. A subsequent SESSION_COMPLETED event matching the NEW session_id
+       is consumed and correctly completes the task.
+    """
+    _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+    # Step 1: pre-existing phantom DAEMON session + RUNNING task with
+    # the old session's id stamped.
+    save_state(
+        CwState(
+            sessions=[
+                Session(
+                    id="old-session",
+                    name=f"{sample_client_config.name}/auto-dev/TKT-RACE",
+                    client=sample_client_config.name,
+                    purpose=SessionPurpose.IMPL,
+                    origin=SessionOrigin.DAEMON,
+                    status=SessionStatus.ACTIVE,
+                    workspace_path=sample_client_config.workspace_path,
+                    surface_ref="dead",
+                ),
+            ]
+        )
+    )
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="TKT-RACE",
+                    client=sample_client_config.name,
+                    status=QueueItemStatus.RUNNING,
+                    session_id="old-session",
+                ),
+            ]
+        )
+    )
+
+    adapter = FakeCmuxAdapter()
+    adapter.spawn("decoy-ws", "echo")  # non-empty live set bypasses outage guard
+
+    # Step 2: tick triggers reconcile (revert + emit crashed event), then
+    # claims and respawns the same ticket with a new session id.
+    spawned = dispatch_tick(simple_config, adapter=adapter)
+    assert spawned == 1
+
+    queue = load_dev_queue()
+    running = queue.running()
+    assert len(running) == 1
+    new_session_id = running[0].session_id
+    assert new_session_id is not None
+    assert new_session_id != "old-session"
+
+    # Step 3: consume the queued events. The reconcile-emitted crashed
+    # event is skipped; the task stays RUNNING.
+    consume_completed_sessions()
+    queue = load_dev_queue()
+    assert queue.tasks[0].status == QueueItemStatus.RUNNING
+    assert queue.tasks[0].session_id == new_session_id
+
+    # Step 4: a real completion event for the NEW session arrives and
+    # correctly completes the task.
+    record_event(
+        OrchestratorEventType.SESSION_COMPLETED,
+        {
+            "ticket_id": "TKT-RACE",
+            "session_id": new_session_id,
+            "client": sample_client_config.name,
+        },
+    )
+    completed = consume_completed_sessions()
+    assert completed == 1
+    assert load_dev_queue().tasks[0].status == QueueItemStatus.COMPLETED

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -157,6 +157,39 @@ def test_reconcile_reverts_daemon_session_ticket_to_pending(
     assert events[0].payload.get("ticket_id") == "TKT-1"
 
 
+def test_reconcile_clears_session_id_on_revert(
+    tmp_config_dir: Path,
+) -> None:
+    """Revert clears the stamped session_id so respawn gets a clean slate.
+
+    If the stale session_id lingered on the reverted task, the next
+    dispatch_tick would briefly leave it on a freshly RUNNING task before
+    re-stamping with the new session_id, opening a window where a
+    last-second event from the OLD session could match. Clearing on
+    revert closes the window. See GitHub issue #97.
+    """
+    sess = _mk_session("sess-old", "dead-ref")
+    sess.origin = SessionOrigin.DAEMON
+    sess.name = "client-a/auto-dev/TKT-CLEAR"
+    save_state(CwState(sessions=[sess]))
+
+    task = TicketTask(
+        ticket_id="TKT-CLEAR",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="old-session",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    adapter = FakeCmuxAdapter()
+    adapter.spawn("ws", "echo decoy")
+    reconcile(adapter)
+
+    queue = load_dev_queue()
+    assert queue.tasks[0].status == QueueItemStatus.PENDING
+    assert queue.tasks[0].session_id is None
+
+
 def test_reconcile_noop_when_no_phantoms(
     tmp_config_dir: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #97. `consume_completed_sessions` matched SESSION_COMPLETED events to queue tasks on `ticket_id` alone, ignoring `session_id` and `crashed`. Two failure modes followed:

1. A reconcile-emitted `crashed: true` event would shadow reconcile's own RUNNING → PENDING revert by re-marking the task COMPLETED — and when the dispatcher had already respawned the same ticket, the crashed event would falsely retire the freshly-spawned session.
2. A non-crashed event from an older session for the same ticket_id could match a respawn already in progress, completing it prematurely.

Both fixes suggested in the issue are applied (belt-and-suspenders):

- **Skip crashed events.** The consumer is now a no-op for `crashed: true`; reconcile is authoritative.
- **Match on `session_id`.** `TicketTask` carries a `session_id` field stamped by `dispatch_tick` after `spawn_create_impl` returns and cleared by `reconcile` on revert. The consumer requires agreement when both sides have a `session_id`; legacy tasks/events fall back to `ticket_id`-only matching.

## Test plan

- [x] Unit tests cover both fixes individually (skip-crashed, session_id mismatch rejection, session_id match completion, legacy ticket_id-only fallback)
- [x] Integration test composes the full crash → reconcile-revert → respawn → stale-event-rejected → fresh-event-completes sequence (`test_crash_revert_respawn_rejects_old_event_completes_new`)
- [x] Updated `test_consume_recovers_ticket_id_from_session_name` to drop `crashed: true` (it was incidentally exercising the broken path)
- [x] `ruff check` clean, `mypy` clean, full suite (759 tests) passes

## Reviewer notes

- The two-lock pattern in `dispatch_tick` (claim under one lock, stamp `session_id` under a second after `spawn_create_impl`) leaves a window where a freshly-RUNNING task has `session_id=None`. Within `run_dispatch_loop` this is single-threaded and not exploitable; an external concurrent `consume_completed_sessions` caller could hit it but no such CLI entry point exists.
- The blanket `crashed: true` skip is conservative-correct for non-DAEMON sessions: reconcile emits crashed events for all phantom sessions but only reverts queue tasks for DAEMON ones, so non-DAEMON crashed events have no matching queue task to skip anyway.
- `DEV_QUEUE_SCHEMA_VERSION` intentionally not bumped — `session_id: str | None = None` is a nullable optional with a safe default that round-trips cleanly through Pydantic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)