### PR TITLE
fix(dispatch): contain spawn failures so loop survives backend errors (#149)

### DIFF
--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -143,7 +143,7 @@ def dispatch_tick(
                 # worked because that flag takes a name rather than a path.
                 worktree_path = create_worktree(client, branch)
 
-                label = f"{AUTO_DEV_LABEL_PREFIX}{task.ticket_id}"
+                label = branch
                 session_id = spawn_create_impl(
                     client=client,
                     worktree=worktree_path,

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -134,52 +134,84 @@ def dispatch_tick(
             if task is None:
                 break
 
-            branch = f"{AUTO_DEV_LABEL_PREFIX}{task.ticket_id}"
-            # Create a real git worktree (idempotent — returns existing path
-            # if already created). Replaces a previous bug where dispatch
-            # made an empty directory and relied on ``claude -w`` to turn
-            # it into a worktree, which never worked because that flag
-            # takes a name rather than a path.
-            worktree_path = create_worktree(client, branch)
+            try:
+                branch = f"{AUTO_DEV_LABEL_PREFIX}{task.ticket_id}"
+                # Create a real git worktree (idempotent — returns existing
+                # path if already created). Replaces a previous bug where
+                # dispatch made an empty directory and relied on
+                # ``claude -w`` to turn it into a worktree, which never
+                # worked because that flag takes a name rather than a path.
+                worktree_path = create_worktree(client, branch)
 
-            label = f"{AUTO_DEV_LABEL_PREFIX}{task.ticket_id}"
-            session_id = spawn_create_impl(
-                client=client,
-                worktree=worktree_path,
-                prompt=f"/auto-dev {task.ticket_id} --headless",
-                surface="split",
-                label=label,
-                adapter=resolved_adapter,
-                parent=parent,
-            )
+                label = f"{AUTO_DEV_LABEL_PREFIX}{task.ticket_id}"
+                session_id = spawn_create_impl(
+                    client=client,
+                    worktree=worktree_path,
+                    prompt=f"/auto-dev {task.ticket_id} --headless",
+                    surface="split",
+                    label=label,
+                    adapter=resolved_adapter,
+                    parent=parent,
+                )
 
-            # Stamp session_id on the queued task so the completion consumer
-            # can match SESSION_COMPLETED events to the correct (current)
-            # session and reject stale events from prior crashed sessions
-            # for the same ticket. See GitHub issue #97.
-            with dev_queue_lock():
-                store = load_dev_queue()
-                for stored_task in store.tasks:
-                    if (
-                        stored_task.ticket_id == task.ticket_id
-                        and stored_task.client == client.name
-                        and stored_task.status == QueueItemStatus.RUNNING
-                    ):
-                        stored_task.session_id = session_id
-                        break
-                save_dev_queue(store)
+                # Stamp session_id on the queued task so the completion
+                # consumer can match SESSION_COMPLETED events to the
+                # correct (current) session and reject stale events from
+                # prior crashed sessions for the same ticket. See GitHub
+                # issue #97.
+                with dev_queue_lock():
+                    store = load_dev_queue()
+                    for stored_task in store.tasks:
+                        if (
+                            stored_task.ticket_id == task.ticket_id
+                            and stored_task.client == client.name
+                            and stored_task.status == QueueItemStatus.RUNNING
+                        ):
+                            stored_task.session_id = session_id
+                            break
+                    save_dev_queue(store)
 
-            record_event(
-                OrchestratorEventType.SESSION_SPAWNED,
-                {
-                    "ticket_id": task.ticket_id,
-                    "client": client.name,
-                    "session_id": session_id,
-                },
-            )
+                record_event(
+                    OrchestratorEventType.SESSION_SPAWNED,
+                    {
+                        "ticket_id": task.ticket_id,
+                        "client": client.name,
+                        "session_id": session_id,
+                    },
+                )
 
-            running_count += 1
-            spawned += 1
+                running_count += 1
+                spawned += 1
+            except Exception:
+                # Catch broad like the reconcile guard above: a backend
+                # outage (tmux pane exhaustion, transient daemon failure,
+                # OSError from the adapter) must NOT kill the loop. The
+                # task was just claimed RUNNING by _claim_next_pending; it
+                # would otherwise be left in a half-state (status=RUNNING,
+                # session_id=None) requiring manual repair. Revert to
+                # PENDING + clear session_id so the next tick (or
+                # reconcile) can retry. Break to skip this client's
+                # remaining slots this tick — re-trying the same failing
+                # backend immediately would just spin. See GitHub issue
+                # #149.
+                _log.exception(
+                    "dispatch_tick: spawn failed for %s/%s; reverting task to PENDING",
+                    client.name,
+                    task.ticket_id,
+                )
+                with dev_queue_lock():
+                    store = load_dev_queue()
+                    for stored_task in store.tasks:
+                        if (
+                            stored_task.ticket_id == task.ticket_id
+                            and stored_task.client == client.name
+                            and stored_task.status == QueueItemStatus.RUNNING
+                        ):
+                            stored_task.status = QueueItemStatus.PENDING
+                            stored_task.session_id = None
+                            break
+                    save_dev_queue(store)
+                break
 
     return spawned
 

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -16,6 +18,7 @@ from cw.dispatch import (
     persist_last_result,
 )
 from cw.events import record_event
+from cw.exceptions import WorktreeError
 from cw.models import (
     ClientConfig,
     CwState,
@@ -992,3 +995,108 @@ def test_crash_revert_respawn_rejects_old_event_completes_new(
     completed = consume_completed_sessions()
     assert completed == 1
     assert load_dev_queue().tasks[0].status == QueueItemStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# TestDispatchTickSpawnErrors
+# ---------------------------------------------------------------------------
+
+
+class _RaisingAdapter(FakeCmuxAdapter):
+    """Adapter whose ``spawn`` always raises the configured exception.
+
+    Used to exercise the spawn-failure containment added for issue #149:
+    a single failure must not crash dispatch_tick.
+    """
+
+    def __init__(self, exc: BaseException) -> None:
+        super().__init__()
+        self._exc = exc
+
+    def spawn(self, workspace: str, command: str, surface: str = "right") -> str:
+        # Record the attempt for parity with FakeCmuxAdapter call-tracking.
+        self.calls["spawn"].append((workspace, command, surface))
+        raise self._exc
+
+
+class TestDispatchTickSpawnErrors:
+    """Spawn failure inside dispatch_tick is contained, not propagated.
+
+    The dispatch loop is the substrate the dev queue runs on; a single
+    spawn failure (subprocess error, worktree error, adapter exception)
+    used to kill the entire loop and leave a half-claimed task at
+    ``status=RUNNING, session_id=None``.  These tests pin the new
+    behaviour: log + revert task to PENDING + don't propagate.
+    """
+
+    def test_subprocess_error_does_not_crash_loop(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        add_ticket(TicketTask(ticket_id="GEN-149A", client="test-client"))
+
+        adapter = _RaisingAdapter(
+            subprocess.CalledProcessError(
+                returncode=1,
+                cmd=["tmux", "split-window"],
+                output=b"no space for new pane",
+            ),
+        )
+
+        caplog.set_level(logging.ERROR, logger="cw.dispatch")
+        spawned = dispatch_tick(simple_config, adapter=adapter)
+
+        assert spawned == 0
+
+        queue = load_dev_queue()
+        assert len(queue.tasks) == 1
+        task = queue.tasks[0]
+        assert task.status == QueueItemStatus.PENDING
+        assert task.session_id is None
+
+        assert any(
+            "spawn failed" in record.getMessage().lower()
+            for record in caplog.records
+            if record.name == "cw.dispatch"
+        ), "expected ERROR log from cw.dispatch mentioning 'spawn failed'"
+
+    def test_worktree_error_does_not_crash_loop(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        add_ticket(TicketTask(ticket_id="GEN-149B", client="test-client"))
+
+        def _boom(*_args: object, **_kwargs: object) -> Path:
+            msg = "git worktree add failed"
+            raise WorktreeError(msg)
+
+        # Patch the name as imported into cw.dispatch, not the source module.
+        monkeypatch.setattr("cw.dispatch.create_worktree", _boom)
+
+        adapter = FakeCmuxAdapter()
+
+        caplog.set_level(logging.ERROR, logger="cw.dispatch")
+        spawned = dispatch_tick(simple_config, adapter=adapter)
+
+        assert spawned == 0
+        assert adapter.calls["spawn"] == []
+
+        queue = load_dev_queue()
+        task = queue.tasks[0]
+        assert task.status == QueueItemStatus.PENDING
+        assert task.session_id is None
+
+        assert any(
+            "spawn failed" in record.getMessage().lower()
+            for record in caplog.records
+            if record.name == "cw.dispatch"
+        ), "expected ERROR log from cw.dispatch mentioning 'spawn failed'"

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1009,7 +1009,7 @@ class _RaisingAdapter(FakeCmuxAdapter):
     a single failure must not crash dispatch_tick.
     """
 
-    def __init__(self, exc: BaseException) -> None:
+    def __init__(self, exc: Exception) -> None:
         super().__init__()
         self._exc = exc
 
@@ -1061,7 +1061,7 @@ class TestDispatchTickSpawnErrors:
         assert any(
             "spawn failed" in record.getMessage().lower()
             for record in caplog.records
-            if record.name == "cw.dispatch"
+            if record.name == "cw.dispatch" and record.levelno >= logging.ERROR
         ), "expected ERROR log from cw.dispatch mentioning 'spawn failed'"
 
     def test_worktree_error_does_not_crash_loop(
@@ -1098,5 +1098,5 @@ class TestDispatchTickSpawnErrors:
         assert any(
             "spawn failed" in record.getMessage().lower()
             for record in caplog.records
-            if record.name == "cw.dispatch"
+            if record.name == "cw.dispatch" and record.levelno >= logging.ERROR
         ), "expected ERROR log from cw.dispatch mentioning 'spawn failed'"


### PR DESCRIPTION
## Summary

- Closes #149
- Wraps the spawn block in \`dispatch_tick\` with a broad \`try/except Exception\` so a single spawn failure (tmux pane exhaustion, transient backend error, OSError from the adapter) no longer kills the dispatch loop.
- Reverts the half-claimed TicketTask back to \`PENDING\` and clears its \`session_id\` so the next tick (or reconcile) can retry, instead of leaving the queue in a half-state requiring manual repair.
- Logs the failure with \`_log.exception\` and breaks the inner while to skip the failing client's remaining slots this tick (re-trying the same failing backend immediately would just spin).

## Origin

This branch was produced by \`/auto-dev 149 --headless\` during the controlled retest of PR #148's settings injection. The agent landed a complete fix + tests, resolved a merge conflict with main (#148's \`ticket_id\` param), and pushed — but stopped before opening this PR. Opening it manually after human review.

The implementation is broader than the ticket's proposed snippet: it catches \`Exception\` instead of \`(WorktreeError, subprocess.CalledProcessError, CwError)\`, matching the existing \`reconcile\` guard pattern in the same file. This addresses Ambiguity #3 raised in #149's body (uncaught \`OSError\` / undocumented adapter exceptions would still crash under the narrow catch).

## Test plan

- [x] \`uv run pytest tests/test_dispatch.py::TestDispatchTickSpawnErrors\` — 2 PASS (subprocess error + worktree error paths)
- [x] \`uv run pytest tests/\` — 799/799 passing
- [x] \`uv run ruff check src/cw/dispatch.py tests/test_dispatch.py\` — clean
- [x] \`uv run mypy src/cw/dispatch.py\` — clean