### PR TITLE
feat(doctor): cw 1.0 setup checks — bypass-disclaimer, claude-version, daemon-reachable (#142)

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -26,6 +26,39 @@ test -S ~/Library/Application\ Support/cmux/cmux.sock && echo cmux-ok
 peon status           # optional
 ```
 
+## 1.0 Prerequisites — One-time Setup Steps
+
+### Accept the bypass-permissions disclaimer
+
+Before `cw` can spawn background Claude sessions, the `claude` binary requires you to accept its bypass-permissions disclaimer. Run this once interactively:
+
+```bash
+claude --dangerously-skip-permissions
+```
+
+This persists `skipDangerousModePermissionPrompt: true` in `~/.claude/settings.json`. You only need to do this once; subsequent `cw` sessions will pick it up automatically.
+
+### Verify with `cw doctor`
+
+After installation, run `cw doctor` to confirm your environment is ready:
+
+```
+cw doctor
+```
+
+Expected output for a healthy setup:
+
+```
+  [OK]   bypass-disclaimer — accepted
+  [OK]   claude-version — 2.1.150 (Claude Code)
+  [WARN] daemon-reachable — roster.json not found at ... — daemon not started?
+```
+
+- `[OK] bypass-disclaimer — accepted` — disclaimer accepted; `cw` can spawn sessions.
+- `[WARN] bypass-disclaimer — ...` — disclaimer not yet accepted; run `claude --dangerously-skip-permissions` interactively.
+- `[OK] claude-version` — `claude` binary found and responsive.
+- `[WARN] daemon-reachable` — the Claude native daemon has not been started yet; this resolves automatically when `cw` first spawns a worker session.
+
 ## Installation
 
 ### From GitHub (recommended)

--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -333,13 +333,6 @@ def _check_bypass_disclaimer() -> CheckResult:
             warn=True,
             detail=f"settings.json not found at {_CLAUDE_SETTINGS_PATH}",
         )
-    except Exception as exc:
-        return CheckResult(
-            "bypass-disclaimer",
-            ok=True,
-            warn=True,
-            detail=f"could not read settings.json: {exc}",
-        )
     try:
         data: dict[str, object] = json.loads(raw)
     except json.JSONDecodeError as exc:
@@ -434,13 +427,6 @@ def _check_daemon_reachable() -> CheckResult:
             ok=True,
             warn=True,
             detail=f"roster.json not found at {_ROSTER_PATH} — daemon not started?",
-        )
-    except Exception as exc:
-        return CheckResult(
-            "daemon-reachable",
-            ok=True,
-            warn=True,
-            detail=f"could not read roster.json: {exc}",
         )
     try:
         data: dict[str, object] = json.loads(raw)

--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -30,6 +30,7 @@ from cw.config import (
 from cw.dev_queue import load_dev_queue
 from cw.exceptions import CwError
 from cw.models import BackendName, CwState, Session
+from cw.native_daemon import _ROSTER_PATH
 from cw.reconcile import reconcile
 
 
@@ -55,6 +56,11 @@ class DoctorReport:
     def ok(self) -> bool:
         return all(c.ok for c in self.checks)
 
+    @property
+    def clean(self) -> bool:
+        """True only when every check is both ok and not warned."""
+        return all(c.ok and not c.warn for c in self.checks)
+
 
 _CMUX_SOCKET_PATH = (
     Path.home() / "Library" / "Application Support" / "cmux" / "cmux.sock"
@@ -63,12 +69,11 @@ _CMUX_SOCKET_PATH = (
 # Path to Claude Code user settings — read for the disclaimer-acceptance flag.
 _CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 
-# Re-export _ROSTER_PATH for an independent module-level binding (so tests can
-# patch cw.doctor._ROSTER_PATH separately from cw.native_daemon._ROSTER_PATH —
-# the autouse conftest fixture patches only the native_daemon binding).
-from cw.native_daemon import _ROSTER_PATH as _NATIVE_ROSTER_PATH  # noqa: E402
+# Minimum supported Claude Code version for native-daemon dispatch.
+_MIN_CLAUDE_VERSION = (2, 1, 139)
 
-_ROSTER_PATH = _NATIVE_ROSTER_PATH
+# Number of components (major.minor.patch) required in a version string.
+_VERSION_PARTS = 3
 
 
 def _check_backend_binary(backend: BackendName) -> CheckResult:
@@ -342,7 +347,7 @@ def _check_bypass_disclaimer() -> CheckResult:
             "bypass-disclaimer",
             ok=True,
             warn=True,
-            detail=f"could not read settings.json: {exc}",
+            detail=f"could not parse settings.json: {exc}",
         )
     if data.get("skipDangerousModePermissionPrompt"):
         return CheckResult("bypass-disclaimer", ok=True, warn=False, detail="accepted")
@@ -358,7 +363,12 @@ def _check_bypass_disclaimer() -> CheckResult:
 
 
 def _check_claude_version() -> CheckResult:
-    """Check that the claude binary is reachable and return its version."""
+    """Check that the claude binary is reachable and return its version.
+
+    Returns ok=True, warn=True when the binary ran but exited non-zero, or when
+    the version string cannot be parsed, or when the version is below the floor
+    required for native-daemon dispatch.
+    """
     try:
         proc = subprocess.run(
             ["claude", "--version"],
@@ -373,11 +383,44 @@ def _check_claude_version() -> CheckResult:
         return CheckResult(
             "claude-version", ok=False, detail="claude --version timed out (10s)"
         )
-    version_line = (
-        (proc.stdout or proc.stderr or "").splitlines()[0]
-        if (proc.stdout or proc.stderr)
-        else ""
-    )
+
+    output = proc.stdout or proc.stderr or ""
+    version_line = output.splitlines()[0] if output else ""
+
+    if proc.returncode != 0:
+        return CheckResult(
+            "claude-version",
+            ok=True,
+            warn=True,
+            detail=f"claude --version exited {proc.returncode}: {version_line}",
+        )
+
+    # Parse the leading X.Y.Z token from the version line.
+    first_token = version_line.split()[0] if version_line else ""
+    parts = first_token.split(".")
+    try:
+        if len(parts) < _VERSION_PARTS:
+            raise ValueError("fewer than three version components")
+        parsed = tuple(int(p) for p in parts[:3])
+    except (ValueError, AttributeError):
+        return CheckResult(
+            "claude-version",
+            ok=True,
+            warn=True,
+            detail=f"could not parse version: {version_line}",
+        )
+
+    if parsed < _MIN_CLAUDE_VERSION:
+        min_str = ".".join(str(x) for x in _MIN_CLAUDE_VERSION)
+        return CheckResult(
+            "claude-version",
+            ok=True,
+            warn=True,
+            detail=(
+                f"{version_line} — upgrade to >= {min_str} for native-daemon dispatch"
+            ),
+        )
+
     return CheckResult("claude-version", ok=True, detail=version_line)
 
 
@@ -406,7 +449,7 @@ def _check_daemon_reachable() -> CheckResult:
             "daemon-reachable",
             ok=True,
             warn=True,
-            detail=f"could not read roster.json: {exc}",
+            detail=f"could not parse roster.json: {exc}",
         )
     pid = data.get("supervisorPid", 0)
     if isinstance(pid, int) and pid > 0:
@@ -436,5 +479,11 @@ def format_report(report: DoctorReport) -> str:
             line += f" — {check.detail}"
         lines.append(line)
     lines.append("")
-    lines.append("status: healthy" if report.ok else "status: problems detected")
+    if not report.ok:
+        footer = "status: problems detected"
+    elif report.clean:
+        footer = "status: healthy"
+    else:
+        footer = "status: healthy — advisory warnings"
+    lines.append(footer)
     return "\n".join(lines)

--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -11,7 +11,9 @@ assert on specific checks.
 
 from __future__ import annotations
 
+import json
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -38,6 +40,7 @@ class CheckResult:
     name: str
     ok: bool
     detail: str
+    warn: bool = False
 
 
 @dataclass
@@ -56,6 +59,16 @@ class DoctorReport:
 _CMUX_SOCKET_PATH = (
     Path.home() / "Library" / "Application Support" / "cmux" / "cmux.sock"
 )
+
+# Path to Claude Code user settings — read for the disclaimer-acceptance flag.
+_CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+
+# Re-export _ROSTER_PATH for an independent module-level binding (so tests can
+# patch cw.doctor._ROSTER_PATH separately from cw.native_daemon._ROSTER_PATH —
+# the autouse conftest fixture patches only the native_daemon binding).
+from cw.native_daemon import _ROSTER_PATH as _NATIVE_ROSTER_PATH  # noqa: E402
+
+_ROSTER_PATH = _NATIVE_ROSTER_PATH
 
 
 def _check_backend_binary(backend: BackendName) -> CheckResult:
@@ -295,16 +308,129 @@ def run_doctor(*, reap: bool = False) -> DoctorReport:
     if link_state is not None:
         report.checks.extend(_check_linkage(link_state))
 
+    report.checks.append(_check_bypass_disclaimer())
+    report.checks.append(_check_claude_version())
+    report.checks.append(_check_daemon_reachable())
+
     if reap:
         report.checks.append(_check_reconcile())
     return report
+
+
+def _check_bypass_disclaimer() -> CheckResult:
+    """Check whether the user has accepted the bypass-permissions disclaimer."""
+    try:
+        raw = _CLAUDE_SETTINGS_PATH.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return CheckResult(
+            "bypass-disclaimer",
+            ok=True,
+            warn=True,
+            detail=f"settings.json not found at {_CLAUDE_SETTINGS_PATH}",
+        )
+    except Exception as exc:
+        return CheckResult(
+            "bypass-disclaimer",
+            ok=True,
+            warn=True,
+            detail=f"could not read settings.json: {exc}",
+        )
+    try:
+        data: dict[str, object] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return CheckResult(
+            "bypass-disclaimer",
+            ok=True,
+            warn=True,
+            detail=f"could not read settings.json: {exc}",
+        )
+    if data.get("skipDangerousModePermissionPrompt"):
+        return CheckResult("bypass-disclaimer", ok=True, warn=False, detail="accepted")
+    return CheckResult(
+        "bypass-disclaimer",
+        ok=True,
+        warn=True,
+        detail=(
+            "skipDangerousModePermissionPrompt not set"
+            " — run `claude --dangerously-skip-permissions` once interactively"
+        ),
+    )
+
+
+def _check_claude_version() -> CheckResult:
+    """Check that the claude binary is reachable and return its version."""
+    try:
+        proc = subprocess.run(
+            ["claude", "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        return CheckResult("claude-version", ok=False, detail="claude binary not found")
+    except subprocess.TimeoutExpired:
+        return CheckResult(
+            "claude-version", ok=False, detail="claude --version timed out (10s)"
+        )
+    version_line = (
+        (proc.stdout or proc.stderr or "").splitlines()[0]
+        if (proc.stdout or proc.stderr)
+        else ""
+    )
+    return CheckResult("claude-version", ok=True, detail=version_line)
+
+
+def _check_daemon_reachable() -> CheckResult:
+    """Check whether the Claude native daemon's roster reports a running supervisor."""
+    try:
+        raw = _ROSTER_PATH.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return CheckResult(
+            "daemon-reachable",
+            ok=True,
+            warn=True,
+            detail=f"roster.json not found at {_ROSTER_PATH} — daemon not started?",
+        )
+    except Exception as exc:
+        return CheckResult(
+            "daemon-reachable",
+            ok=True,
+            warn=True,
+            detail=f"could not read roster.json: {exc}",
+        )
+    try:
+        data: dict[str, object] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return CheckResult(
+            "daemon-reachable",
+            ok=True,
+            warn=True,
+            detail=f"could not read roster.json: {exc}",
+        )
+    pid = data.get("supervisorPid", 0)
+    if isinstance(pid, int) and pid > 0:
+        return CheckResult(
+            "daemon-reachable", ok=True, warn=False, detail=f"supervisorPid={pid}"
+        )
+    return CheckResult(
+        "daemon-reachable",
+        ok=True,
+        warn=True,
+        detail="supervisorPid absent or zero — daemon may not be running",
+    )
 
 
 def format_report(report: DoctorReport) -> str:
     """Render a :class:`DoctorReport` as a human-readable block."""
     lines = [f"cw {report.version}"]
     for check in report.checks:
-        mark = "OK" if check.ok else "FAIL"
+        if check.warn:
+            mark = "WARN"
+        elif check.ok:
+            mark = "OK"
+        else:
+            mark = "FAIL"
         line = f"  [{mark}] {check.name}"
         if check.detail:
             line += f" — {check.detail}"

--- a/src/cw/exceptions.py
+++ b/src/cw/exceptions.py
@@ -20,3 +20,21 @@ class HookContextConflictError(CwError):
     (Phase C of multiplexer-removal) route this to a clean failure mode
     rather than overwriting.
     """
+
+
+class DisclaimerNotAcceptedError(CwError):
+    """Raised when ``claude --bg`` fails because the user has not accepted
+    the bypass-permissions disclaimer.
+
+    Detection: the substring ``"requires accepting the disclaimer first"`` is
+    present in ``CalledProcessError.stderr``. Verified against the live
+    ``claude`` binary at version 2.1.150 via ``strings`` — the full stderr line
+    emitted by that binary is::
+
+        --bg with bypassPermissions requires accepting the disclaimer first.
+        Run `claude --dangerously-skip-permissions` once interactively.
+
+    Remediation: run ``claude --dangerously-skip-permissions`` once interactively
+    to accept the disclaimer (persisted to ``~/.claude/settings.json`` as
+    ``skipDangerousModePermissionPrompt: true``).
+    """

--- a/src/cw/native_daemon.py
+++ b/src/cw/native_daemon.py
@@ -23,7 +23,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
-from cw.exceptions import CwError
+from cw.exceptions import CwError, DisclaimerNotAcceptedError
 
 _log = logging.getLogger(__name__)
 
@@ -49,6 +49,11 @@ _BG_STDOUT_PATTERN = re.compile(r"backgrounded\s*·\s*([0-9a-f]{8})")
 # (``backgrounded · \x1b[36m<id>\x1b[39m``). Strip CSI SGR sequences before
 # matching so the parser tolerates terminal-formatted output.
 _ANSI_CSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+
+# Substring verified against claude binary 2.1.150 via ``strings``; full stderr is:
+# "--bg with bypassPermissions requires accepting the disclaimer first.
+#  Run `claude --dangerously-skip-permissions` once interactively."
+_DISCLAIMER_REJECTION_PATTERN = "requires accepting the disclaimer first"
 
 
 @runtime_checkable
@@ -107,6 +112,13 @@ class RealNativeDaemonClient:
             msg = "claude binary not on PATH; cannot spawn background session"
             raise CwError(msg) from exc
         except subprocess.CalledProcessError as exc:
+            stderr_text = (exc.stderr or exc.stdout or "").strip()
+            if _DISCLAIMER_REJECTION_PATTERN in stderr_text:
+                msg = (
+                    "claude --bg requires accepting the disclaimer first. "
+                    "Run `claude --dangerously-skip-permissions` once interactively."
+                )
+                raise DisclaimerNotAcceptedError(msg) from exc
             msg = (
                 f"claude --bg exited {exc.returncode}: "
                 f"{(exc.stderr or exc.stdout or '').strip()}"

--- a/src/cw/native_daemon.py
+++ b/src/cw/native_daemon.py
@@ -115,8 +115,9 @@ class RealNativeDaemonClient:
             stderr_text = (exc.stderr or exc.stdout or "").strip()
             if _DISCLAIMER_REJECTION_PATTERN in stderr_text:
                 msg = (
-                    "claude --bg requires accepting the disclaimer first. "
-                    "Run `claude --dangerously-skip-permissions` once interactively."
+                    "claude --bg failed: bypassPermissions disclaimer not accepted."
+                    " To fix, run `claude --dangerously-skip-permissions`"
+                    " once interactively."
                 )
                 raise DisclaimerNotAcceptedError(msg) from exc
             msg = (

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -18,6 +18,20 @@ if TYPE_CHECKING:
     from cw.models import ClientConfig, Session
 
 
+def _stub_claude_version_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub _check_claude_version to return ok=True.
+
+    The real check runs ``claude --version``, which is not on the GH Actions
+    runners. Healthy-path tests that assert ``report.ok`` (no failing checks)
+    must neutralise the binary lookup; other tests covering this check
+    directly remain in :class:`TestCheckClaudeVersionDirect`.
+    """
+    monkeypatch.setattr(
+        "cw.doctor._check_claude_version",
+        lambda: CheckResult("claude-version", ok=True, detail="2.1.139 (stubbed)"),
+    )
+
+
 class TestRunDoctorFakeBackend:
     """When CW_BACKEND=fake the backend binary check is a no-op."""
 
@@ -25,6 +39,7 @@ class TestRunDoctorFakeBackend:
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
         monkeypatch.setenv("CW_BACKEND", "fake")
+        _stub_claude_version_ok(monkeypatch)
         report = run_doctor()
         assert report.backend is BackendName.FAKE
         assert report.ok
@@ -53,6 +68,7 @@ class TestRunDoctorTmuxBackend:
     ) -> None:
         monkeypatch.setenv("CW_BACKEND", "tmux")
         monkeypatch.setattr("cw.doctor.shutil.which", lambda _name: "/usr/bin/tmux")
+        _stub_claude_version_ok(monkeypatch)
         report = run_doctor()
         assert report.ok
 
@@ -84,6 +100,7 @@ class TestFormatReport:
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
         monkeypatch.setenv("CW_BACKEND", "fake")
+        _stub_claude_version_ok(monkeypatch)
         report = run_doctor()
         rendered = format_report(report)
         assert "status: healthy" in rendered
@@ -94,6 +111,7 @@ class TestDoctorCli:
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
         monkeypatch.setenv("CW_BACKEND", "fake")
+        _stub_claude_version_ok(monkeypatch)
         runner = CliRunner()
         result = runner.invoke(main, ["doctor"])
         assert result.exit_code == 0
@@ -171,6 +189,7 @@ def test_cw_doctor_cli_reap_flag(
     # Force fake backend so the binary/socket check passes on every platform
     # (macOS default is cmux, whose socket does not exist in CI).
     monkeypatch.setenv("CW_BACKEND", "fake")
+    _stub_claude_version_ok(monkeypatch)
     runner = CliRunner()
     result = runner.invoke(main, ["doctor", "--reap"])
     assert result.exit_code == 0
@@ -610,6 +629,7 @@ class TestCheckLinkageIndependence:
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
         monkeypatch.setenv("CW_BACKEND", "fake")
+        _stub_claude_version_ok(monkeypatch)
         save_state(
             CwState(
                 sessions=[

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from click.testing import CliRunner
 
 from cw.cli import main
-from cw.doctor import format_report, run_doctor
+from cw.doctor import CheckResult, DoctorReport, format_report, run_doctor
 from cw.models import BackendName
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     import pytest
 
     from cw.models import ClientConfig, Session
@@ -826,3 +826,199 @@ def test_doctor_reap_reverts_completed_silent_dev_queue_task(
     t = next(t for t in store.tasks if t.ticket_id == "TKT-DR1")
     assert t.status == QueueItemStatus.PENDING
     assert t.session_id is None
+
+
+# ---------------------------------------------------------------------------
+# New checks: bypass-disclaimer, claude-version, daemon-reachable
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_run_version(stdout: str = "2.1.150 (Claude Code)\n") -> object:
+    """Return a subprocess.run replacement that succeeds for --version."""
+
+    class _FakeCompleted:
+        def __init__(self) -> None:
+            self.stdout = stdout
+            self.stderr = ""
+            self.returncode = 0
+
+    def fake_run(args: list[str], **_kwargs: object) -> _FakeCompleted:
+        return _FakeCompleted()
+
+    return fake_run
+
+
+class TestRunDoctor10Checks:
+    """Tests for bypass-disclaimer, claude-version, and daemon-reachable checks."""
+
+    def _monkeypatch_paths(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        *,
+        settings_content: str | None = None,
+        roster_content: str | None = None,
+        fake_run: object | None = None,
+    ) -> tuple[Path, Path]:
+        """Set up isolated path monkeypatches for new doctor checks.
+
+        Returns (settings_path, roster_path) for further manipulation.
+        """
+        settings_path = tmp_path / ".claude" / "settings.json"
+        roster_path = tmp_path / ".claude" / "daemon" / "roster.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        roster_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if settings_content is not None:
+            settings_path.write_text(settings_content)
+        if roster_content is not None:
+            roster_path.write_text(roster_content)
+
+        monkeypatch.setattr("cw.doctor._CLAUDE_SETTINGS_PATH", settings_path)
+        monkeypatch.setattr("cw.doctor._ROSTER_PATH", roster_path)
+
+        if fake_run is not None:
+            monkeypatch.setattr("cw.doctor.subprocess.run", fake_run)
+        else:
+            monkeypatch.setattr(
+                "cw.doctor.subprocess.run",
+                _make_fake_run_version(),
+            )
+        return settings_path, roster_path
+
+    def test_all_three_checks_present(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        """run_doctor() includes bypass-disclaimer, claude-version, daemon-reachable."""
+        monkeypatch.setenv("CW_BACKEND", "fake")
+        settings_path = tmp_config_dir / ".claude" / "settings.json"
+        roster_path = tmp_config_dir / ".claude" / "daemon" / "roster.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        roster_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(
+            json.dumps({"skipDangerousModePermissionPrompt": True})
+        )
+        roster_path.write_text(json.dumps({"supervisorPid": 12345, "workers": {}}))
+
+        monkeypatch.setattr("cw.doctor._CLAUDE_SETTINGS_PATH", settings_path)
+        monkeypatch.setattr("cw.doctor._ROSTER_PATH", roster_path)
+        monkeypatch.setattr("cw.doctor.subprocess.run", _make_fake_run_version())
+
+        report = run_doctor()
+        names = {c.name for c in report.checks}
+        assert "bypass-disclaimer" in names
+        assert "claude-version" in names
+        assert "daemon-reachable" in names
+
+    def test_bypass_disclaimer_warns_when_not_accepted(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        """settings.json with {} → bypass-disclaimer is ok=True warn=True."""
+        monkeypatch.setenv("CW_BACKEND", "fake")
+        self._monkeypatch_paths(
+            monkeypatch,
+            tmp_config_dir,
+            settings_content=json.dumps({}),
+            roster_content=json.dumps({"supervisorPid": 12345}),
+        )
+        report = run_doctor()
+        check = next(c for c in report.checks if c.name == "bypass-disclaimer")
+        assert check.ok is True
+        assert check.warn is True
+
+    def test_bypass_disclaimer_ok_when_accepted(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        """settings.json with flag set → bypass-disclaimer ok=True warn=False."""
+        monkeypatch.setenv("CW_BACKEND", "fake")
+        self._monkeypatch_paths(
+            monkeypatch,
+            tmp_config_dir,
+            settings_content=json.dumps({"skipDangerousModePermissionPrompt": True}),
+            roster_content=json.dumps({"supervisorPid": 12345}),
+        )
+        report = run_doctor()
+        check = next(c for c in report.checks if c.name == "bypass-disclaimer")
+        assert check.ok is True
+        assert check.warn is False
+
+    def test_daemon_reachable_warns_when_roster_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        """No roster file → daemon-reachable is ok=True warn=True."""
+        monkeypatch.setenv("CW_BACKEND", "fake")
+        # Provide settings so bypass-disclaimer doesn't interfere
+        self._monkeypatch_paths(
+            monkeypatch,
+            tmp_config_dir,
+            settings_content=json.dumps({"skipDangerousModePermissionPrompt": True}),
+            # no roster_content — file won't exist
+        )
+        report = run_doctor()
+        check = next(c for c in report.checks if c.name == "daemon-reachable")
+        assert check.ok is True
+        assert check.warn is True
+
+    def test_daemon_reachable_ok_when_supervisor_running(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        """roster with supervisorPid: 12345 → daemon-reachable is ok=True warn=False."""
+        monkeypatch.setenv("CW_BACKEND", "fake")
+        self._monkeypatch_paths(
+            monkeypatch,
+            tmp_config_dir,
+            settings_content=json.dumps({"skipDangerousModePermissionPrompt": True}),
+            roster_content=json.dumps({"supervisorPid": 12345, "workers": {}}),
+        )
+        report = run_doctor()
+        check = next(c for c in report.checks if c.name == "daemon-reachable")
+        assert check.ok is True
+        assert check.warn is False
+
+    def test_daemon_reachable_warns_on_missing_supervisor_pid(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        """roster with workers but no supervisorPid → WARN, no KeyError."""
+        monkeypatch.setenv("CW_BACKEND", "fake")
+        self._monkeypatch_paths(
+            monkeypatch,
+            tmp_config_dir,
+            settings_content=json.dumps({"skipDangerousModePermissionPrompt": True}),
+            roster_content=json.dumps({"workers": {}}),
+        )
+        report = run_doctor()
+        check = next(c for c in report.checks if c.name == "daemon-reachable")
+        assert check.ok is True
+        assert check.warn is True
+
+    def test_claude_version_missing_binary_fails(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        """FileNotFoundError from claude binary → claude-version is ok=False."""
+        monkeypatch.setenv("CW_BACKEND", "fake")
+
+        def fake_run_not_found(*_a: object, **_kw: object) -> object:
+            raise FileNotFoundError("no claude")
+
+        self._monkeypatch_paths(
+            monkeypatch,
+            tmp_config_dir,
+            settings_content=json.dumps({"skipDangerousModePermissionPrompt": True}),
+            roster_content=json.dumps({"supervisorPid": 12345}),
+            fake_run=fake_run_not_found,
+        )
+        report = run_doctor()
+        check = next(c for c in report.checks if c.name == "claude-version")
+        assert check.ok is False
+
+
+def test_report_ok_unaffected_by_warn_checks() -> None:
+    """WARN checks have ok=True; DoctorReport.ok stays True; cw doctor exits 0."""
+    # Construct a DoctorReport with only WARN checks (ok=True, warn=True)
+    warn_check = CheckResult("bypass-disclaimer", ok=True, warn=True, detail="not set")
+    report = DoctorReport(
+        version="0.0.0",
+        backend=BackendName.FAKE,
+        checks=[warn_check],
+    )
+    assert report.ok is True

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -807,6 +807,7 @@ def test_doctor_reap_reverts_completed_silent_dev_queue_task(
     )
 
     monkeypatch.setenv("CW_BACKEND", "fake")
+    _stub_claude_version_ok(monkeypatch)
 
     comp_session = Session(
         id="comp-doctor-1",

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1022,3 +1022,177 @@ def test_report_ok_unaffected_by_warn_checks() -> None:
         checks=[warn_check],
     )
     assert report.ok is True
+
+
+# ---------------------------------------------------------------------------
+# format_report footer tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatReportFooter:
+    """format_report footer reflects ok/warn/fail state without contradicting."""
+
+    def test_all_ok_no_warn_shows_healthy(self) -> None:
+        """Only OK checks (no WARN, no FAIL) → 'status: healthy'."""
+        report = DoctorReport(
+            version="0.0.0",
+            backend=BackendName.FAKE,
+            checks=[
+                CheckResult("check-a", ok=True, warn=False, detail=""),
+                CheckResult("check-b", ok=True, warn=False, detail=""),
+            ],
+        )
+        rendered = format_report(report)
+        assert rendered.endswith("status: healthy")
+
+    def test_warn_checks_present_shows_advisory(self) -> None:
+        """Any WARN check (ok=True, warn=True) → advisory footer, not plain healthy."""
+        report = DoctorReport(
+            version="0.0.0",
+            backend=BackendName.FAKE,
+            checks=[
+                CheckResult("bypass-disclaimer", ok=True, warn=True, detail="not set"),
+                CheckResult("check-ok", ok=True, warn=False, detail=""),
+            ],
+        )
+        rendered = format_report(report)
+        # Must contain advisory wording — not plain 'healthy' by itself.
+        assert "status: healthy — advisory warnings" in rendered
+        # Exit-code contract: ok is still True, so this is NOT "problems detected".
+        assert "problems detected" not in rendered
+
+    def test_fail_check_shows_problems_detected(self) -> None:
+        """Any FAIL check → 'status: problems detected'."""
+        report = DoctorReport(
+            version="0.0.0",
+            backend=BackendName.FAKE,
+            checks=[
+                CheckResult("check-fail", ok=False, warn=False, detail="broken"),
+            ],
+        )
+        rendered = format_report(report)
+        assert "status: problems detected" in rendered
+        assert "healthy" not in rendered
+
+    def test_clean_property_true_when_all_ok_no_warn(self) -> None:
+        """DoctorReport.clean is True only when every check is ok and not warned."""
+        report = DoctorReport(
+            version="0.0.0",
+            backend=BackendName.FAKE,
+            checks=[CheckResult("x", ok=True, warn=False, detail="")],
+        )
+        assert report.clean is True
+
+    def test_clean_property_false_when_any_warn(self) -> None:
+        """DoctorReport.clean is False when any check has warn=True."""
+        report = DoctorReport(
+            version="0.0.0",
+            backend=BackendName.FAKE,
+            checks=[
+                CheckResult("x", ok=True, warn=True, detail=""),
+                CheckResult("y", ok=True, warn=False, detail=""),
+            ],
+        )
+        assert report.clean is False
+
+    def test_clean_property_false_when_any_fail(self) -> None:
+        """DoctorReport.clean is False when any check has ok=False."""
+        report = DoctorReport(
+            version="0.0.0",
+            backend=BackendName.FAKE,
+            checks=[CheckResult("x", ok=False, warn=False, detail="")],
+        )
+        assert report.clean is False
+
+
+# ---------------------------------------------------------------------------
+# _check_claude_version: version-floor and returncode tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckClaudeVersion:
+    """Direct tests for _check_claude_version via monkeypatched subprocess.run."""
+
+    def _mk_proc(self, stdout: str = "", returncode: int = 0) -> object:
+        class _Proc:
+            pass
+
+        p = _Proc()
+        p.stdout = stdout  # type: ignore[attr-defined]
+        p.stderr = ""  # type: ignore[attr-defined]
+        p.returncode = returncode  # type: ignore[attr-defined]
+        return p
+
+    def test_version_above_floor_ok_no_warn(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Version >= 2.1.139 → ok=True, warn=False."""
+        from cw.doctor import _check_claude_version
+
+        monkeypatch.setattr(
+            "cw.doctor.subprocess.run",
+            lambda *_a, **_kw: self._mk_proc("2.1.150 (Claude Code)\n"),
+        )
+        result = _check_claude_version()
+        assert result.ok is True
+        assert result.warn is False
+        assert "2.1.150" in result.detail
+
+    def test_version_equal_floor_ok_no_warn(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Version == 2.1.139 → ok=True, warn=False (floor is inclusive)."""
+        from cw.doctor import _check_claude_version
+
+        monkeypatch.setattr(
+            "cw.doctor.subprocess.run",
+            lambda *_a, **_kw: self._mk_proc("2.1.139 (Claude Code)\n"),
+        )
+        result = _check_claude_version()
+        assert result.ok is True
+        assert result.warn is False
+
+    def test_version_below_floor_ok_and_warns(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Version < 2.1.139 → ok=True, warn=True, detail contains upgrade hint."""
+        from cw.doctor import _check_claude_version
+
+        monkeypatch.setattr(
+            "cw.doctor.subprocess.run",
+            lambda *_a, **_kw: self._mk_proc("2.0.0 (Claude Code)\n"),
+        )
+        result = _check_claude_version()
+        assert result.ok is True
+        assert result.warn is True
+        assert "2.1.139" in result.detail
+
+    def test_unparseable_version_ok_and_warns(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-numeric version → ok=True, warn=True, detail mentions parse failure."""
+        from cw.doctor import _check_claude_version
+
+        monkeypatch.setattr(
+            "cw.doctor.subprocess.run",
+            lambda *_a, **_kw: self._mk_proc("not-a-version\n"),
+        )
+        result = _check_claude_version()
+        assert result.ok is True
+        assert result.warn is True
+        assert "could not parse" in result.detail
+
+    def test_nonzero_returncode_ok_and_warns(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Binary exits non-zero → ok=True, warn=True, detail includes returncode."""
+        from cw.doctor import _check_claude_version
+
+        monkeypatch.setattr(
+            "cw.doctor.subprocess.run",
+            lambda *_a, **_kw: self._mk_proc("some output\n", returncode=1),
+        )
+        result = _check_claude_version()
+        assert result.ok is True
+        assert result.warn is True
+        assert "1" in result.detail  # returncode appears in detail

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -25,3 +25,14 @@ class TestExceptionHierarchy:
     def test_raise_and_catch_as_cw_error(self) -> None:
         with pytest.raises(CwError, match="subclass"):
             raise WorktreeError("subclass caught by base")
+
+    def test_disclaimer_not_accepted_is_cw_error(self) -> None:
+        from cw.exceptions import DisclaimerNotAcceptedError
+
+        assert issubclass(DisclaimerNotAcceptedError, CwError)
+
+    def test_disclaimer_message_propagates(self) -> None:
+        from cw.exceptions import DisclaimerNotAcceptedError
+
+        err = DisclaimerNotAcceptedError("run interactively first")
+        assert "interactively" in str(err)

--- a/tests/test_native_daemon.py
+++ b/tests/test_native_daemon.py
@@ -153,6 +153,30 @@ class TestRealNativeDaemonClientSpawn:
         with pytest.raises(DisclaimerNotAcceptedError, match="disclaimer"):
             client.spawn_bg(cwd=tmp_path, prompt="x")
 
+    def test_disclaimer_error_message_contains_verbatim_ac_substring(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC2: error message must contain verbatim AC2 lowercase-r substring."""
+        from cw.exceptions import DisclaimerNotAcceptedError
+
+        full_stderr = (
+            "--bg with bypassPermissions requires accepting the disclaimer first. "
+            "Run `claude --dangerously-skip-permissions` once interactively."
+        )
+
+        def fake_run(*_a: object, **_kw: object) -> _FakeCompleted:
+            raise subprocess.CalledProcessError(
+                1, ["claude"], output="", stderr=full_stderr
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        client = RealNativeDaemonClient()
+        exc_info: pytest.ExceptionInfo[DisclaimerNotAcceptedError]
+        with pytest.raises(DisclaimerNotAcceptedError) as exc_info:
+            client.spawn_bg(cwd=tmp_path, prompt="x")
+        # Verbatim AC2 substring (lowercase 'r') must appear in the message.
+        assert "run `claude --dangerously-skip-permissions` once" in str(exc_info.value)
+
 
 class TestRealNativeDaemonClientRoster:
     """list_live_session_short_ids reads roster.json."""

--- a/tests/test_native_daemon.py
+++ b/tests/test_native_daemon.py
@@ -132,6 +132,27 @@ class TestRealNativeDaemonClientSpawn:
         with pytest.raises(CwError, match="claude --bg exited 2"):
             client.spawn_bg(cwd=tmp_path, prompt="x")
 
+    def test_disclaimer_not_accepted_raises_typed_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Uses FULL verified stderr from claude binary 2.1.150."""
+        from cw.exceptions import DisclaimerNotAcceptedError
+
+        full_stderr = (
+            "--bg with bypassPermissions requires accepting the disclaimer first. "
+            "Run `claude --dangerously-skip-permissions` once interactively."
+        )
+
+        def fake_run(*_a: object, **_kw: object) -> _FakeCompleted:
+            raise subprocess.CalledProcessError(
+                1, ["claude"], output="", stderr=full_stderr
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        client = RealNativeDaemonClient()
+        with pytest.raises(DisclaimerNotAcceptedError, match="disclaimer"):
+            client.spawn_bg(cwd=tmp_path, prompt="x")
+
 
 class TestRealNativeDaemonClientRoster:
     """list_live_session_short_ids reads roster.json."""


### PR DESCRIPTION
## Summary

Implements GitHub issue #142 — surfaces three `cw doctor` checks needed before cw 1.0 native-daemon dispatch can work cleanly:

- **`bypass-disclaimer`** — reads `~/.claude/settings.json` for `skipDangerousModePermissionPrompt` (verified against claude binary 2.1.150). WARN with the exact remediation command if absent.
- **`claude-version`** — runs `claude --version`, parses semver, WARNs if below `_MIN_CLAUDE_VERSION = (2, 1, 139)`. FAIL only when the binary is missing or hangs.
- **`daemon-reachable`** — reads `~/.claude/daemon/roster.json` (defensive `data.get("supervisorPid", 0)` against schema drift). WARN when roster missing or supervisor not running.

Plus typed error for the first-dispatch failure path:

- **`DisclaimerNotAcceptedError(CwError)`** raised from `RealNativeDaemonClient.spawn_bg` when stderr substring `"requires accepting the disclaimer first"` matches. Error message includes the verbatim remediation: `run \`claude --dangerously-skip-permissions\` once`.

WARN tier added to `CheckResult` (`warn: bool = False`); `DoctorReport.clean` distinguishes "fully clean" from "ok with advisories"; `format_report` footer reads `status: healthy` / `status: healthy — advisory warnings` / `status: problems detected` accordingly. **WARN does not flip `DoctorReport.ok`** — `cw doctor` exit code is unchanged for WARN-only reports.

`docs/INSTALL.md` gets a `## 1.0 Prerequisites` section explaining the one-time `claude --dangerously-skip-permissions` acceptance step.

## Scope

- 7 files: \`src/cw/{doctor,native_daemon,exceptions}.py\`, \`tests/test_{doctor,native_daemon,exceptions}.py\`, \`docs/INSTALL.md\`
- +671 / -6 lines (Small scope per /auto-dev)
- Honours all 5 user-dispositioned ambiguities from issue #142

## Test plan

- [x] ruff check — zero violations
- [x] mypy — zero type errors on touched files
- [x] pytest tests/test_doctor.py tests/test_exceptions.py tests/test_native_daemon.py — 71 passed
- [x] Full suite (excluding above) — 844 passed, no regression
- [x] PM Reviewer Mode 2 — all acceptance criteria SATISFIED (verbatim AC2 substring verified by dedicated test)

Closes #142

🤖 Shipped via /auto-dev (Stage 1 plan + Plan Quality Review + Stage 2 impl + Stage 3 review with 1 fix-loop cycle + Stage 4 /prep-pr)