### PR TITLE
docs(rfc): RFC 0002 orchestrator on Agent SDK + channels (#106 spike)

### DIFF
--- a/docs/adr/0000-native-supervisor-migration.md
+++ b/docs/adr/0000-native-supervisor-migration.md
@@ -1,0 +1,179 @@
+# Migrate session lifecycle from wrapper + multiplexer to `claude --bg` + supervisor
+
+**Status:** Accepted
+**Driven by:** #105, #108, #109, #111, #112, #113, #114, #119
+
+## Decision
+
+cw is migrating its daemon-session lifecycle off the hand-rolled
+`wrapper.py` + multiplexer (`cmux` / `tmux`) + `reconcile.py` substrate
+and onto Claude Code's native primitives: `claude --bg`, the per-user
+supervisor process, `~/.claude/jobs/<id>/state.json`, and the
+`claude agents --json` query interface.
+
+This ADR is the foundational record. All other ADRs assume this
+trajectory as ground truth.
+
+## Initial state (pre-migration, today)
+
+The wrapper-based stack that cw shipped through 0.8.x:
+
+1. **Spawn** (`src/cw/spawn.py`). Dispatch composes a shell command of the
+   form `cd <cwd> && CW_CLIENT=... cw run-claude -- --print <prompt>` and
+   hands it to the multiplexer adapter (`cmux.spawn` or `tmux.spawn`),
+   which creates a pane and returns a `surface_ref` (pane id).
+2. **Wrapping** (`src/cw/wrapper.py`, 282 LoC). `cw run-claude` is a
+   Python subprocess wrapper that:
+   - launches `claude` as a child process
+   - captures stdout into a 1 MiB circular buffer
+   - parses the `<<<AUTO_DEV_RESULT` sentinel on exit
+   - writes either `SESSION_IDLED` or `SESSION_COMPLETED` signal files
+     to `events_dir()`
+3. **Lifecycle signal pickup** (`src/cw/dispatch.py:consume_completed_sessions`).
+   The dispatch loop polls those signal files per tick, advances the
+   matching `TicketTask` to `COMPLETED`, and calls `persist_last_result`
+   to dump the parsed `AutoDevResult` onto the Session.
+4. **Reconciliation** (`src/cw/reconcile.py`, 219 LoC). Periodically
+   compares persisted `sessions.json` against `adapter.list_surfaces()`;
+   sessions in state but with no live pane are reaped (DAEMON-origin
+   reverts RUNNING → PENDING). A transient-outage guard prevents
+   mass-reaping when the adapter returns zero surfaces while state has
+   many.
+5. **Resume** (`src/cw/session.py`). Resume re-attaches to a multiplexer
+   surface (if alive) or spawns a new `claude --resume <claude_session_id>`
+   when the original surface is gone.
+
+The substrate works, has paid for itself, and is being deliberately
+retired — not because it's broken, but because the native primitives
+now exist and cover the surface more cleanly.
+
+## Target state (`claude --bg` + supervisor)
+
+Claude Code v2.1.139+ ships a per-user supervisor process. Each
+background-launched session is owned by the supervisor:
+
+- **Spawn:** `claude --bg --name <name> --add-dir <cwd> "<prompt>"`
+  returns a short session id immediately. The supervisor owns the
+  process and persists state under `~/.claude/jobs/<id>/state.json`.
+- **Query:** `claude agents --json` lists every live session with its
+  `sessionId`, `status` (`working` / `idle` / `completed` / `failed`),
+  `pid`, `cwd`, `kind`, `startedAt`, `name`.
+- **Attach / resume:** `claude --bg <id>` foregrounds an existing
+  backgrounded session. `claude attach <id>` and `claude --resume <id>`
+  enter the same transcript. `claude respawn <id>` restarts a stopped
+  session from its transcript.
+- **Terminate:** `claude stop <id>` ends the session; `claude rm <id>`
+  removes it from the supervisor.
+- **Crash handling:** the supervisor watches each session's process;
+  on crash, state transitions to `failed` and surfaces via the JSON
+  query. cw no longer has to detect this from the outside.
+
+The supervisor replaces three things at once: the wrapper subprocess,
+the multiplexer surface as the source of truth, and the
+phantom-detection job that reconcile.py performs.
+
+## Conversion path
+
+Phased per the issues listed under *Driven by*. Roughly:
+
+1. **#105 (Phase 0 spike)** — confirm the native primitives cover every
+   cw lifecycle surface; write the gap analysis. Throwaway code, written
+   decision deliverable.
+2. **#108 / #109 (Phase 1)** — implement `NativeBackend` as a new
+   multiplexer adapter behind the existing `CmuxAdapter` protocol so
+   the choice of backend stays a single config switch.
+3. **#111 (Phase 2)** — rewrite `spawn.py` to call `claude --bg` when
+   `NativeBackend` is selected. Legacy cmux/tmux spawn path retained
+   for compatibility.
+4. **#112 (Phase 2)** — replace `wrapper.py` IDLE/COMPLETED signaling
+   with reads from `~/.claude/jobs/<id>/state.json`. RFC under #105
+   picks between polling, Stop-hook, and the channels-based push.
+5. **#113 (Phase 2)** — retire `reconcile.py` phantom detection on
+   native backend; reduce it to a thin shim over `claude agents --json`.
+6. **#114 (Phase 3)** — `cw-pr-events` channel demonstrates the
+   push-based reaction model; future lifecycle events can follow the
+   same pattern.
+7. **#119 (Phase 6)** — delete the obsolete code. `wrapper.py`,
+   `reconcile.py`'s legacy phantom-detection path, the `cmux` and
+   `tmux` backends, and `handoff.py`'s wrapper-specific bits come out
+   once the native path is the only path in use.
+
+During the transition (phases 2 through 5), both stacks coexist.
+Backend selection (`orchestrator.yaml` `backend:`, `CW_BACKEND` env,
+platform default) already exists for this reason. The wrapper +
+multiplexer stack stays the default on platforms where the supervisor
+is not yet usable — but only until #119, at which point the native
+path is the only path and there is no compatibility surface to
+preserve.
+
+## Reconciliation
+
+Reconciliation is the load-bearing piece that changes the most:
+
+- **Today:** "is this session's multiplexer pane still alive?"
+  Answered by `adapter.list_surfaces()`. False negatives possible
+  during multiplexer outages, hence the transient-outage guard.
+- **Target:** "does the supervisor still own this session?"
+  Answered by `claude agents --json`. The supervisor itself tracks
+  process liveness; cw's job becomes status sync, not liveness probing.
+
+The native reconciliation shim (#113) keeps three responsibilities
+cw owns even after the migration:
+
+1. **Status sync.** Map supervisor status → `SessionStatus` and
+   `CompletionReason`. Update cw state accordingly.
+2. **Queue revert.** When a DAEMON-origin Session transitions to
+   `failed` or disappears from the supervisor, revert its `TicketTask`
+   from RUNNING → PENDING (existing behavior, new trigger).
+3. **Transient-outage guard.** Distinguish "supervisor unreachable"
+   (e.g., `subprocess.CalledProcessError`) from "supervisor returns
+   empty list." Only the second is allowed to reap.
+
+Phantom detection driven by surface absence (the original reconcile
+job) becomes redundant once #112 + #113 land, and the body of
+`reconcile.py` shrinks accordingly.
+
+## Consequences
+
+- The wrapper substrate (`wrapper.py`, signal files, sentinel-block
+  parsing on exit) is retired in phases 2–3 and **deleted in #119**.
+  No long-lived compatibility shim survives the migration; the
+  end-state is single-path and the obsolete modules are removed from
+  the tree.
+- The `cmux` and `tmux` multiplexer backends are deleted alongside
+  the wrapper in #119. The `MultiplexerAdapter` protocol may survive
+  in name if it still has one implementation (`NativeBackend`), or
+  may be inlined away — that's a tactical call left to #119.
+- cw's state model gains a load-bearing dependency on
+  `Session.claude_session_id`. Pre-migration sessions that lack this
+  field keep working via the wrapper path during the transition; once
+  #119 deletes the wrapper path, every persisted Session must either
+  have `claude_session_id` populated or be treated as orphaned by a
+  one-time state migration shipped with #119.
+- See [ADR-0001](0001-parked-tasks-pin-their-session.md) — the
+  parked-tasks invariant only makes sense in a world where the
+  supervisor + `claude --bg` resume primitive is the floor.
+- cw loses direct control of session stdout capture. Stdout for
+  `AutoDevResult` parsing now flows through `claude logs <id>` or the
+  supervisor's transcript files, not the wrapper's circular buffer.
+  Parsing logic in `auto_dev_result.py` is unchanged; the source of
+  the string differs.
+- Crash semantics get clearer. `completed_reason` distinctions
+  (`CRASHED` vs `NORMAL`) are read from supervisor status rather than
+  inferred from wrapper exit codes.
+
+## Alternatives considered
+
+- **Stay on the wrapper substrate indefinitely.** Rejected. The
+  hand-rolled approach was correct when no native equivalent existed;
+  with the supervisor available, every additional feature we built on
+  the wrapper path was net technical debt.
+- **Build a thin native adapter without retiring the wrapper.**
+  Rejected. Two parallel lifecycle paths produce two parallel bug
+  surfaces. The migration is phased so that *during* the transition
+  both exist, but the end-state is single-path.
+
+## Referenced by
+
+- ADR-0001 (parked tasks pin their Session)
+- #58, #59, #105, #108, #109, #111, #112, #113, #114, #119, #126, #127

--- a/docs/adr/0001-parked-tasks-pin-their-session.md
+++ b/docs/adr/0001-parked-tasks-pin-their-session.md
@@ -1,0 +1,60 @@
+# Parked tasks pin their Session
+
+**Status:** Accepted
+**Driven by:** #58
+
+## Decision
+
+When a `TicketTask` is parked (in `PAUSED_NEEDS_HUMAN` or `REQUEUED_DEFERRED`),
+its underlying `Session` and worktree MUST remain intact and resumable. No
+sweep — reconcile, doctor, or future cleanup — may garbage-collect them.
+
+## Invariant
+
+When `TicketTask.status ∈ {PAUSED_NEEDS_HUMAN, REQUEUED_DEFERRED}`:
+
+1. `TicketTask.session_id` resolves to a real `Session` in `sessions.json`.
+2. That `Session` has `claude_session_id` set (so `claude --bg <id>` resumes).
+3. That `Session`'s `worktree_path` exists on disk and remains a valid git
+   worktree.
+4. `Session.last_result` is populated with the parsed `AutoDevResult` that
+   drove the parked state.
+
+## What this means for callers
+
+- **`reconcile.py`** must not reap Sessions whose `id` is referenced by a
+  parked `TicketTask`. Today reconcile reaps any Session whose multiplexer
+  surface is dead; this carve-out lands with #58.
+- **`cw doctor`** may warn about long-parked items but MUST NOT delete them.
+- **Any future cleanup sweep** must check the queue before touching a Session.
+- **Resume implementations** (see #59) read context from `Session.last_result`
+  and the worktree; they depend on this invariant.
+
+## What this means for producers
+
+- The `/auto-dev` skill must emit its `<<<AUTO_DEV_RESULT` sentinel block
+  before the worker exits or its worktree is torn down. Today's contract:
+  §3 of [`docs/headless-contract.md`](../headless-contract.md).
+- `merge_gate_blocked` workers do not create a branch (per §3.3 pre-branch
+  statuses). The worktree is still preserved; deferred-retry reuses it.
+
+## Consequences
+
+- Disk usage grows monotonically with parked items until an operator runs
+  `cw dev-queue purge` or `cw dev-queue retry`. Accepted: losing diagnostic
+  or in-progress state is worse than the disk cost.
+- Reconcile must learn one new exception (skip-if-parked). Covered by tests
+  in #58.
+
+## Alternatives considered
+
+- **Auto-reap parked items after N days.** Rejected. Operators cannot
+  reliably distinguish "still working on approving" from "abandoned"; reaping
+  in-flight work silently is a worse failure mode than disk growth.
+- **Inline the invariant as a comment on `QueueItemStatus`.** Rejected.
+  Multiple modules (`reconcile`, `doctor`, #59, #127) need to cite the same
+  rule; a comment on one enum value doesn't carry.
+
+## Referenced by
+
+- #58, #59, #126, #127

--- a/docs/adr/0001-parked-tasks-pin-their-session.md
+++ b/docs/adr/0001-parked-tasks-pin-their-session.md
@@ -2,6 +2,8 @@
 
 **Status:** Accepted
 **Driven by:** #58
+**Builds on:** [ADR-0000](0000-native-supervisor-migration.md) — assumes
+`claude --bg <id>` is the resume primitive.
 
 ## Decision
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,45 @@
+# Architecture Decision Records
+
+This directory holds ADRs — durable records of architectural decisions whose
+consequences ripple across multiple modules or future work items.
+
+## When to write one
+
+Write an ADR when a decision:
+
+- introduces an invariant that more than one module must honor
+- constrains how future tickets can be implemented
+- closes off alternatives that a reasonable future engineer might otherwise
+  re-open
+- is referenced from multiple GitHub issues as a "see ADR-XXXX"
+
+Plain implementation choices, file-level refactors, and one-off design calls
+do NOT need an ADR — they belong in the ticket that drives them.
+
+## File naming
+
+`NNNN-kebab-case-title.md` where `NNNN` is the next zero-padded integer in
+sequence. Do not renumber existing ADRs.
+
+## How to add one
+
+1. Pick the next number from the index below.
+2. Copy `template.md` to `NNNN-<title>.md`.
+3. Fill it in. Keep it short — an ADR is reference material, not a tutorial.
+4. Add a line to the index below, in number order.
+5. Link to it from the relevant GitHub issue(s) so the connection is durable.
+
+## Status values
+
+- **Proposed** — under discussion; do not act on yet.
+- **Accepted** — current law of the land.
+- **Superseded by ADR-NNNN** — replaced; kept for history.
+- **Deprecated** — no longer applies; not (yet) superseded.
+
+When an ADR is superseded, edit the old one's status line — don't delete it.
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-parked-tasks-pin-their-session.md) | Parked tasks pin their Session | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,4 +42,9 @@ When an ADR is superseded, edit the old one's status line — don't delete it.
 
 | # | Title | Status |
 |---|---|---|
+| [0000](0000-native-supervisor-migration.md) | Migrate session lifecycle to `claude --bg` + supervisor | Accepted |
 | [0001](0001-parked-tasks-pin-their-session.md) | Parked tasks pin their Session | Accepted |
+
+ADR-0000 is the foundational record — the trajectory it captures is
+assumed as ground truth by every subsequent ADR. Future ADRs start
+at 0002 and number sequentially.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,37 @@
+# <Title — short, declarative, present tense>
+
+**Status:** Proposed | Accepted | Superseded by ADR-NNNN | Deprecated
+**Driven by:** #<issue-number> (and any others)
+
+## Decision
+
+One or two sentences. What is true now that wasn't before.
+
+## Invariant (if applicable)
+
+If this ADR establishes an invariant, state it here as a numbered list —
+the kind of thing a code reviewer can cite when rejecting a PR.
+
+## What this means for callers
+
+Bullet list of modules / behaviors that must honor the decision.
+
+## What this means for producers (if applicable)
+
+Bullet list of modules that must uphold the decision on the emitting side.
+
+## Consequences
+
+Honest list of trade-offs. What gets worse so that something else can get
+better. Include disk/memory/latency costs if non-trivial.
+
+## Alternatives considered
+
+If any were seriously weighed. Skip if the decision was forced by external
+constraints.
+
+## Referenced by
+
+- #<issue>, #<issue>, ADR-NNNN
+
+Update this list as new issues link in.

--- a/docs/rfcs/0002-orchestrator-on-agent-sdk.md
+++ b/docs/rfcs/0002-orchestrator-on-agent-sdk.md
@@ -1,0 +1,202 @@
+# RFC 0002 — Orchestrator on Agent SDK + Channels
+
+| Field | Value |
+|---|---|
+| Status | Draft — ready for review |
+| Owner | @mattwwarren |
+| Spike ticket | #106 |
+| CLI version under test | Claude Code 2.1.148 |
+| SDK version under test | `claude-agent-sdk` 0.2.85 |
+| Date | 2026-05-22 |
+| Sibling RFCs | 0001 (#105 backend), 0003 (#107 worktree) |
+
+## Summary
+
+cw's 0.8.x orchestrator substrate (`dispatch.py`, `daemon.py`, `events.py`, `pr_responder.py`) is a hand-rolled tick loop on top of cmux: poll the file-based queue, spawn workers via cmux, parse `<<<AUTO_DEV_RESULT>>>` sentinels from stdout, react to file-based PR events. The Claude Agent SDK (Python) plus MCP push channels cover almost all of this natively, and crucially, **the SDK closes the env-var injection gap** that RFC 0001 left as a Phase 1 open question.
+
+## TL;DR
+
+**Decisions:**
+- ✅ **Green-light Phase 4** (rewrite dispatch on Agent SDK). Smoke test 1 passed. SDK signature fits cw's needs and is strictly cleaner than the cmux + sentinel approach.
+- ⚠️ **Conditional green-light Phase 3** (channels for PR events). Architecture verified; flag exists; SDK types support the receive-side. A 50-line channel-server prototype was descoped from this spike — Phase 3 must build one before commit.
+- 🎁 **Bonus:** `ClaudeAgentOptions.env: dict[str, str]` resolves RFC 0001's Row 10 env-injection gap. cw can pass `CW_CLIENT`/`CW_PURPOSE`/`CW_SESSION_ID` directly through the SDK without per-cwd `.claude/settings.json` hacks. Update RFC 0001's Phase 1 design accordingly.
+
+## Smoke test 1 — three concurrent `ClaudeSDKClient` workers
+
+**Script:** `/tmp/sdk_smoke.py` (~70 lines). Three `asyncio.gather`'d `ClaudeSDKClient` instances, each told to emit a `<<<AUTO_DEV_RESULT … AUTO_DEV_RESULT>>>` sentinel.
+
+**Result:** ✅ All three completed successfully.
+
+```jsonc
+{"worker": 0, "session_id": "17cd2ff5-…", "sentinel": {"status": "completed", "ticket_id": "1001", "worker": 0}, "captured_count": 12}
+{"worker": 1, "session_id": "a18cc016-…", "sentinel": {"status": "completed", "ticket_id": "1002", "worker": 1}, "captured_count": 12}
+{"worker": 2, "session_id": "801ffb7e-…", "sentinel": {"status": "completed", "ticket_id": "1003", "worker": 2}, "captured_count": 12}
+```
+
+Each worker:
+- Got a distinct `session_id` (available on the streamed assistant messages — round-trips for stale-event rejection per ticket #97)
+- Streamed 12 message events through `client.receive_response()`
+- Emitted the sentinel exactly as instructed; cw's existing `<<<AUTO_DEV_RESULT … >>>` regex parser worked unchanged
+
+**Concurrency model:** straight `asyncio.gather()` works. The SDK is async-native — no need for cw's per-client semaphore-via-state if `asyncio.Semaphore` is used.
+
+**API shape:**
+
+```python
+import claude_agent_sdk as sdk
+
+options = sdk.ClaudeAgentOptions(
+    cwd=str(worktree_path),
+    permission_mode="bypassPermissions",  # or "acceptEdits"
+    max_turns=1,
+    env={
+        "CW_CLIENT": client.name,
+        "CW_PURPOSE": "impl",
+        "CW_SESSION_ID": session_id,
+    },
+    model="claude-opus-4-7",
+    system_prompt="...",
+)
+
+async with sdk.ClaudeSDKClient(options=options) as client:
+    await client.query("/auto-dev #105 --headless")
+    async for msg in client.receive_response():
+        # msg.content[].text contains worker output
+        ...
+```
+
+## Smoke test 2 — channel server (descoped, evidence-based architecture)
+
+**Status:** Not built. A working MCP channel server is ~150 lines (HTTP server speaking MCP, with channel-emit + external-POST endpoint) — too much for an evidence-only spike.
+
+**Architecture verified by other means:**
+
+1. **`--channels` flag exists in 2.1.148** (hidden from `--help`). Probed via `claude --channels` (errors with arg-missing) and `claude --channels server:bogus-test` (accepted and dispatched a session — no allowlist check for `server:` entries; allowlist only applies to `plugin:` entries).
+2. **`--dangerously-load-development-channels` flag exists** for `plugin:` entries that bypass the allowlist.
+3. **SDK supports MCP servers natively** — `ClaudeAgentOptions.mcp_servers: dict[str, McpStdioServerConfig | McpSSEServerConfig | McpHttpServerConfig | McpSdkServerConfig]`. cw can spin up the channel server in-process (`McpSdkServerConfig`) without `--channels` at all.
+4. **SDK has `Notification` hook** — `ClaudeAgentOptions.hooks={"Notification": [HookMatcher(...)]}` receives `NotificationHookInput(message, title, notification_type)`. That's how channel events arrive in the SDK session.
+
+**Phase 3 build list (before commit):**
+- a) Tiny `cw_pr_events_server.py` (MCP HTTP server, ≤80 lines)
+- b) Endpoint: `POST /pr-event` accepting JSON `{repo, pr_number, event_type, payload}`
+- c) Emit MCP notification with `notification_type="cw-pr-event"`
+- d) Smoke: `curl -X POST localhost:8788/pr-event …` while a `claude --bg --channels server:cw-pr-events …` session is live; verify `Notification` hook fires
+
+## SDK fit per ticket table
+
+| cw behavior | SDK candidate | Verdict |
+|---|---|---|
+| `dispatch_tick()` spawns N workers per client up to `per_client_max_parallel` (dispatch.py:71-184) | `asyncio.gather()` over N `ClaudeSDKClient` with `asyncio.Semaphore` | ✅ verified by smoke test 1 |
+| Worker invocation: `claude --print "/auto-dev <t> --headless"` with `origin=DAEMON` | `ClaudeSDKClient(options=ClaudeAgentOptions(cwd=, permission_mode=, system_prompt=, model=, env=))` then `await client.query("/auto-dev …")` | ✅ verified |
+| Capture worker stdout for `<<<AUTO_DEV_RESULT` parsing (wrapper.py:94-162) | Iterate `client.receive_response()` collecting `AssistantMessage.content[].text` | ✅ verified — sentinel parsed unchanged |
+| Structured output via Pydantic `AutoDevResult` with cross-field invariants | `output_format="json"` + `json_schema=…` returning `structured_output` field | ✅ supported via `ClaudeAgentOptions.output_format`. **Recommendation:** migrate sentinel → JSON Schema in Phase 4 |
+| Worker session ID for stale-event rejection (#97) | `session_id` field on assistant messages; `ClaudeAgentOptions.session_id` + `resume` for explicit control | ✅ verified |
+| Parent/worker linkage (cw `parent_session_id`, `worker_session_ids`) | SDK has no native parent-child; cw state owns this | ✅ unchanged — keep cw-owned |
+| Per-client `model`/`effort` overrides | `ClaudeAgentOptions(model=…, effort=…)` | ✅ first-class field |
+| Cost tracking (#82) | SDK exposes `total_cost_usd` via `output_format="json"` result message | ✅ drop custom cost-from-sentinel path in Phase 4 |
+| **Env-var injection (RFC 0001 Row 10 gap)** | `ClaudeAgentOptions.env: dict[str, str]` | ✅ **gap closed** for SDK-dispatched sessions |
+| Per-tool permission decisions | `ClaudeAgentOptions.can_use_tool: CanUseTool` callable | ✅ programmatic policy beats the `--allowedTools` list |
+| Session resume / fork | `resume`, `fork_session`, `continue_conversation` fields | ✅ all there |
+| Tool restriction | `allowed_tools`, `disallowed_tools` fields | ✅ matches cw's needs |
+| Custom hooks (PreToolUse, PostToolUse, etc.) | `hooks: dict[Literal[...], list[HookMatcher]]` | ✅ enables cw's per-session policy without shell-out |
+
+## Channel fit per ticket table
+
+| cw behavior | Channel candidate | Verdict |
+|---|---|---|
+| `cw event record pr.ci_failed --payload …` writing to `inbox.jsonl` (events.py:50-76) | MCP notification: server pushes to subscribed sessions in real-time | ✅ better — no file polling |
+| `pr_responder.respond_to_pr_events` cursor-based consumption (pr_responder.py:130-150) | Channel events delivered while session is live; no cursor | ⚠️ **gap: no durable replay-after-restart.** Acceptable iff cw's dispatcher session is always live |
+| PR event decision table (CI failed → `/fix-ci`, etc.) (pr_responder.py:118-128) | Session-side `Notification` hook reads `notification_type="cw-pr-event"` and dispatches the right slash command | ✅ same logic, in-session transport |
+| Throttling per `(repo, pr_number, role)` via `PRDispatchRecord` (pr_responder.py:47-51) | cw state stays source of truth; channel emits, dispatcher dedups | ✅ unchanged |
+| Multiple consumers via cursor-per-consumer (events.py:advance_cursor) | Channel: every subscribed session receives every event | ⚠️ **semantic shift** — verify cw has no multi-consumer dependency today |
+| External GitHub webhook integration | Channel server's HTTP POST endpoint binds to localhost:8788 | ✅ direct fit; webhook → POST → notification |
+
+### The durable-replay gap (the one real concern)
+
+If cw's dispatcher session crashes between a PR event firing and the responder reacting, the event is lost. `events.py`'s cursor model survives this case; channels don't.
+
+**Mitigations:**
+1. **Dispatcher always-alive invariant.** cw's `cw dev-queue run` daemon already wants to be always-up (#86 was about restart resilience; RFC 0001's `claude respawn --all` handles that automatically now). If dispatcher is up, channels never miss.
+2. **Persist-on-emit at the server side.** The channel server writes each event to a file (essentially the same `inbox.jsonl`) *and* pushes to subscribers. On dispatcher restart, replay unconsumed entries on first subscription. Same durability as today, plus push for the happy path.
+3. **Hybrid:** keep `events.py` as the canonical record; channels are the real-time delivery on top. Most invasive transition (both code paths during cutover), most robust outcome.
+
+**Recommendation:** option 2 for Phase 3. Channel server is the single store; subscribers replay missed events on connect.
+
+### `--dangerously-load-development-channels` allowlist concern
+
+Per the ticket: "Custom channels are gated behind an Anthropic allowlist during research preview."
+
+Probed in 2.1.148:
+- `claude --channels server:bogus-test` → accepted, dispatched
+- `claude --dangerously-load-development-channels server:bogus-test` → accepted, dispatched
+
+The allowlist enforcement appears to apply **only to `plugin:<name>@<marketplace>` entries**, not `server:<name>` entries. cw's `cw-pr-events` is a `server:` entry, so no allowlist gate.
+
+If that behavior changes, the `--dangerously-load-development-channels` flag is the escape hatch. Not pretty but acceptable for cw users.
+
+## Decision
+
+**Phase 4 (#1??):** green-light. Replace `dispatch.py` with an Agent SDK orchestrator:
+
+```python
+# rough shape — Phase 4 design
+class SDKDispatcher:
+    def __init__(self, max_parallel_per_client: dict[str, int]):
+        self._semaphores = {c: asyncio.Semaphore(n) for c, n in max_parallel_per_client.items()}
+
+    async def dispatch(self, ticket: Ticket) -> AutoDevResult:
+        async with self._semaphores[ticket.client]:
+            options = sdk.ClaudeAgentOptions(
+                cwd=str(ticket.worktree_path),
+                permission_mode="bypassPermissions",
+                model=ticket.model_override,
+                env={"CW_CLIENT": ticket.client, "CW_PURPOSE": ticket.purpose,
+                     "CW_SESSION_ID": ticket.session_id},
+                output_format="json",
+                json_schema=AutoDevResult.model_json_schema(),
+                system_prompt=load_prompt("auto-dev"),
+                max_budget_usd=ticket.budget_usd,
+            )
+            async with sdk.ClaudeSDKClient(options=options) as client:
+                await client.query(f"/auto-dev #{ticket.id} --headless")
+                async for msg in client.receive_response():
+                    # ResultMessage at end carries structured_output + total_cost_usd
+                    if isinstance(msg, sdk.ResultMessage):
+                        return AutoDevResult.model_validate(msg.structured_output)
+```
+
+**Phase 3 (#1??):** conditional green-light. Build the `cw_pr_events_server.py` channel + a smoke test (curl POST → Notification hook fires) before commit. Use option 2 (server-side persistence) for durable replay.
+
+## Crossover with RFC 0001 (#105)
+
+**Update needed for RFC 0001 (PR #130):** Row 10 (env-var injection gap) is closed for SDK-dispatched sessions via `ClaudeAgentOptions.env`. Phase 1 NativeBackend's design question #1 ("which workaround for env injection?") becomes simpler:
+
+- If `NativeBackend` uses `claude --bg` CLI: the workarounds in RFC 0001 still apply (per-cwd settings.json, etc.)
+- If `NativeBackend` uses `ClaudeSDKClient`: env vars passed directly — no workaround needed
+
+This suggests Phase 1 should consider whether `NativeBackend` should be SDK-backed from day one, skipping the `claude --bg` shell layer entirely. Trade-off: SDK requires Python import in cw's hot path (already true since cw is Python), but loses the daemon's auto-respawn (SDK sessions are bound to cw's process lifetime).
+
+**My recommendation:** keep `NativeBackend` on `claude --bg` (gets daemon-managed auto-respawn for free, per RFC 0001 Row 7). Use SDK only for the orchestrator's dispatch loop and PR-event handling (where the dispatcher *is* the always-alive process).
+
+## Open questions for Phase 3 + Phase 4
+
+1. **JSON Schema migration for sentinel.** Phase 4 should land an `AutoDevResult.model_json_schema()` → `json_schema` option migration. Backwards-compat: keep regex parser as fallback for 1-2 releases.
+2. **Per-tool permission policy via `can_use_tool`.** Worth migrating cw's existing approve-by-default + per-client overrides to a programmatic `CanUseTool` callable?
+3. **Channel server location.** In-process via `McpSdkServerConfig`, or out-of-process via `McpHttpServerConfig`? In-process is simpler; out-of-process survives orchestrator restart.
+4. **Notification hook ergonomics.** SDK's `NotificationHookInput.notification_type` is a `str` — should cw enum it (`"cw-pr-event"`, `"cw-ci-status"`, etc.) and document?
+5. **Cost-tracking migration.** Drop cw's sentinel `cost_usd` field, read `ResultMessage.total_cost_usd` instead. #82 can close.
+6. **Multi-consumer semantics.** If two cw dispatcher instances run in parallel (e.g., during graceful restart), do they both receive every channel event? Verify or design dedup.
+
+## References
+
+- [Agent SDK Python reference](https://code.claude.com/docs/en/agent-sdk/python)
+- [Channels](https://code.claude.com/docs/en/channels), [Channels reference](https://code.claude.com/docs/en/channels-reference)
+- cw modules: `src/cw/dispatch.py`, `src/cw/daemon.py`, `src/cw/auto_dev_result.py`, `src/cw/pr_responder.py`, `src/cw/events.py`
+- #82 (cost tracking), #97 (stale-event rejection), #99/#101/#103 (sentinel + wrapper completion path)
+- `docs/headless-contract.md` §3, §6 (sentinel format)
+- RFC 0001 (#105) — `Row 10` env-injection gap is **closed** via SDK
+- Crossover handoff: `~/.claude/handoffs/2026-05-22-cw-spike-105-followup.md`
+
+## Test artifact
+
+The 3-worker SDK smoke test script is at `/tmp/sdk_smoke.py`. Drop into `tests/` as `test_sdk_dispatch_smoke.py` once Phase 4 starts and you want a recurring integration test.


### PR DESCRIPTION
## Summary

Phase 0 spike #106 result:
- ✅ **Phase 4 (dispatch on Agent SDK):** green-light. Smoke test 1 passed.
- ⚠️ **Phase 3 (channels for PR events):** conditional green-light. Architecture verified; channel-server prototype descoped from spike, must be built before Phase 3 commit.
- 🎁 **Bonus:** SDK closes RFC 0001 Row 10's env-injection gap.

## Smoke test 1 (`/tmp/sdk_smoke.py`)

Three concurrent `ClaudeSDKClient` workers, each told to emit an `AUTO_DEV_RESULT` sentinel:

```jsonc
{"worker": 0, "session_id": "17cd2ff5-…", "sentinel": {"status": "completed", "ticket_id": "1001"}, "captured_count": 12}
{"worker": 1, "session_id": "a18cc016-…", "sentinel": {"status": "completed", "ticket_id": "1002"}, "captured_count": 12}
{"worker": 2, "session_id": "801ffb7e-…", "sentinel": {"status": "completed", "ticket_id": "1003"}, "captured_count": 12}
```

cw's existing sentinel regex parser worked unchanged. Concurrency via `asyncio.gather` + `asyncio.Semaphore` — drop cw's per-client semaphore-via-state model.

## Bonus — RFC 0001 Row 10 gap closes

`ClaudeAgentOptions` has `env: dict[str, str]`. cw's `CW_CLIENT`/`CW_PURPOSE`/`CW_SESSION_ID` injection (the only gap RFC 0001 flagged for Phase 1) gets a clean answer if NativeBackend is SDK-backed.

**My recommendation in RFC 0002:** keep `NativeBackend` on `claude --bg` to get daemon auto-respawn for free (RFC 0001 Row 7). Use SDK only for the orchestrator and PR-events where the dispatcher is itself the always-alive process. Reuse per-process.

## Phase 3 build list (before commit)

- `cw_pr_events_server.py` (MCP HTTP server, ≤80 lines)
- `POST /pr-event` accepting `{repo, pr_number, event_type, payload}`
- Emit MCP `Notification` with `notification_type="cw-pr-event"`
- Smoke: `curl -X POST localhost:8788/pr-event …` while `claude --bg --channels server:cw-pr-events …` is live; verify `Notification` hook fires

## The one Phase 3 concern — durable replay

Channels lack `events.py`'s cursor-based replay. Mitigation: persist-on-emit at the channel server (server writes events to file AND pushes; subscribers replay missed events on connect). Same durability as today, plus push for the happy path.

## Headline wins for Phase 4

- Drop sentinel regex → `output_format="json"` + `json_schema=AutoDevResult.model_json_schema()`
- Drop custom `cost_usd` parsing → `ResultMessage.total_cost_usd` (closes #82)
- Programmatic permissions via `can_use_tool: CanUseTool` callable
- Native session_id round-trips (resolves #97 design open question)
- Per-tool allowed/disallowed at dispatch time, no global config drift

## Open questions for Phase 3 + Phase 4

1. Channel server location: in-process (`McpSdkServerConfig`) vs out-of-process (`McpHttpServerConfig`)?
2. Drop sentinel entirely or keep regex parser as fallback for 1-2 releases?
3. Multi-consumer semantics — two dispatcher instances during graceful restart both receive every event; verify or design dedup
4. `notification_type` enum (`cw-pr-event`, `cw-ci-status`, etc.) for type safety

## Test plan
- [ ] Reviewer reads RFC, confirms decision rationale
- [ ] Reviewer scans open-question list — flags any that should block Phase 3 or Phase 4
- [ ] Phase 3 author builds the channel-server prototype before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)