### PR TITLE
fix(signal-stop): parse sentinel into session.last_result (#225)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -15,7 +15,7 @@ import click
 from click.shell_completion import CompletionItem
 
 from cw import __version__
-from cw.auto_dev_result import extract_block
+from cw.auto_dev_result import AutoDevResult, BlockedResult, extract_block, parse_stdout
 from cw.cmux import CmuxAdapter, get_cmux_adapter
 from cw.config import (
     get_client,
@@ -824,11 +824,11 @@ def run_claude(extra_args: tuple[str, ...]) -> None:
     run_claude_wrapper(extra_args)
 
 
-def _sentinel_present_in_transcript(
+def _parse_sentinel_from_transcript(
     cwd: str,
     claude_session_id: str | None,
-) -> bool:
-    """Return True if the AUTO_DEV_RESULT sentinel block appears in the transcript.
+) -> AutoDevResult | BlockedResult | None:
+    """Return the parsed sentinel from the transcript, or None if absent.
 
     Claude stores session transcripts at:
       ``~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl``
@@ -839,17 +839,22 @@ def _sentinel_present_in_transcript(
     newlines become the two-character sequence ``\\n``). Running ``extract_block``
     against the raw file therefore misses sentinels that are valid in their
     decoded form, so this scans each assistant text block individually after
-    JSON decoding. Returns False on any I/O or parse error (fail-open: defer
-    rather than falsely report sentinel present). See GitHub issue #176 Layer 1.
+    JSON decoding. Returns None on any I/O error or when no complete sentinel
+    pair is found — distinct from a BlockedResult, which means the sentinel
+    framing was present but the inner payload was unusable (§6 failure modes).
+
+    Used by ``signal_stop`` for headless DAEMON sessions, whose result must
+    be captured here because they bypass the cw wrapper entirely. See GitHub
+    issue #225 (capture gap) and issue #176 Layer 1 (transcript-walk origin).
     """
     if not claude_session_id:
-        return False
+        return None
     encoded = cwd.replace("/", "-").replace(".", "-")
     transcript_path = (
         Path.home() / ".claude" / "projects" / encoded / f"{claude_session_id}.jsonl"
     )
     if not transcript_path.is_file():
-        return False
+        return None
     try:
         with transcript_path.open(encoding="utf-8", errors="replace") as handle:
             for line in handle:
@@ -870,10 +875,25 @@ def _sentinel_present_in_transcript(
                         continue
                     text = block.get("text")
                     if isinstance(text, str) and extract_block(text) is not None:
-                        return True
+                        return parse_stdout(text)
     except OSError:
-        return False
-    return False
+        return None
+    return None
+
+
+def _sentinel_present_in_transcript(
+    cwd: str,
+    claude_session_id: str | None,
+) -> bool:
+    """Return True if the AUTO_DEV_RESULT sentinel block appears in the transcript.
+
+    Thin wrapper around :func:`_parse_sentinel_from_transcript` preserved for
+    callers that only need the boolean (Layer 1 budget gate in signal_stop).
+    A non-None return — including a BlockedResult for malformed payloads —
+    means the agent emitted *something*; the result-capture path uses the
+    full parsed value, but the budget path only cares "did it emit?"
+    """
+    return _parse_sentinel_from_transcript(cwd, claude_session_id) is not None
 
 
 @main.command(name="signal-stop")
@@ -1007,11 +1027,12 @@ def signal_stop() -> None:
         context.get("headless")
     )
     now = datetime.now(UTC)
+    parsed_sentinel: AutoDevResult | BlockedResult | None = None
     if is_headless:
-        has_sentinel = _sentinel_present_in_transcript(
+        parsed_sentinel = _parse_sentinel_from_transcript(
             cwd_value, claude_session_id if isinstance(claude_session_id, str) else None
         )
-        if not has_sentinel:
+        if parsed_sentinel is None:
             elapsed = (now - session.started_at).total_seconds()
             if elapsed < HEADLESS_TIMEOUT_SECONDS:
                 # Under budget — defer. Another Stop hook turn will fire, or
@@ -1058,6 +1079,14 @@ def signal_stop() -> None:
     session.completed_reason = CompletionReason.NORMAL
     if isinstance(claude_session_id, str):
         session.claude_session_id = claude_session_id
+    # Issue #225: headless DAEMON sessions bypass the cw wrapper, so
+    # signal_completed (wrapper.py) never runs and last_result stayed None.
+    # Capture the parsed sentinel here before save_state so downstream
+    # consumers (consume_completed_sessions, /cw-followup) can route by
+    # status. parse_stdout returns BlockedResult on malformed payloads — we
+    # persist either shape; both serialize to a dict with a "status" field.
+    if parsed_sentinel is not None:
+        session.last_result = parsed_sentinel.model_dump(mode="json")
     save_state(state)
 
     payload: dict[str, object] = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1090,36 +1090,31 @@ class TestSignalStop:
         save_state(state)
         self._write_headless_context(worktree, session_id=session.id)
 
-        # Write a fake transcript with a valid sentinel block so the
-        # sentinel-detection helper finds it.
+        # Write a real Claude-shaped transcript JSONL with an assistant
+        # record carrying a parseable sentinel block. The parser walks the
+        # same shape signal_stop sees in production (issue #176 Layer 1).
         claude_session_id = "abc12345"
+        fake_home = tmp_path / "fake-home"
         encoded = str(worktree).replace("/", "-").replace(".", "-")
-        transcript_dir = tmp_path / "fake-claude-home" / "projects" / encoded
+        transcript_dir = fake_home / ".claude" / "projects" / encoded
         transcript_dir.mkdir(parents=True, exist_ok=True)
-        sentinel_content = (
-            "<<<AUTO_DEV_RESULT\n"
-            '{"schema_version": 1, "status": "shipped"}\n'
-            "AUTO_DEV_RESULT>>>"
+        # Use the preserved #215 fixture — it parses to a valid AutoDevResult
+        # with status=plan_pending_approval and exercises every cross-field
+        # invariant in auto_dev_result.py.
+        record = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": _SENTINEL_215_PLAN_PENDING}],
+            },
+        }
+        (transcript_dir / f"{claude_session_id}.jsonl").write_text(
+            json.dumps(record) + "\n"
         )
-        (transcript_dir / f"{claude_session_id}.jsonl").write_text(sentinel_content)
+        monkeypatch.setattr("cw.cli.Path.home", lambda: fake_home)
 
         daemon = FakeNativeDaemonClient()
         monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: daemon)
-        # Patch Path.home() to return our fake home so the transcript path resolves.
-        fake_home = tmp_path / "fake-claude-home"
-
-        def _fake_sentinel(cwd: str, sid: str | None) -> bool:
-            from cw.auto_dev_result import extract_block
-
-            if not sid:
-                return False
-            enc = cwd.replace("/", "-").replace(".", "-")
-            tp = fake_home / "projects" / enc / f"{sid}.jsonl"
-            if not tp.is_file():
-                return False
-            return extract_block(tp.read_text()) is not None
-
-        monkeypatch.setattr("cw.cli._sentinel_present_in_transcript", _fake_sentinel)
 
         hook_stdin = json.dumps(
             {
@@ -1143,6 +1138,89 @@ class TestSignalStop:
         assert not any(
             e.payload.get("session_id") == session.id for e in timed_out_events
         )
+
+    def test_signal_stop_populates_last_result_on_sentinel(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Headless session with a parseable sentinel → session.last_result set.
+
+        Regression for GitHub issue #225: signal_stop previously called
+        the bool sentinel-check helper and threw the parse away. Headless
+        DAEMON sessions completed with last_result=None even when the
+        agent emitted a valid AUTO_DEV_RESULT block. The orchestrator's
+        consume_completed_sessions then had nothing to route on.
+        """
+        import datetime as dt
+
+        from cw.native_daemon import FakeNativeDaemonClient
+
+        started_at = dt.datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        hook_time = dt.datetime(2026, 1, 1, 0, 31, 0, tzinfo=UTC)
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir(parents=True, exist_ok=True)
+        worktree = tmp_path / "worktree-225"
+        worktree.mkdir(parents=True, exist_ok=True)
+
+        session = Session(
+            id="sess-225",
+            name="test-client/auto-dev/214",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            workspace_path=workspace,
+            worktree_path=worktree,
+            status=SessionStatus.ACTIVE,
+            started_at=started_at,
+        )
+        state = load_state()
+        state.sessions.append(session)
+        save_state(state)
+        self._write_headless_context(worktree, session_id=session.id)
+
+        # Write a real transcript with the preserved #214 sentinel — the
+        # exact failure mode that motivated #225.
+        claude_session_id = "uuid-225"
+        fake_home = tmp_path / "fake-home"
+        encoded = str(worktree).replace("/", "-").replace(".", "-")
+        project_dir = fake_home / ".claude" / "projects" / encoded
+        project_dir.mkdir(parents=True, exist_ok=True)
+        record = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": _SENTINEL_214_BLOCKED}],
+            },
+        }
+        (project_dir / f"{claude_session_id}.jsonl").write_text(
+            json.dumps(record) + "\n"
+        )
+        monkeypatch.setattr("cw.cli.Path.home", lambda: fake_home)
+
+        daemon = FakeNativeDaemonClient()
+        monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: daemon)
+
+        hook_stdin = json.dumps(
+            {
+                "session_id": claude_session_id,
+                "cwd": str(worktree),
+                "hook_event_name": "Stop",
+            }
+        )
+        runner = CliRunner()
+        with freeze_time(hook_time):
+            result = runner.invoke(main, ["signal-stop"], input=hook_stdin)
+        assert result.exit_code == 0, result.output
+
+        updated = next(s for s in load_state().sessions if s.id == session.id)
+        assert updated.status == SessionStatus.COMPLETED
+        assert updated.last_result is not None
+        assert updated.last_result["status"] == "blocked"
+        assert updated.last_result["ticket_id"] == "214"
+        assert updated.last_result["stage_reached"] == "stage1_plan"
 
     def test_signal_stop_defers_under_budget_no_sentinel(
         self,
@@ -1405,6 +1483,250 @@ class TestSentinelPresentInTranscript:
         )
 
         assert _sentinel_present_in_transcript(str(worktree), "uuid-mixed")
