### PR TITLE
feat(dispatch): inject Stop hook for direct completion signal (#147)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import json
 import subprocess
+import sys
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -804,6 +805,79 @@ def run_claude(extra_args: tuple[str, ...]) -> None:
     run_claude_wrapper(extra_args)
 
 
+@main.command(name="signal-stop")
+@handle_errors
+def signal_stop() -> None:
+    """Emit SESSION_COMPLETED on a Stop hook fire.
+
+    Reads the hook JSON from stdin, extracts ``cwd`` (the worktree path),
+    reads ``<cwd>/.claude/cw-context.json`` for cw correlation IDs,
+    transitions the matching Session to COMPLETED, and posts a
+    ``session.completed`` event to the inbox so the dispatch consumer
+    can transition the matching TicketTask to COMPLETED.
+
+    Wired in via ``.claude/settings.local.json`` written by spawn into
+    each dispatched session's worktree. Bypasses env-var loss under
+    ``claude --bg`` (see GitHub issue #133, design in #147).
+
+    Idempotent: a session already COMPLETED is a no-op (re-firing the
+    Stop hook on a subsequent turn won't double-record).
+
+    Best-effort: a missing or unreadable context file is a silent no-op
+    so hook execution never blocks claude from exiting.
+    """
+    try:
+        stdin_text = sys.stdin.read()
+    except (OSError, ValueError):
+        return
+    if not stdin_text:
+        return
+    try:
+        hook_payload = json.loads(stdin_text)
+    except json.JSONDecodeError:
+        return
+    cwd_value = hook_payload.get("cwd") if isinstance(hook_payload, dict) else None
+    if not isinstance(cwd_value, str):
+        return
+    context_path = Path(cwd_value) / ".claude" / "cw-context.json"
+    if not context_path.is_file():
+        return
+    try:
+        context = json.loads(context_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return
+    if not isinstance(context, dict):
+        return
+
+    cw_session_id = context.get("session_id")
+    if not isinstance(cw_session_id, str):
+        return
+
+    state = load_state()
+    session = next((s for s in state.sessions if s.id == cw_session_id), None)
+    if session is None or session.status == SessionStatus.COMPLETED:
+        return
+
+    session.status = SessionStatus.COMPLETED
+    session.completed_at = datetime.now(UTC)
+    session.completed_reason = CompletionReason.NORMAL
+    claude_session_id = hook_payload.get("session_id")
+    if isinstance(claude_session_id, str):
+        session.claude_session_id = claude_session_id
+    save_state(state)
+
+    payload: dict[str, object] = {
+        "session_id": session.id,
+        "session_name": session.name,
+        "client": context.get("client"),
+        "ticket_id": context.get("ticket_id"),
+        "claude_session_id": claude_session_id,
+        "hook_event": hook_payload.get("hook_event_name"),
+        "crashed": False,
+    }
+    record_event(OrchestratorEventType.SESSION_COMPLETED, payload)
+
+
 @main.command(name="pane-exited")
 @click.option("--client", "-c", required=True, help="Client name.")
 @click.option("--purpose", "-p", required=True, help="Session purpose.")
@@ -1075,22 +1149,19 @@ def _format_status_human(status: OrchestratorStatus) -> str:
         for t in status.pending_tickets
     )
 
-    lines.append("")
-    lines.append(f"Running sessions:  {len(status.running_sessions)}")
+    lines.extend(("", f"Running sessions:  {len(status.running_sessions)}"))
     lines.extend(
         f"  - {s.id}  {s.name}  status={s.status}" for s in status.running_sessions
     )
 
-    lines.append("")
-    lines.append(f"Monitored PRs:     {len(status.monitored_prs)}")
+    lines.extend(("", f"Monitored PRs:     {len(status.monitored_prs)}"))
     lines.extend(
         f"  - {pr.repo}#{pr.pr_number}  status={pr.status}"
         f"  unresolved={pr.unresolved_threads}"
         for pr in status.monitored_prs
     )
 
-    lines.append("")
-    lines.append(f"Recent events:     {len(status.recent_events)}")
+    lines.extend(("", f"Recent events:     {len(status.recent_events)}"))
     lines.extend(
         f"  - {e.created_at.strftime('%Y-%m-%dT%H:%M:%SZ')}  {e.id}  {e.type}"
         for e in status.recent_events
@@ -1289,7 +1360,7 @@ def _spawn_create_impl(
     return spawn_create_impl(
         client=client,
         worktree=worktree,
-        prompt=prompt_file.read_text(),
+        prompt=prompt_file.read_text(encoding="utf-8"),
         surface=surface,
         label=label,
         adapter=adapter,

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -151,6 +151,7 @@ def dispatch_tick(
                 label=label,
                 adapter=resolved_adapter,
                 parent=parent,
+                ticket_id=task.ticket_id,
             )
 
             # Stamp session_id on the queued task so the completion consumer

--- a/src/cw/spawn.py
+++ b/src/cw/spawn.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import shlex
 from typing import TYPE_CHECKING
 
@@ -16,6 +17,53 @@ if TYPE_CHECKING:
     from cw.models import ClientConfig
 
 
+_HOOK_SETTINGS_TEMPLATE = {
+    "hooks": {
+        "Stop": [
+            {
+                "matcher": "",
+                "hooks": [{"type": "command", "command": "cw signal-stop"}],
+            }
+        ]
+    }
+}
+
+
+def _write_hook_context(
+    worktree: Path,
+    *,
+    session_id: str,
+    session_name: str,
+    client: str,
+    purpose: str,
+    ticket_id: str | None,
+) -> None:
+    """Write hook config + correlation context into the worktree pre-spawn.
+
+    Two files land under ``<worktree>/.claude/``:
+
+    - ``settings.local.json`` — configures a Stop hook that invokes
+      ``cw signal-stop`` after each agent turn.
+    - ``cw-context.json`` — correlation metadata the hook reads to emit a
+      ``SESSION_COMPLETED`` event keyed back to the cw session + dev_queue
+      task. Bypasses the env-var injection limitation on ``claude --bg``
+      (see GitHub issue #133).
+    """
+    claude_dir = worktree / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    (claude_dir / "settings.local.json").write_text(
+        json.dumps(_HOOK_SETTINGS_TEMPLATE, indent=2) + "\n",
+    )
+    context = {
+        "session_id": session_id,
+        "session_name": session_name,
+        "client": client,
+        "purpose": purpose,
+        "ticket_id": ticket_id,
+    }
+    (claude_dir / "cw-context.json").write_text(json.dumps(context, indent=2) + "\n")
+
+
 def spawn_create_impl(
     *,
     client: ClientConfig,
@@ -25,6 +73,7 @@ def spawn_create_impl(
     label: str | None,
     adapter: CmuxAdapter,
     parent: str | None = None,
+    ticket_id: str | None = None,
 ) -> str:
     """Create a daemon-spawned session.
 
@@ -66,6 +115,19 @@ def spawn_create_impl(
         origin=SessionOrigin.DAEMON,
         workspace_path=client.workspace_path,
         worktree_path=worktree,
+    )
+
+    # Inject Stop-hook config + correlation context into the worktree so
+    # the spawned session emits a SESSION_COMPLETED event when its agent
+    # turn finishes — works even under ``claude --bg`` where env vars are
+    # not propagated. See GitHub issue #147.
+    _write_hook_context(
+        worktree,
+        session_id=sess.id,
+        session_name=sess.name,
+        client=client.name,
+        purpose=SessionPurpose.IMPL.value,
+        ticket_id=ticket_id,
     )
 
     env_prefix = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -363,6 +363,73 @@ class TestSignalStop:
         result = runner.invoke(main, ["signal-stop"], input="")
         assert result.exit_code == 0
 
+    def test_cwd_not_string_is_noop(self, tmp_config_dir: Path) -> None:
+        # Hook payload with non-string cwd → silent no-op.
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["signal-stop"],
+            input=json.dumps({"cwd": 42, "session_id": "x"}),
+        )
+        assert result.exit_code == 0
+
+    def test_corrupt_context_file_is_noop(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        worktree = tmp_path / "bad-ctx"
+        (worktree / ".claude").mkdir(parents=True)
+        (worktree / ".claude" / "cw-context.json").write_text("{not valid json")
+        hook_stdin = json.dumps({"cwd": str(worktree), "session_id": "c-uuid"})
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["signal-stop"], input=hook_stdin)
+        assert result.exit_code == 0
+
+    def test_context_not_dict_is_noop(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        worktree = tmp_path / "list-ctx"
+        (worktree / ".claude").mkdir(parents=True)
+        # Valid JSON, but a list rather than a dict.
+        (worktree / ".claude" / "cw-context.json").write_text("[1, 2, 3]")
+        hook_stdin = json.dumps({"cwd": str(worktree), "session_id": "c-uuid"})
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["signal-stop"], input=hook_stdin)
+        assert result.exit_code == 0
+
+    def test_context_missing_session_id_is_noop(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        worktree = tmp_path / "no-sid"
+        (worktree / ".claude").mkdir(parents=True)
+        (worktree / ".claude" / "cw-context.json").write_text(
+            json.dumps({"client": "c", "ticket_id": "1"})  # no session_id
+        )
+        hook_stdin = json.dumps({"cwd": str(worktree), "session_id": "c-uuid"})
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["signal-stop"], input=hook_stdin)
+        assert result.exit_code == 0
+
+    def test_stdin_read_oserror_is_noop(self, tmp_config_dir: Path) -> None:
+        """Direct-call the underlying callback with stdin raising OSError.
+
+        CliRunner.invoke installs its own sys.stdin wrapper that out-races a
+        patch on ``cw.cli.sys.stdin``, so this case is exercised by calling
+        the command's callback directly with a fake stdin instead.
+        """
+
+        class _RaisingStdin:
+            def read(self) -> str:
+                error_msg = "broken pipe"
+                raise OSError(error_msg)
+
+        callback = main.commands["signal-stop"].callback
+        assert callable(callback)
+        with patch("cw.cli.sys.stdin", _RaisingStdin()):
+            callback()
+
 
 class TestCompletion:
     def test_completion_command_bash(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -18,12 +19,15 @@ from cw.cli import (
     main,
 )
 from cw.config import load_clients, load_state, save_state
+from cw.events import read_events
 from cw.exceptions import CwError
 from cw.models import (
     ClientConfig,
     CwState,
+    OrchestratorEventType,
     QueueItem,
     Session,
+    SessionOrigin,
     SessionPurpose,
     SessionStatus,
     TaskSpec,
@@ -228,6 +232,136 @@ class TestUpgradeWorkers:
         result = runner.invoke(main, ["upgrade-workers", "--help"])
         assert result.exit_code == 0
         assert "respawn" in result.output
+
+
+class TestSignalStop:
+    """Tests for the `cw signal-stop` Stop-hook handler (issue #147)."""
+
+    def _seed_session(self, tmp_path: Path, sess_id: str = "sess-147") -> Session:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir(parents=True, exist_ok=True)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir(parents=True, exist_ok=True)
+        session = Session(
+            id=sess_id,
+            name="test-client/auto-dev/137",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            workspace_path=workspace,
+            worktree_path=worktree,
+            status=SessionStatus.IDLE,
+        )
+        state = load_state()
+        state.sessions.append(session)
+        save_state(state)
+        return session
+
+    def _write_context(
+        self,
+        worktree: Path,
+        *,
+        session_id: str,
+        ticket_id: str | None = "137",
+    ) -> None:
+        claude_dir = worktree / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        (claude_dir / "cw-context.json").write_text(
+            json.dumps(
+                {
+                    "session_id": session_id,
+                    "session_name": "test-client/auto-dev/137",
+                    "client": "test-client",
+                    "purpose": "impl",
+                    "ticket_id": ticket_id,
+                }
+            )
+        )
+
+    def test_happy_path_emits_event_and_completes_session(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        session = self._seed_session(tmp_path)
+        assert session.worktree_path is not None
+        worktree = session.worktree_path
+        self._write_context(worktree, session_id=session.id)
+        hook_stdin = json.dumps(
+            {
+                "session_id": "claude-uuid-abc",
+                "cwd": str(worktree),
+                "hook_event_name": "Stop",
+                "last_assistant_message": "all done",
+            }
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["signal-stop"], input=hook_stdin)
+        assert result.exit_code == 0, result.output
+
+        state = load_state()
+        updated = next(s for s in state.sessions if s.id == session.id)
+        assert updated.status == SessionStatus.COMPLETED
+        assert updated.claude_session_id == "claude-uuid-abc"
+
+        events = read_events(
+            consumer="test-signal-stop",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        assert any(
+            e.payload.get("session_id") == session.id
+            and e.payload.get("ticket_id") == "137"
+            for e in events
+        )
+
+    def test_idempotent_when_already_completed(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        session = self._seed_session(tmp_path)
+        session.status = SessionStatus.COMPLETED
+        state = load_state()
+        state.sessions = [session]
+        save_state(state)
+        assert session.worktree_path is not None
+        worktree = session.worktree_path
+        self._write_context(worktree, session_id=session.id)
+        hook_stdin = json.dumps({"session_id": "c-uuid", "cwd": str(worktree)})
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["signal-stop"], input=hook_stdin)
+        assert result.exit_code == 0
+
+        events = read_events(
+            consumer="test-idem",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        assert not any(e.payload.get("session_id") == session.id for e in events)
+
+    def test_missing_context_file_is_noop(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        worktree = tmp_path / "no-context"
+        worktree.mkdir()
+        hook_stdin = json.dumps({"cwd": str(worktree), "session_id": "c-uuid"})
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["signal-stop"], input=hook_stdin)
+        assert result.exit_code == 0
+
+        events = read_events(
+            consumer="test-missing-ctx",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        assert events == []
+
+    def test_malformed_stdin_is_noop(self, tmp_config_dir: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["signal-stop"], input="not json at all")
+        assert result.exit_code == 0
+
+    def test_empty_stdin_is_noop(self, tmp_config_dir: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["signal-stop"], input="")
+        assert result.exit_code == 0
 
 
 class TestCompletion:

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -281,6 +282,72 @@ class TestSpawnCreate:
         state = load_state()
         assert state.sessions == []
         assert adapter.calls["spawn"] == []
+
+
+class TestHookContextInjection:
+    """Tests for the Stop-hook + cw-context file injection (issue #147)."""
+
+    def test_writes_settings_and_context_files(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn_create_impl writes .claude/settings.local.json + cw-context.json."""
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        adapter = FakeCmuxAdapter()
+        worktree = tmp_path / "worktree"
+        worktree.mkdir(parents=True)
+
+        session_id = spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt="/auto-dev 137 --headless",
+            surface="split",
+            label="auto-dev/137",
+            adapter=adapter,
+            ticket_id="137",
+        )
+
+        settings_path = worktree / ".claude" / "settings.local.json"
+        context_path = worktree / ".claude" / "cw-context.json"
+        assert settings_path.exists()
+        assert context_path.exists()
+
+        settings = json.loads(settings_path.read_text())
+        stop_hooks = settings["hooks"]["Stop"]
+        assert any(
+            entry["hooks"][0]["command"] == "cw signal-stop" for entry in stop_hooks
+        )
+
+        context = json.loads(context_path.read_text())
+        assert context["session_id"] == session_id
+        assert context["session_name"] == "test-client/auto-dev/137"
+        assert context["client"] == "test-client"
+        assert context["purpose"] == "impl"
+        assert context["ticket_id"] == "137"
+
+    def test_ticket_id_optional_writes_null(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """When no ticket_id is supplied, cw-context.json carries null."""
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        adapter = FakeCmuxAdapter()
+        worktree = tmp_path / "worktree"
+        worktree.mkdir(parents=True)
+
+        spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt="just do it",
+            surface="split",
+            label=None,
+            adapter=adapter,
+        )
+
+        context = json.loads((worktree / ".claude" / "cw-context.json").read_text())
+        assert context["ticket_id"] is None
 
 
 class TestSpawnClose:


### PR DESCRIPTION
## Summary

- Closes #147
- Moves the dispatch completion signal off stdout-scraping (`AUTO_DEV_RESULT` sentinel parsing) and onto a Claude Code `Stop` hook injected directly into each dispatched session's worktree.
- Resolves the silent queue-wedge mode where successful auto-dev work landed a commit but left the dev_queue task stuck `running` because the sentinel wasn't parseable (observed live on ticket #137 this session).

## Mechanism

Before each daemon-origin session is spawned, `spawn_create_impl` writes two files into the target worktree:

- `.claude/settings.local.json` — configures a `Stop` hook → `cw signal-stop`
- `.claude/cw-context.json` — `{session_id, session_name, client, purpose, ticket_id}` correlation metadata

When the agent finishes a turn, Claude Code invokes the hook. The new `cw signal-stop` command:
1. Reads the hook JSON from stdin
2. Resolves the worktree via `stdin.cwd` (sidesteps the env-var-loss limitation on `claude --bg` — see #133)
3. Reads `cw-context.json` for cw's correlation IDs
4. Transitions the matching `Session` to `COMPLETED` + records `claude_session_id`
5. Emits a `session.completed` event with `ticket_id` so the existing dispatch consumer marks the dev_queue task COMPLETED

Idempotent and best-effort: missing context file, malformed stdin, or already-completed sessions are silent no-ops so a hook misfire never blocks claude from exiting.

## Verified end-to-end this session

Dispatched ticket #136 through this path. Inbox event:

\`\`\`json
{\"type\":\"session.completed\",\"payload\":{\"ticket_id\":\"136\",\"session_id\":\"8b34a3e3\",\"hook_event\":\"Stop\",\"crashed\":false}}
\`\`\`

Consumer matched, task transitioned \`running → completed\`. Session status flipped to \`COMPLETED\`. No sentinel involvement.

## Files changed

| File | Δ | Notes |
|---|---|---|
| \`src/cw/spawn.py\` | +62 | New \`_write_hook_context\` helper; new \`ticket_id\` parameter on \`spawn_create_impl\`; injection call before \`adapter.spawn\` |
| \`src/cw/dispatch.py\` | +1 | Pass \`task.ticket_id\` through to \`spawn_create_impl\` |
| \`src/cw/cli.py\` | +85 / -7 | New \`cw signal-stop\` Click command |
| \`tests/test_spawn.py\` | +67 | \`TestHookContextInjection\` — verifies both files written with correct contents, ticket_id optional |
| \`tests/test_cli.py\` | +134 | \`TestSignalStop\` — happy path, idempotency, missing context, malformed stdin, empty stdin |

## Test plan

- [x] \`uv run ruff check src/ tests/test_spawn.py tests/test_cli.py\` — passes
- [x] \`uv run mypy src/ tests/test_cli.py\` — passes
- [x] \`uv run pytest tests/\` — 788/788 passing
- [x] Manual end-to-end: dispatched #136 through new path; observed \`Stop\` event arrival, task transition, session completion (this session)

## Follow-ups filed

- **#149** — \`dispatch_tick\` crashes the entire loop on a single spawn failure (tmux exhaustion exposed during this verification)
- **#150** — Migrate daemon-origin spawn from tmux to \`claude --bg\` (subset of #108 Phase 1; smaller, focused move that resolves pane-exhaustion + reconcile blindness for dispatched workers)

## Relationships

- Closes #147
- Subsumes much of #140 (sentinel → JSON Schema): the hook is the completion contract; structured payload available via \`stdin.transcript_path\` when needed
- Resolves #133 (env-injection workaround) by passing context via worktree file
- Partially mitigates #144 (reconcile blind spot) for happy-path completions; crash-path coverage still needs the pane-liveness check
- Unblocks #149 (loop-robustness) and #150 (native dispatch migration) as proper follow-ups