### PR TITLE
fix(contract): allow blocked at stage1_pre_flight with retry next_actions (#226)

### DIFF
--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -180,6 +180,13 @@ _TERMINAL_REJECT_STATUSES: frozenset[Status] = frozenset(
 _PRE_BRANCH_STATUSES: frozenset[Status] = frozenset(
     {"plan_pending_approval", "scope_exceeded", "forbidden_area", "no_op"},
 )
+# Pre-flight + blocked is a retry/escalation shape, not a terminal reject —
+# next_actions must signal the recovery verb. The Origin Sync block (#226)
+# emits `sync_local_main`; `manual_intervention` covers escalation cases
+# (e.g. local main has unmerged commits the orchestrator can't auto-resolve).
+_PRE_FLIGHT_BLOCKED_NEXT_ACTIONS: frozenset[str] = frozenset(
+    {"sync_local_main", "manual_intervention"},
+)
 
 
 class AutoDevResult(BaseModel):
@@ -279,17 +286,53 @@ class AutoDevResult(BaseModel):
             )
             raise ValueError(msg)
 
-        # stage1_pre_flight can only exit as no_op (pre-flight exits before any
-        # plan is produced — other statuses are not possible here).
-        if self.stage_reached == "stage1_pre_flight" and self.status != "no_op":
+        # stage1_pre_flight can exit as no_op (work not needed) or blocked
+        # (work needed but a pre-flight gate failed, e.g. Origin Sync — see
+        # issue #226). Other statuses still violate the pre-impl contract.
+        pre_flight_blocked = (
+            self.stage_reached == "stage1_pre_flight" and self.status == "blocked"
+        )
+        if self.stage_reached == "stage1_pre_flight" and self.status not in (
+            "no_op",
+            "blocked",
+        ):
             msg = (
-                f"stage_reached='stage1_pre_flight' requires status='no_op', "
-                f"got status={self.status!r}"
+                f"stage_reached='stage1_pre_flight' requires status in "
+                f"('no_op', 'blocked'), got status={self.status!r}"
             )
             raise ValueError(msg)
 
-        # §4.3 terminal-reject statuses have empty next_actions
-        if self.status in _TERMINAL_REJECT_STATUSES and self.next_actions:
+        # Pre-flight + blocked is a retry/escalation shape: next_actions must
+        # be non-empty and drawn from the allowed verb set. The generic
+        # terminal-reject rule below (empty next_actions) does NOT apply here.
+        if pre_flight_blocked:
+            if not self.next_actions:
+                msg = (
+                    "next_actions must be non-empty when status='blocked' at "
+                    "stage1_pre_flight (got empty list); expected one of "
+                    f"{sorted(_PRE_FLIGHT_BLOCKED_NEXT_ACTIONS)}"
+                )
+                raise ValueError(msg)
+            invalid = [
+                a
+                for a in self.next_actions
+                if a not in _PRE_FLIGHT_BLOCKED_NEXT_ACTIONS
+            ]
+            if invalid:
+                msg = (
+                    f"next_actions {invalid!r} not allowed for blocked at "
+                    f"stage1_pre_flight; expected subset of "
+                    f"{sorted(_PRE_FLIGHT_BLOCKED_NEXT_ACTIONS)}"
+                )
+                raise ValueError(msg)
+
+        # §4.3 terminal-reject statuses have empty next_actions, EXCEPT for
+        # the pre-flight + blocked retry shape covered above.
+        if (
+            self.status in _TERMINAL_REJECT_STATUSES
+            and self.next_actions
+            and not pre_flight_blocked
+        ):
             msg = (
                 f"next_actions must be empty for terminal-reject status "
                 f"{self.status!r}, got {self.next_actions!r}"

--- a/tests/test_auto_dev_result.py
+++ b/tests/test_auto_dev_result.py
@@ -806,10 +806,27 @@ class TestStage1PreFlightBlocked:
             AutoDevResult.model_validate(p)
 
     def test_invalid_next_action_rejected_at_pre_flight_blocked(self) -> None:
-        """next_actions for pre-flight blocked is a closed set, not free-form."""
+        """next_actions for pre-flight blocked is a closed set, not free-form.
+
+        ``wait_for_ci`` would short-circuit on the earlier §4.3 ``wait_for_ci
+        iff shipped`` rule, so use a verb that only the pre-flight closed-set
+        check can reject. Asserts the rejection message points at the
+        closed-set so we know the right branch fired.
+        """
         p = _pre_flight_blocked_payload()
-        p["next_actions"] = ["wait_for_ci"]  # shipped-only verb
-        with pytest.raises(ValidationError, match="next_actions"):
+        p["next_actions"] = ["close_issue_as_completed"]  # valid for no_op, not blocked
+        with pytest.raises(ValidationError, match="expected subset of"):
+            AutoDevResult.model_validate(p)
+
+    def test_mixed_valid_and_invalid_next_actions_rejected(self) -> None:
+        """If any entry is outside the allowed set, the whole list is invalid.
+
+        Producer must emit a pure list of allowed verbs — partial validity
+        doesn't pass.
+        """
+        p = _pre_flight_blocked_payload()
+        p["next_actions"] = ["sync_local_main", "free_text_recovery"]
+        with pytest.raises(ValidationError, match="free_text_recovery"):
             AutoDevResult.model_validate(p)
 
     def test_pre_flight_blocked_through_parse_stdout(self) -> None:

--- a/tests/test_auto_dev_result.py
+++ b/tests/test_auto_dev_result.py
@@ -686,8 +686,13 @@ class TestPreFlightNoOp:
         assert result.plan_source == "none"
         assert result.schema_version == 2
 
-    def test_stage1_pre_flight_requires_no_op_status(self) -> None:
-        # stage_reached=stage1_pre_flight with any non-no_op status is rejected.
+    def test_stage1_pre_flight_rejects_incompatible_status(self) -> None:
+        """Pre-flight exit only allows {no_op, blocked} — shipped et al are rejected.
+
+        The `blocked` admission was added for #226 (Origin Sync block); see
+        TestStage1PreFlightBlocked for the positive cases. Any other status
+        at pre-flight is still a contract violation.
+        """
         p = _no_op_payload()
         p["status"] = "shipped"
         p["pr"] = {
@@ -713,6 +718,122 @@ class TestPreFlightNoOp:
         p = _no_op_payload()
         p["scope"]["lines_actual"] = 10
         with pytest.raises(ValidationError, match="lines_actual"):
+            AutoDevResult.model_validate(p)
+
+
+# ---------------------------------------------------------------------------
+# stage1_pre_flight + blocked (added per #226 — Origin Sync block emits this
+# combo legitimately; the consumer previously rejected it as a §4.3 violation,
+# so every Origin-Sync-blocked sentinel became validation_failed). When status
+# is blocked at pre-flight, next_actions is constrained to retry/escalation
+# verbs rather than empty (which is required for the generic terminal-reject
+# `blocked` shape at later stages).
+# ---------------------------------------------------------------------------
+
+
+def _pre_flight_blocked_payload() -> dict[str, Any]:
+    """Origin-Sync-shaped sentinel: stage1_pre_flight + blocked + sync_local_main.
+
+    Matches the producer's emit shape from commit 97c92b3 (cf #178). The
+    blocker.reason is open-enum (§4.2) — `origin_sync_required` is the
+    canonical value but any string is allowed.
+    """
+    return {
+        "schema_version": 3,
+        "ticket_id": "GEN-pre-flight-blocked",
+        "status": "blocked",
+        "stage_reached": "stage1_pre_flight",
+        "scope": {
+            "tier": "small",
+            "files": 0,
+            "lines_estimate": 0,
+            "lines_actual": None,
+            "forbidden_touched": False,
+        },
+        "plan_source": "none",
+        "branch": None,
+        "worktree_path": None,
+        "fork_point_sha": None,
+        "commits": [],
+        "pr": None,
+        "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+        "health": {
+            "lowest_agent_confidence": "HIGH",
+            "any_incomplete_risk": False,
+            "shortcuts": [],
+            "recommendation": "EXIT_FOR_HUMAN_REVIEW",
+            "downgrade_applied": False,
+            "fix_loop_escalated": False,
+        },
+        "friction_highlights": [],
+        "blocker": {
+            "stage": "stage1_pre_flight",
+            "reason": "origin_sync_required",
+            "details": "local main behind origin/main; sync before dispatch",
+        },
+        "next_actions": ["sync_local_main"],
+    }
+
+
+class TestStage1PreFlightBlocked:
+    def test_origin_sync_shaped_sentinel_parses_cleanly(self) -> None:
+        """The exact shape the producer emits for Origin Sync block (#226)."""
+        p = _pre_flight_blocked_payload()
+        result = AutoDevResult.model_validate(p)
+        assert result.status == "blocked"
+        assert result.stage_reached == "stage1_pre_flight"
+        assert result.next_actions == ["sync_local_main"]
+        assert result.blocker is not None
+        assert result.blocker.reason == "origin_sync_required"
+
+    def test_manual_intervention_next_action_allowed(self) -> None:
+        """Escalation path: blocker that needs human action, not retry."""
+        p = _pre_flight_blocked_payload()
+        p["next_actions"] = ["manual_intervention"]
+        result = AutoDevResult.model_validate(p)
+        assert result.next_actions == ["manual_intervention"]
+
+    def test_empty_next_actions_rejected_when_blocked_at_pre_flight(self) -> None:
+        """Pre-flight blocked must signal a recovery path — empty list is a bug.
+
+        A producer emitting `blocked` with no next_actions at pre-flight
+        gives the orchestrator nothing to route on. Force the producer to
+        emit at least one of the allowed verbs.
+        """
+        p = _pre_flight_blocked_payload()
+        p["next_actions"] = []
+        with pytest.raises(ValidationError, match="next_actions"):
+            AutoDevResult.model_validate(p)
+
+    def test_invalid_next_action_rejected_at_pre_flight_blocked(self) -> None:
+        """next_actions for pre-flight blocked is a closed set, not free-form."""
+        p = _pre_flight_blocked_payload()
+        p["next_actions"] = ["wait_for_ci"]  # shipped-only verb
+        with pytest.raises(ValidationError, match="next_actions"):
+            AutoDevResult.model_validate(p)
+
+    def test_pre_flight_blocked_through_parse_stdout(self) -> None:
+        """End-to-end: a captured sentinel block round-trips via parse_stdout.
+
+        The wrapper path (`_parse_sentinel_from_transcript` in signal_stop)
+        uses parse_stdout, so the round-trip must succeed without falling
+        into the BlockedResult fail-open path.
+        """
+        p = _pre_flight_blocked_payload()
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "blocked"
+        assert result.stage_reached == "stage1_pre_flight"
+
+    def test_blocked_at_later_stage_still_requires_empty_next_actions(self) -> None:
+        """Regression guard: widening for pre-flight must NOT widen mid-pipeline.
+
+        A `blocked` exit at stage2_impl is the generic terminal-reject shape
+        — §4.3 still requires empty next_actions there.
+        """
+        p = _blocked_payload()  # blocked at stage2_impl
+        p["next_actions"] = ["sync_local_main"]
+        with pytest.raises(ValidationError, match="next_actions"):
             AutoDevResult.model_validate(p)
 
 


### PR DESCRIPTION
## Summary
- The /auto-dev producer (commit `97c92b3` introduced this) legitimately emits `stage_reached=stage1_pre_flight` + `status=blocked` for the Origin Sync pre-flight block. The consumer §4.3 invariant table rejected the combo — pre-flight allowed only `no_op` — so every Origin-Sync-blocked sentinel became `validation_failed` (BlockedResult), masquerading as a parse failure rather than a recognised retry-eligible blocker.
- Widen the invariant table:
  - `stage1_pre_flight` allows `{no_op, blocked}` (not just no_op).
  - pre-flight + blocked requires `next_actions ⊆ {sync_local_main, manual_intervention}` (a closed set of retry/escalation verbs).
  - pre-flight + blocked requires **non-empty** `next_actions` (must signal a recovery path).
  - The generic terminal-reject empty-next_actions rule still applies at later stages (blocked at stage2_impl etc. still requires empty next_actions).

## Test plan
- [x] 6 new tests in `TestStage1PreFlightBlocked`: clean Origin-Sync-shaped sentinel parses; `manual_intervention` allowed; empty next_actions rejected; invalid next_action (e.g. `wait_for_ci`) rejected; full `parse_stdout` round-trip; regression guard that blocked at stage2_impl still requires empty next_actions.
- [x] 1 existing test renamed (`test_stage1_pre_flight_rejects_incompatible_status`) to reflect the widened contract (rejects only non-{no_op, blocked} statuses now).
- [x] Full suite: 932 tests pass; ruff & mypy clean.

Closes #226. Independent of #228 (different files; no functional dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)