### PR TITLE
feat(observability): stage-transition events on cw event bus (#173)

### DIFF
--- a/docs/headless-contract.md
+++ b/docs/headless-contract.md
@@ -358,3 +358,61 @@ When bumping, update this doc, `commands/auto-dev.md`, and the cw parser in lock
   - cw#59 — https://github.com/mattwwarren/claude-workspace/issues/59
 - **Substrate** (cw 0.8.0 milestone, prerequisite for #56–#59): cw#52–#55.
 - **Skill-side resume implementation:** https://github.com/mattwwarren/global-claude/issues/2.
+
+---
+
+## 10. Stage Event Taxonomy (Producer Contract)
+
+### 10.1 Event Types
+
+`stage.entered` and `stage.errored` are **orchestrator events** — recorded on cw's event bus, not part of the `<<<AUTO_DEV_RESULT` sentinel block in §3. The skill records them via `cw event record …` at each stage boundary while running in headless mode. Consumers (cw status output, TUI dashboard, automation hooks) read them back through `cw event tail` and `read_events`.
+
+### 10.2 Stage Identifiers (closed enum)
+
+Every `stage` and `prev_stage` payload value MUST match one of:
+
+- `s0_intake`
+- `s1_plan_generated`
+- `s1_ambiguity_scan_complete`
+- `s1_plan_reviewed`
+- `s2_impl_started`
+- `s2_impl_complete`
+- `s3_review_started`
+- `s3_review_complete`
+- `s4_pr_created`
+- `s5_ci_waiting`
+- `done`
+
+### 10.3 Payload Schema
+
+**Required for both `stage.entered` and `stage.errored`:**
+
+- `session_id` (str) — the cw session that owns the run.
+- `ticket_id` (str) — the ticket being worked.
+- `stage` (str) — the stage being entered or that errored; MUST match the closed enum in §10.2.
+- `started_at` (str) — ISO8601 UTC timestamp, e.g. `2026-05-23T13:01:42Z`.
+
+**Optional:**
+
+- `prev_stage` (str) — the stage being departed; MUST also match the closed enum in §10.2.
+
+**`stage.errored`-only:**
+
+- `error_kind` (str) — free-form classifier such as `agent_block`, `impl_failed`, `review_blocked`. Open enum — consumers MUST tolerate unknown values.
+
+### 10.4 Producer Invocation
+
+The skill emits stage transitions via `cw event record` from inside the headless session:
+
+```bash
+cw event record stage.entered \
+  --payload '{"session_id":"$CW_SESSION_ID","ticket_id":"173","stage":"s2_impl_started","prev_stage":"s1_plan_reviewed","started_at":"2026-05-23T13:01:42Z"}'
+```
+
+### 10.5 Consumer Behavior
+
+cw surfaces `last_stage` per running session in `cw orchestrate status` (text output) and the TUI sessions table (rendered by `cw orchestrate watch`). The value is derived at render time by filtering recorded events to `STAGE_ENTERED` and mapping `payload.session_id → payload.stage` (latest event wins). `STAGE_ERRORED` events are visible in `cw event tail` and `recent_events` but do NOT redefine `last_stage`. Sessions with no stage events render as `—` in the TUI and omit the `last_stage=…` token in the text output.
+
+### 10.6 Cross-Repo Status
+
+The producer side ships in `mattwwarren/global-claude` `commands/auto-dev.md` as a coordinated PR; the consumer side (event taxonomy + `last_stage` plumbing) ships in cw#173.

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -694,8 +694,9 @@ def event_record(
     """Record an event to the inbox.
 
     EVENT_TYPE must be one of: ticket.enqueued, session.spawned,
-    session.completed, pr.registered, pr.ci_failed,
-    pr.review_received, pr.mergeable, pr.merged.
+    session.completed, session.timed_out, stage.entered, stage.errored,
+    pr.registered, pr.ci_failed, pr.review_received, pr.mergeable,
+    pr.merged.
     """
     if event_type not in _VALID_EVENT_TYPES:
         valid = ", ".join(sorted(_VALID_EVENT_TYPES))
@@ -1349,9 +1350,11 @@ def _format_status_human(status: OrchestratorStatus) -> str:
     )
 
     lines.extend(("", f"Running sessions:  {len(status.running_sessions)}"))
-    lines.extend(
-        f"  - {s.id}  {s.name}  status={s.status}" for s in status.running_sessions
-    )
+    for s in status.running_sessions:
+        line = f"  - {s.id}  {s.name}  status={s.status}"
+        if s.last_stage:
+            line += f"  last_stage={s.last_stage}"
+        lines.append(line)
 
     lines.extend(("", f"Monitored PRs:     {len(status.monitored_prs)}"))
     lines.extend(

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -117,6 +117,8 @@ class OrchestratorEventType(StrEnum):
     SESSION_SPAWNED = "session.spawned"
     SESSION_COMPLETED = "session.completed"
     SESSION_TIMED_OUT = "session.timed_out"
+    STAGE_ENTERED = "stage.entered"
+    STAGE_ERRORED = "stage.errored"
     PR_REGISTERED = "pr.registered"
     PR_CI_FAILED = "pr.ci_failed"
     PR_REVIEW_RECEIVED = "pr.review_received"

--- a/src/cw/orchestrate.py
+++ b/src/cw/orchestrate.py
@@ -306,6 +306,7 @@ class SessionSummary(BaseModel):
     started_at: datetime
     surface_ref: str | None = None
     worktree_path: Path | None = None
+    last_stage: str | None = None
 
 
 class TicketSummary(BaseModel):
@@ -354,7 +355,11 @@ def _summarise_ticket(task: TicketTask) -> TicketSummary:
     )
 
 
-def _summarise_session(sess: Session) -> SessionSummary:
+def _summarise_session(
+    sess: Session,
+    *,
+    last_stage: str | None = None,
+) -> SessionSummary:
     return SessionSummary(
         id=sess.id,
         name=sess.name,
@@ -364,7 +369,29 @@ def _summarise_session(sess: Session) -> SessionSummary:
         started_at=sess.started_at,
         surface_ref=sess.surface_ref,
         worktree_path=sess.worktree_path,
+        last_stage=last_stage,
     )
+
+
+def _derive_last_stage_by_session(
+    events: list[OrchestratorEvent],
+) -> dict[str, str]:
+    """Map session_id -> most recent STAGE_ENTERED.stage.
+
+    Iterates events in chronological order; later events overwrite
+    earlier ones. STAGE_ERRORED events are deliberately ignored — they
+    remain visible in recent_events but do not redefine the "current
+    stage" of a session.
+    """
+    result: dict[str, str] = {}
+    for ev in events:
+        if ev.type is not OrchestratorEventType.STAGE_ENTERED:
+            continue
+        session_id = ev.payload.get("session_id")
+        stage = ev.payload.get("stage")
+        if isinstance(session_id, str) and isinstance(stage, str):
+            result[session_id] = stage
+    return result
 
 
 def _summarise_event(event: OrchestratorEvent) -> EventSummary:
@@ -428,17 +455,20 @@ def orchestrator_status() -> OrchestratorStatus:
         _summarise_ticket(t) for t in queue.tasks if t.status == QueueItemStatus.PENDING
     ]
 
+    # Read all events first so we can derive last_stage per session before
+    # summarising the running list.
+    all_events = read_events()
+    last_stage_by_session = _derive_last_stage_by_session(all_events)
+
     state = load_state()
     running = [
-        _summarise_session(s)
+        _summarise_session(s, last_stage=last_stage_by_session.get(s.id))
         for s in state.sessions
         if s.status in (SessionStatus.ACTIVE, SessionStatus.IDLE)
     ]
 
     monitored = _load_monitored_prs()
 
-    # Read all events, then take the last N (chronological order from the inbox).
-    all_events = read_events()
     tail = all_events[-_RECENT_EVENTS_LIMIT:]
     recent = [_summarise_event(e) for e in tail]
 

--- a/src/cw/tui.py
+++ b/src/cw/tui.py
@@ -110,6 +110,7 @@ def _sessions_table(
     table.add_column("ID", width=10, no_wrap=True)
     table.add_column("PURPOSE", width=8)
     table.add_column("WORKTREE", overflow="fold")
+    table.add_column("STAGE", width=28, no_wrap=True)
     if level is DetailLevel.VERBOSE:
         table.add_column("SURFACE", width=12, no_wrap=True)
     table.add_column("ELAPSED", width=8, justify="right", no_wrap=True)
@@ -118,6 +119,7 @@ def _sessions_table(
             sess.id,
             sess.purpose,
             _shorten_worktree(sess.worktree_path, home),
+            sess.last_stage or "—",
         ]
         if level is DetailLevel.VERBOSE:
             row.append(sess.surface_ref or "—")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -382,3 +382,112 @@ def test_cli_event_tail_since_consumer_advances_cursor(tmp_events_dir: Path) -> 
     assert ev3.id in result2.output
     assert ev1.id not in result2.output
     assert ev2.id not in result2.output
+
+
+# ---------------------------------------------------------------------------
+# Stage event tests (issue #173)
+# ---------------------------------------------------------------------------
+
+
+def test_record_event_stage_entered_persists(tmp_events_dir: Path) -> None:
+    """record_event persists a STAGE_ENTERED event with its full payload."""
+    payload = {
+        "session_id": "abc12345",
+        "ticket_id": "173",
+        "stage": "s2_impl_started",
+        "prev_stage": "s1_plan_reviewed",
+        "started_at": "2026-05-23T13:01:42Z",
+    }
+    events_record_event(OrchestratorEventType.STAGE_ENTERED, payload)
+
+    events = read_events()
+    assert len(events) == 1
+    assert events[0].type is OrchestratorEventType.STAGE_ENTERED
+    assert events[0].payload == payload
+
+
+def test_record_event_stage_errored_persists(tmp_events_dir: Path) -> None:
+    """record_event persists a STAGE_ERRORED event including error_kind."""
+    payload = {
+        "session_id": "abc12345",
+        "ticket_id": "173",
+        "stage": "s2_impl_started",
+        "started_at": "2026-05-23T13:01:42Z",
+        "error_kind": "agent_block",
+    }
+    events_record_event(OrchestratorEventType.STAGE_ERRORED, payload)
+
+    events = read_events()
+    assert len(events) == 1
+    assert events[0].type is OrchestratorEventType.STAGE_ERRORED
+    assert events[0].payload == payload
+
+
+def test_read_events_type_filter_stage_entered(tmp_events_dir: Path) -> None:
+    """read_events(event_types=[STAGE_ENTERED]) returns only stage_entered events."""
+    ev_stage = events_record_event(
+        OrchestratorEventType.STAGE_ENTERED,
+        {
+            "session_id": "abc",
+            "ticket_id": "173",
+            "stage": "s2_impl_started",
+            "started_at": "2026-05-23T13:01:42Z",
+        },
+    )
+    events_record_event(OrchestratorEventType.PR_MERGED, {"pr": 1})
+    events_record_event(
+        OrchestratorEventType.STAGE_ERRORED,
+        {
+            "session_id": "abc",
+            "ticket_id": "173",
+            "stage": "s2_impl_started",
+            "started_at": "2026-05-23T13:01:45Z",
+            "error_kind": "agent_block",
+        },
+    )
+
+    result = read_events(event_types=[OrchestratorEventType.STAGE_ENTERED])
+    assert len(result) == 1
+    assert result[0].id == ev_stage.id
+
+
+def test_cli_event_record_stage_entered_works(tmp_events_dir: Path) -> None:
+    """cw event record stage.entered persists a STAGE_ENTERED event to disk."""
+    payload_json = (
+        '{"session_id":"x","ticket_id":"173",'
+        '"stage":"s2_impl_started","started_at":"2026-05-23T13:01:42Z"}'
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["event", "record", "stage.entered", "--payload", payload_json],
+    )
+    assert result.exit_code == 0, result.output
+
+    events = read_events()
+    assert len(events) == 1
+    assert events[0].type is OrchestratorEventType.STAGE_ENTERED
+    assert events[0].payload["stage"] == "s2_impl_started"
+
+
+def test_cli_event_tail_type_filter_stage_entered(tmp_events_dir: Path) -> None:
+    """cw event tail --type stage.entered filters out non-stage events."""
+    events_record_event(
+        OrchestratorEventType.STAGE_ENTERED,
+        {
+            "session_id": "abc",
+            "ticket_id": "173",
+            "stage": "s2_impl_started",
+            "started_at": "2026-05-23T13:01:42Z",
+        },
+    )
+    events_record_event(OrchestratorEventType.PR_MERGED, {"pr": 99})
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["event", "tail", "--type", "stage.entered"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "stage.entered" in result.output
+    assert "pr.merged" not in result.output

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,6 +14,8 @@ from cw.models import (
     CompletionReason,
     CwState,
     OrchestratorConfig,
+    OrchestratorEvent,
+    OrchestratorEventType,
     Session,
     SessionPurpose,
     SessionStatus,
@@ -483,3 +485,39 @@ class TestOrchestratorConfigLegacyDefault:
         """Default fallback is 1 when neither field is set."""
         config = OrchestratorConfig()
         assert config.default_max_parallel == 1
+
+
+@pytest.mark.parametrize(
+    ("event_type", "payload"),
+    [
+        (
+            OrchestratorEventType.STAGE_ENTERED,
+            {
+                "session_id": "abc12345",
+                "ticket_id": "173",
+                "stage": "s2_impl_started",
+                "prev_stage": "s1_plan_reviewed",
+                "started_at": "2026-05-23T13:01:42Z",
+            },
+        ),
+        (
+            OrchestratorEventType.STAGE_ERRORED,
+            {
+                "session_id": "abc12345",
+                "ticket_id": "173",
+                "stage": "s2_impl_started",
+                "started_at": "2026-05-23T13:01:42Z",
+                "error_kind": "agent_block",
+            },
+        ),
+    ],
+)
+def test_stage_event_types_round_trip(
+    event_type: OrchestratorEventType,
+    payload: dict[str, str],
+) -> None:
+    """STAGE_ENTERED / STAGE_ERRORED survive a Pydantic model round-trip."""
+    event = OrchestratorEvent(type=event_type, payload=payload)
+    restored = OrchestratorEvent.model_validate_json(event.model_dump_json())
+    assert restored.type is event_type
+    assert restored.payload == payload

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -866,3 +866,235 @@ class TestOrchestratorParent:
         entry = orchestrator_parent("wrk81")
         assert entry is not None
         assert entry.surface_ref is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: last_stage derivation from stage events (issue #173)
+# ---------------------------------------------------------------------------
+
+
+class TestRunningSessionLastStage:
+    def test_running_session_last_stage_picks_most_recent(
+        self,
+        tmp_orchestrate_dirs: Path,
+        workspace: Path,
+    ) -> None:
+        """Last STAGE_ENTERED event wins per session_id."""
+        save_state(
+            CwState(
+                sessions=[
+                    _make_session("s1", workspace, status=SessionStatus.ACTIVE),
+                    _make_session("s2", workspace, status=SessionStatus.ACTIVE),
+                ]
+            )
+        )
+        record_event(
+            OrchestratorEventType.STAGE_ENTERED,
+            {
+                "session_id": "s1",
+                "ticket_id": "173",
+                "stage": "s1_plan_reviewed",
+                "started_at": "2026-05-23T13:00:00Z",
+            },
+        )
+        record_event(
+            OrchestratorEventType.STAGE_ENTERED,
+            {
+                "session_id": "s1",
+                "ticket_id": "173",
+                "stage": "s2_impl_started",
+                "started_at": "2026-05-23T13:01:00Z",
+            },
+        )
+        record_event(
+            OrchestratorEventType.STAGE_ENTERED,
+            {
+                "session_id": "s2",
+                "ticket_id": "174",
+                "stage": "s1_plan_generated",
+                "started_at": "2026-05-23T13:02:00Z",
+            },
+        )
+
+        snapshot = orchestrator_status()
+        by_id = {s.id: s for s in snapshot.running_sessions}
+        assert by_id["s1"].last_stage == "s2_impl_started"
+        assert by_id["s2"].last_stage == "s1_plan_generated"
+
+    def test_running_session_last_stage_none_when_no_events(
+        self,
+        tmp_orchestrate_dirs: Path,
+        workspace: Path,
+    ) -> None:
+        """A running session with no stage events has last_stage=None."""
+        save_state(
+            CwState(
+                sessions=[
+                    _make_session("s1", workspace, status=SessionStatus.ACTIVE),
+                ]
+            )
+        )
+        snapshot = orchestrator_status()
+        assert len(snapshot.running_sessions) == 1
+        assert snapshot.running_sessions[0].last_stage is None
+
+    def test_running_session_last_stage_ignores_completed_session_events(
+        self,
+        tmp_orchestrate_dirs: Path,
+        workspace: Path,
+    ) -> None:
+        """COMPLETED sessions don't appear in running_sessions even with events."""
+        save_state(
+            CwState(
+                sessions=[
+                    _make_session("s1", workspace, status=SessionStatus.ACTIVE),
+                    _make_session("c1", workspace, status=SessionStatus.COMPLETED),
+                ]
+            )
+        )
+        record_event(
+            OrchestratorEventType.STAGE_ENTERED,
+            {
+                "session_id": "s1",
+                "ticket_id": "173",
+                "stage": "s2_impl_started",
+                "started_at": "2026-05-23T13:00:00Z",
+            },
+        )
+        record_event(
+            OrchestratorEventType.STAGE_ENTERED,
+            {
+                "session_id": "c1",
+                "ticket_id": "172",
+                "stage": "done",
+                "started_at": "2026-05-23T13:01:00Z",
+            },
+        )
+
+        snapshot = orchestrator_status()
+        ids = [s.id for s in snapshot.running_sessions]
+        assert "c1" not in ids
+        by_id = {s.id: s for s in snapshot.running_sessions}
+        assert by_id["s1"].last_stage == "s2_impl_started"
+
+    def test_running_session_last_stage_ignores_non_stage_events(
+        self,
+        tmp_orchestrate_dirs: Path,
+        workspace: Path,
+    ) -> None:
+        """PR_MERGED and other non-stage events don't redefine last_stage."""
+        save_state(
+            CwState(
+                sessions=[
+                    _make_session("s1", workspace, status=SessionStatus.ACTIVE),
+                ]
+            )
+        )
+        record_event(
+            OrchestratorEventType.STAGE_ENTERED,
+            {
+                "session_id": "s1",
+                "ticket_id": "173",
+                "stage": "s1_plan_reviewed",
+                "started_at": "2026-05-23T13:00:00Z",
+            },
+        )
+        record_event(
+            OrchestratorEventType.PR_MERGED,
+            {"session_id": "s1", "pr_number": 42},
+        )
+
+        snapshot = orchestrator_status()
+        by_id = {s.id: s for s in snapshot.running_sessions}
+        assert by_id["s1"].last_stage == "s1_plan_reviewed"
+
+    def test_running_session_last_stage_handles_errored_event(
+        self,
+        tmp_orchestrate_dirs: Path,
+        workspace: Path,
+    ) -> None:
+        """STAGE_ERRORED is deliberately ignored when deriving last_stage."""
+        save_state(
+            CwState(
+                sessions=[
+                    _make_session("s1", workspace, status=SessionStatus.ACTIVE),
+                ]
+            )
+        )
+        record_event(
+            OrchestratorEventType.STAGE_ENTERED,
+            {
+                "session_id": "s1",
+                "ticket_id": "173",
+                "stage": "s2_impl_started",
+                "started_at": "2026-05-23T13:00:00Z",
+            },
+        )
+        record_event(
+            OrchestratorEventType.STAGE_ERRORED,
+            {
+                "session_id": "s1",
+                "ticket_id": "173",
+                "stage": "s2_impl_started",
+                "started_at": "2026-05-23T13:01:00Z",
+                "error_kind": "agent_block",
+            },
+        )
+
+        snapshot = orchestrator_status()
+        by_id = {s.id: s for s in snapshot.running_sessions}
+        assert by_id["s1"].last_stage == "s2_impl_started"
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI orchestrate status surfaces last_stage (issue #173)
+# ---------------------------------------------------------------------------
+
+
+class TestCliOrchestrateStatusLastStage:
+    def test_cli_orchestrate_status_includes_last_stage(
+        self,
+        tmp_orchestrate_dirs: Path,
+        workspace: Path,
+    ) -> None:
+        """Running-sessions section includes last_stage=<value> when set."""
+        save_state(
+            CwState(
+                sessions=[
+                    _make_session("s1", workspace, status=SessionStatus.ACTIVE),
+                ]
+            )
+        )
+        record_event(
+            OrchestratorEventType.STAGE_ENTERED,
+            {
+                "session_id": "s1",
+                "ticket_id": "173",
+                "stage": "s2_impl_started",
+                "started_at": "2026-05-23T13:00:00Z",
+            },
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["orchestrate", "status"])
+        assert result.exit_code == 0, result.output
+        assert "last_stage=s2_impl_started" in result.output
+
+    def test_cli_orchestrate_status_omits_last_stage_when_none(
+        self,
+        tmp_orchestrate_dirs: Path,
+        workspace: Path,
+    ) -> None:
+        """No last_stage token when the session has no stage events."""
+        save_state(
+            CwState(
+                sessions=[
+                    _make_session("s1", workspace, status=SessionStatus.ACTIVE),
+                ]
+            )
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["orchestrate", "status"])
+        assert result.exit_code == 0, result.output
+        assert "last_stage=" not in result.output

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -242,3 +242,71 @@ class TestWatch:
             status_fn=lambda: sample_status,
         )
         assert buffer.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# STAGE column tests (issue #173)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stage_status(frozen_now: datetime) -> OrchestratorStatus:
+    """A status with one session having last_stage and one without."""
+    return OrchestratorStatus(
+        generated_at=frozen_now,
+        running_sessions=[
+            SessionSummary(
+                id="withst01",
+                name="personal/impl",
+                client="personal",
+                status="active",
+                purpose="impl",
+                started_at=datetime(2026, 4, 18, 11, 55, 0, tzinfo=UTC),
+                worktree_path=Path("/home/matthew/workspace/personal/wt/abc"),
+                last_stage="s2_impl_started",
+            ),
+            SessionSummary(
+                id="nostage1",
+                name="personal/idea",
+                client="personal",
+                status="active",
+                purpose="idea",
+                started_at=datetime(2026, 4, 18, 10, 0, 0, tzinfo=UTC),
+                worktree_path=None,
+                last_stage=None,
+            ),
+        ],
+    )
+
+
+class TestSessionsTableStageColumn:
+    def test_default_level_shows_last_stage_when_present(
+        self,
+        stage_status: OrchestratorStatus,
+        frozen_now: datetime,
+    ) -> None:
+        """The session with last_stage set surfaces the stage value at DEFAULT."""
+        output = _render(stage_status, DetailLevel.DEFAULT, frozen_now=frozen_now)
+        assert "s2_impl_started" in output
+
+    def test_default_level_renders_dash_when_last_stage_absent(
+        self,
+        stage_status: OrchestratorStatus,
+        frozen_now: datetime,
+    ) -> None:
+        """A session with last_stage=None renders an em-dash in the STAGE column."""
+        output = _render(stage_status, DetailLevel.DEFAULT, frozen_now=frozen_now)
+        # The STAGE column header is present in DEFAULT.
+        assert "STAGE" in output
+        # The em-dash sentinel for missing values is present.
+        assert "—" in output
+
+    def test_compact_level_omits_last_stage(
+        self,
+        stage_status: OrchestratorStatus,
+        frozen_now: datetime,
+    ) -> None:
+        """COMPACT mode renders only counts -- no STAGE column or stage value."""
+        output = _render(stage_status, DetailLevel.COMPACT, frozen_now=frozen_now)
+        assert "STAGE" not in output
+        assert "s2_impl_started" not in output


### PR DESCRIPTION
## Summary

Adds stage-transition observability to cw's event bus. New event types record stage enter/error transitions per session, with derived "last stage" surfaced through orchestrate CLI and TUI.

- test: failing tests for stage event taxonomy
- feat(models): add STAGE_ENTERED and STAGE_ERRORED event types
- feat(orchestrate): derive last_stage per active session from stage events
- feat(cli): surface last_stage in orchestrate status output
- feat(tui): add STAGE column to sessions table
- docs(headless-contract): document stage event taxonomy

Closes #173.

## Test plan

- [x] ruff check — zero violations
- [x] mypy — zero type errors (59 source files)
- [x] pytest — 887 passed
- [ ] No regressions in dispatch, reconcile, or other affected modules

Reviewer notes (Stage 3, all clear): Code Quality NO_ISSUES; SysAdmin 2 SHOULD_FIX deferred to follow-up (stage-id validation, scan-all pattern in _derive_last_stage_by_session); PM Mode-2 NO_ISSUES.

Shipped via /prep-pr + project /ship-it