+
+
+# Real sentinel payloads preserved from the 2026-05-24 dogfood wave (see #225).
+# Embedded inline so the regression tests survive worktree cleanup. Both blocks
+# parse cleanly under the current invariants; their presence as fixtures locks
+# in the round-trip through _parse_sentinel_from_transcript.
+_SENTINEL_214_BLOCKED = (
+    "<<<AUTO_DEV_RESULT\n"
+    "{\n"
+    '  "schema_version": 1,\n'
+    '  "ticket_id": "214",\n'
+    '  "status": "blocked",\n'
+    '  "stage_reached": "stage1_plan",\n'
+    '  "scope": {"tier": "small", "files": 0, "lines_estimate": 0, '
+    '"lines_actual": null, "forbidden_touched": false},\n'
+    '  "plan_source": "linear_existing",\n'
+    '  "branch": null,\n'
+    '  "worktree_path": null,\n'
+    '  "fork_point_sha": null,\n'
+    '  "commits": [],\n'
+    '  "pr": null,\n'
+    '  "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},\n'
+    '  "health": {"lowest_agent_confidence": "HIGH", "any_incomplete_risk": false, '
+    '"shortcuts": [], "recommendation": "EXIT_FOR_HUMAN_REVIEW", '
+    '"downgrade_applied": false, "fix_loop_escalated": false},\n'
+    '  "friction_highlights": [],\n'
+    '  "blocker": {"stage": "stage1_plan", "reason": "agent_block", '
+    '"details": "cross-repo scope"},\n'
+    '  "next_actions": []\n'
+    "}\n"
+    "AUTO_DEV_RESULT>>>"
+)
+
+_SENTINEL_215_PLAN_PENDING = (
+    "<<<AUTO_DEV_RESULT\n"
+    "{\n"
+    '  "schema_version": 2,\n'
+    '  "ticket_id": "215",\n'
+    '  "status": "plan_pending_approval",\n'
+    '  "stage_reached": "stage1_plan",\n'
+    '  "scope": {"tier": "large", "files": 11, "lines_estimate": 626, '
+    '"lines_actual": null, "forbidden_touched": false},\n'
+    '  "plan_source": "generated",\n'
+    '  "branch": null,\n'
+    '  "worktree_path": null,\n'
+    '  "fork_point_sha": null,\n'
+    '  "commits": [],\n'
+    '  "pr": null,\n'
+    '  "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},\n'
+    '  "health": {"lowest_agent_confidence": "HIGH", "any_incomplete_risk": false, '
+    '"shortcuts": [], "recommendation": "PROCEED", '
+    '"downgrade_applied": false, "fix_loop_escalated": false},\n'
+    '  "friction_highlights": [],\n'
+    '  "blocker": null,\n'
+    '  "next_actions": ["user_approve_plan"]\n'
+    "}\n"
+    "AUTO_DEV_RESULT>>>"
+)
+
+
+class TestParseSentinelFromTranscript:
+    """Tests for _parse_sentinel_from_transcript (GitHub issue #225).
+
+    Headless DAEMON sessions complete via signal_stop, not the cw wrapper.
+    The wrapper's signal_completed is the only path that assigns
+    session.last_result today, so headless sessions emit valid sentinels
+    that the orchestrator never sees. This helper walks the same Claude
+    transcript JSONL the bool checker uses, but on a sentinel hit it
+    returns the parsed AutoDevResult (or BlockedResult for malformed
+    blocks) instead of throwing the parse away.
+    """
+
+    def _write_transcript(
+        self,
+        worktree: Path,
+        claude_session_id: str,
+        assistant_text: str,
+        home: Path,
+    ) -> None:
+        encoded = str(worktree).replace("/", "-").replace(".", "-")
+        project_dir = home / ".claude" / "projects" / encoded
+        project_dir.mkdir(parents=True, exist_ok=True)
+        record = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": assistant_text}],
+            },
+        }
+        (project_dir / f"{claude_session_id}.jsonl").write_text(
+            json.dumps(record) + "\n"
+        )
+
+    def test_returns_auto_dev_result_on_clean_sentinel(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Clean sentinel block → AutoDevResult instance, not bool or BlockedResult."""
+        from cw.auto_dev_result import AutoDevResult
+        from cw.cli import _parse_sentinel_from_transcript
+
+        fake_home = tmp_path / "fake-home"
+        monkeypatch.setattr("cw.cli.Path.home", lambda: fake_home)
+
+        worktree = tmp_path / "wt" / "auto-dev-215"
+        worktree.mkdir(parents=True)
+        self._write_transcript(
+            worktree, "uuid-215", _SENTINEL_215_PLAN_PENDING, fake_home
+        )
+
+        parsed = _parse_sentinel_from_transcript(str(worktree), "uuid-215")
+        assert isinstance(parsed, AutoDevResult)
+        assert parsed.status == "plan_pending_approval"
+        assert parsed.ticket_id == "215"
+
+    def test_returns_auto_dev_result_for_blocked_sentinel(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Regression fixture: real #214 transcript shape parses cleanly."""
+        from cw.auto_dev_result import AutoDevResult
+        from cw.cli import _parse_sentinel_from_transcript
+
+        fake_home = tmp_path / "fake-home"
+        monkeypatch.setattr("cw.cli.Path.home", lambda: fake_home)
+
+        worktree = tmp_path / "wt" / "auto-dev-214"
+        worktree.mkdir(parents=True)
+        self._write_transcript(worktree, "uuid-214", _SENTINEL_214_BLOCKED, fake_home)
+
+        parsed = _parse_sentinel_from_transcript(str(worktree), "uuid-214")
+        assert isinstance(parsed, AutoDevResult)
+        assert parsed.status == "blocked"
+        assert parsed.ticket_id == "214"
+        assert parsed.blocker is not None
+        assert parsed.blocker.reason == "agent_block"
+
+    def test_returns_blocked_result_when_sentinel_json_invalid(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sentinel framing present but inner JSON malformed → BlockedResult.
+
+        Mirrors parse_stdout's §6 (3) handling: the parser does not raise.
+        """
+        from cw.auto_dev_result import BlockedResult
+        from cw.cli import _parse_sentinel_from_transcript
+
+        fake_home = tmp_path / "fake-home"
+        monkeypatch.setattr("cw.cli.Path.home", lambda: fake_home)
+
+        worktree = tmp_path / "wt" / "auto-dev-bad"
+        worktree.mkdir(parents=True)
+        bad_sentinel = "<<<AUTO_DEV_RESULT\n{this is not valid JSON\nAUTO_DEV_RESULT>>>"
+        self._write_transcript(worktree, "uuid-bad", bad_sentinel, fake_home)
+
+        parsed = _parse_sentinel_from_transcript(str(worktree), "uuid-bad")
+        assert isinstance(parsed, BlockedResult)
+        assert parsed.status == "blocked"
+
+    def test_returns_none_when_no_sentinel(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No sentinel in transcript → None (distinct from BlockedResult).
+
+        Callers (signal_stop) use None to mean "no result yet, defer or
+        time out per budget"; a non-None return means the agent emitted
+        something — even an invalid block — and we should capture it.
+        """
+        from cw.cli import _parse_sentinel_from_transcript
+
+        fake_home = tmp_path / "fake-home"
+        monkeypatch.setattr("cw.cli.Path.home", lambda: fake_home)
+
+        worktree = tmp_path / "wt" / "auto-dev-empty"
+        worktree.mkdir(parents=True)
+        self._write_transcript(
+            worktree, "uuid-empty", "Status update with no sentinel.", fake_home
+        )
+
+        assert _parse_sentinel_from_transcript(str(worktree), "uuid-empty") is None
+
+    def test_returns_none_when_transcript_missing(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Missing transcript file → None (fail-open like the bool helper)."""
+        from cw.cli import _parse_sentinel_from_transcript
+
+        fake_home = tmp_path / "fake-home"
+        monkeypatch.setattr("cw.cli.Path.home", lambda: fake_home)
+        worktree = tmp_path / "wt" / "auto-dev-missing"
+        worktree.mkdir(parents=True)
+
+        assert _parse_sentinel_from_transcript(str(worktree), "uuid-missing") is None
+
+    def test_returns_none_when_session_id_is_none(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """No claude_session_id → None without touching the filesystem."""
+        from cw.cli import _parse_sentinel_from_transcript
+
+        assert _parse_sentinel_from_transcript(str(tmp_path), None) is None
+
+    def test_skips_non_assistant_records(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sentinel inside a user message must not be captured.
+
+        Mirrors the bool helper's same-block scoping — only assistant text
+        emissions count as a real sentinel.
+        """
+        from cw.cli import _parse_sentinel_from_transcript
+
+        fake_home = tmp_path / "fake-home"
+        monkeypatch.setattr("cw.cli.Path.home", lambda: fake_home)
+        worktree = tmp_path / "wt" / "auto-dev-userblock"
+        worktree.mkdir(parents=True)
+        encoded = str(worktree).replace("/", "-").replace(".", "-")
+        project_dir = fake_home / ".claude" / "projects" / encoded
+        project_dir.mkdir(parents=True)
+        user_record = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": _SENTINEL_215_PLAN_PENDING},
+                ],
+            },
+        }
+        (project_dir / "uuid-userblock.jsonl").write_text(
+            json.dumps(user_record) + "\n"
+        )
+
+        assert _parse_sentinel_from_transcript(str(worktree), "uuid-userblock") is None
 
 
 class TestCompletion:


