### PR TITLE
fix(signal-stop): defer when background_tasks pending (#151)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -827,6 +827,12 @@ def signal_stop() -> None:
 
     Best-effort: a missing or unreadable context file is a silent no-op
     so hook execution never blocks claude from exiting.
+
+    Defers when the hook payload carries a non-empty ``background_tasks``
+    list: the Stop hook fires at every main-agent turn boundary, and
+    dispatching a ``run_in_background: true`` subagent ends the parent's
+    turn while the subagent is still running. Completing the session
+    here would orphan the subagent. See issue #151.
     """
     try:
         stdin_text = sys.stdin.read()
@@ -853,6 +859,19 @@ def signal_stop() -> None:
 
     cw_session_id = context.get("session_id")
     if not isinstance(cw_session_id, str):
+        return
+
+    bg_tasks = hook_payload.get("background_tasks")
+    if isinstance(bg_tasks, list) and bg_tasks:
+        # Turn boundary with pending background work — leave the session
+        # in its current status; another Stop hook will fire when the bg
+        # work drains (the contract `claude --bg + run_in_background: true`
+        # relies on: the subagent's result arrives as the next main-agent
+        # turn, which then ends, firing Stop again with background_tasks
+        # empty). Without this guard, dispatching a run_in_background: true
+        # subagent causes the parent to be marked COMPLETED and, for
+        # DAEMON-origin sessions, killed via `claude stop`, orphaning the
+        # in-flight subagent. See issue #151.
         return
 
     state = load_state()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -514,6 +514,177 @@ class TestSignalStop:
 
         assert daemon.stop_calls == []
 
+    def test_signal_stop_defers_when_background_tasks_pending(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A Stop hook with pending background_tasks must NOT complete.
+
+        Dispatching a ``run_in_background: true`` subagent ends the parent's
+        turn while the subagent is still running. The Stop hook fires with
+        a populated ``background_tasks`` list; we must leave the session
+        in its current status so the parent isn't killed mid-flight.
+        See issue #151.
+        """
+        from cw.native_daemon import FakeNativeDaemonClient
+
+        session = self._seed_session(tmp_path, sess_id="sess-bg")
+        # Override default IDLE status: this session is actively running
+        # a background subagent when the Stop hook fires.
+        state = load_state()
+        target = next(s for s in state.sessions if s.id == session.id)
+        target.status = SessionStatus.ACTIVE
+        target.surface_ref = "claude-short-id"
+        save_state(state)
+        assert session.worktree_path is not None
+        worktree = session.worktree_path
+        self._write_context(worktree, session_id=session.id)
+
+        daemon = FakeNativeDaemonClient()
+        monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: daemon)
+
+        hook_stdin = json.dumps(
+            {
+                "session_id": "claude-uuid-bg",
+                "cwd": str(worktree),
+                "hook_event_name": "Stop",
+                "background_tasks": [
+                    {"id": "task-1", "description": "Plan subagent running"},
+                ],
+            }
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["signal-stop"], input=hook_stdin)
+        assert result.exit_code == 0, result.output
+
+        # Session must remain ACTIVE — no completion side effects.
+        state = load_state()
+        updated = next(s for s in state.sessions if s.id == session.id)
+        assert updated.status == SessionStatus.ACTIVE
+        assert updated.claude_session_id is None
+
+        # No SESSION_COMPLETED event must have been emitted.
+        events = read_events(
+            consumer="test-bg-defer",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        assert not any(e.payload.get("session_id") == session.id for e in events)
+
+        # native_daemon.stop must NOT have been called.
+        assert daemon.stop_calls == []
+
+    def test_signal_stop_proceeds_when_background_tasks_empty_list(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """An empty background_tasks list is treated as no pending work."""
+        session = self._seed_session(tmp_path, sess_id="sess-bg-empty")
+        assert session.worktree_path is not None
+        worktree = session.worktree_path
+        self._write_context(worktree, session_id=session.id)
+        hook_stdin = json.dumps(
+            {
+                "session_id": "claude-uuid-empty",
+                "cwd": str(worktree),
+                "hook_event_name": "Stop",
+                "background_tasks": [],
+            }
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["signal-stop"], input=hook_stdin)
+        assert result.exit_code == 0, result.output
+
+        state = load_state()
+        updated = next(s for s in state.sessions if s.id == session.id)
+        assert updated.status == SessionStatus.COMPLETED
+        assert updated.claude_session_id == "claude-uuid-empty"
+
+        events = read_events(
+            consumer="test-bg-empty",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        assert any(
+            e.payload.get("session_id") == session.id
+            and e.payload.get("ticket_id") == "137"
+            for e in events
+        )
+
+    def test_signal_stop_proceeds_when_background_tasks_absent(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Payload without a background_tasks key behaves like no pending work.
+
+        Explicit coverage so a future payload-normalization step can't
+        silently regress the contract.
+        """
+        session = self._seed_session(tmp_path, sess_id="sess-bg-absent")
+        assert session.worktree_path is not None
+        worktree = session.worktree_path
+        self._write_context(worktree, session_id=session.id)
+        hook_stdin = json.dumps(
+            {
+                "session_id": "claude-uuid-absent",
+                "cwd": str(worktree),
+                "hook_event_name": "Stop",
+            }
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["signal-stop"], input=hook_stdin)
+        assert result.exit_code == 0, result.output
+
+        state = load_state()
+        updated = next(s for s in state.sessions if s.id == session.id)
+        assert updated.status == SessionStatus.COMPLETED
+        assert updated.claude_session_id == "claude-uuid-absent"
+
+        events = read_events(
+            consumer="test-bg-absent",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        assert any(
+            e.payload.get("session_id") == session.id
+            and e.payload.get("ticket_id") == "137"
+            for e in events
+        )
+
+    def test_signal_stop_ignores_non_list_background_tasks(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """A malformed background_tasks (non-list) is treated as no pending work.
+
+        Mirrors the defensive-payload pattern used by test_cwd_not_string_is_noop
+        and test_context_not_dict_is_noop.
+        """
+        session = self._seed_session(tmp_path, sess_id="sess-bg-bad")
+        assert session.worktree_path is not None
+        worktree = session.worktree_path
+        self._write_context(worktree, session_id=session.id)
+        hook_stdin = json.dumps(
+            {
+                "session_id": "claude-uuid-bad",
+                "cwd": str(worktree),
+                "hook_event_name": "Stop",
+                "background_tasks": "not-a-list",
+            }
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["signal-stop"], input=hook_stdin)
+        assert result.exit_code == 0, result.output
+
+        state = load_state()
+        updated = next(s for s in state.sessions if s.id == session.id)
+        assert updated.status == SessionStatus.COMPLETED
+
+        events = read_events(
+            consumer="test-bg-bad",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        assert any(e.payload.get("session_id") == session.id for e in events)
+
 
 class TestCompletion:
     def test_completion_command_bash(self) -> None:


### PR DESCRIPTION
## Summary

Closes #151.

`cw signal-stop` was killing parent sessions while `run_in_background: true` subagents were still running. The Stop hook fires on every main-agent turn boundary (not just session end). Dispatching a `run_in_background: true` subagent from the Task tool ends the parent's turn while the subagent is still in flight — Stop fires, the existing handler transitions the session to COMPLETED and (for DAEMON-origin sessions) calls `claude stop`, orphaning the subagent.

This was identified during investigation as the cw-side half of the orphan failure mode. A sibling skill-side fix (pin agent dispatch to synchronous in headless mode in `auto-dev.md`) is filed separately against the global-claude repo.

## Mechanism

Gate `signal_stop` on `hook_payload.background_tasks`. When present and non-empty (the contract field documented in the Stop hook payload per PR #147 prototype), defer:

```python
bg_tasks = hook_payload.get("background_tasks")
if isinstance(bg_tasks, list) and bg_tasks:
    return
```

The guard sits after the `cw_session_id` `isinstance(str)` validation and before `load_state()` — deferral is a pure no-op (no state mutation, no I/O, no event emission, no `claude stop` call). When the background work drains, the subagent's result arrives as the next main-agent turn, which then ends, firing Stop again with `background_tasks` empty — the existing completion path then runs.

Backstop: if the second Stop hook ever fails to fire (daemon bug, subagent hard crash), `reconcile.py` eventually detects the phantom and marks the session CRASHED, reverting the dev_queue task to PENDING for retry. Recovery, not silent wedge.

## Files changed

| File | Δ | Notes |
|---|---|---|
| `src/cw/cli.py` | +19 | `signal_stop` guard + docstring paragraph |
| `tests/test_cli.py` | +171 | 4 new tests in `TestSignalStop`: pending defer, empty-list proceed, absent-key proceed, non-list malformed proceed |

## Test plan

- [x] `uv run ruff check src/cw/cli.py tests/test_cli.py` — pass
- [x] `uv run ruff format --check src/cw/cli.py tests/test_cli.py` — pass
- [x] `uv run mypy src/cw/cli.py tests/test_cli.py` — Success
- [x] `uv run pytest tests/test_cli.py::TestSignalStop -v` — 16/16 pass (12 existing + 4 new)
- [x] Stage 3 multi-reviewer pass (Code Quality, SysAdmin, Product Manager) — 0 MUST_FIX, 4 SHOULD_FIX accepted for Small scope

## Follow-ups noted

- Sibling skill-side fix (pin to synchronous in headless mode) for `global-claude/commands/auto-dev.md` — separate ticket
- Optional cleanup from review SHOULD_FIX (not blocking): extract `_SEED_TICKET_ID` constant in test class, snapshot-based assertion in defer test, expand guard comment to mention reconciler backstop

🤖 Generated with [Claude Code](https://claude.com/claude-code)