### PR TITLE
feat(skill): /cw-validate-result — forensic sentinel validator (#172)

### DIFF
--- a/.claude/skills/cw-validate-result/SKILL.md
+++ b/.claude/skills/cw-validate-result/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: cw-validate-result
+description: Inspect what a cw-dispatched /auto-dev session actually did — locate its transcript, extract the AUTO_DEV_RESULT sentinel, validate against the headless contract, and print a clear PASS/FAIL with what the run shipped, blocked on, or skipped. Use when the user asks "what happened on session X", "did #N actually ship", "validate the headless result", "why did /auto-dev exit", or wants any forensic read on a completed auto-dev run.
+---
+
+# cw-validate-result
+
+Forensic validator for a finished `/auto-dev` session. Answers "what actually happened" with concrete PASS/FAIL rows instead of a vague "looks blocked".
+
+This is the diagnostic surface. For taking action on the result, hand off to `/cw-followup`.
+
+## When to use
+
+- A `/auto-dev` session finished but the worker session's `last_result` is null.
+- The user asks "did session X actually ship the thing".
+- A run looks blocked and the cause is unclear — what failure mode hit?
+- After a meta-test spray, when you need to triage N sessions in parallel without acting on any of them yet.
+
+## Inputs
+
+One of:
+- `--session-id <SHORT>` — short cw session id (prefix match allowed).
+- `--ticket-id <N>` — most recent session matching the ticket.
+- `--transcript-path <PATH>` — direct path to a Claude JSONL transcript (for off-machine or archived runs).
+
+## How it works
+
+Runs the bundled validator script:
+
+```bash
+uv run --project /home/matthew/workspace/personal/claude-workspace python \
+  .claude/skills/cw-validate-result/scripts/validate_sentinel.py \
+  --ticket-id <N>
+```
+
+The script delegates transcript resolution + sentinel parsing to the `/cw-followup` skill's `parse_sentinel.py` (single source of truth — never re-implement). On top of that, it walks the headless-contract checklist and emits PASS/FAIL per row.
+
+## Outcomes
+
+The script reports one of four `outcome` values. Treat each differently:
+
+| `outcome` | Meaning | Exit |
+|---|---|---|
+| `valid` | Sentinel parsed cleanly as a canonical `AutoDevResult` | 0 |
+| `producer_status_unknown` | Sentinel present, but the producer emitted a status not yet in the parser's enum (e.g. `premises_pending_verification`). Treat as a real outcome the human should act on. | 0 |
+| `invalid_sentinel` | Sentinel present but schema validation failed. Producer/consumer drift — report it. | 1 |
+| `no_sentinel` | No sentinel block in the transcript — the run exited before emitting. Diagnose via `references/no-sentinel-patterns.md`. | 1 |
+
+## Checks
+
+Each output row is one of:
+
+| Check | What it verifies |
+|---|---|
+| `sentinel_emitted` | At least one assistant text block contained the sentinel pair. |
+| `status_is_canonical` | `effective_status` is one of the 8 canonical `Status` Literal values. Failing this with `outcome=producer_status_unknown` is expected today; failing it with other outcomes is a bug. |
+| `health_present` | `health` carries `lowest_agent_confidence`, `any_incomplete_risk`, `recommendation`. |
+| `blocker_iff_blocked` | Cross-field invariant from §3.3: `blocker` non-null iff `status=blocked`. |
+| `pr_iff_shipped` | Cross-field invariant: `pr` non-null iff `status=shipped`. |
+| `wait_for_ci_iff_shipped` | Cross-field invariant from §4.3: `wait_for_ci` in `next_actions` iff `status=shipped`. |
+
+## Reporting
+
+After running the validator, print:
+
+1. The `outcome` (one of the four above).
+2. The `effective_status` and the session's worktree path.
+3. Any failing checks with their `detail` fields.
+4. The `next_actions` array verbatim — these are the producer's own follow-up hints.
+
+Keep it tight — caveman style:
+
+```
+session 76f060e7 (#185): outcome=producer_status_unknown, status=premises_pending_verification
+  - status_is_canonical: FAIL (premises_pending_verification not in Status enum)
+  next_actions: ['resolve_premises', 're_dispatch_after_disposition']
+```
+
+If outcome is `valid` or `producer_status_unknown` and the user wants to act on the result, suggest `/cw-followup --session-id <SHORT>`.
+
+If outcome is `no_sentinel`, read `references/no-sentinel-patterns.md` and surface the most likely cause based on what the transcript tail looks like.
+
+If outcome is `invalid_sentinel`, surface the validation error verbatim — the parser's `BlockedResult.blocker.details` carries it.
+
+## Out of scope
+
+- Performing post-run actions — that's `/cw-followup`.
+- Re-dispatching — that's `cw spawn --headless` or `cw dev-queue add`.
+- Modifying the sentinel schema — surfacing drift is in scope, fixing the parser is a separate ticket (#190, #191 surfaced via dogfood today).
+
+## Related
+
+- #188 / PR #189 — `/cw-followup` (companion skill; owns `parse_sentinel.py`)
+- #171 — `/cw-smoke-test` (end-to-end dogfood; uses this validator as its check step)
+- #117 / #140 — sentinel parsing / schema migration (this skill rides on top of whatever schema is current)
+- #190 / #191 — producer/consumer drift surfaced through dogfood; will reduce the `producer_status_unknown` / `invalid_sentinel` outcomes when fixed

--- a/.claude/skills/cw-validate-result/references/no-sentinel-patterns.md
+++ b/.claude/skills/cw-validate-result/references/no-sentinel-patterns.md
@@ -1,0 +1,13 @@
+# No-sentinel patterns
+
+When `validate_sentinel.py` reports `outcome=no_sentinel`, the `/auto-dev` run exited before emitting `<<<AUTO_DEV_RESULT ... AUTO_DEV_RESULT>>>`. Same diagnostic table as the `/cw-followup` skill — see `../../cw-followup/references/no-sentinel-patterns.md`.
+
+Quick reference (most common to least):
+
+1. **Step 1 mid-dispatch failure** — Plan Quality sub-agent spawned, parent's Stop hook fired first. Issues #175 / #176; fixed by serial-headless landing in `global-claude` `82e2e02`.
+2. **Stop-hook orphan with no `background_tasks`** — agent stalled mid-turn (often waiting on a tool denial), Stop hook never fires, JSONL just ends. Issue #185.
+3. **Pre-flight `no_op` exit without emit** — skill detected ticket already satisfied and exited before reaching the sentinel emit step. Producer bug — should always emit `no_op` here.
+4. **Tool denial deadlock** — tool call denied, skill stalls indefinitely. Issue #182. Catch via Layer 1 30-min `TIMED_OUT` backstop (PR #179).
+5. **Process killed externally** — disconnect, OOM, manual SIGKILL. JSONL truncated mid-write.
+
+Diagnosis: pull the last few assistant turns from the transcript and check whether the agent was mid-tool-call when the JSONL ended (orphan-style) versus emitted normal text and just stopped short of the sentinel (emit-step skipped).

--- a/.claude/skills/cw-validate-result/scripts/validate_sentinel.py
+++ b/.claude/skills/cw-validate-result/scripts/validate_sentinel.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Forensic validator for a cw-dispatched /auto-dev session's AUTO_DEV_RESULT.
+
+Wraps the cw-followup skill's ``parse_sentinel.py`` to resolve and parse the
+sentinel, then walks the headless-contract checklist and emits a PASS/FAIL
+summary per row. Distinguishes the four important outcomes:
+
+- ``no_sentinel`` — the run exited without emitting a sentinel at all
+- ``invalid_sentinel`` — the sentinel was present but failed schema validation
+- ``producer_status_unknown`` — the parser couldn't type the producer's status
+- ``valid`` — the sentinel parsed cleanly
+
+Output is one JSON object on stdout with ``outcome``, ``checks`` (list of rows
+with ``name``, ``passed``, ``detail``), and the embedded parser output. Exit
+code reflects the outcome: 0 on ``valid`` or ``producer_status_unknown`` (the
+run finished and emitted something usable), 1 on ``no_sentinel`` or
+``invalid_sentinel`` (the run did not produce a usable result).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_SKILL_DIR = Path(__file__).resolve().parents[1]
+# cw-followup's parse_sentinel lives in a sibling skill — it owns transcript
+# resolution + parsing so we don't reimplement either.
+_PARSE_SCRIPT = _SKILL_DIR.parent / "cw-followup" / "scripts" / "parse_sentinel.py"
+_REPO_ROOT = _SKILL_DIR.parents[2]
+
+
+def _run_parser(args: list[str]) -> dict[str, Any]:
+    """Shell out to cw-followup's parse_sentinel.py with the given args.
+
+    Uses ``uv run`` against the cw repo so the parser's import of
+    ``cw.auto_dev_result`` resolves the same way the production code does.
+    """
+    cmd = [
+        "uv",
+        "run",
+        "--project",
+        str(_REPO_ROOT),
+        "python",
+        str(_PARSE_SCRIPT),
+        *args,
+    ]
+    completed = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        sys.stderr.write(completed.stderr)
+        raise SystemExit(completed.returncode)
+    try:
+        parsed: Any = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"could not parse parse_sentinel.py stdout: {exc}\n")
+        raise SystemExit(2) from exc
+    if not isinstance(parsed, dict):
+        sys.stderr.write("parse_sentinel.py emitted a non-object\n")
+        raise SystemExit(2)
+    return parsed
+
+
+def _outcome(parser_output: dict[str, Any]) -> str:
+    if not parser_output.get("sentinel_found"):
+        return "no_sentinel"
+    kind = parser_output.get("result_kind")
+    if kind == "AutoDevResult":
+        return "valid"
+    result = parser_output.get("result") or {}
+    blocker = result.get("blocker") or {}
+    reason = blocker.get("reason")
+    if reason == "status_unknown":
+        return "producer_status_unknown"
+    return "invalid_sentinel"
+
+
+def _check(name: str, passed: bool, detail: str = "") -> dict[str, Any]:
+    return {"name": name, "passed": passed, "detail": detail}
+
+
+def _build_checks(parser_output: dict[str, Any], outcome: str) -> list[dict[str, Any]]:
+    raw = parser_output.get("raw_payload") or {}
+    result = parser_output.get("result") or {}
+    checks: list[dict[str, Any]] = []
+
+    checks.append(
+        _check(
+            "sentinel_emitted",
+            outcome != "no_sentinel",
+            f"assistant_blocks_scanned={parser_output.get('assistant_blocks_scanned')}",
+        ),
+    )
+
+    canonical_statuses = {
+        "shipped",
+        "plan_pending_approval",
+        "review_pending_approval",
+        "merge_gate_blocked",
+        "scope_exceeded",
+        "forbidden_area",
+        "blocked",
+        "no_op",
+    }
+    effective_status = raw.get("status") or result.get("status")
+    checks.append(
+        _check(
+            "status_is_canonical",
+            effective_status in canonical_statuses,
+            f"effective_status={effective_status!r}",
+        ),
+    )
+
+    result_kind = parser_output.get("result_kind")
+    blocker_reason = ((result.get("blocker") or {}) or {}).get("reason")
+    checks.append(
+        _check(
+            "schema_validates",
+            result_kind == "AutoDevResult",
+            f"result_kind={result_kind!r}, blocker_reason={blocker_reason!r}",
+        ),
+    )
+
+    health = raw.get("health") or {}
+    expected_health = {
+        "lowest_agent_confidence",
+        "any_incomplete_risk",
+        "recommendation",
+    }
+    health_keys = set(health) if isinstance(health, dict) else set()
+    checks.append(
+        _check(
+            "health_present",
+            expected_health.issubset(health_keys),
+            f"missing={sorted(expected_health - health_keys)}",
+        ),
+    )
+
+    blocker = raw.get("blocker")
+    is_blocked = effective_status == "blocked"
+    blocker_present = blocker is not None
+    blocker_invariant = (is_blocked and blocker_present) or (
+        not is_blocked and not blocker_present
+    )
+    checks.append(
+        _check(
+            "blocker_iff_blocked",
+            blocker_invariant,
+            f"is_blocked={is_blocked}, blocker_present={blocker_present}",
+        ),
+    )
+
+    pr = raw.get("pr")
+    is_shipped = effective_status == "shipped"
+    checks.append(
+        _check(
+            "pr_iff_shipped",
+            (is_shipped and pr is not None) or (not is_shipped and pr is None),
+            f"is_shipped={is_shipped}, pr_present={pr is not None}",
+        ),
+    )
+
+    next_actions = raw.get("next_actions") or []
+    wait_present = "wait_for_ci" in next_actions
+    checks.append(
+        _check(
+            "wait_for_ci_iff_shipped",
+            (is_shipped and wait_present) or (not is_shipped and not wait_present),
+            f"is_shipped={is_shipped}, wait_for_ci_present={wait_present}",
+        ),
+    )
+
+    return checks
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--session-id")
+    source.add_argument("--ticket-id")
+    source.add_argument("--transcript-path")
+    args = parser.parse_args()
+
+    parser_args: list[str] = []
+    if args.session_id:
+        parser_args = ["--session-id", args.session_id]
+    elif args.ticket_id:
+        parser_args = ["--ticket-id", args.ticket_id]
+    elif args.transcript_path:
+        parser_args = ["--transcript-path", args.transcript_path]
+
+    parser_output = _run_parser(parser_args)
+    outcome = _outcome(parser_output)
+    checks = _build_checks(parser_output, outcome)
+
+    summary = {
+        "outcome": outcome,
+        "checks": checks,
+        "session": parser_output.get("session"),
+        "transcript_path": parser_output.get("transcript_path"),
+        "effective_status": (parser_output.get("raw_payload") or {}).get("status")
+        or (parser_output.get("result") or {}).get("status"),
+        "next_actions": (parser_output.get("raw_payload") or {}).get("next_actions")
+        or [],
+    }
+    sys.stdout.write(json.dumps(summary, indent=2) + "\n")
+    return 0 if outcome in {"valid", "producer_status_unknown"} else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #172. Companion to `/cw-followup` (#188 / PR #189). Where followup acts on the result, this skill answers **"what actually happened"** — locates the JSONL transcript, parses the sentinel, walks the headless-contract checklist, and emits a PASS/FAIL summary.

## Architecture

`validate_sentinel.py` shells out to `/cw-followup`'s `parse_sentinel.py` for transcript resolution + parsing (single source of truth), then layers checklist evaluation on top. No code duplication between the two skills.

## Outcomes distinguished

| Outcome | Meaning |
|---|---|
| `valid` | Sentinel parses cleanly as canonical `AutoDevResult`. |
| `producer_status_unknown` | Sentinel present but emits a status not in the parser's Literal (e.g. `premises_pending_verification` — see #191). |
| `invalid_sentinel` | Sentinel present but schema validation fails (e.g. `plan_source='github_issue_existing'` — see #190). |
| `no_sentinel` | Run exited before emitting. Diagnose via the reference doc. |

## Checks emitted per row

- `sentinel_emitted` — at least one assistant text block contained the sentinel pair
- `status_is_canonical` — `effective_status` is in the 8-value `Status` Literal
- `schema_validates` — parsed to `AutoDevResult` (not `BlockedResult`)
- `health_present` — `health` carries `lowest_agent_confidence`, `any_incomplete_risk`, `recommendation`
- `blocker_iff_blocked` — §3.3 cross-field invariant
- `pr_iff_shipped` — §3.3 cross-field invariant
- `wait_for_ci_iff_shipped` — §4.3 cross-field invariant

## Test plan

- [x] `uv run ruff check .claude/skills/cw-validate-result/scripts/` — zero violations
- [x] `uv run mypy .claude/skills/cw-validate-result/scripts/` — zero type errors
- [x] `uv run pytest tests/ -q` — 860 passing
- [x] Dogfood #136 → outcome=`invalid_sentinel`, `schema_validates: FAIL (blocker_reason=validation_failed)` correctly surfaces #190
- [x] Dogfood #185 → outcome=`producer_status_unknown`, `status_is_canonical: FAIL (premises_pending_verification)` correctly surfaces #191
- [x] Dogfood #141 → same as #185 (post-verification premises shape)

## Related

- #188 / PR #189 — /cw-followup (companion skill)
- #190 / #191 — producer/consumer drift surfaced through dogfood today
- #171 — /cw-smoke-test (will use this as the check step in the end-to-end test)