### PR DESCRIPTION
## Summary
- Headless DAEMON sessions bypass the cw wrapper, so `signal_completed` (the only path that assigned `session.last_result`) never ran. `signal_stop` detected the sentinel as a bool only — every headless run completed with `last_result=None`, and the orchestrator's `consume_completed_sessions` saw nothing to route on. This is the foundational bug under every "auto-dev didn't surface its result" complaint.
- Extract `_parse_sentinel_from_transcript()` from the bool helper. Walk the JSONL the same way; on a hit, call `parse_stdout()` to return either an `AutoDevResult` or a `BlockedResult` (§6 fail-open).
- `signal_stop` wires this on the headless branch and persists `parsed.model_dump(mode="json")` to `session.last_result` before `save_state`.
- The bool `_sentinel_present_in_transcript` becomes a thin wrapper preserving the Layer 1 budget gate (issue #176).

## Test plan
- [x] 7 new tests for `_parse_sentinel_from_transcript`: clean AutoDevResult, blocked AutoDevResult (regression fixture from real #214 transcript), BlockedResult on invalid JSON, None on no-sentinel/missing-file/None-sid, skips non-assistant records.
- [x] 1 new `signal_stop` test: headless DAEMON session with parseable sentinel populates `session.last_result` with status/ticket_id/stage_reached.
- [x] 1 existing test updated (`test_signal_stop_completes_normally_with_sentinel`) to exercise the real code path via proper JSONL + home patching instead of mocking the helper.
- [x] Full suite: 926 tests pass; ruff & mypy clean.

Closes #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)