### PR TITLE
chore(tests): clear pre-existing mypy errors in 5 test files (#170)

### DIFF
--- a/tests/test_adapter_protocol.py
+++ b/tests/test_adapter_protocol.py
@@ -48,19 +48,19 @@ class TestProtocolConformance:
         adapter = _instantiate(adapter_cls, monkeypatch)
         assert isinstance(adapter, MultiplexerAdapter)
 
-    def test_spawn_signature(self, adapter_cls: type) -> None:
+    def test_spawn_signature(self, adapter_cls: type[MultiplexerAdapter]) -> None:
         sig = inspect.signature(adapter_cls.spawn)
         params = list(sig.parameters.keys())
         # self, workspace, command, surface
         assert params[1:] == ["workspace", "command", "surface"]
         assert sig.parameters["surface"].default == "right"
 
-    def test_close_signature(self, adapter_cls: type) -> None:
+    def test_close_signature(self, adapter_cls: type[MultiplexerAdapter]) -> None:
         sig = inspect.signature(adapter_cls.close)
         params = list(sig.parameters.keys())
         assert params[1:] == ["surface_ref"]
 
-    def test_identify_signature(self, adapter_cls: type) -> None:
+    def test_identify_signature(self, adapter_cls: type[MultiplexerAdapter]) -> None:
         sig = inspect.signature(adapter_cls.identify)
         params = list(sig.parameters.keys())
         # self only

--- a/tests/test_cmux.py
+++ b/tests/test_cmux.py
@@ -72,10 +72,9 @@ class TestFakeCmuxAdapterClose:
         assert adapter.calls["close"][0] == ("ref-a",)
         assert adapter.calls["close"][1] == ("ref-b",)
 
-    def test_close_returns_none(self) -> None:
+    def test_close_does_not_raise(self) -> None:
         adapter = FakeCmuxAdapter()
-        result = adapter.close("any-ref")
-        assert result is None
+        adapter.close("any-ref")
 
 
 class TestFakeCmuxAdapterIdentify:
@@ -790,9 +789,7 @@ def test_real_cmux_call_translates_json_decode_error_to_cwerror(
 
     monkeypatch.setattr(
         "socket.socket",
-        # FakeSock mimics the socket.socket protocol structurally; mypy
-        # cannot see that and flags the return type as incompatible.
-        lambda *_args: FakeSock(),  # type: ignore[misc]
+        lambda *_args: FakeSock(),
     )
     adapter = RealCmuxAdapter(socket_path=Path("/tmp/fake.sock"))
 

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -6,7 +6,6 @@ import json
 import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 from click.testing import CliRunner
@@ -37,10 +36,6 @@ from cw.orchestrate import (
     retire_merged_prs,
 )
 from cw.pr_responder import PRDispatchRecord, save_dispatch_record
-
-if TYPE_CHECKING:
-    from collections.abc import Iterator
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -90,7 +85,7 @@ def captured_runner() -> tuple[
 
 
 @pytest.fixture
-def fake_runner() -> Iterator[tuple[list[list[str]], object]]:
+def fake_runner() -> tuple[list[list[str]], object]:
     """Yield (recorded_calls, runner_callable)."""
     calls: list[list[str]] = []
 

--- a/tests/test_pr_responder.py
+++ b/tests/test_pr_responder.py
@@ -145,6 +145,7 @@ class TestCIFailedSpawnsFixCI:
         assert spawned == 1
         assert len(adapter.calls["spawn"]) == 1
         _workspace, command, _surface = adapter.calls["spawn"][0]
+        assert isinstance(command, str)
         assert "/fix-ci 42" in command
         assert configured_client.name == "myproject"
 
@@ -163,6 +164,7 @@ class TestReviewReceivedSpawnsAddressReview:
         assert spawned == 1
         assert len(adapter.calls["spawn"]) == 1
         _workspace, command, _surface = adapter.calls["spawn"][0]
+        assert isinstance(command, str)
         assert "/address-review 17" in command
         assert configured_client.name == "myproject"
 

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -38,7 +38,7 @@ def _mk_session(
         purpose=SessionPurpose.IMPL,
         status=status,
         workspace_path=ClientConfig(
-            name="client-a", workspace_path="/tmp/ws"
+            name="client-a", workspace_path=Path("/tmp/ws")
         ).workspace_path,
         surface_ref=surface_ref,
         started_at=datetime(2026, 4, 19, tzinfo=UTC),
@@ -397,7 +397,7 @@ def test_reconcile_timed_out_session_reverts_dev_queue_task_to_pending(
         origin=SessionOrigin.DAEMON,
         status=SessionStatus.TIMED_OUT,
         workspace_path=ClientConfig(
-            name="client-a", workspace_path="/tmp/ws"
+            name="client-a", workspace_path=Path("/tmp/ws")
         ).workspace_path,
         surface_ref=None,
         started_at=datetime(2026, 4, 19, tzinfo=UTC),
@@ -442,7 +442,7 @@ def test_reconcile_timed_out_task_revert_called_during_reconcile(
         origin=SessionOrigin.DAEMON,
         status=SessionStatus.TIMED_OUT,
         workspace_path=ClientConfig(
-            name="client-a", workspace_path="/tmp/ws"
+            name="client-a", workspace_path=Path("/tmp/ws")
         ).workspace_path,
         surface_ref=None,
         started_at=datetime(2026, 4, 19, tzinfo=UTC),


### PR DESCRIPTION
## Summary

Implements #170: clears the 9 (actually 11) pre-existing mypy errors across 5 untouched test files so `uv run mypy src/ tests/` is clean from repo root.

**Note:** Plan agent found 11 errors on fresh `origin/main`, not the 9 in the ticket body — the two extras at `tests/test_reconcile.py:400` and `:445` share the line-41 `ClientConfig` root cause. All 11 fixed per the [Decisions section](https://github.com/mattwwarren/claude-workspace/issues/170#issuecomment-4525572629) on the ticket.

## Changes per test file

| File | Fix |
|---|---|
| `tests/test_adapter_protocol.py:52,59,64` | `"type" has no attribute "spawn"/"close"/"identify"` — fix protocol attribute access |
| `tests/test_cmux.py:77` | `"close" of "FakeCmuxAdapter" does not return a value` — drop the `result =` assignment |
| `tests/test_cmux.py:75` | Test rename `test_close_returns_none → test_close_does_not_raise` per Decision 5 — name now reflects the invariant actually tested |
| `tests/test_cmux.py:795` | Drop the `# type: ignore[misc]` AND the stale 2-line explanatory comment above it per Decision 3 |
| `tests/test_pr_responder.py:148,166` | `Unsupported right operand type for in ("object")` — narrow types before `in` |
| `tests/test_reconcile.py:41,400,445` | `ClientConfig(workspace_path="/tmp/ws")` — wrap str → `Path()` per Decision 1 (all three sites) |
| `tests/test_orchestrate.py:92` | `fake_runner` fixture annotation `Iterator[tuple[...]]` → `tuple[...]` per Decision 4 — matches actual body (returns, doesn't yield) |

`captured_runner` fixture in `test_orchestrate.py:75-89` left untouched per Decision 2 — scope discipline; not one of the 11 errors.

## Provenance

Produced by `/auto-dev 170 --headless` (the cw dogfood). Pipeline ran end-to-end through plan → ambiguity scan → plan quality review → impl → 5 serial reviewers (Code Quality, SysAdmin, Test Quality, Product Manager, Architecture) in 25 minutes. Review outcome: 0 MUST_FIX, 3 SHOULD_FIX (all explicit out-of-scope per Decisions section). Health: HIGH confidence, no agent degradation.

Original auto-dev exit at Stage 4 was `merge_gate_blocked` because the worktree branch carried local-only #176 commits not yet on origin — resolved by landing #176 first via PR #179, then rebasing this branch onto the updated origin/main.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — no issues
- [x] `uv run mypy src/ tests/` — clean from repo root (the acceptance criterion)
- [x] `uv run pytest tests/` — 858 passed

## Related

- #170 — original ticket
- #175, #176, #177, #178 — bootstrap rough patches that enabled this dogfood
- PR #179 — Layer 1 + sentinel detector fixes that PRE-LANDED to make this dogfood reach Stage 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)