### PR TITLE
fix(reconcile): catch zombie-bash panes whose claude process exited

### DIFF
--- a/src/cw/cmux.py
+++ b/src/cw/cmux.py
@@ -245,6 +245,7 @@ class FakeCmuxAdapter:
         }
         self._live: set[str] = set()
         self._live_commands: dict[str, str] = {}
+        self._commands_fail: bool = False
 
     def spawn(self, workspace: str, command: str, surface: str = "right") -> str:
         """Record call and return a deterministic fake surface ref."""
@@ -277,8 +278,15 @@ class FakeCmuxAdapter:
         return set(self._live)
 
     def list_live_surface_commands(self) -> dict[str, str]:
-        """Return a copy of the current foreground-command map."""
+        """Return a copy of the current foreground-command map.
+
+        If ``_commands_fail`` is True, returns an empty dict to simulate a
+        backend enumeration failure (exercises the fail-open path in
+        :func:`cw.reconcile.compute_drift`).
+        """
         self.calls["list_live_surface_commands"].append(())
+        if self._commands_fail:
+            return {}
         return dict(self._live_commands)
 
     def set_pane_command(self, surface_ref: str, command: str) -> None:

--- a/src/cw/cmux.py
+++ b/src/cw/cmux.py
@@ -80,6 +80,26 @@ class MultiplexerAdapter(Protocol):
         """
         ...
 
+    def list_live_surface_commands(self) -> dict[str, str]:
+        """Return a mapping of surface_ref to foreground command name.
+
+        Used as a second-pass filter in reconciliation to detect zombie
+        panes whose surface still exists but whose claude process has
+        exited (the pane is back at the shell prompt). Returns the same
+        keys as :meth:`list_surfaces`.
+
+        Same all-or-nothing contract as :meth:`list_surfaces`: return an
+        empty dict if the backend cannot enumerate commands reliably. An
+        empty return is treated by reconcile as "command info
+        unavailable; skip command filter" — fail-open, no false-positive
+        reaping.
+
+        For backends where command introspection is unsupported (cmux),
+        return every live surface mapped to a non-shell sentinel so the
+        zombie filter is a transparent no-op for those surfaces.
+        """
+        ...
+
 
 # Legacy alias. Keep for one release so downstream type hints that read
 # `from cw.cmux import CmuxAdapter` don't break mid-upgrade.
@@ -197,6 +217,19 @@ class RealCmuxAdapter:
             return set()
         return live
 
+    def list_live_surface_commands(self) -> dict[str, str]:
+        """Return a no-op command map for cmux surfaces.
+
+        The cmux ``surface.list`` JSON-RPC response does not expose a
+        current-command or process-name field — only ``id``, ``ref``,
+        ``index``, ``type``, ``focused``, ``title`` (see
+        ``docs/cmux-protocol.md``). Until cmux exposes process info, every
+        live cmux surface is reported as running a non-shell sentinel so
+        the zombie-pane filter is transparent for the cmux backend. See
+        GitHub issue #144.
+        """
+        return dict.fromkeys(self.list_surfaces(), "cmux-surface")
+
 
 class FakeCmuxAdapter:
     """In-memory adapter for testing. Records all calls; no real I/O."""
@@ -208,8 +241,10 @@ class FakeCmuxAdapter:
             "close": [],
             "identify": [],
             "list_surfaces": [],
+            "list_live_surface_commands": [],
         }
         self._live: set[str] = set()
+        self._live_commands: dict[str, str] = {}
 
     def spawn(self, workspace: str, command: str, surface: str = "right") -> str:
         """Record call and return a deterministic fake surface ref."""
@@ -217,12 +252,14 @@ class FakeCmuxAdapter:
         ref = f"fake-pane-{self._counter}"
         self.calls["spawn"].append((workspace, command, surface))
         self._live.add(ref)
+        self._live_commands[ref] = "claude"
         return ref
 
     def close(self, surface_ref: str) -> None:
         """Record call and drop from live set (idempotent)."""
         self.calls["close"].append((surface_ref,))
         self._live.discard(surface_ref)
+        self._live_commands.pop(surface_ref, None)
 
     def identify(self) -> dict[str, Any]:
         """Record call and return stub focus context."""
@@ -238,6 +275,19 @@ class FakeCmuxAdapter:
         """Return the current in-memory live-surface set (copy)."""
         self.calls["list_surfaces"].append(())
         return set(self._live)
+
+    def list_live_surface_commands(self) -> dict[str, str]:
+        """Return a copy of the current foreground-command map."""
+        self.calls["list_live_surface_commands"].append(())
+        return dict(self._live_commands)
+
+    def set_pane_command(self, surface_ref: str, command: str) -> None:
+        """Override the foreground command for a surface (test helper).
+
+        No assertion that the ref is in the live set — keeps test helpers
+        flexible for exercising edge-case scenarios.
+        """
+        self._live_commands[surface_ref] = command
 
 
 def _resolve_backend_name() -> BackendName:

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -80,6 +80,10 @@ _LIVE_STATUSES: frozenset[SessionStatus] = frozenset(
 # at the prompt. A session whose ``pane_current_command`` is in this
 # set is treated as a zombie phantom even though the pane itself still
 # exists. See GitHub issue #144.
+# Known limitation: a user who manually attaches to a cw pane and drops
+# to a subshell will also match this predicate and be reaped on the
+# next reconcile tick. cw auto-spawn does not produce this pattern in
+# normal use.
 _IDLE_SHELL_COMMANDS: frozenset[str] = frozenset(
     {"bash", "zsh", "sh", "fish", "dash", "tcsh", "ksh"}
 )

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -75,6 +75,15 @@ _LIVE_STATUSES: frozenset[SessionStatus] = frozenset(
     }
 )
 
+# Shell process names indicating a pane's foreground process is an idle
+# shell — claude (or ``cw run-claude``) has exited and the pane is back
+# at the prompt. A session whose ``pane_current_command`` is in this
+# set is treated as a zombie phantom even though the pane itself still
+# exists. See GitHub issue #144.
+_IDLE_SHELL_COMMANDS: frozenset[str] = frozenset(
+    {"bash", "zsh", "sh", "fish", "dash", "tcsh", "ksh"}
+)
+
 
 @dataclass(frozen=True)
 class ReconcileReport:
@@ -118,13 +127,24 @@ def compute_drift(
     daemon = native_daemon or get_native_daemon_client()
     tmux_live = adapter.list_surfaces()
     native_live = daemon.list_live_session_short_ids()
+    # Second-pass zombie filter: panes that exist but whose foreground
+    # process is a bare shell are not actually live cw sessions. An empty
+    # command map means the backend can't enumerate — skip the filter
+    # (fail-open) rather than risk false-positive reaping.
+    surface_commands = adapter.list_live_surface_commands()
+    zombie_refs: set[str] = set()
+    if surface_commands:
+        zombie_refs = {
+            ref for ref, cmd in surface_commands.items() if cmd in _IDLE_SHELL_COMMANDS
+        }
+
     phantoms: list[str] = []
     for session in state.sessions:
         if session.status not in _LIVE_STATUSES:
             continue
         if session.surface_ref is None:
             continue
-        if session.surface_ref in tmux_live:
+        if session.surface_ref in tmux_live and session.surface_ref not in zombie_refs:
             continue
         if session.surface_ref in native_live:
             continue

--- a/src/cw/tmux.py
+++ b/src/cw/tmux.py
@@ -18,6 +18,13 @@ from cw.exceptions import CwError
 # Pane reference format returned by ``tmux split-window -P -F ...``.
 _PANE_FORMAT = "#{session_name}:#{window_index}.#{pane_index}"
 
+# Pane reference format that also captures the foreground command name.
+# Used by :meth:`TmuxAdapter.list_live_surface_commands` to detect zombie
+# panes whose claude process has exited (pane is back at the shell prompt).
+_PANE_FORMAT_WITH_COMMAND = (
+    "#{session_name}:#{window_index}.#{pane_index} #{pane_current_command}"
+)
+
 # Mapping from the cw-level "surface" hint to tmux's split-window flag.
 # "right" produces a horizontal split (new pane to the right); "bottom"
 # produces a vertical split. Anything else falls back to horizontal.
@@ -123,3 +130,28 @@ class TmuxAdapter:
         if result.returncode != 0 or not result.stdout:
             return set()
         return {line for line in result.stdout.strip().splitlines() if line}
+
+    def list_live_surface_commands(self) -> dict[str, str]:
+        """Return mapping of pane ref to foreground command name.
+
+        Single ``tmux list-panes`` call with a format string capturing
+        both the pane ref and ``pane_current_command``. Returns an empty
+        dict when the tmux server is not running or the call fails —
+        same all-or-nothing semantics as :meth:`list_surfaces`. The
+        reconciler treats an empty return as "command info unavailable,
+        skip the zombie filter" — fail-open, no false-positive reaping.
+        """
+        result = self._run(
+            ["list-panes", "-a", "-F", _PANE_FORMAT_WITH_COMMAND],
+            check=False,
+        )
+        if result.returncode != 0 or not result.stdout:
+            return {}
+        commands: dict[str, str] = {}
+        for line in result.stdout.strip().splitlines():
+            if not line:
+                continue
+            parts = line.split(" ", 1)
+            if len(parts) == 2:
+                commands[parts[0]] = parts[1].strip()
+        return commands

--- a/tests/test_cmux.py
+++ b/tests/test_cmux.py
@@ -549,6 +549,78 @@ class TestGetBackendAdapter:
         assert isinstance(adapter, TmuxAdapter)
 
 
+def test_fake_adapter_list_live_surface_commands_tracks_spawn() -> None:
+    """FakeCmuxAdapter.list_live_surface_commands returns spawned refs as 'claude'."""
+    adapter = FakeCmuxAdapter()
+    ref = adapter.spawn("ws", "claude", "right")
+    assert adapter.list_live_surface_commands() == {ref: "claude"}
+
+
+def test_fake_adapter_list_live_surface_commands_empty_after_close() -> None:
+    """Closing a surface removes it from the command map."""
+    adapter = FakeCmuxAdapter()
+    ref = adapter.spawn("ws", "claude", "right")
+    adapter.close(ref)
+    assert ref not in adapter.list_live_surface_commands()
+
+
+def test_fake_adapter_set_pane_command_override() -> None:
+    """set_pane_command changes the command shown in the live command map."""
+    adapter = FakeCmuxAdapter()
+    ref = adapter.spawn("ws", "claude", "right")
+    adapter.set_pane_command(ref, "bash")
+    assert adapter.list_live_surface_commands() == {ref: "bash"}
+
+
+def test_fake_adapter_records_list_live_surface_commands_call() -> None:
+    """list_live_surface_commands call is recorded in adapter.calls."""
+    adapter = FakeCmuxAdapter()
+    adapter.spawn("ws", "claude", "right")
+    adapter.list_live_surface_commands()
+    assert len(adapter.calls["list_live_surface_commands"]) == 1
+
+
+def test_real_cmux_list_live_surface_commands_uses_sentinel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RealCmuxAdapter.list_live_surface_commands returns non-shell sentinel values.
+
+    The cmux surface.list response does not expose a current-command field,
+    so the adapter maps every live surface to a sentinel ('cmux-surface')
+    so the zombie filter is a transparent no-op for the cmux backend.
+    """
+    import sys
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    from cw.cmux import RealCmuxAdapter
+
+    def fake_call(
+        self: object, method: str, params: dict[str, object]
+    ) -> dict[str, object]:
+        if method == "workspace.list":
+            return {
+                "workspaces": [
+                    {"id": "ws-a", "title": "client-a"},
+                ]
+            }
+        if method == "surface.list":
+            return {"surfaces": [{"id": "surf-1"}, {"id": "surf-2"}]}
+        raise AssertionError(f"unexpected call: {method}")
+
+    monkeypatch.setattr(RealCmuxAdapter, "_call", fake_call)
+    adapter = RealCmuxAdapter(socket_path=Path("/tmp/fake.sock"))
+
+    result = adapter.list_live_surface_commands()
+    assert set(result.keys()) == {"surf-1", "surf-2"}
+    # All values must be the non-shell sentinel — never a shell name.
+    shell_names = {"bash", "zsh", "sh", "fish", "dash", "tcsh", "ksh"}
+    for cmd in result.values():
+        assert cmd not in shell_names, (
+            f"Sentinel should not be a shell name, got {cmd!r}"
+        )
+
+
 def test_fake_adapter_list_surfaces_tracks_spawn_and_close() -> None:
     """FakeCmuxAdapter tracks live surfaces via spawn/close."""
     adapter = FakeCmuxAdapter()

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -295,8 +295,8 @@ def test_compute_drift_command_check_empty_does_not_falsely_reap() -> None:
     that are in list_surfaces — fail-open, no false-positive reaping."""
     adapter = FakeCmuxAdapter()
     ref = adapter.spawn("ws", "claude", "right")
-    # Simulate a backend failure by monkey-patching the adapter method.
-    adapter.list_live_surface_commands = dict  # type: ignore[method-assign]
+    # Simulate a backend failure via the FakeCmuxAdapter fail-mode flag.
+    adapter._commands_fail = True
 
     daemon = FakeNativeDaemonClient()
     state = CwState(sessions=[_mk_session("maybe-alive", ref)])

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -266,6 +266,96 @@ def test_reconcile_refuses_to_mass_reap_on_empty_live_set(
         assert s.completed_reason is None
 
 
+def test_compute_drift_flags_idle_session_when_pane_runs_bash() -> None:
+    """Key zombie test: IDLE session whose pane command is 'bash' is flagged phantom."""
+    adapter = FakeCmuxAdapter()
+    ref = adapter.spawn("ws", "claude", "right")
+    adapter.set_pane_command(ref, "bash")
+
+    daemon = FakeNativeDaemonClient()
+    state = CwState(sessions=[_mk_session("zombie", ref, status=SessionStatus.IDLE)])
+    report = compute_drift(state, adapter, daemon)
+    assert "zombie" in report.phantom_session_ids
+
+
+def test_compute_drift_keeps_session_alive_when_pane_runs_cw() -> None:
+    """Session whose pane foreground process is 'cw' (or 'claude') is alive."""
+    adapter = FakeCmuxAdapter()
+    ref = adapter.spawn("ws", "claude", "right")
+    # Default command from spawn is "claude" — leave it unchanged.
+
+    daemon = FakeNativeDaemonClient()
+    state = CwState(sessions=[_mk_session("alive", ref, status=SessionStatus.IDLE)])
+    report = compute_drift(state, adapter, daemon)
+    assert "alive" not in report.phantom_session_ids
+
+
+def test_compute_drift_command_check_empty_does_not_falsely_reap() -> None:
+    """When list_live_surface_commands returns {} (failure), do not reap sessions
+    that are in list_surfaces — fail-open, no false-positive reaping."""
+    adapter = FakeCmuxAdapter()
+    ref = adapter.spawn("ws", "claude", "right")
+    # Simulate a backend failure by monkey-patching the adapter method.
+    adapter.list_live_surface_commands = dict  # type: ignore[method-assign]
+
+    daemon = FakeNativeDaemonClient()
+    state = CwState(sessions=[_mk_session("maybe-alive", ref)])
+    report = compute_drift(state, adapter, daemon)
+    # list_surfaces has ref, list_live_surface_commands returned {} → fail-open
+    assert "maybe-alive" not in report.phantom_session_ids
+
+
+def test_reconcile_reaps_bash_pane_zombie_session(
+    tmp_config_dir: Path,
+) -> None:
+    """Full reconcile end-to-end: IDLE session with bash pane is COMPLETED+CRASHED."""
+    adapter = FakeCmuxAdapter()
+    bash_ref = adapter.spawn("ws", "claude", "right")
+    adapter.set_pane_command(bash_ref, "bash")
+    # Add a decoy live surface so outage guard doesn't fire.
+    _decoy_ref = adapter.spawn("ws", "claude", "right")
+
+    sess = _mk_session("zombie-full", bash_ref, status=SessionStatus.IDLE)
+    save_state(CwState(sessions=[sess]))
+
+    daemon = FakeNativeDaemonClient()
+    report = reconcile(adapter, daemon)
+
+    assert "zombie-full" in report.phantom_session_ids
+    reloaded = load_state()
+    s = reloaded.find_by_name_or_id("zombie-full")
+    assert s is not None
+    assert s.status == SessionStatus.COMPLETED
+    assert s.completed_reason == CompletionReason.CRASHED
+
+
+def test_reconcile_outage_guard_still_fires_on_empty_list_surfaces(
+    tmp_config_dir: Path,
+) -> None:
+    """Outage guard: when list_surfaces returns empty and state has live sessions,
+    reconcile returns empty report regardless of list_live_surface_commands content."""
+    state = CwState(
+        sessions=[
+            _mk_session("s1", "r1"),
+            _mk_session("s2", "r2", status=SessionStatus.IDLE),
+        ]
+    )
+    save_state(state)
+
+    adapter = FakeCmuxAdapter()  # empty live set → outage guard fires
+    daemon = FakeNativeDaemonClient()
+    report = reconcile(adapter, daemon)
+
+    assert report.phantom_session_ids == []
+    assert report.phantom_session_names == []
+
+    reloaded = load_state()
+    for sid in ("s1", "s2"):
+        s = reloaded.find_by_name_or_id(sid)
+        assert s is not None
+        assert s.status in {SessionStatus.ACTIVE, SessionStatus.IDLE}
+
+
 def test_reconcile_with_only_native_live_proceeds(
     tmp_config_dir: Path,
 ) -> None:

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -201,6 +201,71 @@ def test_tmux_list_surfaces_returns_empty_when_no_panes(
     assert adapter.list_surfaces() == set()
 
 
+def test_list_live_surface_commands_returns_ref_to_command_map(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """list_live_surface_commands parses pane-ref → command from list-panes output."""
+    monkeypatch.setattr("cw.tmux.shutil.which", lambda _: "/usr/bin/tmux")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert "list-panes" in cmd
+        assert "-a" in cmd
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout="cw-client-a:0.0 cw\ncw-client-a:0.1 bash\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr("cw.tmux.subprocess.run", fake_run)
+    adapter = TmuxAdapter()
+    assert adapter.list_live_surface_commands() == {
+        "cw-client-a:0.0": "cw",
+        "cw-client-a:0.1": "bash",
+    }
+
+
+def test_list_live_surface_commands_returns_empty_on_server_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-zero returncode from tmux means server is down; return empty dict."""
+    monkeypatch.setattr("cw.tmux.shutil.which", lambda _: "/usr/bin/tmux")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=1,
+            stdout="",
+            stderr="no server running on /tmp/tmux-1000/default\n",
+        )
+
+    monkeypatch.setattr("cw.tmux.subprocess.run", fake_run)
+    adapter = TmuxAdapter()
+    assert adapter.list_live_surface_commands() == {}
+
+
+def test_list_live_surface_commands_skips_malformed_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lines without a space (no command portion) are silently dropped."""
+    monkeypatch.setattr("cw.tmux.shutil.which", lambda _: "/usr/bin/tmux")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        # "cw-client-a:0.0 cw" is valid; "cw-client-a:0.2" has no command
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout="cw-client-a:0.0 cw\ncw-client-a:0.2\ncw-client-b:1.0 bash\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr("cw.tmux.subprocess.run", fake_run)
+    adapter = TmuxAdapter()
+    result = adapter.list_live_surface_commands()
+    assert "cw-client-a:0.2" not in result
+    assert result == {"cw-client-a:0.0": "cw", "cw-client-b:1.0": "bash"}
+
+
 @pytest.mark.integration
 @pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux not installed")
 class TestTmuxIntegration:


### PR DESCRIPTION
## Summary

- fix(reconcile): replace type:ignore monkey-patch with FakeCmuxAdapter fail-mode (#144)
- feat(reconcile): phantom-bash detection — filter zombie-shell panes (#144)

Closes #144

Adds `list_live_surface_commands()` to `MultiplexerAdapter` Protocol — pane_current_command capture for tmux, no-op sentinel for cmux (schema gap documented). `compute_drift` second-pass filter: refs whose foreground process is in `_IDLE_SHELL_COMMANDS` are demoted from live to phantom. Fail-open contract: empty command map = skip filter, don't reap.

Crash-path coverage (#147 handled happy-path via Stop hook; this covers SIGKILL/segfault). 6 files, +345/-4 (Small), 15 new tests, 840 total passing.

Known limitations:
- cmux backend cannot detect zombies (no process info in surface.list)
- manual-attach-then-subshell footgun documented inline

## Test plan

- [x] ruff check — zero violations
- [x] mypy — zero type errors (9 pre-existing errors on main, none introduced by this branch)
- [x] pytest — 840/840 pass rate
- [x] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it