### PR TITLE
docs(rfc): RFC 0003 native worktree isolation (#107 spike)

### DIFF
--- a/.claude/agents/spike-isolated.md
+++ b/.claude/agents/spike-isolated.md
@@ -1,0 +1,9 @@
+---
+name: spike-isolated
+description: tiny isolation-test subagent for #107 spike
+tools: Read, Write
+isolation: worktree
+---
+
+You are a test subagent. Create a file named SPIKE-AGENT.txt with content
+"isolated agent" in the current working directory, then exit.

--- a/docs/adr/0000-native-supervisor-migration.md
+++ b/docs/adr/0000-native-supervisor-migration.md
@@ -1,0 +1,179 @@
+# Migrate session lifecycle from wrapper + multiplexer to `claude --bg` + supervisor
+
+**Status:** Accepted
+**Driven by:** #105, #108, #109, #111, #112, #113, #114, #119
+
+## Decision
+
+cw is migrating its daemon-session lifecycle off the hand-rolled
+`wrapper.py` + multiplexer (`cmux` / `tmux`) + `reconcile.py` substrate
+and onto Claude Code's native primitives: `claude --bg`, the per-user
+supervisor process, `~/.claude/jobs/<id>/state.json`, and the
+`claude agents --json` query interface.
+
+This ADR is the foundational record. All other ADRs assume this
+trajectory as ground truth.
+
+## Initial state (pre-migration, today)
+
+The wrapper-based stack that cw shipped through 0.8.x:
+
+1. **Spawn** (`src/cw/spawn.py`). Dispatch composes a shell command of the
+   form `cd <cwd> && CW_CLIENT=... cw run-claude -- --print <prompt>` and
+   hands it to the multiplexer adapter (`cmux.spawn` or `tmux.spawn`),
+   which creates a pane and returns a `surface_ref` (pane id).
+2. **Wrapping** (`src/cw/wrapper.py`, 282 LoC). `cw run-claude` is a
+   Python subprocess wrapper that:
+   - launches `claude` as a child process
+   - captures stdout into a 1 MiB circular buffer
+   - parses the `<<<AUTO_DEV_RESULT` sentinel on exit
+   - writes either `SESSION_IDLED` or `SESSION_COMPLETED` signal files
+     to `events_dir()`
+3. **Lifecycle signal pickup** (`src/cw/dispatch.py:consume_completed_sessions`).
+   The dispatch loop polls those signal files per tick, advances the
+   matching `TicketTask` to `COMPLETED`, and calls `persist_last_result`
+   to dump the parsed `AutoDevResult` onto the Session.
+4. **Reconciliation** (`src/cw/reconcile.py`, 219 LoC). Periodically
+   compares persisted `sessions.json` against `adapter.list_surfaces()`;
+   sessions in state but with no live pane are reaped (DAEMON-origin
+   reverts RUNNING → PENDING). A transient-outage guard prevents
+   mass-reaping when the adapter returns zero surfaces while state has
+   many.
+5. **Resume** (`src/cw/session.py`). Resume re-attaches to a multiplexer
+   surface (if alive) or spawns a new `claude --resume <claude_session_id>`
+   when the original surface is gone.
+
+The substrate works, has paid for itself, and is being deliberately
+retired — not because it's broken, but because the native primitives
+now exist and cover the surface more cleanly.
+
+## Target state (`claude --bg` + supervisor)
+
+Claude Code v2.1.139+ ships a per-user supervisor process. Each
+background-launched session is owned by the supervisor:
+
+- **Spawn:** `claude --bg --name <name> --add-dir <cwd> "<prompt>"`
+  returns a short session id immediately. The supervisor owns the
+  process and persists state under `~/.claude/jobs/<id>/state.json`.
+- **Query:** `claude agents --json` lists every live session with its
+  `sessionId`, `status` (`working` / `idle` / `completed` / `failed`),
+  `pid`, `cwd`, `kind`, `startedAt`, `name`.
+- **Attach / resume:** `claude --bg <id>` foregrounds an existing
+  backgrounded session. `claude attach <id>` and `claude --resume <id>`
+  enter the same transcript. `claude respawn <id>` restarts a stopped
+  session from its transcript.
+- **Terminate:** `claude stop <id>` ends the session; `claude rm <id>`
+  removes it from the supervisor.
+- **Crash handling:** the supervisor watches each session's process;
+  on crash, state transitions to `failed` and surfaces via the JSON
+  query. cw no longer has to detect this from the outside.
+
+The supervisor replaces three things at once: the wrapper subprocess,
+the multiplexer surface as the source of truth, and the
+phantom-detection job that reconcile.py performs.
+
+## Conversion path
+
+Phased per the issues listed under *Driven by*. Roughly:
+
+1. **#105 (Phase 0 spike)** — confirm the native primitives cover every
+   cw lifecycle surface; write the gap analysis. Throwaway code, written
+   decision deliverable.
+2. **#108 / #109 (Phase 1)** — implement `NativeBackend` as a new
+   multiplexer adapter behind the existing `CmuxAdapter` protocol so
+   the choice of backend stays a single config switch.
+3. **#111 (Phase 2)** — rewrite `spawn.py` to call `claude --bg` when
+   `NativeBackend` is selected. Legacy cmux/tmux spawn path retained
+   for compatibility.
+4. **#112 (Phase 2)** — replace `wrapper.py` IDLE/COMPLETED signaling
+   with reads from `~/.claude/jobs/<id>/state.json`. RFC under #105
+   picks between polling, Stop-hook, and the channels-based push.
+5. **#113 (Phase 2)** — retire `reconcile.py` phantom detection on
+   native backend; reduce it to a thin shim over `claude agents --json`.
+6. **#114 (Phase 3)** — `cw-pr-events` channel demonstrates the
+   push-based reaction model; future lifecycle events can follow the
+   same pattern.
+7. **#119 (Phase 6)** — delete the obsolete code. `wrapper.py`,
+   `reconcile.py`'s legacy phantom-detection path, the `cmux` and
+   `tmux` backends, and `handoff.py`'s wrapper-specific bits come out
+   once the native path is the only path in use.
+
+During the transition (phases 2 through 5), both stacks coexist.
+Backend selection (`orchestrator.yaml` `backend:`, `CW_BACKEND` env,
+platform default) already exists for this reason. The wrapper +
+multiplexer stack stays the default on platforms where the supervisor
+is not yet usable — but only until #119, at which point the native
+path is the only path and there is no compatibility surface to
+preserve.
+
+## Reconciliation
+
+Reconciliation is the load-bearing piece that changes the most:
+
+- **Today:** "is this session's multiplexer pane still alive?"
+  Answered by `adapter.list_surfaces()`. False negatives possible
+  during multiplexer outages, hence the transient-outage guard.
+- **Target:** "does the supervisor still own this session?"
+  Answered by `claude agents --json`. The supervisor itself tracks
+  process liveness; cw's job becomes status sync, not liveness probing.
+
+The native reconciliation shim (#113) keeps three responsibilities
+cw owns even after the migration:
+
+1. **Status sync.** Map supervisor status → `SessionStatus` and
+   `CompletionReason`. Update cw state accordingly.
+2. **Queue revert.** When a DAEMON-origin Session transitions to
+   `failed` or disappears from the supervisor, revert its `TicketTask`
+   from RUNNING → PENDING (existing behavior, new trigger).
+3. **Transient-outage guard.** Distinguish "supervisor unreachable"
+   (e.g., `subprocess.CalledProcessError`) from "supervisor returns
+   empty list." Only the second is allowed to reap.
+
+Phantom detection driven by surface absence (the original reconcile
+job) becomes redundant once #112 + #113 land, and the body of
+`reconcile.py` shrinks accordingly.
+
+## Consequences
+
+- The wrapper substrate (`wrapper.py`, signal files, sentinel-block
+  parsing on exit) is retired in phases 2–3 and **deleted in #119**.
+  No long-lived compatibility shim survives the migration; the
+  end-state is single-path and the obsolete modules are removed from
+  the tree.
+- The `cmux` and `tmux` multiplexer backends are deleted alongside
+  the wrapper in #119. The `MultiplexerAdapter` protocol may survive
+  in name if it still has one implementation (`NativeBackend`), or
+  may be inlined away — that's a tactical call left to #119.
+- cw's state model gains a load-bearing dependency on
+  `Session.claude_session_id`. Pre-migration sessions that lack this
+  field keep working via the wrapper path during the transition; once
+  #119 deletes the wrapper path, every persisted Session must either
+  have `claude_session_id` populated or be treated as orphaned by a
+  one-time state migration shipped with #119.
+- See [ADR-0001](0001-parked-tasks-pin-their-session.md) — the
+  parked-tasks invariant only makes sense in a world where the
+  supervisor + `claude --bg` resume primitive is the floor.
+- cw loses direct control of session stdout capture. Stdout for
+  `AutoDevResult` parsing now flows through `claude logs <id>` or the
+  supervisor's transcript files, not the wrapper's circular buffer.
+  Parsing logic in `auto_dev_result.py` is unchanged; the source of
+  the string differs.
+- Crash semantics get clearer. `completed_reason` distinctions
+  (`CRASHED` vs `NORMAL`) are read from supervisor status rather than
+  inferred from wrapper exit codes.
+
+## Alternatives considered
+
+- **Stay on the wrapper substrate indefinitely.** Rejected. The
+  hand-rolled approach was correct when no native equivalent existed;
+  with the supervisor available, every additional feature we built on
+  the wrapper path was net technical debt.
+- **Build a thin native adapter without retiring the wrapper.**
+  Rejected. Two parallel lifecycle paths produce two parallel bug
+  surfaces. The migration is phased so that *during* the transition
+  both exist, but the end-state is single-path.
+
+## Referenced by
+
+- ADR-0001 (parked tasks pin their Session)
+- #58, #59, #105, #108, #109, #111, #112, #113, #114, #119, #126, #127

--- a/docs/adr/0001-parked-tasks-pin-their-session.md
+++ b/docs/adr/0001-parked-tasks-pin-their-session.md
@@ -1,0 +1,60 @@
+# Parked tasks pin their Session
+
+**Status:** Accepted
+**Driven by:** #58
+
+## Decision
+
+When a `TicketTask` is parked (in `PAUSED_NEEDS_HUMAN` or `REQUEUED_DEFERRED`),
+its underlying `Session` and worktree MUST remain intact and resumable. No
+sweep — reconcile, doctor, or future cleanup — may garbage-collect them.
+
+## Invariant
+
+When `TicketTask.status ∈ {PAUSED_NEEDS_HUMAN, REQUEUED_DEFERRED}`:
+
+1. `TicketTask.session_id` resolves to a real `Session` in `sessions.json`.
+2. That `Session` has `claude_session_id` set (so `claude --bg <id>` resumes).
+3. That `Session`'s `worktree_path` exists on disk and remains a valid git
+   worktree.
+4. `Session.last_result` is populated with the parsed `AutoDevResult` that
+   drove the parked state.
+
+## What this means for callers
+
+- **`reconcile.py`** must not reap Sessions whose `id` is referenced by a
+  parked `TicketTask`. Today reconcile reaps any Session whose multiplexer
+  surface is dead; this carve-out lands with #58.
+- **`cw doctor`** may warn about long-parked items but MUST NOT delete them.
+- **Any future cleanup sweep** must check the queue before touching a Session.
+- **Resume implementations** (see #59) read context from `Session.last_result`
+  and the worktree; they depend on this invariant.
+
+## What this means for producers
+
+- The `/auto-dev` skill must emit its `<<<AUTO_DEV_RESULT` sentinel block
+  before the worker exits or its worktree is torn down. Today's contract:
+  §3 of [`docs/headless-contract.md`](../headless-contract.md).
+- `merge_gate_blocked` workers do not create a branch (per §3.3 pre-branch
+  statuses). The worktree is still preserved; deferred-retry reuses it.
+
+## Consequences
+
+- Disk usage grows monotonically with parked items until an operator runs
+  `cw dev-queue purge` or `cw dev-queue retry`. Accepted: losing diagnostic
+  or in-progress state is worse than the disk cost.
+- Reconcile must learn one new exception (skip-if-parked). Covered by tests
+  in #58.
+
+## Alternatives considered
+
+- **Auto-reap parked items after N days.** Rejected. Operators cannot
+  reliably distinguish "still working on approving" from "abandoned"; reaping
+  in-flight work silently is a worse failure mode than disk growth.
+- **Inline the invariant as a comment on `QueueItemStatus`.** Rejected.
+  Multiple modules (`reconcile`, `doctor`, #59, #127) need to cite the same
+  rule; a comment on one enum value doesn't carry.
+
+## Referenced by
+
+- #58, #59, #126, #127

--- a/docs/adr/0001-parked-tasks-pin-their-session.md
+++ b/docs/adr/0001-parked-tasks-pin-their-session.md
@@ -2,6 +2,8 @@
 
 **Status:** Accepted
 **Driven by:** #58
+**Builds on:** [ADR-0000](0000-native-supervisor-migration.md) — assumes
+`claude --bg <id>` is the resume primitive.
 
 ## Decision
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,45 @@
+# Architecture Decision Records
+
+This directory holds ADRs — durable records of architectural decisions whose
+consequences ripple across multiple modules or future work items.
+
+## When to write one
+
+Write an ADR when a decision:
+
+- introduces an invariant that more than one module must honor
+- constrains how future tickets can be implemented
+- closes off alternatives that a reasonable future engineer might otherwise
+  re-open
+- is referenced from multiple GitHub issues as a "see ADR-XXXX"
+
+Plain implementation choices, file-level refactors, and one-off design calls
+do NOT need an ADR — they belong in the ticket that drives them.
+
+## File naming
+
+`NNNN-kebab-case-title.md` where `NNNN` is the next zero-padded integer in
+sequence. Do not renumber existing ADRs.
+
+## How to add one
+
+1. Pick the next number from the index below.
+2. Copy `template.md` to `NNNN-<title>.md`.
+3. Fill it in. Keep it short — an ADR is reference material, not a tutorial.
+4. Add a line to the index below, in number order.
+5. Link to it from the relevant GitHub issue(s) so the connection is durable.
+
+## Status values
+
+- **Proposed** — under discussion; do not act on yet.
+- **Accepted** — current law of the land.
+- **Superseded by ADR-NNNN** — replaced; kept for history.
+- **Deprecated** — no longer applies; not (yet) superseded.
+
+When an ADR is superseded, edit the old one's status line — don't delete it.
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-parked-tasks-pin-their-session.md) | Parked tasks pin their Session | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,4 +42,9 @@ When an ADR is superseded, edit the old one's status line — don't delete it.
 
 | # | Title | Status |
 |---|---|---|
+| [0000](0000-native-supervisor-migration.md) | Migrate session lifecycle to `claude --bg` + supervisor | Accepted |
 | [0001](0001-parked-tasks-pin-their-session.md) | Parked tasks pin their Session | Accepted |
+
+ADR-0000 is the foundational record — the trajectory it captures is
+assumed as ground truth by every subsequent ADR. Future ADRs start
+at 0002 and number sequentially.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,37 @@
+# <Title — short, declarative, present tense>
+
+**Status:** Proposed | Accepted | Superseded by ADR-NNNN | Deprecated
+**Driven by:** #<issue-number> (and any others)
+
+## Decision
+
+One or two sentences. What is true now that wasn't before.
+
+## Invariant (if applicable)
+
+If this ADR establishes an invariant, state it here as a numbered list —
+the kind of thing a code reviewer can cite when rejecting a PR.
+
+## What this means for callers
+
+Bullet list of modules / behaviors that must honor the decision.
+
+## What this means for producers (if applicable)
+
+Bullet list of modules that must uphold the decision on the emitting side.
+
+## Consequences
+
+Honest list of trade-offs. What gets worse so that something else can get
+better. Include disk/memory/latency costs if non-trivial.
+
+## Alternatives considered
+
+If any were seriously weighed. Skip if the decision was forced by external
+constraints.
+
+## Referenced by
+
+- #<issue>, #<issue>, ADR-NNNN
+
+Update this list as new issues link in.

--- a/docs/rfcs/0003-native-worktree-isolation.md
+++ b/docs/rfcs/0003-native-worktree-isolation.md
@@ -1,0 +1,192 @@
+# RFC 0003 — Native worktree isolation
+
+| Field | Value |
+|---|---|
+| Status | Draft — ready for review |
+| Owner | @mattwwarren |
+| Spike ticket | #107 |
+| CLI version under test | Claude Code 2.1.148 |
+| Date | 2026-05-22 |
+| Sibling RFCs | 0001 (#105 backend), 0002 (#106 SDK/channels) |
+
+## Summary
+
+cw's `worktree.py` pre-creates git worktrees for daemon-spawned sessions: per-client base directory, slugified branch names, 64-char path cap with hash fallback, `.gitmodules` init, and idempotent reuse. The ticket assumed Claude Code's native supervisor handles all of this automatically ("every `claude --bg` session moves itself into a worktree under `.claude/worktrees/`"). **It doesn't.** Native worktree creation is user-driven (`--worktree=NAME` flag or subagent `isolation: worktree` frontmatter), and the auto-isolate-on-edit behavior the ticket cites is gated by an unset-by-default `worktree.bgIsolation` setting.
+
+## TL;DR
+
+**Decision: keep `worktree.py` as a thin policy layer.** Five gaps vs cw's current behavior, three of them load-bearing. Native primitives are useful inside `worktree.py`, but they don't replace it.
+
+| Surface | Verdict |
+|---|---|
+| Worktree creation | ❌ **not automatic** in default settings; opt-in via `--worktree=NAME` or `worktree.bgIsolation` setting |
+| Worktree path | ⚠️ root checkout's `.claude/worktrees/<name>` only — no per-client base |
+| Branch naming | ⚠️ prefixes `worktree-` to user-supplied name |
+| Same-name reuse | ✅ idempotent (matches cw) |
+| Slug validation | ✅ `[A-Za-z0-9._-]` only; cw's existing slugifier suffices |
+| 64-char cap | unknown — native didn't error on the test name, but a longer one might |
+| Submodule init | unknown — defer to Phase 1 verification |
+| Cleanup | ✅ `claude rm` honors uncommitted-work safety; cw should adopt |
+| `worktree.bgIsolation: "none"` | untested |
+| Subagent `isolation: worktree` | ⚠️ requires interactive disclaimer (`claude --dangerously-skip-permissions` once) before `--bg` can use bypass mode; otherwise blocks on permission dialog |
+
+## Smoke test results
+
+### Test 1 — Three `claude --bg` against the same branch
+
+**Setup:** `cd /home/matthew/.cw/wt/758234be/auto-dev-107` (a worktree on branch `auto-dev/107`), then three `claude --bg "Create SPIKE-X.txt..."` dispatches.
+
+**Result:** ❌ No worktrees created. All three sessions wrote `SPIKE-{A,B,C}.txt` directly into `auto-dev-107/`. The ticket's assumed auto-isolate behavior is **not the default**.
+
+| Session | state | output |
+|---|---|---|
+| `af3ad4d1` | `working/blocked` | hung on `"approve Write: …/SPIKE-A.txt"` — permission gate |
+| `22358c20` | `done` | created `SPIKE-B.txt` in `auto-dev-107/` |
+| `f4a68dd6` | `done` | created `SPIKE-C.txt` in `auto-dev-107/` |
+
+Notes:
+- The permission gate fired for session A but not B/C — session-level approval cache appears to propagate within the same dispatch batch (corroborating finding for RFC 0001 Row 10 workarounds).
+- A new `status` value `waiting` appeared in `agents --json` (alongside `idle`/`busy`).
+
+### Test 2 — `claude --bg --worktree=NAME`
+
+**Setup:** Same cwd; `claude --bg --worktree=spike-c-test "Create SPIKE-WT.txt..."`.
+
+**Result:** ✅ Worktree created at `/home/matthew/workspace/personal/claude-workspace/.claude/worktrees/spike-c-test` — that is, in the **root checkout's** `.claude/worktrees/`, NOT under the calling worktree. `SPIKE-WT.txt` was created inside the new worktree.
+
+`state.json` gained two fields:
+
+```jsonc
+{
+  "worktreePath": "/home/matthew/workspace/.../claude-workspace/.claude/worktrees/spike-c-test",
+  "worktreeBranch": "worktree-spike-c-test",      // prefixed with "worktree-"
+  "respawnFlags": ["--worktree=spike-c-test"],    // preserved across respawn
+  ...
+}
+```
+
+Re-spawning with the same `--worktree=spike-c-test` name reused the existing worktree (created `SPIKE-WT2.txt` alongside `SPIKE-WT.txt`). Idempotent reuse confirmed.
+
+**Naming gotchas:**
+- `claude --bg --worktree "Print READY..."` (positional, no `=`) consumed the prompt **as the worktree name** and errored: `Invalid worktree name "Print READY then exit.": each "/"-separated segment must be non-empty and contain only letters, digits, dots, underscores, and dashes`. cw must always supply `--worktree=name` form, never positional.
+- Branch name is `worktree-<user-name>` — Claude prefixes. cw's existing branch-name policy (#84 slugify) can stay in front, but the published branch name will differ from what cw passes.
+
+### Test 3 — Subagent `isolation: worktree`
+
+**Setup:** Wrote `.claude/agents/spike-isolated.md` with `isolation: worktree` frontmatter, then `claude --bg --agent spike-isolated`.
+
+**Result:** ⚠️ Session entered `working/blocked` with `detail: "stuck on a startup dialog"`, `needs: "open this session to continue setup"`. Subagent dispatched but couldn't run autonomously.
+
+Subsequent attempt with `--permission-mode bypassPermissions`:
+
+```
+--bg with bypassPermissions requires accepting the disclaimer first.
+Run `claude --dangerously-skip-permissions` once interactively.
+```
+
+So cw's NativeBackend needs:
+- **Onboarding step:** detect whether the user has accepted the bypass disclaimer; if not, surface a one-line "run `claude --dangerously-skip-permissions` once" message at first dispatch.
+- **Fallback:** without bypass, dispatch via `--allowedTools` enumeration (the existing `~/.claude/settings.json` allow list is what makes interactive sessions like this one work).
+
+State.json fields specific to subagent dispatch:
+
+```jsonc
+{
+  "template": "spike-isolated",          // == agent name (was "bg" otherwise)
+  "respawnFlags": ["--agent", "spike-isolated"],
+}
+```
+
+Whether `isolation: worktree` frontmatter would create a worktree if the session had run autonomously is **not verified** by this spike. Defer to Phase 1.
+
+### Test 4 — `claude rm` cleanup safety
+
+Issued `claude rm bf57fea0` against a session whose worktree had uncommitted changes:
+
+```
+removed bf57fea0
+  worktree has uncommitted changes — kept at .../spike-c-test
+```
+
+- Session record (`~/.claude/jobs/bf57fea0/`) deleted
+- Worktree **preserved** because of uncommitted work
+- Branch `worktree-spike-c-test` retained
+
+cw should adopt this safety in `cw done --cleanup`: never delete a worktree with uncommitted work unless `--force` is supplied.
+
+## Gap analysis per ticket table
+
+| cw behavior | Native | Verdict |
+|---|---|---|
+| Pre-create worktree at predictable path before spawn (worktree.py:127-176) | Native creates when `--worktree=NAME` is passed; **no auto-creation** in default settings | ⚠️ partial — cw can still hand creation to native by passing `--worktree=<slugified-branch>`, but path is fixed to `<root>/.claude/worktrees/`, not `client.worktree_base` |
+| Slugify branch name (worktree.py:34-42, charset `[A-Za-z0-9._-]`, #84) | Native validates exactly the same charset (observed in error message) | ✅ cw's existing slugifier works; rule matches |
+| 64-char cap with hash fallback (worktree.py:80-94, cmux-specific) | Not directly tested; native's underlying mechanism is `git worktree add`, which has no hard cap | ✅ becomes irrelevant once cmux retires |
+| Per-client `worktree_base` override (clients.example.yaml:24) | **No native equivalent.** All native worktrees land in `<root>/.claude/worktrees/<name>` | ❌ **gap** — see below |
+| Submodule init via `.gitmodules` (worktree.py:166-174) | Not tested in this spike | unknown — defer to Phase 1 verification |
+| Branch already exists vs new branch (#92, #93) | Native creates `worktree-<name>` branch; presumably fails if exists | unknown — defer |
+| Idempotent reuse (worktree.py:129) | ✅ `--worktree=NAME` reuses if path exists | matches cw |
+| Cleanup on `cw done --cleanup` (cli.py:220) | `claude rm <id>` deletes session + worktree, but **refuses** if uncommitted | ✅ better — preserves uncommitted work |
+| Parallel sessions on same branch | Each `--worktree=NAME` reuses; sessions share the worktree (race conditions possible) | ⚠️ same behavior as cw, but worth documenting |
+
+### The per-client `worktree_base` gap
+
+cw users with multi-client setups configure `worktree_base` in `clients.yaml` to land worktrees on a fast scratch disk:
+
+```yaml
+ClientA:
+  workspace_path: /work/clienta
+  worktree_base: /scratch/wt-clienta
+```
+
+Native always puts worktrees at `<root>/.claude/worktrees/<name>` — there is no way to override the base directory via flag or setting (no `--worktree-base` flag in `claude --help`; no `worktree.path` in the settings docs).
+
+**Workaround paths:**
+
+1. **cw creates the worktree manually** (current behavior), then `claude --bg` runs *inside* that worktree without `--worktree=…`. Pros: keeps `worktree_base` policy. Cons: cw still owns worktree lifecycle (can't retire `worktree.py`).
+2. **Symlink** `<root>/.claude/worktrees → /scratch/<root>-claude-worktrees`. Brittle; needs setup per repo.
+3. **Upstream ask** for `--worktree-base <path>` flag. Lowest-friction long-term fix.
+
+**Phase 1 recommendation:** keep option 1 — `worktree.py` continues to own creation; NativeBackend's `spawn()` `cd`s into the cw-created worktree and dispatches a plain `claude --bg` (without `--worktree`). This loses native's `worktreePath`/`worktreeBranch` state.json fields, but those are derivable from cw's own state.
+
+## Decision
+
+**Retain `worktree.py` as a thin policy layer.** Phase 1 NativeBackend's `spawn()`:
+
+1. cw creates the worktree at `client.worktree_base / slugified-branch` (existing `create_worktree()`)
+2. cw initializes submodules (existing `.gitmodules` step)
+3. cw dispatches `claude --bg [prompt]` with `cwd=` the new worktree
+4. cw does **not** pass `--worktree=…` (avoids the path lock-in and the `worktree-` branch-name prefix)
+5. cw maps `cw done --cleanup` to:
+   - `claude rm <short>` first (gets the safety check for uncommitted work)
+   - if rm refused (uncommitted), prompt the user before falling back to `git worktree remove --force`
+
+**Close-as-obsolete candidates:**
+- **#92** ("hand worktree creation back to claude"): close as **rejected** — gap analysis shows native's path policy doesn't fit multi-client cw users.
+- **#93** ("worktree edge cases"): keep open — cw still owns creation, so these edge cases remain in scope.
+
+## Open questions for Phase 1
+
+1. **Submodule init.** Does native run `git submodule update --init`? Quick test once Phase 1 starts. If not, cw's post-worktree hook stays.
+2. **`worktree.bgIsolation` setting.** Does setting it in `~/.claude/settings.json` change defaults? (e.g., `bgIsolation: "auto"` triggers per-session worktrees with auto-named paths.) Worth testing — if it works, cw users could opt into native auto-creation per-repo.
+3. **Subagent `isolation: worktree`.** Smoke test 3 didn't finish due to the bypass disclaimer. Verify in Phase 1 whether the frontmatter produces a worktree (auto-named) per dispatch. If yes, Phase 4's per-ticket subagents inherit isolation for free.
+4. **Long path names.** Native didn't error on `spike-c-test` (12 chars). cw's `worktree-` prefix + slug for real branch names could push past 60 chars. Verify what native does with a 70-char name.
+5. **`claude --dangerously-skip-permissions` onboarding.** Where does cw surface this requirement? Setup wizard? First-dispatch error message?
+
+## Phase 4 implications (per-ticket worktrees)
+
+Subagent isolation (Test 3) is the intended Phase 4 substrate: each `/auto-dev` ticket dispatches `claude --bg --agent ticket-worker`, and the subagent's `isolation: worktree` frontmatter creates a per-ticket worktree. This RFC didn't finish that verification — Phase 4 design should not assume it works until Phase 1 confirms.
+
+## Crossover with RFC 0001 (#105)
+
+- `claude rm` retains worktree on uncommitted work — useful as policy in Phase 1, file referenced in RFC 0001 Row 4.
+- `state.json.worktreePath` + `worktreeBranch` only populated when `--worktree=NAME` was used at dispatch. NativeBackend that doesn't pass `--worktree` (per this RFC's recommendation) won't get these fields — cw's own `Session.worktree_path` remains the source of truth.
+
+## References
+
+- [Agent view § how file edits are isolated](https://code.claude.com/docs/en/agent-view#how-file-edits-are-isolated)
+- [Settings § worktree-settings](https://code.claude.com/docs/en/settings#worktree-settings)
+- [Subagents § isolation frontmatter](https://code.claude.com/docs/en/sub-agents)
+- cw: `src/cw/worktree.py`
+- RFC 0001 (#105 native session backend)
+- #92, #93 (worktree edge cases), #84 (slugify charset), #90 (stale-worktree pruning)
+- Crossover handoff: `~/.claude/handoffs/2026-05-22-cw-spike-105-followup.md`


### PR DESCRIPTION
## Summary

Phase 0 spike #107 result: **keep `worktree.py` as a thin policy layer.**

Five gaps vs cw's current behavior, three load-bearing. Native worktree primitives are useful but they don't replace `worktree.py`.

## Critical reframing of ticket assumption

The ticket and `worktree.py` design assumed "every `claude --bg` session moves itself into a worktree under `.claude/worktrees/`". **It doesn't, in default settings.** Auto-isolation is gated by an unset-by-default `worktree.bgIsolation` setting. Spawning 3 `claude --bg` in the same cwd just wrote files into the parent — no worktree creation. Explicit `--worktree=NAME` is required.

## Phase 1 recommendation

`NativeBackend.spawn()`:
1. `worktree.py` creates worktree at `client.worktree_base / slugified-branch` (existing)
2. Initialize submodules (existing)
3. Dispatch `claude --bg [prompt]` with `cwd=` the new worktree
4. **Do not pass `--worktree=…`** — avoids native's path lock-in (`<root>/.claude/worktrees/`) and `worktree-` branch-name prefix

`cw done --cleanup`:
- Call `claude rm <short>` first (gets uncommitted-work safety check)
- If refused, prompt user before `git worktree remove --force`

## Headline findings

- `claude rm` **refuses to delete worktrees with uncommitted changes** — cw should adopt this safety
- `--worktree=NAME` is **idempotent** (reuses existing) — matches cw
- `--worktree "prompt-text"` (no `=`) consumes the prompt **as the worktree name** — cw must always use `--worktree=name` form
- `--bg --permission-mode bypassPermissions` requires `claude --dangerously-skip-permissions` once interactively first — **onboarding step for cw users**
- New observed state.json values: `state="failed"` (in addition to working/running/done/crashed), `status="waiting"` (in addition to idle/busy)
- When `--worktree=NAME` is supplied, state.json gains `worktreePath` + `worktreeBranch` (e.g., user-supplied `spike-c-test` becomes branch `worktree-spike-c-test`)
- From inside a worktree, `claude --bg --worktree=X` puts the new worktree under the **root checkout's** `.claude/worktrees/`, not nested

## Tickets to close

- **#92** (hand worktree creation back to claude): close as **rejected** — multi-client `worktree_base` has no native equivalent
- **#93** (worktree edge cases): keep open — cw still owns creation

## Open questions for Phase 1

1. Submodule init — does native run `git submodule update --init`?
2. `worktree.bgIsolation` setting semantics — does setting it trigger auto-isolation?
3. Subagent `isolation: worktree` frontmatter — confirmed dispatched, blocked on bypass-disclaimer wall. Verify behavior with bypass enabled.
4. Long path names — what does native do with a 70-char `--worktree=…` name?
5. Where does cw surface the `claude --dangerously-skip-permissions` setup requirement?

## Test plan
- [ ] Reviewer reads RFC, confirms decision rationale
- [ ] Reviewer scans open-question list — flags any that should block Phase 1
- [ ] Phase 1 (#108) author runs the four open-question verifications before NativeBackend merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)