### PR TITLE
feat(contract): expand Blocker for orchestrator routing + retry semantics (#174 Phase B+E)

### DIFF
--- a/docs/headless-contract.md
+++ b/docs/headless-contract.md
@@ -171,8 +171,25 @@ The `status` field is a closed set. Consumers MUST treat unknown statuses as a p
 
 ### 4.2 `blocker.reason` (when `status = "blocked"`)
 
+Minimum shape (v1+):
+
 ```json
 {"stage": "stage2_impl", "reason": "agent_block", "details": "<verbatim blocker text>"}
+```
+
+Full v3 shape with Phase B and Phase E fields (issue #174):
+
+```json
+{
+  "stage": "stage4a_merge_gate",
+  "reason": "ci_timeout",
+  "details": "<verbatim blocker text>",
+  "exception_type": "CITimeoutError",
+  "message": "CI did not complete within 30 minutes",
+  "recovery_hint": "Re-dispatch after CI watchers settle",
+  "retry_eligible": true,
+  "retry_delay_seconds": 120
+}
 ```
 
 | Reason | Meaning |
@@ -182,6 +199,28 @@ The `status` field is a closed set. Consumers MUST treat unknown statuses as a p
 | `agent_block` | Any other agent returned friction level BLOCK that the pipeline could not auto-resolve. |
 
 `blocker.reason` is an **open enum** — the producer may add new reasons without a `schema_version` bump. Consumers MUST treat unknown reasons as opaque strings and surface verbatim. (Unlike `status`, which is closed: see §4 and §8.)
+
+#### Phase B fields (orchestrator routing context)
+
+| Field | Type | Notes |
+|---|---|---|
+| `exception_type` | string \| null | Producer-side exception class name when the blocker originated from a raised exception. Free-form; consumers surface verbatim. |
+| `message` | string \| null | Single-line summary of the blocker suitable for notification text. Distinct from `details` (which is verbatim multi-line context). |
+| `recovery_hint` | string \| null | Producer's suggestion for the recovery action — typically what the human or orchestrator should try next. Free-form text. |
+
+All three are optional. Producers SHOULD populate them when the underlying failure has a structured exception; they MAY remain null for blocker reasons that don't map to an exception (e.g. soft-blocks like `review_blocked`).
+
+#### Phase E fields (queue-aware retry semantics)
+
+| Field | Type | Notes |
+|---|---|---|
+| `retry_eligible` | bool \| null | `true` when the orchestrator MAY re-dispatch this ticket without human intervention. `false` when human review is required (MUST_FIX persistence, scope ambiguity, etc.). `null` means the producer didn't commit either way — consumer defaults to human escalation. |
+| `retry_delay_seconds` | int \| null | Suggested backoff before re-dispatch when `retry_eligible=true`. Non-negative. Set to `null` to mean "no specific delay required". Invariant: a non-null `retry_delay_seconds` REQUIRES `retry_eligible=true`. |
+
+The pair encodes three policies:
+- **Retry now**: `retry_eligible=true`, `retry_delay_seconds=null` — transient or no-backoff failures.
+- **Retry after delay**: `retry_eligible=true`, `retry_delay_seconds=N` — CI timeouts, classifier non-determinism (issue #183), rate-limit hits.
+- **Human required**: `retry_eligible=false`, `retry_delay_seconds=null` — semantic blockers where another try with the same input won't help.
 
 ### 4.3 `next_actions` Vocabulary
 

--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -120,11 +120,45 @@ class Blocker(BaseModel):
     ``reason`` is intentionally typed as ``str`` (open enum per §4.2). The
     producer may add new reasons without a schema bump; consumers surface
     unknown reasons verbatim.
+
+    Phase B and Phase E of the queue-orchestrator observability expansion
+    (issue #174) added five optional fields. All default to None so v1/v2
+    blocks without them parse unchanged; producers emitting v3 should
+    populate them per the headless-contract spec.
     """
 
     stage: str
     reason: str
     details: str = ""
+    # Phase B — blocker context for orchestrator routing.
+    exception_type: str | None = None
+    message: str | None = None
+    recovery_hint: str | None = None
+    # Phase E — queue-aware retry semantics. ``retry_eligible=True`` paired
+    # with a non-null ``retry_delay_seconds`` means the orchestrator can
+    # safely re-dispatch after the given backoff. ``retry_eligible=False``
+    # means human intervention is required.
+    retry_eligible: bool | None = None
+    retry_delay_seconds: int | None = None
+
+    @model_validator(mode="after")
+    def _check_retry_invariants(self) -> Blocker:
+        # If retry_delay_seconds is set, retry_eligible must be True. The
+        # reverse is allowed — a producer can mark retry_eligible without
+        # committing to a specific backoff.
+        if self.retry_delay_seconds is not None and self.retry_eligible is not True:
+            msg = (
+                "retry_delay_seconds set without retry_eligible=True "
+                f"(got retry_eligible={self.retry_eligible!r})"
+            )
+            raise ValueError(msg)
+        if self.retry_delay_seconds is not None and self.retry_delay_seconds < 0:
+            msg = (
+                f"retry_delay_seconds must be non-negative, "
+                f"got {self.retry_delay_seconds}"
+            )
+            raise ValueError(msg)
+        return self
 
 
 _TERMINAL_REJECT_STATUSES: frozenset[Status] = frozenset(

--- a/tests/test_auto_dev_result.py
+++ b/tests/test_auto_dev_result.py
@@ -561,6 +561,107 @@ class TestInvariants:
 
 
 # ---------------------------------------------------------------------------
+# Phase B + E — Blocker context and retry semantics (#174)
+# ---------------------------------------------------------------------------
+
+
+class TestBlockerPhaseBE:
+    def test_v2_block_without_new_fields_still_parses(self) -> None:
+        """Back-compat: producers on v1/v2 emit no new fields; parser accepts."""
+        p = _blocked_payload()
+        result = AutoDevResult.model_validate(p)
+        assert isinstance(result.blocker, type(result.blocker))
+        assert result.blocker is not None
+        assert result.blocker.exception_type is None
+        assert result.blocker.message is None
+        assert result.blocker.recovery_hint is None
+        assert result.blocker.retry_eligible is None
+        assert result.blocker.retry_delay_seconds is None
+
+    def test_phase_b_fields_round_trip(self) -> None:
+        p = _blocked_payload()
+        p["blocker"].update(
+            {
+                "exception_type": "PlanValidationError",
+                "message": (
+                    "Plan contains MUST_FIX findings that persist after revision"
+                ),
+                "recovery_hint": "Manual review required; update plan and retry",
+            },
+        )
+        result = AutoDevResult.model_validate(p)
+        assert result.blocker is not None
+        assert result.blocker.exception_type == "PlanValidationError"
+        assert "MUST_FIX" in (result.blocker.message or "")
+        assert "Manual review" in (result.blocker.recovery_hint or "")
+
+    def test_phase_e_retry_eligible_with_delay(self) -> None:
+        p = _blocked_payload()
+        p["blocker"].update(
+            {
+                "reason": "ci_timeout",
+                "retry_eligible": True,
+                "retry_delay_seconds": 120,
+            },
+        )
+        result = AutoDevResult.model_validate(p)
+        assert result.blocker is not None
+        assert result.blocker.retry_eligible is True
+        assert result.blocker.retry_delay_seconds == 120
+
+    def test_phase_e_retry_ineligible_no_delay(self) -> None:
+        p = _blocked_payload()
+        p["blocker"].update(
+            {
+                "reason": "plan_unreviewable",
+                "retry_eligible": False,
+                "retry_delay_seconds": None,
+            },
+        )
+        result = AutoDevResult.model_validate(p)
+        assert result.blocker is not None
+        assert result.blocker.retry_eligible is False
+        assert result.blocker.retry_delay_seconds is None
+
+    def test_retry_delay_without_eligible_rejected(self) -> None:
+        # A delay only makes sense when the orchestrator is allowed to retry.
+        p = _blocked_payload()
+        p["blocker"].update(
+            {"retry_eligible": False, "retry_delay_seconds": 30},
+        )
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_retry_delay_negative_rejected(self) -> None:
+        p = _blocked_payload()
+        p["blocker"].update(
+            {"retry_eligible": True, "retry_delay_seconds": -5},
+        )
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_phase_b_and_e_together_on_v3_block(self) -> None:
+        p = _blocked_payload()
+        p["schema_version"] = 3
+        p["blocker"].update(
+            {
+                "reason": "ci_timeout",
+                "exception_type": "CITimeoutError",
+                "message": "CI did not complete within 30 minutes",
+                "recovery_hint": "Re-dispatch with a 2-minute delay",
+                "retry_eligible": True,
+                "retry_delay_seconds": 120,
+            },
+        )
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.blocker is not None
+        assert result.blocker.exception_type == "CITimeoutError"
+        assert result.blocker.retry_eligible is True
+        assert result.blocker.retry_delay_seconds == 120
+
+
+# ---------------------------------------------------------------------------
 # stage1_pre_flight + plan_source=none (v3, with v2 backward-compat exception)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Lands Phase B and Phase E of #174 — the two phases that share the \`Blocker\` struct. Phase C (agent health aggregation) and Phase D (pre-merge PR visibility) tracked separately under #174.

Adds 5 optional fields to \`AutoDevResult.Blocker\`:

**Phase B — orchestrator routing context:**
- \`exception_type\` — producer-side exception class name
- \`message\` — single-line summary suitable for notifications
- \`recovery_hint\` — producer's suggestion for recovery

**Phase E — queue-aware retry semantics:**
- \`retry_eligible\` — bool gating whether orchestrator MAY re-dispatch
- \`retry_delay_seconds\` — backoff hint when \`retry_eligible=true\`

## Invariants

One new cross-field invariant on \`Blocker\`: a non-null \`retry_delay_seconds\` REQUIRES \`retry_eligible=true\`. The reverse is allowed — a producer can mark \`retry_eligible\` without committing to a specific delay. \`retry_delay_seconds\` must be non-negative.

The three retry policies encoded by the pair:
- **Retry now**: \`retry_eligible=true\`, \`retry_delay_seconds=null\`
- **Retry after delay**: \`retry_eligible=true\`, \`retry_delay_seconds=N\`
- **Human required**: \`retry_eligible=false\`, \`retry_delay_seconds=null\`

## Back-compat

All five fields are optional with \`None\` defaults. Existing v1/v2 blocks without them parse unchanged. \`schema_version\` stays in the existing \`{1, 2, 3}\` accepted set — producers SHOULD emit v3 going forward when populating Phase B/E fields.

## What this unblocks

- **#184** (PushNotification on \`tool_denied\`) — \`signal_stop\` can now inspect \`blocker.retry_eligible\` inline to decide escalate vs. silent-retry.
- **\`/cw-followup\`** (PR #189 / #188) — the \`blocked\` branch can now key off \`retry_eligible\` instead of hardcoding per-\`reason\` retry policy.
- **Future SDK orchestrator** (#117 / #140) — when the SDK dispatcher lands, the orchestrator already has structured retry hints to consume.

## Test plan

- [x] \`uv run ruff check src/cw/auto_dev_result.py tests/test_auto_dev_result.py\` — zero violations
- [x] \`uv run mypy src/cw/\` — zero type errors (29 files)
- [x] \`uv run pytest tests/ -q\` — 867 passing (was 860; +7 new tests)
- [x] v1/v2 block without new fields still parses (back-compat)
- [x] Phase B fields round-trip
- [x] Phase E retry-eligible-with-delay and retry-ineligible-no-delay
- [x] \`retry_delay_seconds\` without \`retry_eligible=true\` is rejected
- [x] Negative \`retry_delay_seconds\` is rejected
- [x] Phase B and E together on a v3 block via full sentinel round-trip

## Doc updates

\`docs/headless-contract.md\` §4.2:
- Minimum Blocker shape (v1+)
- Full v3 shape with all new fields
- Sub-tables for Phase B and Phase E fields
- Three policy combinations encoded by the \`retry_eligible\` / \`retry_delay_seconds\` pair

## Out of scope

- **Producer-side emit changes** (\`/auto-dev\` skill in global-claude) — separate PR.
- **Phase C** (agent health aggregation) — same umbrella ticket, different surface.
- **Phase D** (pre-merge PR visibility) — same umbrella ticket, larger behavioral change.