### PR TITLE
fix(native-daemon): strip ANSI escapes from claude --bg stdout (#203)

### DIFF
--- a/src/cw/native_daemon.py
+++ b/src/cw/native_daemon.py
@@ -45,6 +45,11 @@ _ROSTER_PATH = Path.home() / ".claude" / "daemon" / "roster.json"
 # ``claude --bg`` invocation: ``backgrounded · <8 hex chars>``.
 _BG_STDOUT_PATTERN = re.compile(r"backgrounded\s*·\s*([0-9a-f]{8})")
 
+# Claude Code 2.1.150 wraps the short id in ANSI color escapes
+# (``backgrounded · \x1b[36m<id>\x1b[39m``). Strip CSI SGR sequences before
+# matching so the parser tolerates terminal-formatted output.
+_ANSI_CSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+
 
 @runtime_checkable
 class NativeDaemonClient(Protocol):
@@ -108,7 +113,8 @@ class RealNativeDaemonClient:
             )
             raise CwError(msg) from exc
 
-        match = _BG_STDOUT_PATTERN.search(proc.stdout or "")
+        stdout_clean = _ANSI_CSI_PATTERN.sub("", proc.stdout or "")
+        match = _BG_STDOUT_PATTERN.search(stdout_clean)
         if match is None:
             msg = (
                 "claude --bg succeeded but stdout did not contain a "

--- a/tests/test_native_daemon.py
+++ b/tests/test_native_daemon.py
@@ -63,6 +63,36 @@ class TestRealNativeDaemonClientSpawn:
         ]
         assert captured["cwd"] == worktree
 
+    def test_parses_short_id_from_ansi_coded_stdout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression #203: Claude Code 2.1.150 wraps the short id in CSI SGR.
+
+        Real captured output from claude --bg on 2026-05-23::
+
+            'backgrounded \xc2\xb7 \\x1b[36m7719118f\\x1b[39m\\n'
+            '\\x1b[2m  claude agents    list sessions\\x1b[22m\\n'
+            ...
+
+        The parser must strip ANSI escapes before searching, otherwise the
+        ``\\x1b[36m`` between ``\xc2\xb7`` and the hex id breaks the match.
+        """
+        ansi_stdout = (
+            "backgrounded · \x1b[36m7719118f\x1b[39m\n"
+            "\x1b[2m  claude agents             list sessions\x1b[22m\n"
+            "\x1b[2m  claude attach 7719118f    open in this terminal\x1b[22m\n"
+            "\x1b[2m  claude logs 7719118f      show recent output\x1b[22m\n"
+            "\x1b[2m  claude stop 7719118f      stop this session\x1b[22m\n"
+        )
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_, **__: _FakeCompleted(stdout=ansi_stdout),
+        )
+        client = RealNativeDaemonClient()
+
+        assert client.spawn_bg(cwd=tmp_path, prompt="x") == "7719118f"
+
     def test_missing_short_id_raises(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Context

Closes #203. Critical 1.0 blocker — every `cw dev-queue` dispatch tick fails
identically against current Claude Code (2.1.150) because the CLI now wraps
the short session id in ANSI color escapes:

```
backgrounded · \x1b[36m7719118f\x1b[39m
```

The `\x1b[36m` between `·` and the hex id breaks the regex match at
`src/cw/native_daemon.py:46`. Dispatch reverts cleanly to PENDING (no data
corruption) but Wave 1 of today's batch (#184, #186, #170) cannot run.

## Fix

Strip CSI SGR sequences from stdout before pattern-matching. Strip-then-match
is robust against future format changes elsewhere in the output (the
help-cmd suffix also has `\x1b[2m...\x1b[22m` dim codes).

## Test

Added `test_parses_short_id_from_ansi_coded_stdout` with the captured 2.1.150
output verbatim. All 15 `test_native_daemon.py` tests pass; full suite
(870 tests) green.

## Detection gap (followup-worthy, not in this PR)

Our `subprocess.run` mocks don't see real CLI output, so they couldn't catch
this format change. Consider a release-gate or nightly smoke test that
exercises one real `claude --bg` call. Not in scope for the hotfix.

## Test plan

- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run mypy src/cw/native_daemon.py` — zero errors
- [x] `uv run pytest tests/` — 870/870 pass
- [ ] Post-merge: `cw dev-queue run` dispatches Wave 1 without spawn errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)