### PR TITLE
chore(signal-stop): apply SHOULD_FIX polish from #159 review (#151)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -872,6 +872,16 @@ def signal_stop() -> None:
         # subagent causes the parent to be marked COMPLETED and, for
         # DAEMON-origin sessions, killed via `claude stop`, orphaning the
         # in-flight subagent. See issue #151.
+        #
+        # Fast path: no state I/O. The idempotency guard below is
+        # unreachable on this path by design — deferral leaves state
+        # untouched regardless of current session status.
+        #
+        # Backstop: if the second Stop hook ever fails to fire (daemon
+        # bug, subagent hard crash with no clean Stop), reconcile.py
+        # eventually detects the phantom and marks the session CRASHED,
+        # reverting any matching dev_queue task to PENDING for retry.
+        # Recovery, not silent wedge.
         return
 
     state = load_state()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -239,6 +239,11 @@ class TestUpgradeWorkers:
 class TestSignalStop:
     """Tests for the `cw signal-stop` Stop-hook handler (issue #147)."""
 
+    SEED_TICKET_ID = "137"
+    """Default ticket_id stamped into the seeded cw-context.json. Tests that
+    assert event payload propagation reference this constant rather than the
+    bare string."""
+
     def _seed_session(self, tmp_path: Path, sess_id: str = "sess-147") -> Session:
         workspace = tmp_path / "workspace"
         workspace.mkdir(parents=True, exist_ok=True)
@@ -264,7 +269,7 @@ class TestSignalStop:
         worktree: Path,
         *,
         session_id: str,
-        ticket_id: str | None = "137",
+        ticket_id: str | None = SEED_TICKET_ID,
     ) -> None:
         claude_dir = worktree / ".claude"
         claude_dir.mkdir(parents=True, exist_ok=True)
@@ -311,7 +316,7 @@ class TestSignalStop:
         )
         assert any(
             e.payload.get("session_id") == session.id
-            and e.payload.get("ticket_id") == "137"
+            and e.payload.get("ticket_id") == self.SEED_TICKET_ID
             for e in events
         )
 
@@ -545,6 +550,13 @@ class TestSignalStop:
         daemon = FakeNativeDaemonClient()
         monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: daemon)
 
+        # Snapshot session state pre-call. The deferral path must leave it
+        # byte-for-byte unchanged; asserting individual fields would mask
+        # a regression that mutates some other field.
+        pre_state = load_state()
+        pre_target = next(s for s in pre_state.sessions if s.id == session.id)
+        pre_snapshot = pre_target.model_dump()
+
         hook_stdin = json.dumps(
             {
                 "session_id": "claude-uuid-bg",
@@ -559,11 +571,11 @@ class TestSignalStop:
         result = runner.invoke(main, ["signal-stop"], input=hook_stdin)
         assert result.exit_code == 0, result.output
 
-        # Session must remain ACTIVE — no completion side effects.
-        state = load_state()
-        updated = next(s for s in state.sessions if s.id == session.id)
-        assert updated.status == SessionStatus.ACTIVE
-        assert updated.claude_session_id is None
+        # Deferral must not mutate session state. Whole-object snapshot
+        # compare catches any field drift, not just status / claude_session_id.
+        post_state = load_state()
+        post_target = next(s for s in post_state.sessions if s.id == session.id)
+        assert post_target.model_dump() == pre_snapshot
 
         # No SESSION_COMPLETED event must have been emitted.
         events = read_events(
@@ -607,7 +619,7 @@ class TestSignalStop:
         )
         assert any(
             e.payload.get("session_id") == session.id
-            and e.payload.get("ticket_id") == "137"
+            and e.payload.get("ticket_id") == self.SEED_TICKET_ID
             for e in events
         )
 
@@ -646,7 +658,7 @@ class TestSignalStop:
         )
         assert any(
             e.payload.get("session_id") == session.id
-            and e.payload.get("ticket_id") == "137"
+            and e.payload.get("ticket_id") == self.SEED_TICKET_ID
             for e in events
         )
 


### PR DESCRIPTION
## Summary

Follow-ups from the Stage 3 review of #159 — all SHOULD_FIX items, accepted at ship time under Small-scope auto-accept. Captured here so the polish lands and the review trail stays linked.

No behavior change. Tests 16/16 pass.

## Changes

**Guard comment enrichment in `src/cw/cli.py`**

Two notes the Code Quality + SysAdmin reviewers asked for at the bg_tasks guard:

- Mark the no-state-I/O fast-path as intentional — the idempotency check below is unreachable on the deferral path by design.
- Document the reconciler backstop — if the contract assumption ("another Stop fires when bg work drains") ever breaks, `reconcile.py` detects the phantom and marks the session CRASHED, reverting any matching dev_queue task to PENDING for retry. Recovery, not silent wedge.

**Snapshot-compare in defer test (`tests/test_cli.py`)**

Replace the `claude_session_id is None` assertion in `test_signal_stop_defers_when_background_tasks_pending` with a whole-`Session.model_dump()` snapshot compare. The deferral path must leave the session byte-for-byte unchanged; the per-field assertion would mask a regression that mutates some other field.

**`SEED_TICKET_ID` class constant**

Extract `SEED_TICKET_ID = "137"` on `TestSignalStop`, thread through `_write_context` default, and reference it from the three event-payload assertions that previously hardcoded the literal.

## Test plan

- [x] `uv run ruff check src/cw/cli.py tests/test_cli.py` — pass
- [x] `uv run ruff format --check src/cw/cli.py tests/test_cli.py` — pass
- [x] `uv run mypy src/cw/cli.py tests/test_cli.py` — Success
- [x] `uv run pytest tests/test_cli.py::TestSignalStop -v` — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)