### PR TITLE
infra(actions): bump GitHub Actions to Node.js 24 runtimes (#158)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
         python-version: ["3.13"]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           # diff-cover needs main's history to compute the patch diff
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-xml
           path: coverage.xml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
       - name: Set up Python 3.13
         run: uv python install 3.13
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload cmux logs on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: cmux-logs
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
       - name: Install tmux (Linux)
         if: runner.os == 'Linux'
@@ -49,10 +49,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3
         with:
           generate_release_notes: true
           body: |


### PR DESCRIPTION
## Summary

Bumps all four GitHub Actions pinned across `.github/workflows/{ci,nightly,release}.yml` to releases that ship `using: node24`, ahead of GitHub's June 2 2026 forced switch and Sept 16 2026 Node 20 removal.

| Action | Bump |
|---|---|
| `actions/checkout` | v4 -> v6.0.2 |
| `astral-sh/setup-uv` | v6 -> v8.1.0 |
| `actions/upload-artifact` | v4 -> v7.0.1 |
| `softprops/action-gh-release` | v2 -> v3.0.0 |

10 SHA substitutions, 3 files, no logic changes.

## Notes from review

- **`actions/checkout` skips v5 -> lands on v6.0.2.** Both v5 and v6 ship node24; v6 chosen per the "latest stable" planning decision. v6 includes a credential-storage behavior change (creds persisted to a separate file rather than git config), unrelated to anything these workflows do — none of the workflows pass `persist-credentials: false` or use `token:` overrides, and no in-workflow git ops depend on the old credential file location. Surfaced by SysAdmin + Deployment reviewers as advisory; called out here for future auditors.
- **Tag comment style:** major-only (`# v6` / `# v7` / `# v3`) for three actions, full semver (`# v8.1.0`) for `astral-sh/setup-uv` only. setup-uv v8.0.0 explicitly stopped publishing floating major/minor tags as a supply-chain hardening measure, so `# v8` would be a documentation footgun.
- **Plan & decisions** posted on the issue: https://github.com/mattwwarren/claude-workspace/issues/158#issuecomment-4523051027

## Verification (post-merge)

- [ ] No "Node.js 20 actions are deprecated" warning in CI run logs
- [ ] No `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` introduced (verified absent in diff)
- [ ] No `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` introduced (verified absent in diff)
- [ ] Trigger a test-tag (`v0.0.0-test-node24`) post-merge to exercise `release.yml`
- [ ] Wait for next nightly cron OR trigger via `workflow_dispatch` to verify nightly.yml

## Follow-ups filed

- #161 — `infra(actions): add dependabot config for github-actions ecosystem` — automates future runtime bumps so we don't manually swap SHAs again
- #162 — `infra(release): add workflow_dispatch trigger to release.yml for recovery` — eliminates tag-surgery requirement if the release pipeline breaks mid-tag-push

## Test plan

- [x] All 4 target SHAs verified via GitHub API
- [x] All 4 target `action.yml` files confirmed to declare `using: node24`
- [x] Independent diff inspection from main session matches plan (3 files, 10/10 +/-)
- [x] YAML parses cleanly for all 3 files
- [x] Plan + soundness reviewers cleared (RISK acknowledged + lesson written to wiki/local/inbox)
- [x] Deployment + SysAdmin + PM reviewers cleared (no MUST_FIX)
- [ ] CI green on this PR

Closes #158