### PR TITLE
feat(spawn): add _validate_worktree pre-flight gate (#186)

### DIFF
--- a/src/cw/spawn.py
+++ b/src/cw/spawn.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from typing import TYPE_CHECKING
 
 from cw.config import load_state, save_state
-from cw.exceptions import CwError, HookContextConflictError
+from cw.exceptions import CwError, HookContextConflictError, WorktreeError
 from cw.models import Session, SessionOrigin, SessionPurpose
 from cw.native_daemon import get_native_daemon_client
 
@@ -15,6 +17,39 @@ if TYPE_CHECKING:
 
     from cw.models import ClientConfig
     from cw.native_daemon import NativeDaemonClient
+
+
+def _validate_worktree(path: Path) -> None:
+    """Ensure *path* is a real git worktree, not an empty dir.
+
+    Catches the #186 symptom: a prior ``git worktree add -b <branch>``
+    failed (e.g. branch already taken) but the directory was mkdir'd
+    by the shell anyway, leaving cw spawn to run on an empty dir.
+    """
+    if not path.exists():
+        msg = f"Worktree path does not exist: {path}"
+        raise WorktreeError(msg)
+    if not (path / ".git").exists():
+        msg = (
+            f"Worktree path is not a git checkout: {path} (missing .git/). "
+            f"A prior 'git worktree add' likely failed; check that the "
+            f"branch name was not already taken."
+        )
+        raise WorktreeError(msg)
+    clean_env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    result = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "--git-dir"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=clean_env,
+    )
+    if result.returncode != 0:
+        msg = (
+            f"Worktree path failed 'git rev-parse --git-dir': {path}\n"
+            f"stderr: {result.stderr.strip()}"
+        )
+        raise WorktreeError(msg)
 
 
 _HOOK_SETTINGS_TEMPLATE = {
@@ -119,6 +154,7 @@ def spawn_create_impl(
     ``sess.id`` to ``parent.worker_session_ids``. Raises :class:`CwError`
     if the parent session is not in state.
     """
+    _validate_worktree(worktree)
     state = load_state()
 
     parent_session: Session | None = None

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -61,12 +61,18 @@ def workspace_dir(make_git_repo: Callable[[str], Path]) -> Path:
 
 
 @pytest.fixture
-def sample_client_config(workspace_dir: Path) -> ClientConfig:
-    """A ClientConfig for use with dispatch tests."""
+def sample_client_config(workspace_dir: Path, tmp_path: Path) -> ClientConfig:
+    """A ClientConfig for use with dispatch tests.
+
+    Sets worktree_base to a tmp_path subdirectory so create_worktree
+    writes test worktrees under tmp_path (not ~/.cw/wt/), preventing
+    stale-directory accumulation across test runs.
+    """
     return ClientConfig(
         name="test-client",
         workspace_path=workspace_dir,
         default_branch="main",
+        worktree_base=tmp_path / "worktrees",
     )
 
 
@@ -93,12 +99,15 @@ def _make_clients_yaml(tmp_path: Path, client: ClientConfig) -> None:
     config_dir = tmp_path / ".config" / "cw"
     config_dir.mkdir(parents=True, exist_ok=True)
     clients_file = config_dir / "clients.yaml"
-    clients_file.write_text(
-        f"clients:\n"
-        f"  {client.name}:\n"
-        f"    workspace_path: {client.workspace_path}\n"
-        f"    default_branch: {client.default_branch}\n"
-    )
+    lines = [
+        "clients:\n",
+        f"  {client.name}:\n",
+        f"    workspace_path: {client.workspace_path}\n",
+        f"    default_branch: {client.default_branch}\n",
+    ]
+    if client.worktree_base is not None:
+        lines.append(f"    worktree_base: {client.worktree_base}\n")
+    clients_file.write_text("".join(lines))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -20,7 +20,7 @@ from cw.native_daemon import FakeNativeDaemonClient
 from cw.plan import run_planner
 
 if TYPE_CHECKING:
-    pass
+    from collections.abc import Callable
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -28,10 +28,14 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def planner_client(tmp_path: Path) -> ClientConfig:
-    """A ClientConfig usable as the planner host."""
-    workspace = tmp_path / "workspace" / "planner-client"
-    workspace.mkdir(parents=True)
+def planner_client(make_git_repo: Callable[[str], Path]) -> ClientConfig:
+    """A ClientConfig usable as the planner host.
+
+    Uses a real git repo so spawn_create_impl's _validate_worktree check
+    passes (plan.py passes workspace_path as the worktree, which in
+    production is always a real git checkout).
+    """
+    workspace = make_git_repo("workspace/planner-client")
     return ClientConfig(
         name="planner-client",
         workspace_path=workspace,

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -25,7 +25,7 @@ from cw.models import (
 from cw.native_daemon import FakeNativeDaemonClient
 
 if TYPE_CHECKING:
-    pass
+    from collections.abc import Callable
 
 
 # ---------------------------------------------------------------------------
@@ -60,7 +60,10 @@ class TestSpawnCreate:
     """Tests for the spawn_create business logic."""
 
     def test_happy_path_creates_session(
-        self, tmp_config_dir: Path, tmp_path: Path
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
     ) -> None:
         """spawn create: happy path stores session with correct fields."""
         from cw.cli import _spawn_create_impl
@@ -68,8 +71,7 @@ class TestSpawnCreate:
         client = _make_client(tmp_path)
         prompt_file = _make_prompt_file(tmp_path, "Implement the feature.")
         daemon = FakeNativeDaemonClient()
-        worktree = tmp_path / "worktree" / "feat-branch"
-        worktree.mkdir(parents=True)
+        worktree = make_git_repo("worktree-happy")
 
         session_id = _spawn_create_impl(
             client=client,
@@ -94,7 +96,10 @@ class TestSpawnCreate:
         assert sess.status == SessionStatus.ACTIVE
 
     def test_default_label_is_daemon(
-        self, tmp_config_dir: Path, tmp_path: Path
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
     ) -> None:
         """spawn create: default label produces 'client/daemon' session name."""
         from cw.cli import _spawn_create_impl
@@ -102,8 +107,7 @@ class TestSpawnCreate:
         client = _make_client(tmp_path)
         prompt_file = _make_prompt_file(tmp_path)
         daemon = FakeNativeDaemonClient()
-        worktree = tmp_path / "worktree"
-        worktree.mkdir(parents=True)
+        worktree = make_git_repo("worktree-default-label")
 
         _spawn_create_impl(
             client=client,
@@ -117,7 +121,10 @@ class TestSpawnCreate:
         assert state.sessions[0].name == "test-client/daemon"
 
     def test_daemon_receives_cwd_and_prompt(
-        self, tmp_config_dir: Path, tmp_path: Path
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
     ) -> None:
         """spawn_bg gets the worktree path and the raw prompt verbatim.
 
@@ -131,8 +138,7 @@ class TestSpawnCreate:
         client = _make_client(tmp_path, name="acme")
         prompt = "Fix the login bug."
         daemon = FakeNativeDaemonClient()
-        worktree = tmp_path / "worktree"
-        worktree.mkdir(parents=True)
+        worktree = make_git_repo("worktree-cwd-prompt")
 
         spawn_create_impl(
             client=client,
@@ -148,7 +154,10 @@ class TestSpawnCreate:
         assert prompt_arg == prompt
 
     def test_surface_ref_stores_native_short_id(
-        self, tmp_config_dir: Path, tmp_path: Path
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
     ) -> None:
         """surface_ref carries the short Claude session id returned by spawn_bg."""
         from cw.cli import _spawn_create_impl
@@ -156,8 +165,7 @@ class TestSpawnCreate:
         client = _make_client(tmp_path)
         prompt_file = _make_prompt_file(tmp_path)
         daemon = FakeNativeDaemonClient()
-        worktree = tmp_path / "worktree"
-        worktree.mkdir(parents=True)
+        worktree = make_git_repo("worktree-surface-ref")
 
         _spawn_create_impl(
             client=client,
@@ -172,7 +180,10 @@ class TestSpawnCreate:
         assert state.sessions[0].surface_ref == "00000001"
 
     def test_parent_linkage_writes_both_directions(
-        self, tmp_config_dir: Path, tmp_path: Path
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
     ) -> None:
         """spawn create with parent: worker.parent_session_id set and parent's
         worker_session_ids list contains the new worker id (single state save).
@@ -181,8 +192,7 @@ class TestSpawnCreate:
 
         client = _make_client(tmp_path)
         daemon = FakeNativeDaemonClient()
-        worktree = tmp_path / "worktree"
-        worktree.mkdir(parents=True)
+        worktree = make_git_repo("worktree-parent-linkage")
 
         # Seed a parent orchestrator session in state.
         parent_workspace = tmp_path / "workspace" / "orch"
@@ -215,15 +225,17 @@ class TestSpawnCreate:
         assert worker_id in refreshed_parent.worker_session_ids
 
     def test_parent_not_found_raises(
-        self, tmp_config_dir: Path, tmp_path: Path
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
     ) -> None:
         """spawn create with bogus parent ID: CwError, no session created, no spawn."""
         from cw.spawn import spawn_create_impl
 
         client = _make_client(tmp_path)
         daemon = FakeNativeDaemonClient()
-        worktree = tmp_path / "worktree"
-        worktree.mkdir(parents=True)
+        worktree = make_git_repo("worktree-parent-not-found")
 
         with pytest.raises(CwError, match="Parent session not found"):
             spawn_create_impl(
@@ -241,19 +253,178 @@ class TestSpawnCreate:
         assert daemon.spawn_calls == []
 
 
+class TestValidateWorktree:
+    """Tests for the _validate_worktree pre-flight gate (issue #186).
+
+    Catches the bug where 'git worktree add -b <branch>' fails (branch already
+    exists) but the directory was already mkdir'd by the shell, leaving cw
+    spawn to run on an empty dir without complaint.
+    """
+
+    def test_spawn_create_impl_rejects_nonexistent_worktree(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Nonexistent path raises WorktreeError; no daemon call or state write."""
+        from cw.exceptions import WorktreeError
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        daemon = FakeNativeDaemonClient()
+        worktree = tmp_path / "does-not-exist"
+        # Deliberately NOT mkdir'd.
+
+        with pytest.raises(WorktreeError, match="does not exist"):
+            spawn_create_impl(
+                client=client,
+                worktree=worktree,
+                prompt="/auto-dev 186 --headless",
+                label=None,
+                native_daemon=daemon,
+            )
+
+        state = load_state()
+        assert state.sessions == []
+        assert daemon.spawn_calls == []
+
+    def test_spawn_create_impl_rejects_worktree_without_git_dir(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Bare directory (no .git/): WorktreeError raised, no side effects.
+
+        Regression for the exact #186 symptom: shell mkdir'd the path but
+        'git worktree add' failed, leaving an empty dir.
+        """
+        from cw.exceptions import WorktreeError
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        daemon = FakeNativeDaemonClient()
+        worktree = tmp_path / "empty"
+        worktree.mkdir()  # Plain dir, no .git/.
+
+        with pytest.raises(WorktreeError, match="not a git checkout"):
+            spawn_create_impl(
+                client=client,
+                worktree=worktree,
+                prompt="/auto-dev 186 --headless",
+                label=None,
+                native_daemon=daemon,
+            )
+
+        state = load_state()
+        assert state.sessions == []
+        assert daemon.spawn_calls == []
+        # cw-context.json must NOT have been written either.
+        assert not (worktree / ".claude").exists()
+
+    def test_spawn_create_impl_rejects_worktree_where_rev_parse_fails(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """`.git` exists as a stray file (not a real worktree marker): WorktreeError.
+
+        Belt-and-suspenders: `.git` can be a file (worktree gitdir pointer) or
+        symlink — existence alone is insufficient. `git rev-parse --git-dir`
+        is the ground truth that git itself accepts the path.
+        """
+        from cw.exceptions import WorktreeError
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        daemon = FakeNativeDaemonClient()
+        worktree = tmp_path / "corrupt"
+        worktree.mkdir()
+        # `.git` as a file with garbage — passes the existence check but
+        # `git rev-parse --git-dir` will reject it.
+        (worktree / ".git").write_text("garbage not a gitdir pointer")
+
+        with pytest.raises(WorktreeError, match="rev-parse"):
+            spawn_create_impl(
+                client=client,
+                worktree=worktree,
+                prompt="/auto-dev 186 --headless",
+                label=None,
+                native_daemon=daemon,
+            )
+
+        state = load_state()
+        assert state.sessions == []
+        assert daemon.spawn_calls == []
+
+    def test_spawn_create_impl_accepts_valid_worktree(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """Happy path: real git repo passes validation, session is created."""
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        daemon = FakeNativeDaemonClient()
+        worktree = make_git_repo("valid-worktree")
+
+        session_id = spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt="/auto-dev 186 --headless",
+            label="valid",
+            native_daemon=daemon,
+        )
+
+        state = load_state()
+        assert len(state.sessions) == 1
+        assert state.sessions[0].id == session_id
+
+    def test_dispatch_path_rejects_invalid_worktree(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Regression for the dispatch.py:153 call site (issue #186 decision #3).
+
+        Simulates create_worktree returning an unvalidated path (as it does
+        today — it does no post-validation). The validation gate in
+        spawn_create_impl catches it before any daemon spawn.
+        """
+        from cw.exceptions import WorktreeError
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        daemon = FakeNativeDaemonClient()
+        # Simulate the #186 symptom: create_worktree's git worktree add failed
+        # but the dir got mkdir'd anyway by the shell.
+        bad_worktree = tmp_path / "wt" / "auto-dev-186"
+        bad_worktree.mkdir(parents=True)
+
+        with pytest.raises(WorktreeError, match="not a git checkout"):
+            spawn_create_impl(
+                client=client,
+                worktree=bad_worktree,
+                prompt="/auto-dev 186 --headless",
+                label="auto-dev/186",
+                native_daemon=daemon,
+                ticket_id="186",
+                headless=True,
+            )
+
+        state = load_state()
+        assert state.sessions == []
+        assert daemon.spawn_calls == []
+
+
 class TestHookContextInjection:
     """Tests for the Stop-hook + cw-context file injection (issue #147)."""
 
     def test_writes_settings_and_context_files(
-        self, tmp_config_dir: Path, tmp_path: Path
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
     ) -> None:
         """spawn_create_impl writes .claude/settings.local.json + cw-context.json."""
         from cw.spawn import spawn_create_impl
 
         client = _make_client(tmp_path)
         daemon = FakeNativeDaemonClient()
-        worktree = tmp_path / "worktree"
-        worktree.mkdir(parents=True)
+        worktree = make_git_repo("worktree-hook-ctx")
 
         session_id = spawn_create_impl(
             client=client,
@@ -283,15 +454,17 @@ class TestHookContextInjection:
         assert context["ticket_id"] == "137"
 
     def test_ticket_id_optional_writes_null(
-        self, tmp_config_dir: Path, tmp_path: Path
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
     ) -> None:
         """When no ticket_id is supplied, cw-context.json carries null."""
         from cw.spawn import spawn_create_impl
 
         client = _make_client(tmp_path)
         daemon = FakeNativeDaemonClient()
-        worktree = tmp_path / "worktree"
-        worktree.mkdir(parents=True)
+        worktree = make_git_repo("worktree-ticket-null")
 
         spawn_create_impl(
             client=client,
@@ -305,7 +478,10 @@ class TestHookContextInjection:
         assert context["ticket_id"] is None
 
     def test_cli_headless_flag_writes_headless_true_to_context(
-        self, tmp_config_dir: Path, tmp_path: Path
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
     ) -> None:
         """`cw spawn --headless` plumbs `headless: true` into cw-context.json.
 
@@ -320,8 +496,7 @@ class TestHookContextInjection:
         client = _make_client(tmp_path)
         prompt_file = _make_prompt_file(tmp_path, "/auto-dev 171 --headless")
         daemon = FakeNativeDaemonClient()
-        worktree = tmp_path / "worktree" / "manual-headless"
-        worktree.mkdir(parents=True)
+        worktree = make_git_repo("worktree-headless-true")
 
         _spawn_create_impl(
             client=client,
@@ -336,7 +511,10 @@ class TestHookContextInjection:
         assert context["headless"] is True
 
     def test_cli_headless_flag_defaults_to_false(
-        self, tmp_config_dir: Path, tmp_path: Path
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
     ) -> None:
         """`cw spawn` (no --headless) leaves `headless: false` in context.
 
@@ -348,8 +526,7 @@ class TestHookContextInjection:
         client = _make_client(tmp_path)
         prompt_file = _make_prompt_file(tmp_path, "some prompt")
         daemon = FakeNativeDaemonClient()
-        worktree = tmp_path / "worktree" / "manual-default"
-        worktree.mkdir(parents=True)
+        worktree = make_git_repo("worktree-headless-false")
 
         _spawn_create_impl(
             client=client,


### PR DESCRIPTION
## Summary

- feat(spawn): add _validate_worktree pre-flight gate (#186)
- test: add _validate_worktree tests + migrate existing spawn tests to real worktrees

**Review notes:** Stage 3 reviewers (Code Quality + SysAdmin) flagged a SHOULD_FIX (no MUST_FIX): `_validate_worktree`'s GIT_*-env-stripping subprocess call duplicates `_run_git` in `src/cw/worktree.py`. Headless contract auto-continues on SHOULD_FIX-only; refactor as follow-up.

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate (875 tests)
- [ ] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it