### PR TITLE
feat(skill): /cw-followup — sentinel-aware post-run actions (#188)

### DIFF
--- a/.claude/skills/cw-followup/SKILL.md
+++ b/.claude/skills/cw-followup/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: cw-followup
+description: React to a completed /auto-dev session's sentinel result by performing the appropriate post-run action — close a no_op ticket with a citation, rebase + open PR for merge_gate_blocked, draft a Decisions section for ambiguities or premises pending verification, escalate a real blocker, or just confirm a shipped PR. Use when the user asks to follow up on a session, ship a blocked branch, disposition ambiguities or premises, close out an auto-dev run, or generally do "whatever the sentinel says I should do next" for a finished /auto-dev run.
+---
+
+# cw-followup
+
+Performs the post-run action that matches a finished `/auto-dev` session's sentinel.
+
+A headless `/auto-dev` run ends in one of several sentinel shapes. Each shape needs a different next move from a human:
+
+| Sentinel shape | What this skill does |
+|---|---|
+| `shipped` | Print PR URL, confirm auto-merge state. |
+| `no_op` | Close the ticket with a comment citing the satisfying PR. |
+| `merge_gate_blocked` | Rebase the feature branch onto current `origin/main`, force-push, open PR. |
+| `ambiguities_pending_resolution` / `premises_pending_verification` | Render a Decisions section, append to the ticket body, suggest re-dispatch. |
+| `blocked` (real) | Surface `blocker.reason` + `details`; suggest re-dispatch or escalate. |
+| `plan_pending_approval` / `review_pending_approval` | Print plan or review findings; offer to approve, fix-loop, or abandon. |
+| `scope_exceeded` / `forbidden_area` | Surface and stop; ticket needs a human design decision. |
+| `BlockedResult` (parser couldn't validate) | Diagnose — show the validation error, transcript tail, and the raw payload. |
+
+Today the human does each of these by hand. This skill collapses the seven branches into one prompt.
+
+## Inputs
+
+Accepts a single argument identifying the session:
+
+- a short cw session id (e.g. `4f44d145`)
+- a ticket number (e.g. `185` or `#185`) — resolves to the most recent matching session
+- a path to a Claude JSONL transcript
+
+Optional flags from the user:
+- `--dry-run` — describe the action; do not execute side effects.
+- `--auto-accept-defaults` — for ambiguities / premises, take every plan default and append a Decisions section without confirmation.
+
+## How it works
+
+### Step 1 — locate and parse the sentinel
+
+Run the bundled parser to resolve the session and pull the parsed sentinel plus the raw payload:
+
+```bash
+uv run --project /home/matthew/workspace/personal/claude-workspace python \
+  .claude/skills/cw-followup/scripts/parse_sentinel.py \
+  --ticket-id <NUMBER>
+# or --session-id <SHORT> or --transcript-path <PATH>
+```
+
+The script emits one JSON object on stdout with `result_kind`, `result`, `raw_payload`, `session`, `transcript_path`, and `sentinel_found`. Capture it to a variable; the rest of the skill reads from this object.
+
+If `sentinel_found` is false, stop and surface the transcript path + the session record. Treat this as a no-result-emitted failure (see `references/no-sentinel-patterns.md` for likely causes).
+
+### Step 2 — branch on the effective status
+
+The parser's `Status` enum is closed, so producer-emitted statuses like `premises_pending_verification` and `ambiguities_pending_resolution` route through a `BlockedResult` with `reason=status_unknown`. The skill reads the **raw payload** to recover the producer-emitted status, while preferring the validated `result.status` when the kind is `AutoDevResult`.
+
+```text
+effective_status =
+    raw_payload.status   if raw_payload is present
+  else result.status     if result_kind == "AutoDevResult"
+  else result.blocker.reason
+```
+
+The branch table below uses `effective_status`.
+
+### Step 3 — branch dispatch
+
+#### `shipped`
+
+The PR auto-merges via `gh pr merge --auto`. Verify it landed:
+
+```bash
+PR_URL=$(jq -r '.result.pr.url // .raw_payload.pr.url' <<<"$RESULT")
+gh pr view "$PR_URL" --json mergeStateStatus,state,number,title
+```
+
+Print the merge state. If still open, suggest the review-monitor will handle it. If closed, recommend `cw orchestrate retire`.
+
+#### `no_op`
+
+The ticket was satisfied by a prior PR. Pull the citation from `friction_highlights`:
+
+```bash
+jq -r '.raw_payload.friction_highlights[]' <<<"$RESULT"
+# look for the satisfying-PR pointer; spec uses a "satisfying_pr: <url>" highlight
+```
+
+Draft a close comment in the form:
+
+```text
+Closed as no_op by /auto-dev (session <ID>) — already satisfied by <PR URL>.
+```
+
+Confirm with the user unless `--auto-accept-defaults` is set, then:
+
+```bash
+gh issue close <TICKET> --repo mattwwarren/claude-workspace \
+  --comment "$DRAFT_COMMENT"
+```
+
+#### `merge_gate_blocked`
+
+The branch was correctly built but `local main` diverged from `origin/main` before merge gate ran. Read `prior_pr_warnings` to see which PRs need to land first.
+
+Default action (when prior PRs have since merged): rebase + force-push + open PR. Confirm with the user before force-push.
+
+```bash
+WORKTREE=$(jq -r '.session.worktree_path' <<<"$RESULT")
+BRANCH=$(jq -r '.raw_payload.branch' <<<"$RESULT")
+FORK_POINT=$(jq -r '.raw_payload.fork_point_sha' <<<"$RESULT")
+
+git -C "$WORKTREE" fetch origin
+git -C "$WORKTREE" rebase --onto origin/main "$FORK_POINT" "$BRANCH"
+git -C "$WORKTREE" push --force-with-lease origin "$BRANCH"
+gh pr create --base main --head "$BRANCH"  # body derived from the review summary
+```
+
+#### `ambiguities_pending_resolution` / `premises_pending_verification`
+
+Render a Decisions section and append it to the ticket body. Pipe the parser output through `render_decisions.py`:
+
+```bash
+echo "$RESULT" | uv run --project /home/matthew/workspace/personal/claude-workspace \
+  python .claude/skills/cw-followup/scripts/render_decisions.py \
+  --auto-accept-defaults  # only when the user opted in
+```
+
+Without `--auto-accept-defaults`, the script leaves each decision as a fill-in stub. Read each ambiguity / premise to the user, capture their answers inline, then substitute them into the stub before appending.
+
+To append to the ticket body without losing the existing content:
+
+```bash
+TICKET=$(jq -r '.raw_payload.ticket_id' <<<"$RESULT")
+gh issue view "$TICKET" --repo mattwwarren/claude-workspace --json body --jq .body > /tmp/body.md
+cat /tmp/decisions.md >> /tmp/body.md
+gh issue edit "$TICKET" --repo mattwwarren/claude-workspace --body-file /tmp/body.md
+```
+
+After append, suggest re-dispatch: `cw spawn --headless --skill auto-dev <TICKET>` or queueing via `cw dev-queue add`. Do not auto-dispatch — re-dispatch belongs to the user.
+
+#### `blocked` (validated, real `AutoDevResult` with `status=blocked`)
+
+Print the blocker fields verbatim:
+
+```bash
+jq '.result.blocker' <<<"$RESULT"
+# stage, reason, details
+```
+
+When `blocker.reason == "tool_denied"` (issue #182): re-dispatch is the typical recovery, but the classifier non-determinism flagged in #183 means a delay before retry is sensible. Recommend `cw spawn --headless ...` with a 2-3 minute pause for the auto-mode classifier to settle.
+
+When `blocker.reason` is anything else: surface to user, do not auto-route. Ticket #174's Blocker expansion (Phase E) will eventually add `retry_eligible` and `recovery_hint`; until that lands, treat anything non-`tool_denied` as human-escalation.
+
+#### `plan_pending_approval`
+
+The plan stage finished with friction reports; the user gates whether to proceed. Print the friction highlights and the plan-stage review, then offer:
+- approve → re-dispatch with `--proceed-from-plan` or equivalent;
+- modify → edit the ticket body, re-dispatch from scratch;
+- abandon → close the ticket.
+
+#### `review_pending_approval`
+
+Stage 3 review wants the user's eyes. Print `review.should_fix` and `review.must_fix_initial`, plus any health concerns. Offer:
+- approve as-is and ship → invoke `/ship-it` in the worktree;
+- spawn a fix loop → re-dispatch;
+- abandon.
+
+#### `scope_exceeded` / `forbidden_area`
+
+Plan exceeded scope or touched a forbidden area. Surface the scope numbers and the forbidden-touched flag. The ticket needs a human design decision — do not act.
+
+#### `BlockedResult` with `reason != status_unknown`
+
+The parser blocked because the payload itself was malformed. Show the validation error verbatim and link to the transcript. Likely causes:
+- `validation_failed` — producer/consumer schema drift (e.g. `plan_source: github_issue_existing` not yet in the enum). File a ticket against the parser.
+- `multiple_result_blocks` — the producer emitted more than one sentinel; the first one wins by spec but the run is suspect.
+- `no_result_emitted` — see `references/no-sentinel-patterns.md`.
+
+### Step 4 — report
+
+Print one summary line followed by any receipts (URLs, branch refs, ticket numbers). Keep it tight — caveman style:
+
+```
+followup: #185 → premises rendered, ticket body updated, ready for re-dispatch
+followup: #136 → no_op, closed citing PR #154
+followup: #170 → merge_gate_blocked, rebased to origin/main, PR #194 opened
+```
+
+## Failure modes
+
+- **Cannot resolve session** — print the session ref + sessions.json hint; do not guess. The user may have the wrong session id.
+- **Transcript file missing** — likely the session record is stale (`reconcile` ran but the JSONL was rotated). Show the expected path so the user can confirm.
+- **Sentinel parses but `effective_status` is not recognized** — surface verbatim; ask the user to confirm whether to treat it as a real blocker or as a new producer status that should be added to the parser.
+- **Side effects fail** (gh issue close, force-push, rebase conflicts) — stop, surface the error, do not retry silently.
+
+## Out of scope
+
+- Re-dispatching to `/auto-dev`. The skill prepares the ground (decisions appended, branch rebased) but the user owns the dispatch trigger. Pair with `/cw-fanout` (#187) when re-dispatching at N>1.
+- Creating new tickets. `/cw-followup` acts on the existing one only.
+- Mutating the sentinel schema. Schema drift surfaces as `validation_failed`; fixing it is a separate ticket.
+
+## Related
+
+- #172 — `/cw-validate-result` (forensic read on any past session — uses the same parser).
+- #171 — `/cw-smoke-test` (consumes followup as the post-dispatch step).
+- #182 — `/auto-dev` no-recovery-on-deny (defines `tool_denied`).
+- #183 — auto-mode classifier non-determinism (informs the retry-with-delay default).
+- #184 — PushNotification on `tool_denied` (cw-side path; this skill is the human-side companion).
+- #174 — Blocker field expansion (Phase E adds `retry_eligible` / `recovery_hint` — this skill will key off them when they land).
+- #187 — `/cw-fanout` (re-dispatch at N>1 after followup prepares the ground).

--- a/.claude/skills/cw-followup/references/no-sentinel-patterns.md
+++ b/.claude/skills/cw-followup/references/no-sentinel-patterns.md
@@ -1,0 +1,20 @@
+# No-sentinel patterns
+
+When `parse_sentinel.py` reports `sentinel_found: false` the `/auto-dev` skill exited without emitting the `<<<AUTO_DEV_RESULT ... AUTO_DEV_RESULT>>>` block. The likely causes, ranked by how often each one fires in practice:
+
+| Cause | Diagnosis |
+|---|---|
+| **Step 1 mid-dispatch failure** | The skill spawned a Plan Quality sub-agent and the parent's Stop hook fired before the sub-agent returned. Look in the JSONL transcript for an `assistant` block whose tool calls end with a background dispatch and no subsequent assistant message. See issues #175 / #176 — addressed by the serial-headless landing in `global-claude` `82e2e02`. |
+| **Stop-hook orphan with no `background_tasks`** | The Layer 1 budget check only fires on Stop hooks; if the agent stalled mid-turn (e.g., waiting on a tool denial) the Stop hook never fires and the JSONL just ends. See issue #185. |
+| **Pre-flight `no_op` exit but emit step skipped** | The skill detected the ticket was already satisfied (e.g., PR already merged) and exited before reaching the sentinel emit step. The transcript ends with a `gh issue` lookup. The producer should always emit `status=no_op` here — if missing, that's a producer bug, file a ticket. |
+| **Tool denial deadlock** | A tool call (typically `gh issue comment`) was denied; the skill stalls indefinitely with no recovery path. Issue #182. Catch via the Layer 1 30-min TIMED_OUT backstop landed in PR #179. |
+| **Process killed externally** | Disconnect, OOM, manual SIGKILL. The JSONL is truncated mid-write and the last record may be malformed. |
+
+When in doubt, scan the JSONL for the last few records to see what the agent was doing at exit:
+
+```bash
+TRANSCRIPT=$(jq -r '.transcript_path' <<<"$RESULT")
+tail -n 30 "$TRANSCRIPT" | jq -c 'select(.type == "assistant") | .message.content[0].text // .message.content[0].input' 2>/dev/null | head -5
+```
+
+If the final assistant turn ended in a `Bash` or `Task` tool call and there is no subsequent assistant message, the orphan-style explanation (Step 1 mid-dispatch or stalled mid-turn) is most likely. If the final assistant turn is a normal text block that just stops short of emitting the sentinel, the producer skipped the emit step — likely cause: pre-flight `no_op` not yet wired through the emit path.

--- a/.claude/skills/cw-followup/scripts/parse_sentinel.py
+++ b/.claude/skills/cw-followup/scripts/parse_sentinel.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Locate and parse the AUTO_DEV_RESULT sentinel for a cw-dispatched session.
+
+Resolves a session reference (short cw id, ticket id, claude session UUID, or
+direct transcript path) to a JSONL transcript, walks each ``assistant`` text
+block to find the LAST sentinel pair, and parses it via
+``cw.auto_dev_result.parse_stdout`` (the production parser — never reimplement).
+
+Output: a single JSON line on stdout describing the resolved transcript and the
+parsed result. Exit code is 0 when the transcript was located and parsed (even
+when the parse yielded a ``BlockedResult``); 1 when the session reference could
+not be resolved or the transcript file was missing.
+
+Run via ``uv run`` from the cw repo so ``cw.auto_dev_result`` imports cleanly:
+
+    uv run --project /home/matthew/workspace/personal/claude-workspace \\
+        python .claude/skills/cw-followup/scripts/parse_sentinel.py \\
+        --session-id <short-id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from cw.auto_dev_result import AutoDevResult, BlockedResult, extract_block, parse_stdout
+
+_SESSIONS_PATH = Path.home() / ".local" / "share" / "cw" / "sessions.json"
+
+
+def _load_sessions() -> dict[str, dict[str, Any]]:
+    if not _SESSIONS_PATH.is_file():
+        return {}
+    with _SESSIONS_PATH.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    sessions = data.get("sessions", {}) if isinstance(data, dict) else {}
+    if isinstance(sessions, dict):
+        return sessions
+    if isinstance(sessions, list):
+        result: dict[str, dict[str, Any]] = {}
+        for entry in sessions:
+            if not isinstance(entry, dict):
+                continue
+            entry_id = entry.get("id")
+            if isinstance(entry_id, str):
+                result[entry_id] = entry
+        return result
+    return {}
+
+
+def _resolve_by_session_id(session_id: str) -> dict[str, Any] | None:
+    sessions = _load_sessions()
+    if session_id in sessions:
+        return sessions[session_id]
+    # Allow prefix match for the short ID convention
+    matches = [s for sid, s in sessions.items() if sid.startswith(session_id)]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def _resolve_by_ticket_id(ticket_id: str) -> dict[str, Any] | None:
+    """Most recent session whose worktree_path or branch references the ticket."""
+    sessions = _load_sessions()
+    needle = str(ticket_id).lstrip("#")
+    candidates = []
+    for session in sessions.values():
+        worktree = session.get("worktree_path") or ""
+        branch = session.get("branch") or ""
+        # auto-dev/<n>, auto-dev-<n>, dev/issue-<n>-... patterns
+        if (
+            f"auto-dev-{needle}" in worktree
+            or f"auto-dev/{needle}" in branch
+            or f"auto-dev/#{needle}" in branch
+            or f"issue-{needle}" in branch
+        ):
+            candidates.append(session)
+    if not candidates:
+        return None
+    return max(candidates, key=lambda s: s.get("started_at") or "")
+
+
+def _transcript_path_for_session(session: dict[str, Any]) -> Path | None:
+    claude_session_id = session.get("claude_session_id")
+    cwd = session.get("worktree_path")
+    if not claude_session_id or not cwd:
+        return None
+    encoded = str(cwd).replace("/", "-").replace(".", "-")
+    return Path.home() / ".claude" / "projects" / encoded / f"{claude_session_id}.jsonl"
+
+
+def _iter_assistant_text_blocks(transcript_path: Path) -> list[str]:
+    """Yield each assistant message text block in order. JSONL-aware.
+
+    The transcript is one JSON record per line. Assistant events carry their
+    text under ``message.content[*].text`` and the text is itself JSON-escaped
+    (real newlines become ``\\n``), which is why scanning the raw file with the
+    sentinel regex misses real runs — see GitHub issue #176 / PR #179.
+    """
+    blocks: list[str] = []
+    if not transcript_path.is_file():
+        return blocks
+    with transcript_path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(record, dict) or record.get("type") != "assistant":
+                continue
+            message = record.get("message")
+            if not isinstance(message, dict):
+                continue
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if not isinstance(block, dict) or block.get("type") != "text":
+                    continue
+                text = block.get("text")
+                if isinstance(text, str):
+                    blocks.append(text)
+    return blocks
+
+
+def _find_last_sentinel_text(blocks: list[str]) -> str | None:
+    """Walk in reverse — most runs emit the sentinel at the final assistant turn."""
+    for text in reversed(blocks):
+        if extract_block(text) is not None:
+            return text
+    return None
+
+
+def _result_to_dict(result: AutoDevResult | BlockedResult) -> dict[str, Any]:
+    parsed: Any = json.loads(result.model_dump_json())
+    if isinstance(parsed, dict):
+        return parsed
+    return {}
+
+
+def _raw_payload(sentinel_text: str | None) -> dict[str, Any] | None:
+    """Return the raw JSON inside the sentinel block (unvalidated).
+
+    The parser's ``Status`` Literal is closed, so producer-emitted statuses
+    like ``premises_pending_verification`` route through ``BlockedResult``
+    with ``reason=status_unknown``. The skill still needs the original fields
+    (friction reports, ambiguity arrays) to drive the followup action, so we
+    expose the raw payload alongside the validated parse.
+    """
+    if sentinel_text is None:
+        return None
+    inner = extract_block(sentinel_text)
+    if inner is None:
+        return None
+    try:
+        payload = json.loads(inner)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve a cw session and parse its AUTO_DEV_RESULT sentinel.",
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--session-id", help="Short cw session id (prefix match allowed)."
+    )
+    source.add_argument(
+        "--ticket-id",
+        help=("GitHub ticket number; resolves to the most recent matching session."),
+    )
+    source.add_argument(
+        "--transcript-path",
+        help="Direct path to a Claude JSONL transcript file.",
+    )
+    args = parser.parse_args()
+
+    session: dict[str, Any] | None = None
+    transcript_path: Path | None = None
+
+    if args.transcript_path:
+        transcript_path = Path(args.transcript_path)
+    elif args.session_id:
+        session = _resolve_by_session_id(args.session_id)
+    elif args.ticket_id:
+        session = _resolve_by_ticket_id(args.ticket_id)
+
+    if session is not None and transcript_path is None:
+        transcript_path = _transcript_path_for_session(session)
+
+    if transcript_path is None:
+        sys.stderr.write(
+            "could not resolve a transcript path from the given session reference\n",
+        )
+        return 1
+    if not transcript_path.is_file():
+        sys.stderr.write(f"transcript file not found: {transcript_path}\n")
+        return 1
+
+    blocks = _iter_assistant_text_blocks(transcript_path)
+    sentinel_text = _find_last_sentinel_text(blocks)
+
+    if sentinel_text is None:
+        result: AutoDevResult | BlockedResult = parse_stdout(
+            "",
+        )  # produces a BlockedResult(no_result_emitted)
+    else:
+        result = parse_stdout(sentinel_text)
+
+    output: dict[str, Any] = {
+        "transcript_path": str(transcript_path),
+        "assistant_blocks_scanned": len(blocks),
+        "sentinel_found": sentinel_text is not None,
+        "session": {
+            "id": session.get("id") if session else None,
+            "name": session.get("name") if session else None,
+            "status": session.get("status") if session else None,
+            "worktree_path": session.get("worktree_path") if session else None,
+            "branch": session.get("branch") if session else None,
+        }
+        if session
+        else None,
+        "result": _result_to_dict(result),
+        "result_kind": "AutoDevResult"
+        if isinstance(result, AutoDevResult)
+        else "BlockedResult",
+        "raw_payload": _raw_payload(sentinel_text),
+    }
+    sys.stdout.write(json.dumps(output, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/cw-followup/scripts/render_decisions.py
+++ b/.claude/skills/cw-followup/scripts/render_decisions.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Render a ``## Decisions`` markdown section from a sentinel's friction reports.
+
+Reads the JSON output of ``parse_sentinel.py`` on stdin (or from a file with
+``--input``) and emits a markdown section that can be appended to a GitHub
+issue body. Each ambiguity becomes a Q+A with the plan's default surfaced as
+the accepted answer; each premise becomes a verification statement.
+
+In ``--auto-accept-defaults`` mode every default is taken as-is — matches the
+pattern used to clear #170 v2's five ambiguities in one pass. Without the
+flag the script emits a stub that the human can edit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+_DECISIONS_HEADING = "## Decisions"
+
+
+def _render_ambiguity(idx: int, item: dict[str, Any], auto_accept: bool) -> str:
+    question = item.get("question", "(missing question)")
+    default = item.get("plan_assumption", "(no default proposed)")
+    alternatives = item.get("alternatives") or []
+    why = item.get("why_it_matters", "")
+
+    lines = [
+        f"### A{idx}. {question}",
+        "",
+    ]
+    if auto_accept:
+        lines.append(f"**Decision:** accept plan default — _{default}_.")
+    else:
+        lines.append(f"**Plan default:** _{default}_.")
+        lines.append("")
+        lines.append("**Decision:** _<accept default | choose alternative | other>_")
+        if alternatives:
+            lines.append("")
+            lines.append("Alternatives surfaced by the plan:")
+            lines.extend(f"- {alt}" for alt in alternatives)
+    if why:
+        lines.append("")
+        lines.append(f"_Why it matters: {why}_")
+    return "\n".join(lines)
+
+
+def _render_premise(idx: int, item: dict[str, Any], auto_accept: bool) -> str:
+    # Producer emits two shapes today. Pre-verification (Plan Soundness output
+    # surfaced before the human dispositions it) uses "premise" / "verify_by".
+    # Post-verification (Plan Soundness's already-checked verdict) uses
+    # "claim" / "verified" / "resolution". We render both.
+    title = item.get("premise") or item.get("claim") or "(missing premise)"
+    verified = item.get("verified")
+    resolution = item.get("resolution", "")
+    depends_on = item.get("plan_depends_on_it_for", "")
+    evidence = item.get("evidence_in_ticket") or item.get("evidence", "")
+    verify_by = item.get("verify_by", "")
+
+    lines = [
+        f"### P{idx}. {title}",
+        "",
+    ]
+    if verified is not None:
+        # Post-verification shape: surface the verdict + the proposed resolution.
+        lines.append(f"**Verified:** {verified}")
+        if resolution:
+            lines.append("")
+            lines.append(f"**Resolution:** _<{resolution}>_")
+    elif auto_accept:
+        lines.append(
+            "**Verification:** accepted — premise treated as true for re-dispatch."
+        )
+    else:
+        lines.append(
+            "**Verification:** _<verified | falsified | partially-true | unknown>_"
+        )
+        if verify_by:
+            lines.append("")
+            lines.append(f"_Verify by: {verify_by}_")
+    if depends_on:
+        lines.append("")
+        lines.append(f"_Plan depends on this for: {depends_on}_")
+    if evidence:
+        lines.append("")
+        lines.append(f"_Evidence: {evidence}_")
+    return "\n".join(lines)
+
+
+def render(payload: dict[str, Any], *, auto_accept: bool) -> str:
+    ambiguities = payload.get("ambiguities") or []
+    premises = payload.get("premises") or []
+    sections: list[str] = [_DECISIONS_HEADING, ""]
+
+    if ambiguities:
+        sections.append("### Ambiguities")
+        sections.append("")
+        for idx, item in enumerate(ambiguities, start=1):
+            sections.append(_render_ambiguity(idx, item, auto_accept))
+            sections.append("")
+
+    if premises:
+        sections.append("### Premises")
+        sections.append("")
+        for idx, item in enumerate(premises, start=1):
+            sections.append(_render_premise(idx, item, auto_accept))
+            sections.append("")
+
+    if not ambiguities and not premises:
+        sections.append(
+            "_No ambiguities or premises in the sentinel — nothing to disposition._"
+        )
+
+    return "\n".join(sections).rstrip() + "\n"
+
+
+def _load_payload(args: argparse.Namespace) -> dict[str, Any]:
+    if args.input:
+        with open(args.input, encoding="utf-8") as handle:
+            data = json.load(handle)
+    else:
+        data = json.load(sys.stdin)
+
+    if not isinstance(data, dict):
+        sys.stderr.write("expected a JSON object on input\n")
+        raise SystemExit(2)
+
+    # Accept either the parse_sentinel.py output wrapper or a bare raw payload.
+    if "raw_payload" in data:
+        raw = data["raw_payload"]
+        if not isinstance(raw, dict):
+            sys.stderr.write("raw_payload is missing or not an object\n")
+            raise SystemExit(2)
+        return raw
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        help="Path to JSON file (default: read from stdin).",
+    )
+    parser.add_argument(
+        "--auto-accept-defaults",
+        action="store_true",
+        help="Auto-accept the plan default for every ambiguity / premise.",
+    )
+    args = parser.parse_args()
+
+    payload = _load_payload(args)
+    sys.stdout.write(render(payload, auto_accept=args.auto_accept_defaults))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #188. Adds a project-local skill at `.claude/skills/cw-followup/` that performs the matching post-run action for any completed `/auto-dev` session given a session id, ticket id, or transcript path.

Replaces the seven manual followup workflows the dogfood-forward sessions on 2026-05-23 exercised by hand (`shipped` / `no_op` / `merge_gate_blocked` / `ambiguities_pending_resolution` / `premises_pending_verification` / `blocked` / `review_pending_approval`).

## Contents

- **`SKILL.md`** — branch table per `effective_status` with the exact commands for each path (no_op close with citation, merge_gate_blocked rebase + force-push + PR, ambiguities/premises render + ticket-body append, real-blocker surfacing, etc.).
- **`scripts/parse_sentinel.py`** — resolves `--session-id` / `--ticket-id` / `--transcript-path` to a JSONL transcript, walks each assistant text block, parses the LAST sentinel via `cw.auto_dev_result.parse_stdout` (the production parser — never reimplement). Emits both the validated result and the raw payload, so producer-emitted statuses not yet in the `Status` Literal remain reachable downstream.
- **`scripts/render_decisions.py`** — renders a `## Decisions` markdown section from ambiguities + premises arrays. Handles both producer shapes observed today: pre-verification (Plan Soundness output before disposition — `premise` / `verify_by`) and post-verification (`claim` / `verified` / `resolution`). `--auto-accept-defaults` for the bulk-accept path.
- **`references/no-sentinel-patterns.md`** — diagnostic table for the no-sentinel case (Step 1 mid-dispatch, Stop-hook orphan, tool denial deadlock, pre-flight no_op without emit, process killed externally).

## Dogfood findings (noted, not fixed here)

Building the skill surfaced two real producer/consumer drift issues. Noted in the commit body, to be filed as separate tickets:

1. `/auto-dev` producer emits `plan_source="github_issue_existing"`; the parser enum only knows `linear_existing | generated | free_text | none`. Today this routes through `BlockedResult` with `reason=validation_failed` (observed against #136).
2. `/auto-dev` producer emits statuses `premises_pending_verification` and `ambiguities_pending_resolution` that aren't in the `Status` Literal; today they route through `BlockedResult` with `reason=status_unknown` (observed against #141 / #185).

The skill works around both by reading the raw payload — but the parser should catch up with the producer eventually.

## Test plan

- [x] `uv run ruff check .claude/skills/cw-followup/scripts/` — zero violations
- [x] `uv run mypy .claude/skills/cw-followup/scripts/` — zero type errors
- [x] `uv run pytest tests/ -q` — 860 passing
- [x] Dogfood: `parse_sentinel.py --ticket-id 136` correctly identifies `effective_status=no_op` with the satisfying PR pointer in friction
- [x] Dogfood: `parse_sentinel.py --ticket-id 185 | render_decisions.py` renders 4 ambiguities + 1 premise (pre-verification shape) cleanly
- [x] Dogfood: `parse_sentinel.py --ticket-id 141 | render_decisions.py` renders 2 premises (post-verification shape) cleanly
- [x] Dogfood: `parse_sentinel.py --session-id 89e5a50a` resolves correctly via short id

## Related

- #172 — `/cw-validate-result` (sibling skill, parses sentinel for any past session — shares this parser)
- #171 — `/cw-smoke-test` (consumes followup as the post-dispatch step)
- #182 / #183 — `tool_denied` recovery and classifier non-determinism (inform the retry-with-delay default)
- #184 / #174 — Blocker field expansion (Phase E adds `retry_eligible` / `recovery_hint` — skill will key off them when they land)
- #187 — `/cw-fanout` (re-dispatch at N>1 after followup prepares the ground)

🤖 Built via dogfood loop against handoff `session-2026-05-23-1638.md`