### PR TITLE
fix(parser): accept plan_source 'github_issue_existing' (#190)

### DIFF
--- a/docs/headless-contract.md
+++ b/docs/headless-contract.md
@@ -136,7 +136,7 @@ The skill emits **exactly one** sentinel block per invocation. If the parser fin
 | `scope.lines_estimate` | int | Plan-time line estimate. |
 | `scope.lines_actual` | int \| null | Actual lines touched; `null` if exited before impl. |
 | `scope.forbidden_touched` | bool | Whether any `--forbidden` area was touched. |
-| `plan_source` | `"linear_existing"` \| `"generated"` \| `"free_text"` \| `"none"` | How the plan was sourced. `"none"` is used for pre-flight exits where no plan was produced. |
+| `plan_source` | `"linear_existing"` \| `"github_issue_existing"` \| `"generated"` \| `"free_text"` \| `"none"` | How the plan was sourced. `"linear_existing"` and `"github_issue_existing"` are equivalent (the latter is the post-Linear, GitHub-Issues-era label — producers should emit whichever matches their tracker). `"none"` is used for pre-flight exits where no plan was produced. |
 | `branch` | string \| null | Branch name; `null` if exited before branch creation (e.g. `plan_pending_approval`). |
 | `worktree_path` | string \| null | Absolute path; `null` if no worktree was created. |
 | `fork_point_sha` | string \| null | Base commit at branch creation. |
@@ -314,7 +314,7 @@ Until then, cw must treat all non-terminal exits as fully manual recovery: the u
 |---|---|
 | 1 | Initial contract. |
 | 2 | Added `no_op` status (§4.1) and `close_issue_as_completed` advisory action (§4.3). v1-tagged payloads with `status=no_op` are rejected as `validation_failed`. |
-| 3 | Added `stage1_pre_flight` value to `stage_reached` enum (§3.3) and `none` value to `plan_source` enum (§3.3). Used together for pre-flight no_op exits. Parsers also accept this pair under v2 as a one-time rollout exception (the skill emitted them at v2 before the parser caught up — see #103). |
+| 3 | Added `stage1_pre_flight` value to `stage_reached` enum (§3.3) and `none` value to `plan_source` enum (§3.3). Used together for pre-flight no_op exits. Parsers also accept this pair under v2 as a one-time rollout exception (the skill emitted them at v2 before the parser caught up — see #103). Also added `github_issue_existing` to `plan_source` (the post-Linear analog of `linear_existing`; treated identically). Accepted under v2 and v3 — same rollout-exception treatment, since the producer emits this value at v2 today (see #190). |
 
 **Bump required when:**
 - Any field is removed or renamed.
@@ -327,7 +327,7 @@ Until then, cw must treat all non-terminal exits as fully manual recovery: the u
 - A new `next_actions` entry is added (parsers already treat unknown actions as advisory).
 - A new `blocker.reason` value is added (open enum — see §4.2).
 
-**Cross-version status compatibility:** A status introduced at version N is invalid under any `schema_version < N`. Parsers MUST reject mismatched payloads (e.g., v1 + `no_op` → `validation_failed`). **Exception (one-time):** `stage_reached='stage1_pre_flight'` and `plan_source='none'` are accepted under both v2 and v3. This is documented under v3 in the table above; the v2 acceptance covers in-flight skill emissions that predate the parser's v3 awareness.
+**Cross-version status compatibility:** A status introduced at version N is invalid under any `schema_version < N`. Parsers MUST reject mismatched payloads (e.g., v1 + `no_op` → `validation_failed`). **Exception (one-time):** `stage_reached='stage1_pre_flight'`, `plan_source='none'`, and `plan_source='github_issue_existing'` are accepted under both v2 and v3. This is documented under v3 in the table above; the v2 acceptance covers in-flight skill emissions that predate the parser's v3 awareness.
 
 When bumping, update this doc, `commands/auto-dev.md`, and the cw parser in lockstep. **Order matters:** the parser must accept the new version BEFORE the skill emits it, otherwise in-flight emissions land in deployed parsers that don't recognize them. Parsers MUST defensively reject unknown `schema_version` values per §6 (4).
 

--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -71,6 +71,13 @@ _V2_STATUSES: frozenset[str] = frozenset({"no_op"})
 # skill emits them under v2 today (see #103). One-time rollout exception:
 # accept under v2 AND v3 until the skill bumps. When skill emits v3, this
 # exception can be removed and a `_V3_STAGES`/`_V3_PLAN_SOURCES` gate added.
+#
+# Also accepted ungated: "github_issue_existing" (PlanSource). The producer
+# emits this for GitHub-sourced runs (the post-Linear analog of
+# "linear_existing"); the parser previously rejected every such run as
+# validation_failed (see #190). Treated identically to "linear_existing" —
+# pure producer-side relabeling, no consumer behavior change. Accepted under
+# v2 and v3 (the producer emits at v2 today per captured payloads).
 StageReached = Literal[
     "stage1_pre_flight",
     "stage1_plan",
@@ -81,7 +88,13 @@ StageReached = Literal[
     "stage5_post_create",
 ]
 ScopeTier = Literal["small", "large"]
-PlanSource = Literal["linear_existing", "generated", "free_text", "none"]
+PlanSource = Literal[
+    "linear_existing",
+    "github_issue_existing",
+    "generated",
+    "free_text",
+    "none",
+]
 
 
 class Scope(BaseModel):

--- a/tests/test_auto_dev_result.py
+++ b/tests/test_auto_dev_result.py
@@ -714,3 +714,32 @@ class TestPreFlightNoOp:
         p["scope"]["lines_actual"] = 10
         with pytest.raises(ValidationError, match="lines_actual"):
             AutoDevResult.model_validate(p)
+
+
+# ---------------------------------------------------------------------------
+# plan_source="github_issue_existing" (added per #190 — producer-side rename
+# of "linear_existing" for GitHub-sourced runs; treated identically).
+# ---------------------------------------------------------------------------
+
+
+class TestPlanSourceGitHubIssueExisting:
+    def test_shipped_run_with_github_issue_existing_parses(self) -> None:
+        """A real shipped payload (#149 captured) emitted under v2."""
+        p = _shipped_payload()
+        p["schema_version"] = 2
+        p["plan_source"] = "github_issue_existing"
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.plan_source == "github_issue_existing"
+        assert result.status == "shipped"
+        assert result.schema_version == 2
+
+    def test_no_op_run_with_github_issue_existing_parses(self) -> None:
+        """A pre-flight no_op payload (#136 captured) with the GitHub plan_source."""
+        p = _no_op_payload()
+        p["schema_version"] = 2
+        p["plan_source"] = "github_issue_existing"
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.plan_source == "github_issue_existing"
+        assert result.status == "no_op"


### PR DESCRIPTION
## Summary

- Adds `github_issue_existing` to `PlanSource` Literal in `cw.auto_dev_result`. Grafted into the existing v3 rollout exception (semantically identical to `linear_existing`; pure producer-side relabel for the GitHub-Issues era).
- Updates `docs/headless-contract.md` §3.3 (plan_source row) and §8 (v3 history row + cross-version exception note).
- Adds two tests against captured-payload shapes: shipped run (#149) and pre-flight no_op (#136).

## Context

Surfaced by dogfooding `/cw-followup` against session #136 — every GitHub-sourced `/auto-dev` run currently routes through `BlockedResult` with `reason=validation_failed`, hiding the real outcome from any consumer that keys off typed `AutoDevResult.status`.

Closes #190.

## Test plan

- [x] `pytest tests/test_auto_dev_result.py` — 61/61 pass (was 59; +2)
- [x] Full suite: 869 pass (was 867)
- [x] `ruff check src/ tests/` clean
- [x] `mypy src/` clean
- [ ] `/cw-followup --session-id <#136 session>` returns `result_kind: "AutoDevResult"` (currently `BlockedResult`) — verify post-merge