### PR TITLE
feat(skill): /cw-smoke-test — end-to-end auto-dev dogfood loop (#171)

### DIFF
--- a/.claude/skills/cw-smoke-test/SKILL.md
+++ b/.claude/skills/cw-smoke-test/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: cw-smoke-test
+description: Dogfood the /auto-dev --headless pipeline end-to-end against a single ticket via cw — runs pre-flight checks, enqueues + dispatches one tick, monitors until completion, validates the sentinel, and reports PASS/FAIL with a recommended follow-up. Use when the user wants to smoke-test the auto-dev pipeline, validate the headless contract end-to-end, dogfood a fresh tech-debt ticket, run a one-ticket pipeline sanity check, or "run /auto-dev on <id> via cw and tell me what happened".
+---
+
+# cw-smoke-test
+
+End-to-end dogfood loop for the `/auto-dev --headless` pipeline against a single ticket. Composes the existing skills — pre-flight + dispatch + monitor + `/cw-validate-result` + `/cw-followup` suggestion — into one orchestrated call.
+
+This is pure orchestration. No new parsing or validation logic; the heavy lifting belongs to the sibling skills.
+
+## When to use
+
+- The user wants to validate that a producer-side change (e.g. a parser enum fix, a new agent prompt) still works end-to-end before broadcasting it.
+- A freshly opened tech-debt ticket needs a one-shot smoke test before a wider meta-test spray.
+- The user asks "did `/auto-dev` regress?" — the smoke test answers it with a real run.
+
+## Inputs
+
+One required argument:
+- ticket id (e.g. `171` or `#171`) — a GitHub issue in `mattwwarren/claude-workspace` (or `--repo OWNER/NAME` to target another).
+
+Optional flags:
+- `--client <NAME>` — cw client name for the dev-queue lookup (default `claude-workspace`).
+- `--skip-preflight` — run pre-flight in advisory mode (still report; do not abort). Useful when the operator already knows about an issue (e.g. cw doctor reports stale linkage drift).
+
+## How it works
+
+### Step 1 — pre-flight
+
+Run the bundled checker:
+
+```bash
+uv run --project /home/matthew/workspace/personal/claude-workspace python \
+  .claude/skills/cw-smoke-test/scripts/preflight.py \
+  --ticket-id <NUMBER>
+```
+
+The script emits one JSON object with `ok` (bool) and `checks` (list). Each row carries `name`, `passed`, `severity` (`hard` | `soft`), and `detail`.
+
+Hard checks (must pass):
+- `agents_present` — `plan-reviewer.md` and `plan-soundness-reviewer.md` exist under `~/.claude/agents/` or repo-local `.claude/agents/`.
+- `cw_backend_healthy` — `cw doctor` reports backend + config + state file all OK.
+- `ticket_open` — `gh issue view <id>` returns `state=OPEN`.
+- `no_open_pr_for_ticket` — no open PR in the repo whose title references the ticket number.
+- `not_already_queued` — the ticket is not RUNNING / PENDING / CLAIMED in `cw dev-queue status`.
+
+Soft checks (warn but proceed):
+- `cw_doctor_clean` — `cw doctor` reports zero issues. Linkage drift and stale-session warnings are common on a working system; surface them but do not abort.
+
+If `ok` is false (any hard check failed), print the failing rows and stop. Do not dispatch. Unless the user passes `--skip-preflight`, in which case continue with a clear warning banner that includes the failed checks.
+
+### Step 2 — dispatch
+
+Enqueue and run a single tick:
+
+```bash
+cw dev-queue add <TICKET> -c <CLIENT>
+cw dev-queue run --once
+```
+
+Record the wall-clock timestamp before `dev-queue run --once` returns — that's the cursor for Step 3.
+
+### Step 3 — monitor
+
+The dispatch tick spawned a worker session. Tail the event bus for the lifecycle markers:
+
+```bash
+cw event tail --since <DISPATCH_TS> --type session.spawned --type session.completed --json
+```
+
+Resolve the spawned worker's cw session id from the first `session.spawned` event whose payload references the ticket. Then poll:
+
+```bash
+cw event tail --since <DISPATCH_TS> --type session.completed --json | \
+  jq -r 'select(.payload.session_id == "<WORKER_ID>")'
+```
+
+Until that returns a row, or a reasonable timeout (default 30 minutes — match the Layer 1 backstop in `signal-stop`).
+
+While waiting, surface progress sparingly. Print one line on `session.spawned` (with the worker id + worktree path), then go silent until completion. The user can `cw event tail` themselves if they want intermediate noise.
+
+If completion never arrives within the timeout, surface the worker id + `cw status` snapshot and stop. Do not auto-retry — that's the user's call.
+
+### Step 4 — validate
+
+Once the worker completes, hand off to `/cw-validate-result` for the forensic read:
+
+```bash
+/cw-validate-result --session-id <WORKER_SHORT_ID>
+```
+
+That skill resolves the transcript, parses the sentinel via `cw-followup/scripts/parse_sentinel.py`, walks the headless-contract checklist, and prints one of four outcomes:
+
+| Outcome | Smoke-test verdict |
+|---|---|
+| `valid` | PASS — the pipeline produced a usable result. Print the `effective_status` and the PR / branch / worktree as applicable. |
+| `producer_status_unknown` | PASS-WITH-WARNING — the run finished and emitted a structured payload, but the producer used a status not yet in the parser's enum. File against `#190` / `#191` patterns if this is new. |
+| `invalid_sentinel` | FAIL — schema validation failed. This is producer/consumer drift; surface the validation error verbatim and recommend filing a parser bug. |
+| `no_sentinel` | FAIL — the run exited without emitting a sentinel at all. Walk the user through `references/no-sentinel-patterns.md` (in the validator skill's references). |
+
+### Step 5 — suggest follow-up
+
+On PASS / PASS-WITH-WARNING, suggest the appropriate `/cw-followup` invocation:
+
+```text
+smoke-test: #<TICKET> → <effective_status>; ready to <suggested action>
+  /cw-followup --session-id <WORKER_SHORT_ID>
+```
+
+On FAIL, do NOT suggest `/cw-followup` — surface the failure and let the user decide whether to file a producer or parser ticket. If the failure looks like a known drift case (e.g. status not yet in enum, plan_source not yet in enum), point at the relevant open ticket (`#190`, `#191`) so the user can subscribe rather than re-file.
+
+## Output shape
+
+Print exactly one summary line at the end, caveman-tight:
+
+```
+smoke-test: #171 → valid (status=shipped, PR #234) — ready for review
+smoke-test: #185 → producer_status_unknown (status=premises_pending_verification) — disposition via /cw-followup
+smoke-test: #999 → no_sentinel — worker session 4f44d145 exited without emitting; transcript at <path>
+```
+
+## Failure modes
+
+- **Pre-flight refuses, user wants override** — `--skip-preflight` advisory mode. Print a one-line warning banner before dispatching so the user sees the smoke test happened in degraded mode.
+- **Worker spawned but `session.completed` never arrives** — surface worker id + last seen transcript timestamp; stop after the 30-minute window. The Layer 1 backstop should fire a `TIMED_OUT` sentinel; if it didn't, that's #185 / Layer 1 territory.
+- **`/cw-validate-result` fails to resolve the transcript** — the worker session may have been reaped before the smoke test finished. Surface the session id and the `~/.claude/projects/...` candidate paths.
+- **Pre-flight check `not_already_queued` fires for a stale RUNNING entry** — the queue may have a phantom from a prior crash. Surface and suggest `cw doctor --reap`; do not auto-reap.
+
+## Out of scope
+
+- Continuous-loop dispatching (use `cw dev-queue run` without `--once`).
+- Multi-ticket batch dispatch (use `cw spawn --headless` per ticket; or build `/cw-fanout` (#187) for parallel N-way).
+- Phase A stage-transition events. This skill works without them; with them, monitoring becomes more informative.
+- Re-dispatching after a failure. The user owns the dispatch trigger; the smoke test is one-shot.
+
+## Related
+
+- `#172` / PR #192 — `/cw-validate-result` (the diagnostic step this skill delegates to).
+- `#188` / PR #189 — `/cw-followup` (the action step suggested on PASS).
+- `#187` — `/cw-fanout` (multi-ticket parallel dispatch; companion of this skill).
+- `#190` — `plan_source` enum drift surfaced via dogfood.
+- `#191` — Status enum drift (`premises_pending_verification` / `ambiguities_pending_resolution`) surfaced via dogfood.
+- `#185` — Layer 1 backstop edge case (no Stop hook ⇒ no timeout fire). This skill's 30-minute timeout matches the Layer 1 cap.

--- a/.claude/skills/cw-smoke-test/scripts/preflight.py
+++ b/.claude/skills/cw-smoke-test/scripts/preflight.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Pre-flight checks for /cw-smoke-test.
+
+Verifies the environment is healthy enough to dispatch ``/auto-dev`` against
+a single ticket. Emits one JSON object on stdout with ``ok`` (bool) and
+``checks`` (list of ``{name, passed, severity, detail}``). Exits 0 when no
+``severity=hard`` check failed (soft warnings still report ``ok=true``);
+exits 1 when at least one hard check failed.
+
+Each check distinguishes ``severity``:
+- ``hard``  — must pass; failure aborts the smoke test.
+- ``soft``  — warning only; surfaces in the report but does not abort.
+
+Checks performed:
+- ``agents_present``        (hard)  plan-reviewer + plan-soundness-reviewer
+                                   exist under one of ``~/.claude/agents/``
+                                   or the repo-local ``.claude/agents/``.
+- ``cw_backend_healthy``    (hard)  ``cw doctor`` exits 0 OR fails only on
+                                   non-backend categories (linkage drift,
+                                   stale state).
+- ``cw_doctor_clean``       (soft)  ``cw doctor`` reports zero issues.
+- ``ticket_open``           (hard)  ``gh issue view <id>`` returns
+                                   ``state=OPEN``.
+- ``no_open_pr_for_ticket`` (hard)  ``gh pr list --search "<id>"`` returns
+                                   no PR whose title or body references the
+                                   ticket as already in flight.
+- ``not_already_queued``    (hard)  the ticket is not already RUNNING or
+                                   PENDING in ``cw dev-queue status``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_GLOBAL_AGENTS = Path.home() / ".claude" / "agents"
+_REQUIRED_AGENTS = ("plan-reviewer.md", "plan-soundness-reviewer.md")
+_DEV_QUEUE_BLOCKING_STATES = {"PENDING", "RUNNING", "CLAIMED"}
+
+
+def _check_agents(repo_root: Path) -> dict[str, Any]:
+    local_agents = repo_root / ".claude" / "agents"
+    missing: list[str] = []
+    locations: list[str] = []
+    for name in _REQUIRED_AGENTS:
+        found_in: list[str] = []
+        if (_GLOBAL_AGENTS / name).is_file():
+            found_in.append(str(_GLOBAL_AGENTS))
+        if (local_agents / name).is_file():
+            found_in.append(str(local_agents))
+        if not found_in:
+            missing.append(name)
+        else:
+            locations.append(f"{name}@{found_in[0]}")
+    if missing:
+        detail = (
+            f"missing: {', '.join(missing)} "
+            f"(looked in {_GLOBAL_AGENTS}, {local_agents})"
+        )
+        return {
+            "name": "agents_present",
+            "passed": False,
+            "severity": "hard",
+            "detail": detail,
+        }
+    return {
+        "name": "agents_present",
+        "passed": True,
+        "severity": "hard",
+        "detail": "; ".join(locations),
+    }
+
+
+def _check_cw_doctor() -> tuple[dict[str, Any], dict[str, Any]]:
+    cw = shutil.which("cw")
+    if cw is None:
+        hard = {
+            "name": "cw_backend_healthy",
+            "passed": False,
+            "severity": "hard",
+            "detail": "cw binary not on PATH",
+        }
+        soft = {
+            "name": "cw_doctor_clean",
+            "passed": False,
+            "severity": "soft",
+            "detail": "skipped — cw not on PATH",
+        }
+        return hard, soft
+    proc = subprocess.run(
+        [cw, "doctor"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = (proc.stdout + proc.stderr).strip()
+    # cw doctor exits 0 when everything passes. Backend-related failures are
+    # the only category that should hard-block a smoke test — linkage drift
+    # and stale-session warnings are normal on a working system.
+    hard_keywords = ("backend", "binary", "config", "parse")
+    output_lower = output.lower()
+    hard_failed = proc.returncode != 0 and any(k in output_lower for k in hard_keywords)
+    hard = {
+        "name": "cw_backend_healthy",
+        "passed": not hard_failed,
+        "severity": "hard",
+        "detail": output if hard_failed else "backend reachable, config parseable",
+    }
+    soft = {
+        "name": "cw_doctor_clean",
+        "passed": proc.returncode == 0,
+        "severity": "soft",
+        "detail": "no issues"
+        if proc.returncode == 0
+        else f"cw doctor reported issues:\n{output}",
+    }
+    return hard, soft
+
+
+def _check_ticket_open(ticket: str, repo: str) -> dict[str, Any]:
+    gh = shutil.which("gh")
+    if gh is None:
+        return {
+            "name": "ticket_open",
+            "passed": False,
+            "severity": "hard",
+            "detail": "gh CLI not on PATH",
+        }
+    proc = subprocess.run(
+        [gh, "issue", "view", ticket, "-R", repo, "--json", "state,title,number"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return {
+            "name": "ticket_open",
+            "passed": False,
+            "severity": "hard",
+            "detail": (
+                f"gh issue view failed: {proc.stderr.strip() or proc.stdout.strip()}"
+            ),
+        }
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "name": "ticket_open",
+            "passed": False,
+            "severity": "hard",
+            "detail": f"gh output not valid JSON: {exc}",
+        }
+    state = payload.get("state", "UNKNOWN")
+    title = payload.get("title", "")
+    return {
+        "name": "ticket_open",
+        "passed": state == "OPEN",
+        "severity": "hard",
+        "detail": f"#{payload.get('number')} state={state} title={title!r}",
+    }
+
+
+def _check_no_open_pr(ticket: str, repo: str) -> dict[str, Any]:
+    gh = shutil.which("gh")
+    if gh is None:
+        return {
+            "name": "no_open_pr_for_ticket",
+            "passed": False,
+            "severity": "hard",
+            "detail": "gh CLI not on PATH",
+        }
+    # Search both title and body for the ticket reference. The smoke test
+    # should not dispatch onto a ticket that already has work in flight.
+    search = f"#{ticket} in:title,body is:pr is:open"
+    proc = subprocess.run(
+        [
+            gh,
+            "pr",
+            "list",
+            "-R",
+            repo,
+            "--search",
+            search,
+            "--json",
+            "number,title,url",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return {
+            "name": "no_open_pr_for_ticket",
+            "passed": False,
+            "severity": "hard",
+            "detail": (
+                f"gh pr list failed: {proc.stderr.strip() or proc.stdout.strip()}"
+            ),
+        }
+    try:
+        prs = json.loads(proc.stdout) or []
+    except json.JSONDecodeError as exc:
+        return {
+            "name": "no_open_pr_for_ticket",
+            "passed": False,
+            "severity": "hard",
+            "detail": f"gh output not valid JSON: {exc}",
+        }
+    # gh's free-text search is fuzzy — filter to PRs whose title actually
+    # references the ticket (avoids false-positives from unrelated PRs that
+    # mention the number in passing).
+    pattern = re.compile(rf"(^|\D){re.escape(ticket)}(\D|$)")
+    matching = [pr for pr in prs if pattern.search(pr.get("title", ""))]
+    if not matching:
+        return {
+            "name": "no_open_pr_for_ticket",
+            "passed": True,
+            "severity": "hard",
+            "detail": "no open PR references the ticket",
+        }
+    summary = ", ".join(f"#{pr['number']} {pr['title']}" for pr in matching)
+    return {
+        "name": "no_open_pr_for_ticket",
+        "passed": False,
+        "severity": "hard",
+        "detail": f"open PRs reference ticket: {summary}",
+    }
+
+
+def _check_not_queued(ticket: str, client: str) -> dict[str, Any]:
+    cw = shutil.which("cw")
+    if cw is None:
+        return {
+            "name": "not_already_queued",
+            "passed": False,
+            "severity": "hard",
+            "detail": "cw binary not on PATH",
+        }
+    proc = subprocess.run(
+        [cw, "dev-queue", "status", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        # Older builds may not support --json. Fall back to a plain run and
+        # grep for the ticket; the smoke-test is best-effort here.
+        proc = subprocess.run(
+            [cw, "dev-queue", "status"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return {
+                "name": "not_already_queued",
+                "passed": False,
+                "severity": "hard",
+                "detail": (
+                    f"cw dev-queue status failed: "
+                    f"{proc.stderr.strip() or proc.stdout.strip()}"
+                ),
+            }
+        # Plain-text fallback: look for the ticket id alongside a blocking state.
+        text = proc.stdout
+        for state in _DEV_QUEUE_BLOCKING_STATES:
+            if state in text and ticket in text:
+                return {
+                    "name": "not_already_queued",
+                    "passed": False,
+                    "severity": "hard",
+                    "detail": (
+                        f"ticket {ticket} appears with state {state} "
+                        f"in dev-queue status output"
+                    ),
+                }
+        return {
+            "name": "not_already_queued",
+            "passed": True,
+            "severity": "hard",
+            "detail": "ticket not seen in dev-queue status",
+        }
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "name": "not_already_queued",
+            "passed": False,
+            "severity": "hard",
+            "detail": f"cw dev-queue status JSON parse failed: {exc}",
+        }
+    by_client = payload if isinstance(payload, dict) else {}
+    entries = (
+        by_client.get(client, []) if isinstance(by_client.get(client), list) else []
+    )
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if (
+            str(entry.get("ticket_id")) == ticket
+            and entry.get("state") in _DEV_QUEUE_BLOCKING_STATES
+        ):
+            return {
+                "name": "not_already_queued",
+                "passed": False,
+                "severity": "hard",
+                "detail": (
+                    f"ticket {ticket} is {entry.get('state')} "
+                    f"in dev-queue for client {client}"
+                ),
+            }
+    return {
+        "name": "not_already_queued",
+        "passed": True,
+        "severity": "hard",
+        "detail": f"ticket {ticket} not queued or running for client {client}",
+    }
+
+
+def _resolve_repo_root() -> Path:
+    # The script lives at <repo>/.claude/skills/cw-smoke-test/scripts/preflight.py
+    # — climb four parents to land on the repo root.
+    return Path(__file__).resolve().parents[4]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Pre-flight checks for /cw-smoke-test."
+    )
+    parser.add_argument(
+        "--ticket-id", required=True, help="GitHub ticket number (no '#')."
+    )
+    parser.add_argument(
+        "--repo",
+        default="mattwwarren/claude-workspace",
+        help="GitHub repo in OWNER/NAME form (default: mattwwarren/claude-workspace).",
+    )
+    parser.add_argument(
+        "--client",
+        default="claude-workspace",
+        help="cw client name for the dev-queue lookup.",
+    )
+    args = parser.parse_args()
+    ticket = args.ticket_id.lstrip("#")
+    repo_root = _resolve_repo_root()
+
+    checks: list[dict[str, Any]] = []
+    checks.append(_check_agents(repo_root))
+    hard_doctor, soft_doctor = _check_cw_doctor()
+    checks.append(hard_doctor)
+    checks.append(soft_doctor)
+    checks.append(_check_ticket_open(ticket, args.repo))
+    checks.append(_check_no_open_pr(ticket, args.repo))
+    checks.append(_check_not_queued(ticket, args.client))
+
+    hard_failed = any(
+        check["severity"] == "hard" and not check["passed"] for check in checks
+    )
+    report = {
+        "ok": not hard_failed,
+        "ticket_id": ticket,
+        "client": args.client,
+        "repo": args.repo,
+        "checks": checks,
+    }
+    json.dump(report, sys.stdout)
+    sys.stdout.write("\n")
+    return 1 if hard_failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

End-to-end dogfood loop for the `/auto-dev --headless` pipeline against a single ticket. Composes the two skills shipped this session — `/cw-validate-result` (#172, PR #192) and `/cw-followup` (#188, PR #189) — into a one-shot smoke test. Pure orchestration; no parser or validation logic re-implemented.

## What it does

1. **Pre-flight** (bundled script) — six checks, fail-fast on hard failures.
2. **Dispatch** — `cw dev-queue add <id> -c <client>` + `cw dev-queue run --once`.
3. **Monitor** — `cw event tail --type session.spawned --type session.completed`.
4. **Validate** — delegate to `/cw-validate-result --session-id <SHORT>` (uses the canonical checklist; no duplication).
5. **Suggest** — on PASS / PASS-WITH-WARNING, point at `/cw-followup` for the next move.

## Pre-flight checks (`scripts/preflight.py`)

| Check | Severity | What |
|---|---|---|
| `agents_present` | hard | `plan-reviewer.md` + `plan-soundness-reviewer.md` in `~/.claude/agents/` or repo-local. |
| `cw_backend_healthy` | hard | `cw doctor` exits 0 OR fails only on non-backend issues. |
| `cw_doctor_clean` | **soft** | Surfaces linkage drift / stale state without aborting. |
| `ticket_open` | hard | `gh issue view <id>` returns `state=OPEN`. |
| `no_open_pr_for_ticket` | hard | No open PR's title references the ticket (gh search is filtered to avoid false-positives). |
| `not_already_queued` | hard | Ticket not RUNNING / PENDING / CLAIMED in `cw dev-queue status`. |

Emits one JSON object on stdout; exits 1 if any hard check failed.

## Plan-soundness ambiguities resolved

Stage 1c flagged 1 premise + 7 ambiguities on this ticket. Dispositions baked into the implementation:

1. **Project-local skill location** — matches `cw-followup` / `cw-validate-result` siblings.
2. **`--parent` flag dropped** — not core to a one-shot smoke test.
3. **`cw doctor` semantics** — warn on non-backend issues, only hard-block on backend/config/state-parse failures.
4. **Transcript parsing fully delegated** to `/cw-validate-result` — no duplication of `cli.py:824-860`.
5. **Checklist** lives in `/cw-validate-result` already (against current `AutoDevResult` schema); no stale-handoff copy here.
6. **Live end-to-end run** — manual post-merge verification, not CI-gated.
7. **`/cw-validate-result` exists** — shipped in PR #192, used here directly.

## Test plan

- [x] `ruff check` — clean
- [x] `mypy --strict` on `preflight.py` — clean
- [x] Preflight verified against a real open ticket (`--ticket-id 171`) — all 6 checks PASS, exit 0.
- [x] Preflight verified against a non-existent ticket (`--ticket-id 999999`) — `ticket_open` FAIL, exit 1.
- [ ] **Smoke-test the smoke-test post-merge** — pick a fresh tech-debt ticket and run the loop end-to-end.

Closes #171.