### PR TITLE
feat(spawn): expose --headless flag on cw spawn CLI

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -1544,6 +1544,7 @@ def _spawn_create_impl(
     worktree: Path,
     prompt_file: Path,
     label: str | None,
+    headless: bool = False,
     native_daemon: NativeDaemonClient | None = None,
 ) -> str:
     """Create a daemon-spawned session.
@@ -1560,6 +1561,7 @@ def _spawn_create_impl(
         worktree=worktree,
         prompt=prompt_file.read_text(encoding="utf-8"),
         label=label,
+        headless=headless,
         native_daemon=native_daemon,
     )
 
@@ -1605,6 +1607,19 @@ def _spawn_close_impl(
 @click.option("--worktree", "-w", default=None, help="Worktree path.")
 @click.option("--prompt-file", "-f", default=None, help="Path to prompt file.")
 @click.option("--label", "-l", default=None, help="Session label (default: daemon).")
+@click.option(
+    "--headless",
+    is_flag=True,
+    default=False,
+    help=(
+        "Mark the session as headless in cw-context.json so the signal_stop "
+        "Layer 1 backstop (issue #176) activates: a session that exits without "
+        "an AUTO_DEV_RESULT sentinel within the 30-min budget transitions to "
+        "TIMED_OUT (retry-eligible) instead of silently COMPLETED. Use when the "
+        "prompt invokes /auto-dev --headless or any other skill that emits the "
+        "sentinel contract."
+    ),
+)
 @click.pass_context
 @handle_errors
 def spawn(
@@ -1613,6 +1628,7 @@ def spawn(
     worktree: str | None,
     prompt_file: str | None,
     label: str | None,
+    headless: bool,
 ) -> None:
     """Spawn a daemon-managed Claude session or manage spawned sessions.
 
@@ -1648,6 +1664,7 @@ def spawn(
         worktree=Path(cast("str", worktree)),
         prompt_file=Path(cast("str", prompt_file)),
         label=label,
+        headless=headless,
     )
     click.echo(session_id)
 

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -304,6 +304,64 @@ class TestHookContextInjection:
         context = json.loads((worktree / ".claude" / "cw-context.json").read_text())
         assert context["ticket_id"] is None
 
+    def test_cli_headless_flag_writes_headless_true_to_context(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """`cw spawn --headless` plumbs `headless: true` into cw-context.json.
+
+        Without this, the signal_stop Layer 1 backstop (issue #176) won't
+        activate for sessions spawned directly via the CLI — only dev-queue
+        dispatch sets the flag today. Manual meta-test fan-out (parallel
+        /auto-dev runs on the same ticket via cw spawn) needs the same
+        backstop coverage that dev-queue dispatch gets.
+        """
+        from cw.cli import _spawn_create_impl
+
+        client = _make_client(tmp_path)
+        prompt_file = _make_prompt_file(tmp_path, "/auto-dev 171 --headless")
+        daemon = FakeNativeDaemonClient()
+        worktree = tmp_path / "worktree" / "manual-headless"
+        worktree.mkdir(parents=True)
+
+        _spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt_file=prompt_file,
+            label="meta-171-a",
+            headless=True,
+            native_daemon=daemon,
+        )
+
+        context = json.loads((worktree / ".claude" / "cw-context.json").read_text())
+        assert context["headless"] is True
+
+    def test_cli_headless_flag_defaults_to_false(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """`cw spawn` (no --headless) leaves `headless: false` in context.
+
+        Back-compat: existing callers (not /auto-dev dispatch) don't get the
+        backstop applied to them.
+        """
+        from cw.cli import _spawn_create_impl
+
+        client = _make_client(tmp_path)
+        prompt_file = _make_prompt_file(tmp_path, "some prompt")
+        daemon = FakeNativeDaemonClient()
+        worktree = tmp_path / "worktree" / "manual-default"
+        worktree.mkdir(parents=True)
+
+        _spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt_file=prompt_file,
+            label=None,
+            native_daemon=daemon,
+        )
+
+        context = json.loads((worktree / ".claude" / "cw-context.json").read_text())
+        assert context["headless"] is False
+
 
 class TestWriteHookContext:
     """Tests for _write_hook_context's origin-aware settings.local.json behavior.


### PR DESCRIPTION
## Summary

Adds a \`--headless\` flag to \`cw spawn\` so manually-fanned-out sessions get the same Layer 1 signal_stop backstop coverage that dev-queue dispatch gets today.

## Why

The Layer 1 backstop from #176 (PR #179) activates only when \`cw-context.json\` carries \`headless: true\`. \`dispatch.py\` sets this when spawning \`/auto-dev --headless\` via dev-queue, but the \`cw spawn\` CLI did not expose the flag. Without it, the silent-orphan failure mode that motivated #176 was still possible for sessions launched directly via CLI.

Surfaced while prepping an N=3 meta-test on #171: \`cw dev-queue\` can only dispatch one worker per ticket (deterministic worktree name, per #177), so parallel /auto-dev runs of the same ticket must use \`cw spawn\` directly. Without this flag, those parallel runs would lose Layer 1 protection.

## Changes

- \`src/cw/cli.py\`: \`@click.option(\"--headless\", is_flag=True, ...)\` plumbed through \`_spawn_create_impl\` to \`spawn_create_impl\`. Default \`False\` preserves existing behavior.
- \`tests/test_spawn.py\`: two new tests under \`TestHookContextInjection\` assert that \`--headless\` writes \`headless: true\` to the context and that the default writes \`false\`.

## Test plan

- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/\` — no issues
- [x] \`uv run pytest tests/test_spawn.py\` — green

## Related

- #176 — backstop umbrella; this PR is small but enables parallel meta-test dispatch
- #177 — dev-queue parallel-dispatch limitation that motivated the workaround
- PR #179 — landed Layer 1 + sentinel detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)