### PR TITLE
release: 0.8.2 — fix consume falsely COMPLETING respawned tasks (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.2] — 2026-05-06
+
+Patch release — fixes a queue-accounting bug discovered while validating
+0.8.1 end-to-end. With 0.8.1's producer fix in place, `SESSION_COMPLETED`
+events now carry `ticket_id` — but `consume_completed_sessions` was
+matching on `ticket_id` alone, so a `crashed: true` event from a prior
+(reconcile-reverted) session could falsely COMPLETE a freshly-respawned
+task for the same ticket.
+
+### Fixed
+- **`consume_completed_sessions` now skips `crashed: true` events** and
+  matches non-crashed events on `session_id` when both sides have one
+  (#97, #98). Reconcile is the authoritative path for crashed sessions
+  (RUNNING → PENDING revert); the consumer no longer shadows that with a
+  spurious COMPLETED transition. Stale events from older sessions for
+  the same `ticket_id` are rejected via `session_id` disagreement.
+  - `TicketTask` gains a nullable `session_id` field stamped by
+    `dispatch_tick` after spawn returns and cleared by `reconcile` on
+    revert. Legacy tasks/events without the field fall back to
+    `ticket_id`-only matching for backward compatibility.
+
+### Known issues
+- Reconcile still has no clean-completion signal — workers that exit
+  successfully (`/auto-dev` returns to a bash prompt inside the tmux
+  pane) sit `RUNNING` indefinitely, and tmux-session kills are still
+  observed as `crashed: true` (now correctly skipped, but the queue
+  task ping-pongs RUNNING ↔ PENDING via dispatch respawn). Tracked in
+  #99 — not blocking this release; #98's fix prevents the false
+  COMPLETED transitions that previously masked the issue.
+
 ## [0.8.1] — 2026-05-04
 
 Patch release — fixes a queue-accounting bug introduced in 0.8.0 that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-workspace"
-version = "0.8.1"
+version = "0.8.2"
 description = "Multi-session workspace orchestrator for Claude Code"
 readme = "README.md"
 authors = [

--- a/src/cw/__init__.py
+++ b/src/cw/__init__.py
@@ -1,3 +1,3 @@
 """claude-workspace: Multi-session workspace orchestrator for Claude Code."""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,7 @@ class TestCli:
         runner = CliRunner()
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.8.1" in result.output
+        assert "0.8.2" in result.output
 
     def test_help(self) -> None:
         runner = CliRunner()

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,7 @@ wheels = [
 
 [[package]]
 name = "claude-workspace"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Patch release. Ships #98 — fixes a queue-accounting bug discovered while validating 0.8.1 end-to-end.

With 0.8.1's producer fix in place, `SESSION_COMPLETED` events now carry `ticket_id` — but `consume_completed_sessions` was matching on `ticket_id` alone, so a `crashed: true` event from a prior (reconcile-reverted) session could falsely COMPLETE a freshly-respawned task for the same ticket.

#98 applied two layered fixes (skip crashed, match on session_id with ticket_id fallback). This release just bumps version + CHANGELOG.

## Known issue

#99 — reconcile has no clean-completion signal. Workers that exit successfully sit `RUNNING` indefinitely; tmux-session kills trigger a respawn loop. Not blocking this release; #98 prevents the false COMPLETED transitions that previously masked it.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/` — clean
- [x] `pytest tests/` — 759 pass
- [x] `uv lock` regenerated
- [x] CHANGELOG entry added