### PR TITLE
chore(release): cut 0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-workspace"
-version = "0.8.3"
+version = "0.9.0"
 description = "Multi-session workspace orchestrator for Claude Code"
 readme = "README.md"
 authors = [

--- a/src/cw/__init__.py
+++ b/src/cw/__init__.py
@@ -1,3 +1,3 @@
 """claude-workspace: Multi-session workspace orchestrator for Claude Code."""
 
-__version__ = "0.8.3"
+__version__ = "0.9.0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,10 +42,12 @@ if TYPE_CHECKING:
 
 class TestCli:
     def test_version(self) -> None:
+        from cw import __version__
+
         runner = CliRunner()
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.8.3" in result.output
+        assert __version__ in result.output
 
     def test_help(self) -> None:
         runner = CliRunner()

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,7 @@ wheels = [
 
 [[package]]
 name = "claude-workspace"
-version = "0.8.3"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Bumps version to 0.9.0 in pyproject.toml, src/cw/__init__.py, and uv.lock. Pre-1.0 substrate release covering the native-daemon dispatch migration and supporting work merged since 0.8.3.

The full commit body lists the user-visible changes by ticket. GitHub auto-generated release notes (via the existing ``release.yml`` workflow) carry the per-PR breakdown.

Also reworks ``test_version`` to source the expected string from ``cw.__version__`` so it follows future bumps without a manual edit.

## Test plan

- [x] ``uv run ruff check src/ tests/`` — clean
- [x] ``uv run mypy src/`` — clean
- [x] ``uv run pytest tests/`` — full suite passes (version test updated)
- [x] ``uv run python -c 'import cw; print(cw.__version__)'`` — prints 0.9.0
- [ ] After merge: tag ``v0.9.0`` on the merge commit, push tag, confirm release.yml job creates the GitHub release with auto-generated notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)