### PR TITLE
fix(wrapper): emit SESSION_COMPLETED on clean auto-dev exit (#99)

### DIFF
--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -28,6 +28,7 @@ class CompletionReason(StrEnum):
     USER = "user"
     HANDOFF = "handoff"
     CRASHED = "crashed"
+    NORMAL = "normal"
 
 
 class SessionOrigin(StrEnum):

--- a/src/cw/spawn.py
+++ b/src/cw/spawn.py
@@ -54,9 +54,10 @@ def spawn_create_impl(
 
     workspace = client.cmux_workspace or client.name
     cwd = shlex.quote(str(worktree))
-    command = f"cd {cwd} && claude --print {prompt!r}"
-    surface_ref = adapter.spawn(workspace, command, surface)
 
+    # Pre-create the Session so we can pass its ID into the spawned command
+    # via CW_SESSION_ID. The wrapper uses that to disambiguate when multiple
+    # daemon sessions share the same (client, purpose=impl) pair.
     session_label = label or "daemon"
     sess = Session(
         name=f"{client.name}/{session_label}",
@@ -65,8 +66,16 @@ def spawn_create_impl(
         origin=SessionOrigin.DAEMON,
         workspace_path=client.workspace_path,
         worktree_path=worktree,
-        surface_ref=surface_ref,
     )
+
+    env_prefix = (
+        f"CW_CLIENT={shlex.quote(client.name)} "
+        f"CW_PURPOSE={shlex.quote(SessionPurpose.IMPL.value)} "
+        f"CW_SESSION_ID={shlex.quote(sess.id)} "
+    )
+    command = f"cd {cwd} && {env_prefix}cw run-claude -- --print {prompt!r}"
+    surface_ref = adapter.spawn(workspace, command, surface)
+    sess.surface_ref = surface_ref
 
     if parent_session is not None:
         sess.parent_session_id = parent_session.id

--- a/src/cw/wrapper.py
+++ b/src/cw/wrapper.py
@@ -1,21 +1,50 @@
 """Wrapper around Claude that signals cw on exit.
 
 Used as the pane command in the multiplexer workspace so ``cw`` can
-detect when Claude exits and transition the session to IDLE.
+detect when Claude exits and transition the session to IDLE or COMPLETED.
+
+Two modes:
+
+- **Interactive** — no ``--print`` in args. The wrapper passes stdin/stdout
+  through unchanged and signals IDLE on exit (legacy behavior).
+- **Headless** (``--print`` in args) — the wrapper captures stdout (tee'd
+  to the parent's stdout so terminal observers still see it), parses for
+  the ``<<<AUTO_DEV_RESULT…>>>`` sentinel block on exit, and signals
+  SESSION_COMPLETED when a result is found. See issue #99 for why we do
+  this here instead of from reconcile.
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
+import logging
 import os
 import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from cw.auto_dev_result import AutoDevResult, parse_stdout
 from cw.config import events_dir, load_state, save_state
+from cw.events import record_event as record_orchestrator_event
 from cw.history import EventType, HistoryEvent, record_event
-from cw.models import SessionStatus
+from cw.models import (
+    CompletionReason,
+    OrchestratorEventType,
+    SessionStatus,
+)
+
+if TYPE_CHECKING:
+    from cw.models import CwState, Session
+
+_log = logging.getLogger(__name__)
+
+# Sliding-window cap for captured stdout in headless mode. The sentinel block
+# lives at the tail of stdout, so we keep the last N bytes and let earlier
+# noise fall off. 1 MiB comfortably holds any realistic auto-dev run.
+_TAIL_CAPTURE_BYTES = 1_048_576
 
 
 def _idle_signal_path(client: str, purpose: str) -> Path:
@@ -34,7 +63,6 @@ def _detect_claude_session_id(workspace_path: str) -> str | None:
     project_dir = Path.home() / ".claude" / "projects" / encoded
     if not project_dir.is_dir():
         return None
-    # Find the most recently modified .jsonl file
     candidates = sorted(
         project_dir.glob("*.jsonl"),
         key=lambda p: p.stat().st_mtime,
@@ -45,30 +73,116 @@ def _detect_claude_session_id(workspace_path: str) -> str | None:
     return candidates[0].stem
 
 
-def run_claude_wrapper(extra_args: tuple[str, ...]) -> None:
-    """Run Claude and signal IDLE on exit.
+def _is_headless(args: tuple[str, ...]) -> bool:
+    """True when ``--print`` appears in the args passed to claude."""
+    return "--print" in args or "-p" in args
 
-    Reads ``CW_CLIENT`` and ``CW_PURPOSE`` from the environment.  If
-    either is missing, runs Claude once and exits (no IDLE signaling).
+
+def _write_passthrough(chunk: bytes) -> None:
+    """Tee a chunk to fd 1 (parent stdout). Best-effort — errors are swallowed.
+
+    fd 1 may be closed or redirected to a non-writable target. Capture
+    still completes; only the user-visible tee is degraded.
+    """
+    with contextlib.suppress(OSError):
+        os.write(1, chunk)
+
+
+def _run_claude_streaming(
+    args: list[str],
+    *,
+    max_capture_bytes: int = _TAIL_CAPTURE_BYTES,
+) -> tuple[int, str]:
+    """Run claude with stdout streamed to parent and captured into a bounded buffer.
+
+    Returns ``(returncode, captured_text)``. The captured text is the last
+    ``max_capture_bytes`` of stdout, decoded with replacement. stderr is
+    inherited from the parent so terminal observers see errors live.
+    """
+    buf = bytearray()
+    proc = subprocess.Popen(
+        ["claude", *args],
+        stdout=subprocess.PIPE,
+        bufsize=0,
+    )
+    assert proc.stdout is not None  # noqa: S101 - guaranteed by PIPE above
+    try:
+        while True:
+            chunk = proc.stdout.read(4096)
+            if not chunk:
+                break
+            _write_passthrough(chunk)
+            buf.extend(chunk)
+            if len(buf) > max_capture_bytes:
+                del buf[: len(buf) - max_capture_bytes]
+    finally:
+        returncode = proc.wait()
+    return returncode, buf.decode("utf-8", errors="replace")
+
+
+def run_claude_wrapper(extra_args: tuple[str, ...]) -> None:
+    """Run Claude and signal cw on exit.
+
+    Reads ``CW_CLIENT`` and ``CW_PURPOSE`` from the environment. If either
+    is missing, runs Claude once and exits (no signaling).
+
+    In headless mode (``--print`` in args), captures stdout and parses for
+    the AUTO_DEV_RESULT sentinel block. If parsed, signals
+    SESSION_COMPLETED; otherwise falls back to SESSION_IDLED.
     """
     client = os.environ.get("CW_CLIENT")
     purpose = os.environ.get("CW_PURPOSE")
+    session_id_env = os.environ.get("CW_SESSION_ID")
 
     claude_args = list(extra_args)
-    # Resolve workspace path for session ID detection
     workspace_path = os.getcwd()
-    result = subprocess.run(["claude", *claude_args], check=False)
+
+    if _is_headless(extra_args):
+        returncode, captured = _run_claude_streaming(claude_args)
+    else:
+        result = subprocess.run(["claude", *claude_args], check=False)
+        returncode = result.returncode
+        captured = ""
 
     if not client or not purpose:
-        sys.exit(result.returncode)
+        sys.exit(returncode)
 
     claude_session_id = _detect_claude_session_id(workspace_path)
+
+    if captured and returncode == 0:
+        parsed = parse_stdout(captured)
+        if isinstance(parsed, AutoDevResult):
+            signal_completed(
+                client,
+                purpose,
+                result=parsed,
+                session_id=session_id_env,
+                claude_session_id=claude_session_id,
+            )
+            return
+
     signal_idle(
         client,
         purpose,
-        exit_code=result.returncode,
+        exit_code=returncode,
         claude_session_id=claude_session_id,
+        session_id=session_id_env,
     )
+
+
+def _resolve_session(
+    client: str,
+    purpose: str,
+    *,
+    session_id: str | None,
+    state: CwState,
+) -> Session | None:
+    """Look up the session by explicit ID first, then by (client, purpose)."""
+    if session_id:
+        for s in state.sessions:
+            if s.id == session_id:
+                return s
+    return state.find_session(client, purpose)
 
 
 def signal_idle(
@@ -77,10 +191,11 @@ def signal_idle(
     *,
     exit_code: int = 0,
     claude_session_id: str | None = None,
+    session_id: str | None = None,
 ) -> None:
     """Transition the session to IDLE and write an event signal file."""
     state = load_state()
-    session = state.find_session(client, purpose)
+    session = _resolve_session(client, purpose, session_id=session_id, state=state)
     if session is None or session.status != SessionStatus.ACTIVE:
         return
 
@@ -113,3 +228,55 @@ def signal_idle(
             metadata={"exit_code": str(exit_code)},
         ),
     )
+
+
+def signal_completed(
+    client: str,
+    purpose: str,
+    *,
+    result: AutoDevResult,
+    session_id: str | None = None,
+    claude_session_id: str | None = None,
+) -> None:
+    """Transition the session to COMPLETED and emit SESSION_COMPLETED.
+
+    Idempotent: a no-op when the session is already COMPLETED (e.g. when
+    reconcile got there first via the phantom-pane path). Persists the
+    parsed ``result`` to ``session.last_result`` so the daemon's
+    consume_completed_sessions can route by status.
+    """
+    state = load_state()
+    session = _resolve_session(client, purpose, session_id=session_id, state=state)
+    if session is None:
+        _log.debug(
+            "signal_completed: no session found for client=%s purpose=%s id=%s",
+            client,
+            purpose,
+            session_id,
+        )
+        return
+    if session.status == SessionStatus.COMPLETED:
+        _log.debug(
+            "signal_completed: session %s already COMPLETED — no-op",
+            session.id,
+        )
+        return
+
+    now = datetime.now(UTC)
+    session.status = SessionStatus.COMPLETED
+    session.completed_at = now
+    session.completed_reason = CompletionReason.NORMAL
+    session.last_result = result.model_dump(mode="json")
+    if claude_session_id:
+        session.claude_session_id = claude_session_id
+    save_state(state)
+
+    payload: dict[str, object] = {
+        "session_id": session.id,
+        "session_name": session.name,
+        "client": client,
+        "crashed": False,
+        "status": result.status,
+        "ticket_id": result.ticket_id,
+    }
+    record_orchestrator_event(OrchestratorEventType.SESSION_COMPLETED, payload)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -562,6 +562,45 @@ class TestConsumeCompletesTasks:
         assert completed == 1
         assert load_dev_queue().tasks[0].status == QueueItemStatus.COMPLETED
 
+    def test_consume_completes_wrapper_emitted_event_shape(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """The full event payload emitted by wrapper.signal_completed completes.
+
+        Issue #99: the wrapper emits SESSION_COMPLETED with crashed=False
+        plus ``status`` (the parsed auto-dev outcome) and ``session_name``.
+        The consumer must treat this exactly like a legacy non-crashed event
+        — the new fields are forward-compatible metadata, not behavior.
+        """
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        task = TicketTask(
+            ticket_id="GEN-WRAP",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+            session_id="wrapper-session",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {
+                "session_id": "wrapper-session",
+                "session_name": "test-client/auto-dev/GEN-WRAP",
+                "client": "test-client",
+                "crashed": False,
+                "status": "shipped",
+                "ticket_id": "GEN-WRAP",
+            },
+        )
+
+        completed = consume_completed_sessions()
+        assert completed == 1
+        assert load_dev_queue().tasks[0].status == QueueItemStatus.COMPLETED
+
     def test_consume_advances_cursor(
         self,
         tmp_dispatch_dirs: Path,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -444,6 +444,7 @@ class TestCompletionReason:
         assert CompletionReason.USER.value == "user"
         assert CompletionReason.HANDOFF.value == "handoff"
         assert CompletionReason.CRASHED.value == "crashed"
+        assert CompletionReason.NORMAL.value == "normal"
 
     def test_all_values(self) -> None:
-        assert len(CompletionReason) == 3
+        assert len(CompletionReason) == 4

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -148,6 +148,13 @@ class TestSpawnCreate:
         # spawn command must cd into the worktree instead of passing it via -w.
         assert " -w " not in command_arg
         assert command_arg.startswith("cd ")
+        # Daemon spawns go through `cw run-claude` so the wrapper can emit a
+        # SESSION_COMPLETED on clean exit (issue #99). Env vars carry the
+        # session identity through to the wrapper.
+        assert "cw run-claude -- --print" in command_arg
+        assert "CW_CLIENT=acme" in command_arg
+        assert "CW_PURPOSE=impl" in command_arg
+        assert "CW_SESSION_ID=" in command_arg
 
     def test_cmux_workspace_overrides_client_name(
         self, tmp_config_dir: Path, tmp_path: Path

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -5,19 +5,85 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 
+from cw.auto_dev_result import AutoDevResult
 from cw.config import events_dir, load_state, save_state
+from cw.events import read_events
 from cw.history import EventType, load_history
-from cw.models import CwState, Session, SessionPurpose, SessionStatus
+from cw.models import (
+    CompletionReason,
+    CwState,
+    OrchestratorEventType,
+    Session,
+    SessionPurpose,
+    SessionStatus,
+)
 from cw.wrapper import (
     _detect_claude_session_id,
     _idle_signal_path,
+    _is_headless,
+    _run_claude_streaming,
     run_claude_wrapper,
+    signal_completed,
     signal_idle,
 )
+
+
+def _make_result(
+    *,
+    status: str = "shipped",
+    ticket_id: str = "T-1",
+) -> AutoDevResult:
+    """Build a minimal AutoDevResult that satisfies §3-§5 invariants."""
+    payload: dict[str, Any] = {
+        "schema_version": 2,
+        "ticket_id": ticket_id,
+        "status": status,
+        "stage_reached": "stage4b_pr_create",
+        "scope": {
+            "tier": "small",
+            "files": 1,
+            "lines_estimate": 10,
+            "lines_actual": 8,
+            "forbidden_touched": False,
+        },
+        "plan_source": "generated",
+        "branch": "auto-dev/T-1",
+        "fork_point_sha": "abc123",
+        "commits": ["c1"],
+        "pr": {
+            "number": 42,
+            "url": "https://example.com/pr/42",
+            "auto_merge": True,
+            "base": "main",
+        },
+        "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+        "health": {
+            "lowest_agent_confidence": "HIGH",
+            "any_incomplete_risk": False,
+            "recommendation": "PROCEED",
+        },
+        "next_actions": ["wait_for_ci"],
+    }
+    if status == "no_op":
+        payload["status"] = "no_op"
+        payload["branch"] = None
+        payload["pr"] = None
+        payload["next_actions"] = []
+        payload["stage_reached"] = "stage1_plan"
+        payload["scope"]["lines_actual"] = None
+        payload["commits"] = []
+    return AutoDevResult.model_validate(payload)
+
+
+def _sentinel_stdout(result: AutoDevResult, *, prefix: str = "log line\n") -> str:
+    """Wrap a result payload in the AUTO_DEV_RESULT sentinel block."""
+    body = result.model_dump_json()
+    return f"{prefix}<<<AUTO_DEV_RESULT\n{body}\nAUTO_DEV_RESULT>>>\n"
 
 
 class TestIdleSignalPath:
@@ -284,3 +350,338 @@ class TestDetectClaudeSessionId:
             result = _detect_claude_session_id(workspace)
 
         assert result is None
+
+
+class TestIsHeadless:
+    def test_print_flag_long(self) -> None:
+        assert _is_headless(("--print", "hi"))
+
+    def test_print_flag_short(self) -> None:
+        assert _is_headless(("-p", "hi"))
+
+    def test_no_print_flag(self) -> None:
+        assert not _is_headless(("--resume",))
+
+    def test_empty_args(self) -> None:
+        assert not _is_headless(())
+
+
+class TestSignalCompleted:
+    def _seed_active_session(self, sid: str = "w1") -> Session:
+        sess = Session(
+            id=sid,
+            name="c/auto-dev/T-1",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/dev/null"),
+        )
+        save_state(CwState(sessions=[sess]))
+        return sess
+
+    def test_flips_active_to_completed(
+        self, tmp_config_dir: Path, tmp_state_dir: Path
+    ) -> None:
+        """signal_completed transitions ACTIVE → COMPLETED with NORMAL reason."""
+        self._seed_active_session("w1")
+        result = _make_result(status="shipped", ticket_id="T-1")
+
+        signal_completed("c", "impl", result=result, session_id="w1")
+
+        updated = load_state()
+        sess = updated.sessions[0]
+        assert sess.status == SessionStatus.COMPLETED
+        assert sess.completed_reason == CompletionReason.NORMAL
+        assert sess.completed_at is not None
+        assert sess.last_result is not None
+        assert sess.last_result["status"] == "shipped"
+        assert sess.last_result["ticket_id"] == "T-1"
+
+    def test_emits_session_completed_event(
+        self, tmp_config_dir: Path, tmp_state_dir: Path
+    ) -> None:
+        """signal_completed records SESSION_COMPLETED with crashed=False and status."""
+        self._seed_active_session("w2")
+        result = _make_result(status="no_op", ticket_id="T-9")
+
+        signal_completed("c", "impl", result=result, session_id="w2")
+
+        events = read_events(event_types=[OrchestratorEventType.SESSION_COMPLETED])
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.payload["session_id"] == "w2"
+        assert ev.payload["client"] == "c"
+        assert ev.payload["crashed"] is False
+        assert ev.payload["status"] == "no_op"
+        assert ev.payload["ticket_id"] == "T-9"
+
+    def test_idempotent_when_already_completed(
+        self, tmp_config_dir: Path, tmp_state_dir: Path
+    ) -> None:
+        """signal_completed no-ops when session already COMPLETED."""
+        sess = Session(
+            id="done1",
+            name="c/auto-dev/T-1",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.COMPLETED,
+            completed_reason=CompletionReason.CRASHED,
+            workspace_path=Path("/dev/null"),
+        )
+        save_state(CwState(sessions=[sess]))
+        result = _make_result(status="shipped", ticket_id="T-1")
+
+        signal_completed("c", "impl", result=result, session_id="done1")
+
+        updated = load_state()
+        # Original completion reason preserved (no overwrite from idempotency path).
+        assert updated.sessions[0].completed_reason == CompletionReason.CRASHED
+        assert updated.sessions[0].last_result is None
+        # No event emitted.
+        events = read_events(event_types=[OrchestratorEventType.SESSION_COMPLETED])
+        assert events == []
+
+    def test_no_session_is_noop(
+        self, tmp_config_dir: Path, tmp_state_dir: Path
+    ) -> None:
+        """signal_completed silently no-ops when no session exists."""
+        save_state(CwState(sessions=[]))
+        result = _make_result(status="shipped", ticket_id="T-1")
+        # Should not raise.
+        signal_completed("c", "impl", result=result, session_id="missing")
+
+    def test_session_id_lookup_disambiguates(
+        self, tmp_config_dir: Path, tmp_state_dir: Path
+    ) -> None:
+        """When multiple impl sessions for one client exist, CW_SESSION_ID picks one."""
+        # Two ACTIVE impl sessions for same client (simulating parallel dispatch).
+        a = Session(
+            id="aaa",
+            name="c/auto-dev/T-1",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/dev/null"),
+        )
+        b = Session(
+            id="bbb",
+            name="c/auto-dev/T-2",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/dev/null"),
+        )
+        save_state(CwState(sessions=[a, b]))
+        result = _make_result(status="shipped", ticket_id="T-2")
+
+        signal_completed("c", "impl", result=result, session_id="bbb")
+
+        updated = load_state()
+        sess_a = next(s for s in updated.sessions if s.id == "aaa")
+        sess_b = next(s for s in updated.sessions if s.id == "bbb")
+        assert sess_a.status == SessionStatus.ACTIVE
+        assert sess_b.status == SessionStatus.COMPLETED
+
+
+class TestHeadlessWrapper:
+    def test_print_with_sentinel_signals_completed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_config_dir: Path,
+        tmp_state_dir: Path,
+    ) -> None:
+        """--print + AUTO_DEV_RESULT in stdout → SESSION_COMPLETED, not IDLED."""
+        monkeypatch.setenv("CW_CLIENT", "c")
+        monkeypatch.setenv("CW_PURPOSE", "impl")
+        monkeypatch.setenv("CW_SESSION_ID", "h1")
+
+        sess = Session(
+            id="h1",
+            name="c/auto-dev/T-1",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/dev/null"),
+        )
+        save_state(CwState(sessions=[sess]))
+
+        result = _make_result(status="shipped", ticket_id="T-1")
+        captured = _sentinel_stdout(result)
+
+        with patch(
+            "cw.wrapper._run_claude_streaming",
+            return_value=(0, captured),
+        ):
+            run_claude_wrapper(("--print", "/auto-dev T-1 --headless"))
+
+        updated = load_state()
+        assert updated.sessions[0].status == SessionStatus.COMPLETED
+        assert updated.sessions[0].completed_reason == CompletionReason.NORMAL
+        # No IDLE signal file written for the completed path.
+        assert not _idle_signal_path("c", "impl").exists()
+
+    def test_print_without_sentinel_falls_back_to_idle(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_config_dir: Path,
+        tmp_state_dir: Path,
+    ) -> None:
+        """--print but no sentinel block → falls back to signal_idle."""
+        monkeypatch.setenv("CW_CLIENT", "c")
+        monkeypatch.setenv("CW_PURPOSE", "impl")
+        monkeypatch.setenv("CW_SESSION_ID", "h2")
+
+        sess = Session(
+            id="h2",
+            name="c/auto-dev/T-2",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/dev/null"),
+        )
+        save_state(CwState(sessions=[sess]))
+
+        with patch(
+            "cw.wrapper._run_claude_streaming",
+            return_value=(0, "just some output, no sentinel here\n"),
+        ):
+            run_claude_wrapper(("--print", "/auto-dev T-2"))
+
+        updated = load_state()
+        # Idle path was taken, not completed.
+        assert updated.sessions[0].status == SessionStatus.IDLE
+
+    def test_print_nonzero_exit_skips_completed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_config_dir: Path,
+        tmp_state_dir: Path,
+    ) -> None:
+        """Nonzero exit code skips SESSION_COMPLETED even if sentinel is present.
+
+        A worker that crashed mid-write may still have emitted a partial
+        sentinel; we'd rather let reconcile's phantom-pane path handle it.
+        """
+        monkeypatch.setenv("CW_CLIENT", "c")
+        monkeypatch.setenv("CW_PURPOSE", "impl")
+        monkeypatch.setenv("CW_SESSION_ID", "h3")
+
+        sess = Session(
+            id="h3",
+            name="c/auto-dev/T-3",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/dev/null"),
+        )
+        save_state(CwState(sessions=[sess]))
+
+        result = _make_result(status="shipped", ticket_id="T-3")
+        captured = _sentinel_stdout(result)
+
+        with patch(
+            "cw.wrapper._run_claude_streaming",
+            return_value=(1, captured),
+        ):
+            run_claude_wrapper(("--print", "/auto-dev T-3"))
+
+        updated = load_state()
+        assert updated.sessions[0].status == SessionStatus.IDLE
+
+    def test_no_print_uses_subprocess_run(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_config_dir: Path,
+        tmp_state_dir: Path,
+    ) -> None:
+        """Interactive mode keeps subprocess.run + signal_idle, no streaming."""
+        monkeypatch.setenv("CW_CLIENT", "c")
+        monkeypatch.setenv("CW_PURPOSE", "impl")
+
+        sess = Session(
+            id="i1",
+            name="c/impl",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/dev/null"),
+        )
+        save_state(CwState(sessions=[sess]))
+
+        with (
+            patch("cw.wrapper.subprocess.run") as mock_run,
+            patch("cw.wrapper._run_claude_streaming") as mock_stream,
+        ):
+            mock_run.return_value = type("R", (), {"returncode": 0})()
+            run_claude_wrapper(("--resume",))
+
+        mock_stream.assert_not_called()
+        mock_run.assert_called_once_with(["claude", "--resume"], check=False)
+        updated = load_state()
+        assert updated.sessions[0].status == SessionStatus.IDLE
+
+
+class _FakeStdout:
+    """Drip-feed bytes chunk-by-chunk to mimic Popen.stdout."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+
+    def read(self, _size: int) -> bytes:
+        if not self._chunks:
+            return b""
+        return self._chunks.pop(0)
+
+
+class _FakePopen:
+    def __init__(self, chunks: list[bytes], returncode: int = 0) -> None:
+        self.stdout = _FakeStdout(chunks)
+        self._returncode = returncode
+
+    def wait(self) -> int:
+        return self._returncode
+
+
+class TestRunClaudeStreaming:
+    def test_captures_stdout_up_to_cap(self) -> None:
+        """Streaming run keeps only the tail when output exceeds the cap."""
+        chunks = [b"A" * 50, b"TAIL_MARKER"]
+
+        with (
+            patch("cw.wrapper.subprocess.Popen", return_value=_FakePopen(chunks)),
+            patch("cw.wrapper._write_passthrough"),  # silence stdout tee
+        ):
+            rc, captured = _run_claude_streaming([], max_capture_bytes=20)
+
+        assert rc == 0
+        # Tail-truncated buffer keeps the last 20 bytes, which must include the
+        # marker emitted at the very end.
+        assert "TAIL_MARKER" in captured
+        assert len(captured) <= 20
+
+    def test_captures_full_stdout_under_cap(self) -> None:
+        """Output below the cap is captured in full."""
+        chunks = [b"short output\n"]
+
+        with (
+            patch("cw.wrapper.subprocess.Popen", return_value=_FakePopen(chunks)),
+            patch("cw.wrapper._write_passthrough"),
+        ):
+            rc, captured = _run_claude_streaming([], max_capture_bytes=1024)
+
+        assert rc == 0
+        assert captured == "short output\n"
+
+    def test_propagates_returncode(self) -> None:
+        """Non-zero returncode from claude is surfaced unchanged."""
+        with (
+            patch(
+                "cw.wrapper.subprocess.Popen",
+                return_value=_FakePopen([b""], returncode=7),
+            ),
+            patch("cw.wrapper._write_passthrough"),
+        ):
+            rc, captured = _run_claude_streaming([])
+
+        assert rc == 7
+        assert captured == ""


### PR DESCRIPTION
## Summary

Closes #99. Wires `cw run-claude` into the daemon dispatch path so a worker that emits `<<<AUTO_DEV_RESULT…>>>` and exits cleanly produces a `SESSION_COMPLETED` event with `crashed: false` and the parsed status — closing the wedged-RUNNING loop where dispatched workers reached terminal state in their panes but the queue never noticed.

**Root cause:** for tmux, `reconcile.compute_drift` only flips a session to phantom when the pane itself vanishes. But dispatch spawns `cd <wt> && claude --print …` into a bash pane: when claude exits cleanly, control returns to bash, the pane stays alive, and reconcile never fires. Task sits RUNNING forever (concurrency cap consumed).

**Fix (Option A from the ticket):** the wrapper, which is the immediate parent of claude, owns the clean-exit signal.

## Changes

- **Phase 1** — `src/cw/spawn.py` now spawns `cd … && CW_CLIENT=… CW_PURPOSE=impl CW_SESSION_ID=… cw run-claude -- --print '<prompt>'`. Pre-creates the `Session` so the wrapper can target it by ID (disambiguates concurrent daemon sessions sharing `(client, purpose=impl)`).
- **Phase 2** — `src/cw/wrapper.py` detects `--print`, tees claude's stdout to fd 1 while capturing the last 1 MiB into a bounded buffer, parses for `AutoDevResult` on clean exit, and emits `SESSION_COMPLETED` via new `signal_completed()` (idempotent against reconcile racing ahead). Falls back to `signal_idle` on parse failure or non-zero exit so reconcile's phantom-pane path still catches real crashes. Adds `CompletionReason.NORMAL`.
- **Phase 3** — `dispatch.consume_completed_sessions` already handles `crashed: false` events (from #97/#100); no code change, just a regression test asserting the wrapper-emitted payload shape (with `status` + `session_name` fields) routes correctly. Full per-status routing (`shipped`/`no_op` → COMPLETED, `blocked`/`plan_pending_approval` → PAUSED_NEEDS_HUMAN) deferred to #58.

## Test plan

- [x] `uv run pytest tests/ -v` — 776 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] **Live verification (operator-side, post-merge):**
  - [x] Install patched build: `uv tool install --reinstall .`
  - [x] Restart `cw dev-queue run`
  - [x] Dispatch a known-shipped ticket (re-queue something whose PR already merged → `no_op`)
  - [ ] Confirm task transitions RUNNING → COMPLETED within one tick of worker exit
  - [x] Confirm no respawn on subsequent ticks
  - [ ] Confirm `cw status` doesn't accumulate ghost ACTIVE sessions

## Out of scope

- Full #58 queue-routing table per status
- #59 resume-detection on re-invoke (depends on `last_result` populated by this PR)
- Interactive `cw start` sessions — wrapper behavior unchanged for non-`--print`

🤖 Generated with [Claude Code](https://claude.com/claude-code)