### PR TITLE
feat(session): migrate cw start/resume to claude --bg + attach (#166)

### DIFF
--- a/docs/adr/0000-native-supervisor-migration.md
+++ b/docs/adr/0000-native-supervisor-migration.md
@@ -1,7 +1,9 @@
 # Migrate session lifecycle from wrapper + multiplexer to `claude --bg` + supervisor
 
 **Status:** Accepted
-**Driven by:** #105, #108, #109, #111, #112, #113, #114, #119
+**Driven by (multiplexer-removal track):** #165 (B), #166 (C), #167 (D), #119 (F)
+**Driven by (parallel workstreams):** #114, #115 (pr-channel); #116, #117 (sdk-orchestrator)
+**Superseded:** #105, #108, #109, #111, #112, #113 (closed — see 2026-05-22 update)
 
 ## Decision
 
@@ -238,4 +240,7 @@ during Phases B–D. The fix becomes obsolete once Phase F lands.
 ## Referenced by
 
 - ADR-0001 (parked tasks pin their Session)
-- #58, #59, #105, #108, #109, #111, #112, #113, #114, #119, #126, #127
+- Multiplexer-removal track: #165 (B ✅), #166 (C ✅), #167 (D), #119 (F)
+- Spin-out deletion tickets (formerly bundled in #119): #242 wrapper, #243 reconcile slim, #244 daemon PR-watcher, #245 pr_responder, #246 handoff, #247 prompts
+- Parallel workstreams: #114, #115 (pr-channel); #116, #117 (sdk-orchestrator)
+- Adjacent: #58, #59, #126, #127

--- a/src/cw/native_daemon.py
+++ b/src/cw/native_daemon.py
@@ -60,8 +60,17 @@ _DISCLAIMER_REJECTION_PATTERN = "requires accepting the disclaimer first"
 class NativeDaemonClient(Protocol):
     """Protocol for interacting with the Claude background daemon."""
 
-    def spawn_bg(self, *, cwd: Path, prompt: str) -> str:
+    def spawn_bg(
+        self, *, cwd: Path, prompt: str, extra_args: list[str] | None = None
+    ) -> str:
         """Spawn a backgrounded Claude session in *cwd* running *prompt*.
+
+        *extra_args* are inserted before the prompt in the ``claude --bg``
+        invocation — use to pass ``--resume <uuid>`` for transcript-resume
+        or ``--append-system-prompt <text>`` for system-prompt injection.
+        An empty or falsy *prompt* is omitted from the command so the
+        session starts idle (tempo=blocked), ready for the user's first
+        message.
 
         Returns the 8-char short session id. Raises :class:`CwError` on
         spawn failure or unparseable stdout.
@@ -92,17 +101,23 @@ class RealNativeDaemonClient:
     def __init__(self, *, roster_path: Path | None = None) -> None:
         self._roster_path: Path = roster_path or _ROSTER_PATH
 
-    def spawn_bg(self, *, cwd: Path, prompt: str) -> str:
-        """Invoke ``claude --bg --permission-mode auto`` and parse short id."""
+    def spawn_bg(
+        self, *, cwd: Path, prompt: str, extra_args: list[str] | None = None
+    ) -> str:
+        """Invoke ``claude --bg --permission-mode auto`` and parse short id.
+
+        *extra_args* are inserted after ``--permission-mode <mode>`` and
+        before *prompt*. An empty *prompt* is omitted so the session starts
+        idle (tempo=blocked), ready for the user's first message.
+        """
+        cmd = ["claude", "--bg", "--permission-mode", _DEFAULT_PERMISSION_MODE]
+        if extra_args:
+            cmd.extend(extra_args)
+        if prompt:
+            cmd.append(prompt)
         try:
             proc = subprocess.run(
-                [
-                    "claude",
-                    "--bg",
-                    "--permission-mode",
-                    _DEFAULT_PERMISSION_MODE,
-                    prompt,
-                ],
+                cmd,
                 cwd=cwd,
                 capture_output=True,
                 text=True,
@@ -179,14 +194,18 @@ class FakeNativeDaemonClient:
     def __init__(self) -> None:
         self._counter = 0
         self.spawn_calls: list[tuple[Path, str]] = []
+        self.spawn_extra_args: list[list[str] | None] = []
         self.stop_calls: list[str] = []
         self._live: set[str] = set()
 
-    def spawn_bg(self, *, cwd: Path, prompt: str) -> str:
+    def spawn_bg(
+        self, *, cwd: Path, prompt: str, extra_args: list[str] | None = None
+    ) -> str:
         """Record call, register a deterministic short id, return it."""
         self._counter += 1
         short_id = f"{self._counter:08x}"
         self.spawn_calls.append((cwd, prompt))
+        self.spawn_extra_args.append(extra_args)
         self._live.add(short_id)
         return short_id
 

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -110,7 +110,7 @@ class ReconcileReport:
 
 def compute_drift(
     state: CwState,
-    adapter: MultiplexerAdapter,
+    adapter: MultiplexerAdapter | None = None,
     native_daemon: NativeDaemonClient | None = None,
 ) -> ReconcileReport:
     """Return a report naming sessions whose surface is no longer live.
@@ -124,18 +124,25 @@ def compute_drift(
     Claude session id passes liveness via the roster, while an
     interactive session with a tmux pane ref passes via the adapter.
 
+    *adapter* is optional. When ``None``, the multiplexer side of the union
+    is treated as empty; only the native daemon oracle is consulted. Phase D
+    will drop the adapter parameter entirely once the multiplexer is removed
+    from all call sites.
+
     This function does not mutate state. It also does not distinguish
     "backend reports zero live entries" from "backend is unreachable";
     that guard lives in :func:`reconcile`.
     """
     daemon = native_daemon or get_native_daemon_client()
-    tmux_live = adapter.list_surfaces()
+    tmux_live = adapter.list_surfaces() if adapter is not None else set()
     native_live = daemon.list_live_session_short_ids()
     # Second-pass zombie filter: panes that exist but whose foreground
     # process is a bare shell are not actually live cw sessions. An empty
     # command map means the backend can't enumerate — skip the filter
     # (fail-open) rather than risk false-positive reaping.
-    surface_commands = adapter.list_live_surface_commands()
+    surface_commands = (
+        adapter.list_live_surface_commands() if adapter is not None else {}
+    )
     zombie_refs: set[str] = set()
     if surface_commands:
         zombie_refs = {
@@ -188,7 +195,7 @@ def _looks_like_backend_outage(
 
 
 def reconcile(
-    adapter: MultiplexerAdapter,
+    adapter: MultiplexerAdapter | None = None,
     native_daemon: NativeDaemonClient | None = None,
 ) -> ReconcileReport:
     """Apply drift reconciliation against the persisted state.
@@ -203,6 +210,10 @@ def reconcile(
     :func:`_looks_like_backend_outage` matches — a transient multiplexer
     restart (or a missing native roster) must not trigger mass-reaping.
 
+    *adapter* is optional. When ``None``, the multiplexer side is treated
+    as empty; only the native daemon oracle is consulted. Phase D will drop
+    the adapter parameter entirely.
+
     Partial-failure note: state and the dev queue are separate files. If
     ``save_state`` succeeds but the subsequent dev-queue update raises,
     the session will be COMPLETED while its TicketTask stays RUNNING.
@@ -213,7 +224,7 @@ def reconcile(
     """
     daemon = native_daemon or get_native_daemon_client()
     state = load_state()
-    tmux_live = adapter.list_surfaces()
+    tmux_live = adapter.list_surfaces() if adapter is not None else set()
     native_live = daemon.list_live_session_short_ids()
     if _looks_like_backend_outage(state, tmux_live, native_live):
         return ReconcileReport()

--- a/src/cw/session.py
+++ b/src/cw/session.py
@@ -2,154 +2,60 @@
 
 from __future__ import annotations
 
-import shlex
-import time
+import subprocess
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
-from uuid import uuid4
 
 import click
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-from cw.cmux import CmuxAdapter, _resolve_backend_name, get_cmux_adapter
 from cw.config import get_client, load_state, save_state
 from cw.exceptions import CwError
 from cw.handoff import extract_resumption_prompt, find_latest_handoff
 from cw.history import EventType, HistoryEvent, record_event
 from cw.models import (
-    ClientConfig,
     CompletionReason,
     CwState,
     Session,
+    SessionOrigin,
     SessionPurpose,
     SessionStatus,
 )
+from cw.native_daemon import NativeDaemonClient, get_native_daemon_client
 from cw.prompts import build_session_context, get_purpose_prompt
 from cw.reconcile import reconcile
+from cw.spawn import _write_hook_context
 from cw.worktree import create_worktree, remove_worktree
 
 # Purposes that receive worktree cwd (impl works on the feature branch,
 # idea brainstorms within it; debt stays on the main workspace).
 WORKTREE_PURPOSES: frozenset[str] = frozenset({"impl", "idea"})
 
+# Hex characters used in Claude daemon short session ids.
+_HEX_CHARS: frozenset[str] = frozenset("0123456789abcdef")
+# Length of the Claude daemon short session id (8 hex chars).
+_SHORT_ID_LEN: int = 8
 
-def _build_env_prefix(client_name: str, purpose: str) -> str:
-    """Build ``CW_CLIENT=… CW_PURPOSE=…`` shell prefix for claude commands."""
-    return f"CW_CLIENT={client_name} CW_PURPOSE={purpose}"
+_DETACH_HINT = (
+    "Detach with Ctrl+Z. Do NOT use Ctrl+D"
+    " (terminates the daemon session in all attached terminals)."
+)
 
 
-CLAUDE_INIT_DELAY_S = 2
+def _is_native_surface_ref(ref: str) -> bool:
+    """Return True if *ref* looks like an 8-char hex daemon short id."""
+    return len(ref) == _SHORT_ID_LEN and all(c in _HEX_CHARS for c in ref)
 
 
-def _build_pane_args(
-    sessions: dict[str, Session],
-    client: ClientConfig | None = None,
-) -> dict[str, dict[str, str]]:
-    """Build pane data for each session including a claude command.
+def _attach_session(short_id: str) -> None:
+    """Attach the current terminal to ``claude attach <short_id>``.
 
-    Args:
-        sessions: Map of purpose name to Session.
-        client: Client config for resolving purpose prompts.
+    Blocks until the user exits (Ctrl+Z detaches without terminating the
+    session; Ctrl+D terminates the daemon session in all attached terminals).
     """
-    panes: dict[str, dict[str, str]] = {}
-    client_overrides = client.purpose_prompts if client else None
-    client_name = client.name if client else None
-    workspace_path = str(client.workspace_path) if client else None
-    for purpose, session in sessions.items():
-        # Build extra flags (e.g. --append-system-prompt)
-        extra = ""
-        prompt = get_purpose_prompt(
-            purpose,
-            client_overrides,
-            client_name=client_name,
-            workspace_path=workspace_path,
-        )
-        if prompt:
-            # Collapse newlines for single-line shell command
-            escaped_prompt = shlex.quote(prompt.replace("\n", " "))
-            extra = f" --append-system-prompt {escaped_prompt}"
-
-        # Two-mode launch: recovery uses --resume <uuid>, fresh uses --session-id <uuid>
-        if session.claude_session_id:
-            session_flag = f" --resume {session.claude_session_id}"
-        else:
-            new_id = str(uuid4())
-            session.claude_session_id = new_id
-            session_flag = f" --session-id {new_id}"
-
-        if client_name:
-            env_prefix = f"{_build_env_prefix(client_name, purpose)} "
-        else:
-            env_prefix = ""
-        cmd = f"{env_prefix}cw run-claude --{session_flag}{extra}"
-        pane_data: dict[str, str] = {"claude_cmd": cmd}
-        cwd = str(session.worktree_path or session.workspace_path)
-        pane_data["cwd"] = cwd
-        panes[purpose] = pane_data
-    return panes
-
-
-def _create_all_purpose_sessions(
-    client_name: str,
-    client: ClientConfig,
-    state: CwState,
-    *,
-    worktree_path: Path | None = None,
-    worktree_branch: str | None = None,
-    prior_sessions: dict[str, Session] | None = None,
-) -> dict[str, Session]:
-    """Create Session objects for all purposes.
-
-    worktree_path/branch apply to impl and idea purposes.
-    When *prior_sessions* is provided, carries forward ``claude_session_id``
-    from the matching purpose so recovery uses ``--resume <uuid>``.
-    """
-    sessions: dict[str, Session] = {}
-    for purpose_enum in client.auto_purposes:
-        purpose = purpose_enum.value
-        # Carry forward claude_session_id from prior session for recovery
-        prior_claude_id: str | None = None
-        if prior_sessions and purpose in prior_sessions:
-            prior_claude_id = prior_sessions[purpose].claude_session_id
-        session = Session(
-            name=f"{client_name}/{purpose}",
-            client=client_name,
-            purpose=purpose_enum,
-            workspace_path=client.workspace_path,
-            surface_ref=purpose,
-            claude_session_id=prior_claude_id,
-        )
-        # Apply worktree to impl and idea panes
-        if worktree_path and purpose in WORKTREE_PURPOSES:
-            session.worktree_path = worktree_path
-            session.branch = worktree_branch
-        sessions[purpose] = session
-        state.sessions.append(session)
-        record_event(
-            client_name,
-            HistoryEvent(
-                event_type=EventType.SESSION_STARTED,
-                client=client_name,
-                session_id=session.id,
-                session_name=session.name,
-                purpose=purpose,
-            ),
-        )
-    return sessions
-
-
-def _spawn_session_surface(
-    client: ClientConfig,
-    session: Session,
-    command: str,
-    adapter: CmuxAdapter,
-) -> None:
-    """Spawn a cmux surface for the session and store the surface_ref."""
-    workspace = client.cmux_workspace or client.name
-    surface_ref = adapter.spawn(workspace, command)
-    session.surface_ref = surface_ref
+    subprocess.run(["claude", "attach", short_id], check=False)
 
 
 def start_session(
@@ -158,7 +64,7 @@ def start_session(
     *,
     worktree: str | None = None,
     parent: str | None = None,
-    adapter: CmuxAdapter | None = None,
+    native_daemon: NativeDaemonClient | None = None,
 ) -> None:
     """Start or resume a Claude Code session for a client.
 
@@ -167,17 +73,16 @@ def start_session(
         purpose: Session purpose (impl, idea, debt, explore).
         worktree: Optional git branch for worktree isolation.
         parent: Optional parent session ID for bidirectional linkage.
-        adapter: CmuxAdapter instance. Defaults to get_cmux_adapter() (macOS only).
-                 Inject FakeCmuxAdapter for tests.
+        native_daemon: NativeDaemonClient instance. Defaults to
+                       get_native_daemon_client(). Inject FakeNativeDaemonClient
+                       for tests.
     """
-    if adapter is None:
-        adapter = get_cmux_adapter()
-
+    daemon = native_daemon or get_native_daemon_client()
     client = get_client(client_name)
     state = load_state()
 
     # Reap phantom sessions so we don't short-circuit on a dead "active" row.
-    reconcile(adapter)
+    reconcile(native_daemon=daemon)
     state = load_state()
 
     # Validate parent session FIRST so a bad ID always errors, even when
@@ -190,8 +95,6 @@ def start_session(
         if parent_session is None:
             msg = f"Parent session not found: {parent}"
             raise CwError(msg)
-        # --parent links the impl session to the parent. If the client
-        # config excludes 'impl' from auto_purposes there's nothing to link.
         if SessionPurpose.IMPL not in client.auto_purposes:
             msg = (
                 "--parent requires the client config to include 'impl' in auto_purposes"
@@ -209,7 +112,6 @@ def start_session(
         click.echo(f"Creating worktree for branch '{branch}'...")
         worktree_path = create_worktree(client, branch)
         worktree_branch = branch
-        # Patch workspace_path to the real worktree path
         client = client.model_copy(update={"workspace_path": worktree_path})
         click.echo(f"Worktree ready: {worktree_path}")
     elif worktree:
@@ -217,7 +119,7 @@ def start_session(
         worktree_path = create_worktree(client, worktree)
         click.echo(f"Worktree ready: {worktree_path}")
 
-    # Check for existing backgrounded session
+    # Check for existing backgrounded session — resume it rather than spawning.
     existing = state.find_session(client_name, purpose)
 
     if existing and existing.status == SessionStatus.BACKGROUNDED:
@@ -229,7 +131,7 @@ def start_session(
             )
             raise CwError(msg)
         click.echo(f"Found backgrounded session: {existing.name}")
-        resume_session(existing.name, adapter=adapter)
+        resume_session(existing.name, native_daemon=daemon)
         return
 
     if existing and existing.status == SessionStatus.ACTIVE:
@@ -242,38 +144,73 @@ def start_session(
         click.echo(f"Session already active: {existing.name}")
         return
 
-    # Create sessions for ALL purposes
-    all_sessions = _create_all_purpose_sessions(
-        client_name,
-        client,
-        state,
-        worktree_path=worktree_path,
-        worktree_branch=worktree_branch,
+    # Determine cwd: worktree-eligible purposes use worktree_path when available.
+    session_cwd: Path = (
+        worktree_path
+        if (worktree_path and purpose in WORKTREE_PURPOSES)
+        else client.workspace_path
     )
 
-    # Bidirectional linkage: only the impl session is a worker entry.
-    # One cw start call = one worker ID in parent.worker_session_ids.
+    # Build the new session object.
+    session = Session(
+        name=f"{client_name}/{purpose}",
+        client=client_name,
+        purpose=SessionPurpose(purpose),
+        workspace_path=client.workspace_path,
+        origin=SessionOrigin.USER,
+    )
+    if worktree_path and purpose in WORKTREE_PURPOSES:
+        session.worktree_path = worktree_path
+        session.branch = worktree_branch
+
     if parent_session is not None:
-        impl_session = all_sessions["impl"]
-        impl_session.parent_session_id = parent_session.id
-        parent_session.worker_session_ids.append(impl_session.id)
+        session.parent_session_id = parent_session.id
+        parent_session.worker_session_ids.append(session.id)
 
-    panes = _build_pane_args(all_sessions, client=client)
+    state.sessions.append(session)
 
-    for s in all_sessions.values():
-        click.echo(f"  {s.name}")
+    # Write Stop hook + correlation context before spawning. Raises
+    # HookContextConflictError if a USER-origin worktree already has
+    # settings.local.json (gate-behind-worktree strategy from #165).
+    _write_hook_context(
+        session_cwd,
+        session_id=session.id,
+        session_name=session.name,
+        client=client_name,
+        purpose=purpose,
+        ticket_id=None,
+        origin=SessionOrigin.USER,
+    )
 
-    # Spawn surfaces for all purposes
-    backend = _resolve_backend_name()
-    click.echo(f"Launching {backend.value} surfaces for {client_name}...")
-    for purpose_str, session in all_sessions.items():
-        pane_cmd = panes[purpose_str]["claude_cmd"]
-        _spawn_session_surface(client, session, pane_cmd, adapter)
+    # Build per-purpose system prompt for the session.
+    prompt = (
+        get_purpose_prompt(
+            purpose,
+            client.purpose_prompts,
+            client_name=client_name,
+            workspace_path=str(client.workspace_path),
+        )
+        or ""
+    )
 
-    # Single end-to-end persist: state hits disk only after every surface
-    # has been spawned. If any spawn raises, on-disk state is unchanged
-    # (no partial-success window where sessions exist without surface_ref).
+    click.echo(f"Spawning session {session.name}...")
+    short_id = daemon.spawn_bg(cwd=session_cwd, prompt=prompt)
+    session.surface_ref = short_id
+
     save_state(state)
+    record_event(
+        client_name,
+        HistoryEvent(
+            event_type=EventType.SESSION_STARTED,
+            client=client_name,
+            session_id=session.id,
+            session_name=session.name,
+            purpose=purpose,
+        ),
+    )
+    click.echo(f"Session {session.name} started (short-id: {short_id}).")
+    click.echo(_DETACH_HINT)
+    _attach_session(short_id)
 
 
 def _resolve_session(state: CwState, session_name: str | None) -> Session:
@@ -300,42 +237,11 @@ def _resolve_session(state: CwState, session_name: str | None) -> Session:
     raise CwError(msg)
 
 
-def _notify_sibling(
-    client_name: str,
-    source_purpose: str,
-    target_purpose: str,
-    adapter: CmuxAdapter,
-) -> None:
-    """Send a short notification to a sibling session after backgrounding."""
-    state = load_state()
-    target = state.find_session(client_name, target_purpose)
-    if target is None or target.status != SessionStatus.ACTIVE:
-        click.echo(
-            f"Warning: No active {target_purpose} session for {client_name} to notify."
-        )
-        return
-
-    message = (
-        f"\n[cw] {source_purpose} session has been backgrounded."
-        f" Handoff context is available."
-    )
-    if target.surface_ref:
-        try:
-            # Send via cmux surface if we have a reference
-            client = get_client(client_name)
-            workspace = client.cmux_workspace or client_name
-            adapter.spawn(workspace, message)
-        except CwError:
-            pass
-    click.echo(f"Notified {target.name}.")
-
-
 def background_session(
     session_name: str | None = None,
     *,
     notify: str | None = None,
     auto: bool = False,
-    adapter: CmuxAdapter | None = None,
 ) -> None:
     """Background a session by triggering /session-done and recording the handoff."""
     state = load_state()
@@ -347,18 +253,14 @@ def background_session(
 
     click.echo(f"Backgrounding session: {session.name}...")
 
-    if session.status == SessionStatus.IDLE:
-        # Claude already exited — no /session-done needed.
-        latest = find_latest_handoff(session.workspace_path)
-        if latest:
-            session.last_handoff_path = latest
-    else:
-        latest = find_latest_handoff(session.workspace_path)
-        if latest:
-            session.last_handoff_path = latest
+    latest = find_latest_handoff(session.workspace_path)
+    if latest:
+        session.last_handoff_path = latest
+
+    if session.status == SessionStatus.ACTIVE:
         click.echo(
-            "Not inside cmux session."
-            " Marking as backgrounded without /session-done injection."
+            "Marking as backgrounded without /session-done injection"
+            " (not inside a cmux session)."
         )
 
     session.status = SessionStatus.BACKGROUNDED
@@ -379,9 +281,9 @@ def background_session(
     click.echo(f"Session {session.name} backgrounded.")
 
     if notify:
-        if adapter is None:
-            adapter = get_cmux_adapter()
-        _notify_sibling(session.client, session.purpose, notify, adapter)
+        click.echo(
+            f"Warning: --notify {notify!r} is not supported in native daemon mode."
+        )
 
 
 def background_all_sessions(
@@ -407,20 +309,19 @@ def background_all_sessions(
 def resume_session(
     session_name: str,
     *,
-    adapter: CmuxAdapter | None = None,
+    native_daemon: NativeDaemonClient | None = None,
 ) -> None:
-    """Resume a backgrounded session with its handoff context.
+    """Resume a backgrounded session by attaching to its daemon session.
 
     Args:
         session_name: Session name or ID to resume.
-        adapter: CmuxAdapter instance. Defaults to get_cmux_adapter() (macOS only).
-                 Inject FakeCmuxAdapter for tests.
+        native_daemon: NativeDaemonClient instance. Defaults to
+                       get_native_daemon_client(). Inject FakeNativeDaemonClient
+                       for tests.
     """
-    if adapter is None:
-        adapter = get_cmux_adapter()
+    daemon = native_daemon or get_native_daemon_client()
 
     state = load_state()
-
     session = state.find_by_name_or_id(session_name)
     if session is None:
         msg = f"Session not found: {session_name}"
@@ -433,55 +334,82 @@ def resume_session(
         )
         raise CwError(msg)
 
-    # Extract resumption prompt from handoff
-    prompt = None
+    # Extract handoff context for the resumption prompt.
+    handoff_prompt: str | None = None
     handoff_path = session.last_handoff_path
     if handoff_path and handoff_path.exists():
-        prompt = extract_resumption_prompt(handoff_path)
-        if prompt:
+        handoff_prompt = extract_resumption_prompt(handoff_path)
+        if handoff_prompt:
             click.echo(f"Loaded resumption context from: {handoff_path}")
         else:
             click.echo("Warning: Could not extract resumption prompt from handoff.")
     else:
         click.echo("No handoff file available. Starting fresh session.")
 
-    # Get client config
     client = get_client(session.client)
-
-    # Prepend client identity so resumed sessions know who they are
     context = build_session_context(
         session.client,
         str(client.workspace_path),
         session.purpose,
     )
-    full_prompt = f"{context}\n\n{prompt}" if prompt else context
+    full_prompt = f"{context}\n\n{handoff_prompt}" if handoff_prompt else context
 
-    # Spawn a new cmux surface for the resumed session
-    env_prefix = _build_env_prefix(session.client, session.purpose)
-    resume_cmd = f"{env_prefix} claude --resume"
-    _spawn_session_surface(client, session, resume_cmd, adapter)
+    surface = session.surface_ref
+    live_ids = daemon.list_live_session_short_ids()
 
-    session.status = SessionStatus.ACTIVE
-    session.resumed_at = datetime.now(UTC)
-    save_state(state)
-    record_event(
-        session.client,
-        HistoryEvent(
-            event_type=EventType.SESSION_RESUMED,
-            client=session.client,
-            session_id=session.id,
-            session_name=session.name,
-            purpose=session.purpose,
-        ),
-    )
+    if surface and _is_native_surface_ref(surface) and surface in live_ids:
+        # Happy path: session still alive in daemon — attach directly.
+        session.status = SessionStatus.ACTIVE
+        session.resumed_at = datetime.now(UTC)
+        save_state(state)
+        record_event(
+            session.client,
+            HistoryEvent(
+                event_type=EventType.SESSION_RESUMED,
+                client=session.client,
+                session_id=session.id,
+                session_name=session.name,
+                purpose=session.purpose,
+            ),
+        )
+        click.echo(f"Resuming session {session.name} (short-id: {surface}).")
+        click.echo(_DETACH_HINT)
+        _attach_session(surface)
+    else:
+        # Dead or missing surface: spawn a new daemon session using --resume
+        # to re-enter the Claude transcript.
+        session_cwd: Path = session.worktree_path or session.workspace_path
 
-    click.echo(f"Resumed session: {session.name}")
+        extra_args: list[str] = []
+        if session.claude_session_id:
+            extra_args = ["--resume", session.claude_session_id]
 
-    # Output prompt for injection (cmux surface has been spawned with the command)
-    if full_prompt:
-        time.sleep(CLAUDE_INIT_DELAY_S)  # Wait for Claude to initialize
-        click.echo("\nResumption prompt:")
-        click.echo(full_prompt)
+        click.echo(
+            f"Session {session.name} not live in daemon;"
+            " spawning new background session..."
+        )
+        new_short_id = daemon.spawn_bg(
+            cwd=session_cwd,
+            prompt=full_prompt,
+            extra_args=extra_args or None,
+        )
+        session.surface_ref = new_short_id
+        session.status = SessionStatus.ACTIVE
+        session.resumed_at = datetime.now(UTC)
+        save_state(state)
+        record_event(
+            session.client,
+            HistoryEvent(
+                event_type=EventType.SESSION_RESUMED,
+                client=session.client,
+                session_id=session.id,
+                session_name=session.name,
+                purpose=session.purpose,
+            ),
+        )
+        click.echo(f"New daemon session started (short-id: {new_short_id}).")
+        click.echo(_DETACH_HINT)
+        _attach_session(new_short_id)
 
 
 def done_session(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from cw.cmux import FakeCmuxAdapter
 from cw.config import load_state, save_state
 from cw.exceptions import CwError
 from cw.models import (
@@ -14,12 +13,12 @@ from cw.models import (
     CompletionReason,
     CwState,
     Session,
+    SessionOrigin,
     SessionPurpose,
     SessionStatus,
 )
+from cw.native_daemon import FakeNativeDaemonClient
 from cw.session import (
-    _build_pane_args,
-    _create_all_purpose_sessions,
     background_all_sessions,
     background_session,
     done_session,
@@ -31,269 +30,172 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-class TestBuildPaneArgs:
-    def test_includes_system_prompt(self, sample_client: ClientConfig) -> None:
-        session = Session(
-            name="test-client/impl",
-            client="test-client",
-            purpose=SessionPurpose.IMPL,
-            workspace_path=sample_client.workspace_path,
-        )
-        panes = _build_pane_args({"impl": session}, client=sample_client)
-        assert "--append-system-prompt" in panes["impl"]["claude_cmd"]
-        assert "IMPLEMENTATION" in panes["impl"]["claude_cmd"]
-
-    def test_fresh_start_uses_session_id(self, sample_client: ClientConfig) -> None:
-        """Fresh session (no claude_session_id) uses --session-id <uuid>."""
-        session = Session(
-            name="test-client/impl",
-            client="test-client",
-            purpose=SessionPurpose.IMPL,
-            workspace_path=sample_client.workspace_path,
-        )
-        panes = _build_pane_args({"impl": session}, client=sample_client)
-        cmd = panes["impl"]["claude_cmd"]
-        assert "--session-id" in cmd
-        assert "--resume" not in cmd
-        # Session should have claude_session_id set after build
-        assert session.claude_session_id is not None
-
-    def test_recovery_uses_resume_with_id(self, sample_client: ClientConfig) -> None:
-        """Recovery session (claude_session_id set) uses --resume <uuid>."""
-        session = Session(
-            name="test-client/impl",
-            client="test-client",
-            purpose=SessionPurpose.IMPL,
-            workspace_path=sample_client.workspace_path,
-            claude_session_id="550e8400-e29b-41d4-a716-446655440000",
-        )
-        panes = _build_pane_args({"impl": session}, client=sample_client)
-        cmd = panes["impl"]["claude_cmd"]
-        assert "--resume 550e8400-e29b-41d4-a716-446655440000" in cmd
-        assert "--session-id" not in cmd
-
-    def test_client_override_prompt(self, sample_client: ClientConfig) -> None:
-        sample_client.purpose_prompts = {"impl": "Custom impl prompt."}
-        session = Session(
-            name="test-client/impl",
-            client="test-client",
-            purpose=SessionPurpose.IMPL,
-            workspace_path=sample_client.workspace_path,
-        )
-        panes = _build_pane_args({"impl": session}, client=sample_client)
-        assert "Custom impl prompt." in panes["impl"]["claude_cmd"]
-
-    def test_cwd_from_worktree(self, sample_client: ClientConfig) -> None:
-        wt = sample_client.workspace_path.parent / "worktree"
-        session = Session(
-            name="test-client/impl",
-            client="test-client",
-            purpose=SessionPurpose.IMPL,
-            workspace_path=sample_client.workspace_path,
-            worktree_path=wt,
-        )
-        panes = _build_pane_args({"impl": session})
-        assert panes["impl"]["cwd"] == str(wt)
-
-    def test_cwd_falls_back_to_workspace(self, sample_client: ClientConfig) -> None:
-        session = Session(
-            name="test-client/impl",
-            client="test-client",
-            purpose=SessionPurpose.IMPL,
-            workspace_path=sample_client.workspace_path,
-        )
-        panes = _build_pane_args({"impl": session})
-        assert panes["impl"]["cwd"] == str(sample_client.workspace_path)
-
-    def test_no_client_omits_env_vars(self, sample_client: ClientConfig) -> None:
-        session = Session(
-            name="test-client/impl",
-            client="test-client",
-            purpose=SessionPurpose.IMPL,
-            workspace_path=sample_client.workspace_path,
-        )
-        panes = _build_pane_args({"impl": session})
-        cmd = panes["impl"]["claude_cmd"]
-        assert "CW_CLIENT" not in cmd
-        assert "CW_PURPOSE" not in cmd
-
-    def test_env_var_prefix_in_command(self, sample_client: ClientConfig) -> None:
-        session = Session(
-            name="test-client/impl",
-            client="test-client",
-            purpose=SessionPurpose.IMPL,
-            workspace_path=sample_client.workspace_path,
-        )
-        panes = _build_pane_args({"impl": session}, client=sample_client)
-        cmd = panes["impl"]["claude_cmd"]
-        assert "CW_CLIENT=test-client" in cmd
-        assert "CW_PURPOSE=impl" in cmd
-
-    def test_client_identity_in_prompt(self, sample_client: ClientConfig) -> None:
-        session = Session(
-            name="test-client/impl",
-            client="test-client",
-            purpose=SessionPurpose.IMPL,
-            workspace_path=sample_client.workspace_path,
-        )
-        panes = _build_pane_args({"impl": session}, client=sample_client)
-        cmd = panes["impl"]["claude_cmd"]
-        assert "[cw identity]" in cmd
-        assert "test-client" in cmd
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
-class TestCreateAllPurposeSessions:
-    def test_uses_auto_purposes(self, sample_client: ClientConfig) -> None:
-        """_create_all_purpose_sessions iterates client.auto_purposes."""
-        sample_client.auto_purposes = [SessionPurpose.IMPL, SessionPurpose.IDEA]
-        state = CwState()
-        sessions = _create_all_purpose_sessions(
-            sample_client.name,
-            sample_client,
-            state,
-        )
-        assert set(sessions.keys()) == {"impl", "idea"}
-        assert len(state.sessions) == 2
-
-    def test_default_purposes(self, sample_client: ClientConfig) -> None:
-        state = CwState()
-        sessions = _create_all_purpose_sessions(
-            sample_client.name,
-            sample_client,
-            state,
-        )
-        assert set(sessions.keys()) == {"impl", "idea", "debt"}
-
-    def test_single_purpose(self, sample_client: ClientConfig) -> None:
-        sample_client.auto_purposes = [SessionPurpose.IMPL]
-        state = CwState()
-        sessions = _create_all_purpose_sessions(
-            sample_client.name,
-            sample_client,
-            state,
-        )
-        assert set(sessions.keys()) == {"impl"}
-        assert len(state.sessions) == 1
-
-    def test_surface_ref_set_to_purpose(self, sample_client: ClientConfig) -> None:
-        """Sessions get surface_ref set to the purpose name by default."""
-        state = CwState()
-        sessions = _create_all_purpose_sessions(
-            sample_client.name,
-            sample_client,
-            state,
-        )
-        for purpose, session in sessions.items():
-            assert session.surface_ref == purpose
+def _noop(*_args: object, **_kwargs: object) -> None:
+    pass
 
 
-class TestCreateAllPurposeSessionsWithPrior:
-    def test_carries_forward_claude_session_id(
-        self,
-        sample_client: ClientConfig,
-    ) -> None:
-        """Prior sessions' claude_session_id is carried forward."""
-        prior = {
-            "impl": Session(
-                name="test-client/impl",
-                client="test-client",
-                purpose=SessionPurpose.IMPL,
-                workspace_path=sample_client.workspace_path,
-                claude_session_id="old-uuid-impl",
-            ),
-        }
-        state = CwState()
-        sessions = _create_all_purpose_sessions(
-            sample_client.name,
-            sample_client,
-            state,
-            prior_sessions=prior,
-        )
-        assert sessions["impl"].claude_session_id == "old-uuid-impl"
-        # idea and debt have no prior, so no claude_session_id
-        assert sessions["idea"].claude_session_id is None
-        assert sessions["debt"].claude_session_id is None
+# ---------------------------------------------------------------------------
+# TestIsNativeSurfaceRef
+# ---------------------------------------------------------------------------
 
-    def test_no_prior_generates_fresh(
-        self,
-        sample_client: ClientConfig,
-    ) -> None:
-        """Without prior_sessions, all sessions have no claude_session_id."""
-        state = CwState()
-        sessions = _create_all_purpose_sessions(
-            sample_client.name,
-            sample_client,
-            state,
-        )
-        for s in sessions.values():
-            assert s.claude_session_id is None
+
+class TestIsNativeSurfaceRef:
+    def test_valid_8_char_hex(self) -> None:
+        from cw.session import _is_native_surface_ref
+
+        assert _is_native_surface_ref("abcd1234") is True
+        assert _is_native_surface_ref("00000001") is True
+        assert _is_native_surface_ref("deadbeef") is True
+
+    def test_invalid_too_short(self) -> None:
+        from cw.session import _is_native_surface_ref
+
+        assert _is_native_surface_ref("abc1234") is False
+
+    def test_invalid_too_long(self) -> None:
+        from cw.session import _is_native_surface_ref
+
+        assert _is_native_surface_ref("abcd12345") is False
+
+    def test_invalid_non_hex_chars(self) -> None:
+        from cw.session import _is_native_surface_ref
+
+        assert _is_native_surface_ref("abcg1234") is False
+        assert _is_native_surface_ref("impl-pane") is False
+
+    def test_invalid_uppercase(self) -> None:
+        from cw.session import _is_native_surface_ref
+
+        assert _is_native_surface_ref("ABCD1234") is False
+
+
+# ---------------------------------------------------------------------------
+# TestStartSession
+# ---------------------------------------------------------------------------
 
 
 class TestStartSession:
+    def _write_clients_file(
+        self, tmp_config_dir: Path, sample_client: ClientConfig
+    ) -> None:
+        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
+        clients_file.write_text(
+            f"clients:\n"
+            f"  test-client:\n"
+            f"    workspace_path: {sample_client.workspace_path}\n"
+        )
+
     def test_new_session_creates_and_saves(
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # Set up client config
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
-        start_session("test-client", "impl", adapter=mock_cmux_adapter)
+        start_session("test-client", "impl", native_daemon=mock_native_daemon)
 
         state = load_state()
-        # Fresh start creates sessions for all purposes (impl, idea, debt)
-        assert len(state.sessions) == 3
-        purposes = {s.purpose for s in state.sessions}
-        assert purposes == {
-            SessionPurpose.IMPL,
-            SessionPurpose.IDEA,
-            SessionPurpose.DEBT,
-        }
-        for s in state.sessions:
-            assert s.client == "test-client"
-            assert s.status == SessionStatus.ACTIVE
+        assert len(state.sessions) == 1
+        s = state.sessions[0]
+        assert s.client == "test-client"
+        assert s.purpose == SessionPurpose.IMPL
+        assert s.status == SessionStatus.ACTIVE
+        assert s.origin == SessionOrigin.USER
 
-    def test_new_session_spawns_cmux_surfaces(
+    def test_new_session_spawns_via_daemon(
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """start_session calls adapter.spawn for each purpose."""
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
-        start_session("test-client", "impl", adapter=mock_cmux_adapter)
+        start_session("test-client", "impl", native_daemon=mock_native_daemon)
 
-        # Spawned one surface per purpose (3 default purposes)
-        assert len(mock_cmux_adapter.calls["spawn"]) == 3
+        assert len(mock_native_daemon.spawn_calls) == 1
+
+    def test_new_session_surface_ref_is_short_id(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
+
+        start_session("test-client", "impl", native_daemon=mock_native_daemon)
+
+        state = load_state()
+        # FakeNativeDaemonClient returns "00000001" for the first spawn
+        assert state.sessions[0].surface_ref == "00000001"
+
+    def test_new_session_calls_attach(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+
+        attached: list[str] = []
+        monkeypatch.setattr("cw.session._attach_session", attached.append)
+
+        start_session("test-client", "impl", native_daemon=mock_native_daemon)
+
+        assert attached == ["00000001"]
+
+    def test_new_session_writes_hook_context(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
+
+        hook_calls: list[dict[str, object]] = []
+
+        def capture_hook(path: object, **kwargs: object) -> None:
+            hook_calls.append({"path": path, **kwargs})
+
+        monkeypatch.setattr("cw.session._write_hook_context", capture_hook)
+
+        start_session("test-client", "impl", native_daemon=mock_native_daemon)
+
+        assert len(hook_calls) == 1
+        assert hook_calls[0]["client"] == "test-client"
+        assert hook_calls[0]["purpose"] == "impl"
+        assert hook_calls[0]["origin"] == SessionOrigin.USER
 
     def test_existing_backgrounded_triggers_resume(
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
-
-        # Pre-create a backgrounded session
         state = CwState(
             sessions=[
                 Session(
@@ -303,12 +205,15 @@ class TestStartSession:
                     purpose=SessionPurpose.IMPL,
                     status=SessionStatus.BACKGROUNDED,
                     workspace_path=sample_client.workspace_path,
+                    surface_ref="abcd1234",
                 )
             ]
         )
+        # Make the backgrounded session appear live in daemon
+        mock_native_daemon._live.add("abcd1234")
         save_state(state)
 
-        start_session("test-client", "impl", adapter=mock_cmux_adapter)
+        start_session("test-client", "impl", native_daemon=mock_native_daemon)
 
         output = capsys.readouterr().out
         assert (
@@ -319,15 +224,13 @@ class TestStartSession:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
         state = CwState(
             sessions=[
@@ -343,7 +246,7 @@ class TestStartSession:
         )
         save_state(state)
 
-        start_session("test-client", "impl", adapter=mock_cmux_adapter)
+        start_session("test-client", "impl", native_daemon=mock_native_daemon)
 
         output = capsys.readouterr().out
         assert "already active" in output.lower()
@@ -352,17 +255,13 @@ class TestStartSession:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
-        # Mock create_worktree to return a path
         wt_path = sample_client.workspace_path.parent / ".worktrees" / "feat-search"
         wt_path.mkdir(parents=True)
         monkeypatch.setattr(
@@ -371,18 +270,94 @@ class TestStartSession:
         )
 
         start_session(
-            "test-client", "impl", worktree="feat/search", adapter=mock_cmux_adapter
+            "test-client",
+            "impl",
+            worktree="feat/search",
+            native_daemon=mock_native_daemon,
         )
 
         state = load_state()
-        # impl and idea should have worktree_path set
-        impl_sessions = [s for s in state.sessions if s.purpose == SessionPurpose.IMPL]
-        idea_sessions = [s for s in state.sessions if s.purpose == SessionPurpose.IDEA]
-        debt_sessions = [s for s in state.sessions if s.purpose == SessionPurpose.DEBT]
-        assert impl_sessions[0].worktree_path == wt_path
-        assert impl_sessions[0].branch == "feat/search"
-        assert idea_sessions[0].worktree_path == wt_path
-        assert debt_sessions[0].worktree_path is None
+        assert len(state.sessions) == 1
+        s = state.sessions[0]
+        assert s.purpose == SessionPurpose.IMPL
+        assert s.worktree_path == wt_path
+        assert s.branch == "feat/search"
+
+    def test_start_debt_purpose_no_worktree_path(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """debt purpose is not in WORKTREE_PURPOSES; worktree_path stays None."""
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
+
+        wt_path = sample_client.workspace_path.parent / ".worktrees" / "feat"
+        wt_path.mkdir(parents=True)
+        monkeypatch.setattr(
+            "cw.session.create_worktree",
+            lambda _client, _branch: wt_path,
+        )
+
+        start_session(
+            "test-client", "debt", worktree="feat/x", native_daemon=mock_native_daemon
+        )
+
+        state = load_state()
+        assert len(state.sessions) == 1
+        assert state.sessions[0].worktree_path is None
+
+    def test_spawn_failure_leaves_state_unchanged(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If daemon.spawn_bg raises, no session is persisted to disk."""
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
+
+        pre_state = load_state()
+
+        class FlakyDaemon(FakeNativeDaemonClient):
+            def spawn_bg(  # type: ignore[override]
+                self, *, cwd: object, prompt: object, extra_args: object = None
+            ) -> str:
+                msg = "simulated daemon failure"
+                raise CwError(msg)
+
+        with pytest.raises(CwError, match="simulated daemon failure"):
+            start_session("test-client", "impl", native_daemon=FlakyDaemon())
+
+        post_state = load_state()
+        assert len(post_state.sessions) == len(pre_state.sessions)
+
+    def test_detach_hint_printed(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
+
+        start_session("test-client", "impl", native_daemon=mock_native_daemon)
+
+        out = capsys.readouterr().out
+        assert "Ctrl+Z" in out
+        assert "Ctrl+D" in out
+
+
+# ---------------------------------------------------------------------------
+# TestStartWorktreeClient
+# ---------------------------------------------------------------------------
 
 
 class TestStartWorktreeClient:
@@ -390,11 +365,10 @@ class TestStartWorktreeClient:
         self,
         tmp_config_dir: Path,
         tmp_path: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """Worktree-mode client auto-creates worktree at start."""
         repo = tmp_path / "repo"
         repo.mkdir()
         clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
@@ -408,54 +382,25 @@ class TestStartWorktreeClient:
             "cw.session.create_worktree",
             lambda _client, _branch: wt_path,
         )
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
-        start_session("client-a", "impl", adapter=mock_cmux_adapter)
+        start_session("client-a", "impl", native_daemon=mock_native_daemon)
 
         output = capsys.readouterr().out
         assert "Creating worktree for branch 'client-a'" in output
         assert str(wt_path) in output
 
         state = load_state()
-        # All sessions should exist
-        assert len(state.sessions) == 3
-        # impl and idea should have worktree_path
-        impl = next(s for s in state.sessions if s.purpose == SessionPurpose.IMPL)
+        assert len(state.sessions) == 1
+        impl = state.sessions[0]
         assert impl.worktree_path == wt_path
         assert impl.branch == "client-a"
 
-    def test_second_worktree_client_creates_surfaces(
-        self,
-        tmp_config_dir: Path,
-        tmp_path: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Second client creates surfaces via cmux adapter."""
-        repo = tmp_path / "repo"
-        repo.mkdir()
-        ws = tmp_path / "personal"
-        ws.mkdir()
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            "clients:\n"
-            "  personal:\n"
-            f"    workspace_path: {ws}\n"
-            "  client-a:\n"
-            f"    repo_path: {repo}\n"
-            "    branch: client-a\n"
-        )
 
-        wt_path = tmp_path / "wt" / "client-a"
-        wt_path.mkdir(parents=True)
-        monkeypatch.setattr(
-            "cw.session.create_worktree",
-            lambda _client, _branch: wt_path,
-        )
-
-        start_session("client-a", "impl", adapter=mock_cmux_adapter)
-
-        # Should have spawned surfaces for all purposes
-        assert len(mock_cmux_adapter.calls["spawn"]) == 3
+# ---------------------------------------------------------------------------
+# TestBackgroundSession
+# ---------------------------------------------------------------------------
 
 
 class TestBackgroundSession:
@@ -463,7 +408,6 @@ class TestBackgroundSession:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         state = CwState(
@@ -489,7 +433,6 @@ class TestBackgroundSession:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
     ) -> None:
         state = CwState(
             sessions=[
@@ -514,7 +457,6 @@ class TestBackgroundSession:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
     ) -> None:
         state = CwState(
             sessions=[
@@ -544,7 +486,6 @@ class TestBackgroundSession:
     def test_raises_on_no_active(
         self,
         tmp_config_dir: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
     ) -> None:
         save_state(CwState())
 
@@ -555,7 +496,6 @@ class TestBackgroundSession:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
     ) -> None:
         state = CwState(
             sessions=[
@@ -578,10 +518,8 @@ class TestBackgroundSession:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        # Create a handoff file
         handoffs_dir = sample_client.workspace_path / ".handoffs"
         handoffs_dir.mkdir(parents=True)
         handoff = handoffs_dir / "session-test.md"
@@ -606,27 +544,52 @@ class TestBackgroundSession:
         updated = load_state()
         assert updated.sessions[0].last_handoff_path is not None
         output = capsys.readouterr().out
-        assert "Not inside cmux" in output
+        assert "Marking as backgrounded" in output
 
     def test_session_not_found_raises(
         self,
         tmp_config_dir: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
     ) -> None:
         save_state(CwState())
 
         with pytest.raises(CwError, match="Session not found"):
             background_session("nonexistent")
 
-
-class TestResumeSession:
-    def test_extracts_prompt_and_updates_state(
+    def test_notify_warns_not_supported(
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
-        sample_handoff_file: Path,
         capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        state = CwState(
+            sessions=[
+                Session(
+                    id="notifyw1",
+                    name="test-client/impl",
+                    client="test-client",
+                    purpose=SessionPurpose.IMPL,
+                    status=SessionStatus.ACTIVE,
+                    workspace_path=sample_client.workspace_path,
+                )
+            ]
+        )
+        save_state(state)
+
+        background_session("test-client/impl", notify="idea")
+
+        output = capsys.readouterr().out
+        assert "Warning" in output
+        assert "notify" in output.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestResumeSession
+# ---------------------------------------------------------------------------
+
+
+class TestResumeSession:
+    def _write_clients_file(
+        self, tmp_config_dir: Path, sample_client: ClientConfig
     ) -> None:
         clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
         clients_file.write_text(
@@ -634,6 +597,21 @@ class TestResumeSession:
             f"  test-client:\n"
             f"    workspace_path: {sample_client.workspace_path}\n"
         )
+
+    def test_live_session_attaches_directly(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        self._write_clients_file(tmp_config_dir, sample_client)
+        attached: list[str] = []
+        monkeypatch.setattr("cw.session._attach_session", attached.append)
+
+        short_id = "abcd1234"
+        mock_native_daemon._live.add(short_id)
 
         state = CwState(
             sessions=[
@@ -644,71 +622,100 @@ class TestResumeSession:
                     purpose=SessionPurpose.IMPL,
                     status=SessionStatus.BACKGROUNDED,
                     workspace_path=sample_client.workspace_path,
-                    last_handoff_path=sample_handoff_file,
+                    surface_ref=short_id,
                 )
             ]
         )
         save_state(state)
 
-        resume_session("test-client/impl", adapter=mock_cmux_adapter)
+        resume_session("test-client/impl", native_daemon=mock_native_daemon)
 
+        assert attached == [short_id]
         updated = load_state()
         assert updated.sessions[0].status == SessionStatus.ACTIVE
         assert updated.sessions[0].resumed_at is not None
 
-        output = capsys.readouterr().out
-        assert "Resumed session" in output
-
-    def test_resume_spawns_cmux_surface(
+    def test_dead_session_spawns_new(
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
-        sample_handoff_file: Path,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """resume_session calls adapter.spawn to create a new surface."""
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
+        self._write_clients_file(tmp_config_dir, sample_client)
+        attached: list[str] = []
+        monkeypatch.setattr("cw.session._attach_session", attached.append)
 
         state = CwState(
             sessions=[
                 Session(
-                    id="spawn001",
+                    id="resume02",
                     name="test-client/impl",
                     client="test-client",
                     purpose=SessionPurpose.IMPL,
                     status=SessionStatus.BACKGROUNDED,
                     workspace_path=sample_client.workspace_path,
-                    last_handoff_path=sample_handoff_file,
+                    surface_ref="deadbeef",  # not in daemon
                 )
             ]
         )
         save_state(state)
 
-        resume_session("test-client/impl", adapter=mock_cmux_adapter)
+        resume_session("test-client/impl", native_daemon=mock_native_daemon)
 
-        assert len(mock_cmux_adapter.calls["spawn"]) == 1
-        workspace, cmd, _surface = mock_cmux_adapter.calls["spawn"][0]
-        assert "test-client" in str(workspace)
-        assert "claude --resume" in str(cmd)
+        # New session spawned
+        assert len(mock_native_daemon.spawn_calls) == 1
+        # attach called with the new short_id
+        assert len(attached) == 1
+        assert attached[0] == "00000001"
+
+        updated = load_state()
+        assert updated.sessions[0].surface_ref == "00000001"
+        assert updated.sessions[0].status == SessionStatus.ACTIVE
+
+    def test_dead_session_uses_resume_flag_when_has_claude_session_id(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
+
+        state = CwState(
+            sessions=[
+                Session(
+                    id="resume03",
+                    name="test-client/impl",
+                    client="test-client",
+                    purpose=SessionPurpose.IMPL,
+                    status=SessionStatus.BACKGROUNDED,
+                    workspace_path=sample_client.workspace_path,
+                    surface_ref="deadbeef",
+                    claude_session_id="550e8400-e29b-41d4-a716-446655440000",
+                )
+            ]
+        )
+        save_state(state)
+
+        resume_session("test-client/impl", native_daemon=mock_native_daemon)
+
+        assert len(mock_native_daemon.spawn_calls) == 1
+        # Verify --resume <uuid> was passed as extra_args
+        extra = mock_native_daemon.spawn_extra_args[0]
+        assert extra == ["--resume", "550e8400-e29b-41d4-a716-446655440000"]
 
     def test_no_handoff_warns(
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
         state = CwState(
             sessions=[
@@ -724,23 +731,50 @@ class TestResumeSession:
         )
         save_state(state)
 
-        resume_session("test-client/impl", adapter=mock_cmux_adapter)
+        resume_session("test-client/impl", native_daemon=mock_native_daemon)
 
         output = capsys.readouterr().out
         assert "No handoff file" in output
+
+    def test_with_handoff_loads_context(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+        sample_handoff_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
+
+        state = CwState(
+            sessions=[
+                Session(
+                    id="withhand1",
+                    name="test-client/impl",
+                    client="test-client",
+                    purpose=SessionPurpose.IMPL,
+                    status=SessionStatus.BACKGROUNDED,
+                    workspace_path=sample_client.workspace_path,
+                    last_handoff_path=sample_handoff_file,
+                )
+            ]
+        )
+        save_state(state)
+
+        resume_session("test-client/impl", native_daemon=mock_native_daemon)
+
+        output = capsys.readouterr().out
+        assert "Loaded resumption context" in output
 
     def test_not_backgrounded_raises(
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
     ) -> None:
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
+        self._write_clients_file(tmp_config_dir, sample_client)
 
         state = CwState(
             sessions=[
@@ -757,196 +791,63 @@ class TestResumeSession:
         save_state(state)
 
         with pytest.raises(CwError, match="not backgrounded or idle"):
-            resume_session("test-client/impl", adapter=mock_cmux_adapter)
+            resume_session("test-client/impl", native_daemon=mock_native_daemon)
 
     def test_not_found_raises(
         self,
         tmp_config_dir: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
     ) -> None:
         save_state(CwState())
 
         with pytest.raises(CwError, match="Session not found"):
-            resume_session("nonexistent", adapter=mock_cmux_adapter)
+            resume_session("nonexistent", native_daemon=mock_native_daemon)
 
-    def test_resume_shows_prompt(
+    def test_live_session_prints_detach_hint(
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
+
+        short_id = "abcd1234"
+        mock_native_daemon._live.add(short_id)
+
+        state = CwState(
+            sessions=[
+                Session(
+                    id="hinttest1",
+                    name="test-client/impl",
+                    client="test-client",
+                    purpose=SessionPurpose.IMPL,
+                    status=SessionStatus.BACKGROUNDED,
+                    workspace_path=sample_client.workspace_path,
+                    surface_ref=short_id,
+                )
+            ]
+        )
+        save_state(state)
+
+        resume_session("test-client/impl", native_daemon=mock_native_daemon)
+
+        out = capsys.readouterr().out
+        assert "Ctrl+Z" in out
+        assert "Ctrl+D" in out
+
+    def test_resume_preserves_handoff_file(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
         sample_handoff_file: Path,
-        monkeypatch: pytest.MonkeyPatch,
-        capsys: pytest.CaptureFixture[str],
     ) -> None:
-        monkeypatch.setattr("cw.session.time.sleep", lambda _s: None)
-
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
-
-        state = CwState(
-            sessions=[
-                Session(
-                    id="outside2",
-                    name="test-client/impl",
-                    client="test-client",
-                    purpose=SessionPurpose.IMPL,
-                    status=SessionStatus.BACKGROUNDED,
-                    workspace_path=sample_client.workspace_path,
-                    last_handoff_path=sample_handoff_file,
-                )
-            ]
-        )
-        save_state(state)
-
-        resume_session("test-client/impl", adapter=mock_cmux_adapter)
-
-        output = capsys.readouterr().out
-        assert "Resumption prompt:" in output
-        assert "auth feature" in output
-
-    def test_resume_no_handoff_injects_context_only(
-        self,
-        tmp_config_dir: Path,
-        sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
-        monkeypatch: pytest.MonkeyPatch,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        """Without a handoff, resumed session still gets [cw identity] context."""
-        monkeypatch.setattr("cw.session.time.sleep", lambda _s: None)
-
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
-
-        state = CwState(
-            sessions=[
-                Session(
-                    id="nohnd001",
-                    name="test-client/impl",
-                    client="test-client",
-                    purpose=SessionPurpose.IMPL,
-                    status=SessionStatus.BACKGROUNDED,
-                    workspace_path=sample_client.workspace_path,
-                    surface_ref="impl",
-                )
-            ]
-        )
-        save_state(state)
-
-        resume_session("test-client/impl", adapter=mock_cmux_adapter)
-
-        output = capsys.readouterr().out
-        assert "[cw identity]" in output
-        assert "Client: 'test-client'" in output
-
-    def test_resume_command_includes_env_vars(
-        self,
-        tmp_config_dir: Path,
-        sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """The claude --resume command has CW_CLIENT/CW_PURPOSE env vars."""
-        monkeypatch.setattr("cw.session.time.sleep", lambda _s: None)
-
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
-
-        state = CwState(
-            sessions=[
-                Session(
-                    id="envres01",
-                    name="test-client/impl",
-                    client="test-client",
-                    purpose=SessionPurpose.IMPL,
-                    status=SessionStatus.BACKGROUNDED,
-                    workspace_path=sample_client.workspace_path,
-                    surface_ref="impl",
-                )
-            ]
-        )
-        save_state(state)
-
-        resume_session("test-client/impl", adapter=mock_cmux_adapter)
-
-        # The spawn command should include CW_CLIENT/CW_PURPOSE env vars
-        assert len(mock_cmux_adapter.calls["spawn"]) == 1
-        _workspace, cmd, _surface = mock_cmux_adapter.calls["spawn"][0]
-        assert "CW_CLIENT=test-client" in str(cmd)
-        assert "CW_PURPOSE=impl" in str(cmd)
-
-    def test_resume_injects_client_context(
-        self,
-        tmp_config_dir: Path,
-        sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
-        sample_handoff_file: Path,
-        monkeypatch: pytest.MonkeyPatch,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        """Resumed session gets [cw identity] prepended to handoff prompt."""
-        monkeypatch.setattr("cw.session.time.sleep", lambda _s: None)
-
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
-
-        state = CwState(
-            sessions=[
-                Session(
-                    id="ctx00001",
-                    name="test-client/impl",
-                    client="test-client",
-                    purpose=SessionPurpose.IMPL,
-                    status=SessionStatus.BACKGROUNDED,
-                    workspace_path=sample_client.workspace_path,
-                    last_handoff_path=sample_handoff_file,
-                    surface_ref="impl",
-                )
-            ]
-        )
-        save_state(state)
-
-        resume_session("test-client/impl", adapter=mock_cmux_adapter)
-
-        output = capsys.readouterr().out
-        assert "[cw identity]" in output
-        assert "Client: 'test-client'" in output
-        # Original handoff content still present
-        assert "auth feature" in output
-
-    def test_regular_handoff_not_cleaned_up(
-        self,
-        tmp_config_dir: Path,
-        sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
-        sample_handoff_file: Path,
-        monkeypatch: pytest.MonkeyPatch,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        monkeypatch.setattr("cw.session.time.sleep", lambda _s: None)
-
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
         state = CwState(
             sessions=[
@@ -963,12 +864,16 @@ class TestResumeSession:
         )
         save_state(state)
 
-        resume_session("test-client/impl", adapter=mock_cmux_adapter)
+        resume_session("test-client/impl", native_daemon=mock_native_daemon)
 
-        # Regular session-*.md handoffs should be preserved
         assert sample_handoff_file.exists()
         updated = load_state()
         assert updated.sessions[0].last_handoff_path is not None
+
+
+# ---------------------------------------------------------------------------
+# TestDoneSession
+# ---------------------------------------------------------------------------
 
 
 class TestDoneSession:
@@ -976,7 +881,6 @@ class TestDoneSession:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
     ) -> None:
         state = CwState(
             sessions=[
@@ -1001,7 +905,6 @@ class TestDoneSession:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
     ) -> None:
         state = CwState(
             sessions=[
@@ -1024,7 +927,6 @@ class TestDoneSession:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
@@ -1069,7 +971,6 @@ class TestDoneSession:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
@@ -1112,7 +1013,6 @@ class TestDoneSession:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
     ) -> None:
         state = CwState(
             sessions=[
@@ -1138,7 +1038,6 @@ class TestDoneSession:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from cw.exceptions import WorktreeError
@@ -1183,182 +1082,9 @@ class TestDoneSession:
         assert updated.sessions[0].status == SessionStatus.ACTIVE
 
 
-class TestBackgroundNotify:
-    def test_notify_calls_adapter_spawn(
-        self,
-        tmp_config_dir: Path,
-        sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
-            f"clients:\n"
-            f"  test-client:\n"
-            f"    workspace_path: {sample_client.workspace_path}\n"
-        )
-
-        state = CwState(
-            sessions=[
-                Session(
-                    id="bn_src01",
-                    name="test-client/impl",
-                    client="test-client",
-                    purpose=SessionPurpose.IMPL,
-                    status=SessionStatus.ACTIVE,
-                    workspace_path=sample_client.workspace_path,
-                ),
-                Session(
-                    id="bn_tgt01",
-                    name="test-client/idea",
-                    client="test-client",
-                    purpose=SessionPurpose.IDEA,
-                    status=SessionStatus.ACTIVE,
-                    workspace_path=sample_client.workspace_path,
-                    surface_ref="idea",
-                ),
-            ]
-        )
-        save_state(state)
-
-        background_session("test-client/impl", notify="idea", adapter=mock_cmux_adapter)
-
-        output = capsys.readouterr().out
-        assert "Notified" in output
-
-    def test_notify_no_active_target_warns(
-        self,
-        tmp_config_dir: Path,
-        sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        state = CwState(
-            sessions=[
-                Session(
-                    id="bn_src02",
-                    name="test-client/impl",
-                    client="test-client",
-                    purpose=SessionPurpose.IMPL,
-                    status=SessionStatus.ACTIVE,
-                    workspace_path=sample_client.workspace_path,
-                ),
-            ]
-        )
-        save_state(state)
-
-        background_session("test-client/impl", notify="idea", adapter=mock_cmux_adapter)
-
-        output = capsys.readouterr().out
-        assert "No active idea session" in output
-
-
-def test_start_session_reaps_phantom_before_existing_check(
-    tmp_config_dir: Path,
-    sample_client: ClientConfig,
-) -> None:
-    """Phantom ACTIVE session is reaped; start_session then spawns fresh sessions.
-
-    Reconciliation runs before the existing-session check so a dead "active"
-    row doesn't cause start_session to short-circuit.
-    """
-    clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-    clients_file.write_text(
-        f"clients:\n"
-        f"  {sample_client.name}:\n"
-        f"    workspace_path: {sample_client.workspace_path}\n"
-    )
-
-    save_state(
-        CwState(
-            sessions=[
-                Session(
-                    id="phantom",
-                    name=f"{sample_client.name}/impl",
-                    client=sample_client.name,
-                    purpose=SessionPurpose.IMPL,
-                    status=SessionStatus.ACTIVE,
-                    workspace_path=sample_client.workspace_path,
-                    surface_ref="gone-ref",
-                ),
-            ]
-        )
-    )
-
-    adapter = FakeCmuxAdapter()
-    # Non-empty live set bypasses reconcile's outage guard; "gone-ref" still
-    # isn't live so the phantom is still reaped.
-    adapter.spawn("decoy-ws", "echo")
-    start_session(sample_client.name, "impl", adapter=adapter)
-
-    reloaded = load_state()
-    # Phantom got reaped
-    phantom = reloaded.find_by_name_or_id("phantom")
-    assert phantom is not None
-    assert phantom.status == SessionStatus.COMPLETED
-    # New sessions spawned: at least one for impl beyond the decoy
-    assert len(adapter.calls["spawn"]) >= 2
-
-
-def test_start_session_launch_message_names_backend(
-    tmp_config_dir: Path,
-    sample_client: ClientConfig,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The 'Launching X surfaces...' message names the backend in use."""
-    from cw.models import BackendName
-
-    clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-    clients_file.write_text(
-        f"clients:\n"
-        f"  test-client:\n"
-        f"    workspace_path: {sample_client.workspace_path}\n"
-    )
-    monkeypatch.setattr("cw.session._resolve_backend_name", lambda: BackendName.TMUX)
-
-    start_session(sample_client.name, "impl", adapter=FakeCmuxAdapter())
-    out = capsys.readouterr().out
-    assert "Launching tmux surfaces" in out
-
-
-def test_start_session_spawn_failure_leaves_state_unchanged(
-    tmp_config_dir: Path,
-    sample_client: ClientConfig,
-) -> None:
-    """If spawn raises mid-loop, on-disk state is unchanged from pre-call.
-
-    Pins the invariant from issue #63: state persists once at the end after
-    every surface has been spawned. Partial-success window (sessions linked
-    on disk without surface_ref) must not exist.
-    """
-    clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-    clients_file.write_text(
-        f"clients:\n"
-        f"  test-client:\n"
-        f"    workspace_path: {sample_client.workspace_path}\n"
-    )
-
-    # Snapshot pre-call state file (empty initially).
-    pre_state = load_state()
-    pre_session_count = len(pre_state.sessions)
-
-    # Adapter that fails on the second spawn — first one succeeds, then boom.
-    class FlakyAdapter(FakeCmuxAdapter):
-        def spawn(self, workspace: str, command: str, surface: str = "right") -> str:
-            if len(self.calls["spawn"]) >= 1:
-                msg = "simulated spawn failure"
-                raise CwError(msg)
-            return super().spawn(workspace, command, surface)
-
-    adapter = FlakyAdapter()
-
-    with pytest.raises(CwError, match="simulated spawn failure"):
-        start_session("test-client", "impl", adapter=adapter)
-
-    # Post-call: state file must be unchanged (no partial sessions persisted).
-    post_state = load_state()
-    assert len(post_state.sessions) == pre_session_count
+# ---------------------------------------------------------------------------
+# TestBackgroundAllSessions
+# ---------------------------------------------------------------------------
 
 
 class TestBackgroundAllSessions:
@@ -1366,7 +1092,6 @@ class TestBackgroundAllSessions:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
     ) -> None:
         state = CwState(
             sessions=[
@@ -1399,17 +1124,77 @@ class TestBackgroundAllSessions:
     def test_no_active_sessions_is_noop(
         self,
         tmp_config_dir: Path,
-        sample_client: ClientConfig,
     ) -> None:
-        state = CwState(sessions=[])
-        save_state(state)
-
+        save_state(CwState())
         background_all_sessions()  # Should not raise
 
 
-class TestStartSessionParentLinkage:
-    """Tests for bidirectional parent/worker linkage via start_session --parent."""
+# ---------------------------------------------------------------------------
+# Standalone tests
+# ---------------------------------------------------------------------------
 
+
+def test_start_session_reaps_phantom_before_existing_check(
+    tmp_config_dir: Path,
+    sample_client: ClientConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phantom ACTIVE session is reaped; start_session then spawns a fresh session.
+
+    Reconciliation runs before the existing-session check so a dead "active"
+    row doesn't cause start_session to short-circuit.
+    """
+    clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
+    clients_file.write_text(
+        f"clients:\n"
+        f"  {sample_client.name}:\n"
+        f"    workspace_path: {sample_client.workspace_path}\n"
+    )
+
+    save_state(
+        CwState(
+            sessions=[
+                Session(
+                    id="phantom",
+                    name=f"{sample_client.name}/impl",
+                    client=sample_client.name,
+                    purpose=SessionPurpose.IMPL,
+                    status=SessionStatus.ACTIVE,
+                    workspace_path=sample_client.workspace_path,
+                    surface_ref="gone-ref",
+                ),
+            ]
+        )
+    )
+
+    # Inject a daemon with one live session (bypasses outage guard) but
+    # "gone-ref" is not a valid 8-char hex ref, so reconcile treats the
+    # session as phantom (non-hex refs don't appear in native_live set).
+    daemon = FakeNativeDaemonClient()
+    daemon._live.add("00000099")  # keep outage guard from firing
+
+    monkeypatch.setattr("cw.session._write_hook_context", _noop)
+
+    attached: list[str] = []
+    monkeypatch.setattr("cw.session._attach_session", attached.append)
+
+    start_session(sample_client.name, "impl", native_daemon=daemon)
+
+    reloaded = load_state()
+    # Phantom got reaped
+    phantom = reloaded.find_by_name_or_id("phantom")
+    assert phantom is not None
+    assert phantom.status == SessionStatus.COMPLETED
+    # New session spawned and attached
+    assert len(attached) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestStartSessionParentLinkage
+# ---------------------------------------------------------------------------
+
+
+class TestStartSessionParentLinkage:
     def _write_clients_file(
         self, tmp_config_dir: Path, sample_client: ClientConfig
     ) -> None:
@@ -1424,16 +1209,14 @@ class TestStartSessionParentLinkage:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Worker sessions get parent_session_id; parent gains all worker IDs.
-
-        The parent has purpose=DEBT so start_session("impl") doesn't see it
-        as an existing ACTIVE impl session and short-circuit to noop.
-        """
+        """Worker session gets parent_session_id; parent gains the worker ID."""
         self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
-        # Use debt purpose for parent so it doesn't collide with new impl sessions
         parent_session = Session(
             id="parent01",
             name="test-client/debt",
@@ -1445,42 +1228,31 @@ class TestStartSessionParentLinkage:
         save_state(CwState(sessions=[parent_session]))
 
         start_session(
-            "test-client", "impl", parent="parent01", adapter=mock_cmux_adapter
+            "test-client", "impl", parent="parent01", native_daemon=mock_native_daemon
         )
 
         state = load_state()
-        # Original parent session + 3 new sessions (impl, idea, debt)
-        assert len(state.sessions) == 4
-        new_sessions = [s for s in state.sessions if s.id != "parent01"]
-        assert len(new_sessions) == 3
+        # Original parent + 1 new impl session
+        assert len(state.sessions) == 2
+        new_session = next(s for s in state.sessions if s.id != "parent01")
+        assert new_session.purpose == SessionPurpose.IMPL
+        assert new_session.parent_session_id == "parent01"
 
-        # Only the impl session links back to the parent
-        impl_session = next(s for s in new_sessions if s.purpose == SessionPurpose.IMPL)
-        non_impl_sessions = [
-            s for s in new_sessions if s.purpose != SessionPurpose.IMPL
-        ]
-        assert impl_session.parent_session_id == "parent01"
-        for non_impl in non_impl_sessions:
-            assert non_impl.parent_session_id is None
-
-        # Parent accumulates only the impl session's ID (1 entry per start call)
         updated_parent = state.find_by_name_or_id("parent01")
         assert updated_parent is not None
-        assert updated_parent.worker_session_ids == [impl_session.id]
+        assert updated_parent.worker_session_ids == [new_session.id]
 
     def test_two_workers_from_same_parent(
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Calling start_session twice with the same parent accumulates worker IDs.
-
-        The parent has purpose=DEBT to avoid colliding with the new impl sessions
-        created in each call.  After the first call, the three new sessions are
-        marked COMPLETED so the second call creates three more.
-        """
+        """Calling start_session twice with the same parent accumulates worker IDs."""
         self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
         parent_session = Session(
             id="parent02",
@@ -1492,45 +1264,46 @@ class TestStartSessionParentLinkage:
         )
         save_state(CwState(sessions=[parent_session]))
 
-        # First call: start_session creates 3 worker sessions
         start_session(
-            "test-client", "impl", parent="parent02", adapter=mock_cmux_adapter
+            "test-client", "impl", parent="parent02", native_daemon=mock_native_daemon
         )
 
-        # Mark new sessions completed so the second call isn't blocked by ACTIVE check
+        # Mark new session completed so the second call isn't blocked
         state = load_state()
         for s in state.sessions:
             if s.id != "parent02":
                 s.status = SessionStatus.COMPLETED
         save_state(state)
 
-        # Second call: creates another 3 worker sessions
         start_session(
-            "test-client", "impl", parent="parent02", adapter=mock_cmux_adapter
+            "test-client", "impl", parent="parent02", native_daemon=mock_native_daemon
         )
 
         state = load_state()
         updated_parent = state.find_by_name_or_id("parent02")
         assert updated_parent is not None
-        # Parent accumulates 1 impl session ID per start call: 2 total
         assert len(updated_parent.worker_session_ids) == 2
 
     def test_nonexistent_parent_raises_cw_error(
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Unknown parent ID raises CwError before any state is written."""
         self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
         save_state(CwState())
 
         with pytest.raises(CwError, match="Parent session not found: no-such-id"):
             start_session(
-                "test-client", "impl", parent="no-such-id", adapter=mock_cmux_adapter
+                "test-client",
+                "impl",
+                parent="no-such-id",
+                native_daemon=mock_native_daemon,
             )
 
-        # No new sessions written to state
         state = load_state()
         assert state.sessions == []
 
@@ -1538,18 +1311,13 @@ class TestStartSessionParentLinkage:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """If save_state raises after mutations, state file is unchanged.
-
-        The atomic write path (write temp + os.replace) means either the old
-        file or the new file is visible — never a partial write. We simulate
-        the save raising to verify the original state is preserved on disk.
-        """
         self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
-        # debt parent avoids colliding with start_session("impl") active-check
         parent_session = Session(
             id="parent03",
             name="test-client/debt",
@@ -1561,7 +1329,6 @@ class TestStartSessionParentLinkage:
         initial_state = CwState(sessions=[parent_session])
         save_state(initial_state)
 
-        # Patch save_state to raise on the first call after session creation
         call_count = 0
 
         def failing_save(state: CwState) -> None:
@@ -1575,10 +1342,12 @@ class TestStartSessionParentLinkage:
 
         with pytest.raises(OSError, match="Simulated disk failure"):
             start_session(
-                "test-client", "impl", parent="parent03", adapter=mock_cmux_adapter
+                "test-client",
+                "impl",
+                parent="parent03",
+                native_daemon=mock_native_daemon,
             )
 
-        # State on disk is unchanged — still just the parent session
         state = load_state()
         assert len(state.sessions) == 1
         assert state.sessions[0].id == "parent03"
@@ -1588,27 +1357,30 @@ class TestStartSessionParentLinkage:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """start_session without --parent works as before (regression guard)."""
         self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
-        start_session("test-client", "impl", adapter=mock_cmux_adapter)
+        start_session("test-client", "impl", native_daemon=mock_native_daemon)
 
         state = load_state()
-        assert len(state.sessions) == 3
-        for s in state.sessions:
-            assert s.parent_session_id is None
-            assert s.worker_session_ids == []
+        assert len(state.sessions) == 1
+        assert state.sessions[0].parent_session_id is None
+        assert state.sessions[0].worker_session_ids == []
 
     def test_parent_with_existing_active_session_raises(
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """CwError raised when --parent collides with an existing ACTIVE session."""
         self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
         parent_session = Session(
             id="parent04",
@@ -1618,7 +1390,6 @@ class TestStartSessionParentLinkage:
             status=SessionStatus.ACTIVE,
             workspace_path=sample_client.workspace_path,
         )
-        # Pre-create an active impl session to trigger the short-circuit path
         existing_impl = Session(
             id="existing-impl",
             name="test-client/impl",
@@ -1631,10 +1402,12 @@ class TestStartSessionParentLinkage:
 
         with pytest.raises(CwError, match="already active"):
             start_session(
-                "test-client", "impl", parent="parent04", adapter=mock_cmux_adapter
+                "test-client",
+                "impl",
+                parent="parent04",
+                native_daemon=mock_native_daemon,
             )
 
-        # No new sessions and parent's worker_session_ids unchanged
         state = load_state()
         assert len(state.sessions) == 2
         updated_parent = state.find_by_name_or_id("parent04")
@@ -1645,10 +1418,12 @@ class TestStartSessionParentLinkage:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """CwError raised when --parent collides with existing BACKGROUNDED session."""
         self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
         parent_session = Session(
             id="parent05",
@@ -1658,7 +1433,6 @@ class TestStartSessionParentLinkage:
             status=SessionStatus.ACTIVE,
             workspace_path=sample_client.workspace_path,
         )
-        # Pre-create a backgrounded impl session to trigger the short-circuit path
         existing_impl = Session(
             id="existing-impl-bg",
             name="test-client/impl",
@@ -1672,10 +1446,12 @@ class TestStartSessionParentLinkage:
         err_match = "Cannot apply --parent to existing backgrounded session"
         with pytest.raises(CwError, match=err_match):
             start_session(
-                "test-client", "impl", parent="parent05", adapter=mock_cmux_adapter
+                "test-client",
+                "impl",
+                parent="parent05",
+                native_daemon=mock_native_daemon,
             )
 
-        # No new sessions and parent's worker_session_ids unchanged
         state = load_state()
         assert len(state.sessions) == 2
         updated_parent = state.find_by_name_or_id("parent05")
@@ -1686,13 +1462,13 @@ class TestStartSessionParentLinkage:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Bad parent ID raises CwError even when an active session would
-        short-circuit."""
         self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
-        # Pre-create an active impl session that would normally short-circuit
         existing_impl = Session(
             id="existing-impl-sc",
             name="test-client/impl",
@@ -1703,24 +1479,22 @@ class TestStartSessionParentLinkage:
         )
         save_state(CwState(sessions=[existing_impl]))
 
-        # The bad parent ID error must fire BEFORE the active-session short-circuit
         with pytest.raises(CwError, match="Parent session not found: bad-id"):
             start_session(
-                "test-client", "impl", parent="bad-id", adapter=mock_cmux_adapter
+                "test-client", "impl", parent="bad-id", native_daemon=mock_native_daemon
             )
 
     def test_parent_validation_runs_before_backgrounded_short_circuit(
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Bad parent ID raises CwError even when a backgrounded session would
-        short-circuit (resume path)."""
         self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
-        # Pre-create a backgrounded impl session that would normally trigger
-        # the resume_session short-circuit path.
         existing_impl = Session(
             id="existing-impl-bg-sc",
             name="test-client/impl",
@@ -1731,13 +1505,11 @@ class TestStartSessionParentLinkage:
         )
         save_state(CwState(sessions=[existing_impl]))
 
-        # Bad parent ID must error BEFORE resume_session is invoked.
         with pytest.raises(CwError, match="Parent session not found: bad-id"):
             start_session(
-                "test-client", "impl", parent="bad-id", adapter=mock_cmux_adapter
+                "test-client", "impl", parent="bad-id", native_daemon=mock_native_daemon
             )
 
-        # Existing session must remain BACKGROUNDED — short-circuit never ran.
         state = load_state()
         assert len(state.sessions) == 1
         assert state.sessions[0].status == SessionStatus.BACKGROUNDED
@@ -1746,9 +1518,9 @@ class TestStartSessionParentLinkage:
         self,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """--parent raises CwError when client.auto_purposes excludes 'impl'."""
         clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
         clients_file.write_text(
             f"clients:\n"
@@ -1756,6 +1528,8 @@ class TestStartSessionParentLinkage:
             f"    workspace_path: {sample_client.workspace_path}\n"
             f"    auto_purposes: [idea, debt]\n"
         )
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
         parent_session = Session(
             id="parent06",
@@ -1770,10 +1544,12 @@ class TestStartSessionParentLinkage:
         err_match = "--parent requires the client config to include 'impl'"
         with pytest.raises(CwError, match=err_match):
             start_session(
-                "test-client", "impl", parent="parent06", adapter=mock_cmux_adapter
+                "test-client",
+                "impl",
+                parent="parent06",
+                native_daemon=mock_native_daemon,
             )
 
-        # No new sessions created and parent unchanged.
         state = load_state()
         assert len(state.sessions) == 1
         updated_parent = state.find_by_name_or_id("parent06")
@@ -1785,16 +1561,9 @@ class TestStartSessionParentLinkage:
         monkeypatch: pytest.MonkeyPatch,
         tmp_config_dir: Path,
         sample_client: ClientConfig,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        mock_native_daemon: FakeNativeDaemonClient,
     ) -> None:
-        """Bad --parent on a worktree-mode client must error BEFORE
-        create_worktree runs, so no on-disk worktree is orphaned.
-
-        Pins Item 2's stated motivation: a regression that re-orders parent
-        validation back below worktree creation would call create_worktree
-        and leave an orphaned worktree on disk before the validation error
-        fires. This spy catches that regression.
-        """
+        """Bad --parent on a worktree-mode client must error BEFORE create_worktree."""
         clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
         clients_file.write_text(
             f"clients:\n"
@@ -1802,10 +1571,12 @@ class TestStartSessionParentLinkage:
             f"    workspace_path: {sample_client.workspace_path}\n"
             f"    branch: main\n"
         )
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
 
         create_worktree_calls: list[tuple[object, ...]] = []
 
-        def spy_create_worktree(*args: object, **kwargs: object) -> Path:
+        def spy_create_worktree(*args: object, **kwargs: object) -> None:
             create_worktree_calls.append(args)
             msg = "create_worktree should not have been called"
             raise AssertionError(msg)
@@ -1814,7 +1585,7 @@ class TestStartSessionParentLinkage:
 
         with pytest.raises(CwError, match="Parent session not found: bad-id"):
             start_session(
-                "test-client", "impl", parent="bad-id", adapter=mock_cmux_adapter
+                "test-client", "impl", parent="bad-id", native_daemon=mock_native_daemon
             )
 
         assert create_worktree_calls == []


### PR DESCRIPTION
## Summary

- **Replaces** the cmux/tmux multiplexer spawn path in `start_session` and `resume_session` with `claude --bg` + `claude attach` (Phase C of the native supervisor migration, ADR-0000)
- **`start_session`**: spawns via `NativeDaemonClient.spawn_bg`, persists the 8-char hex short id as `Session.surface_ref`, writes Stop hook context via `_write_hook_context` (origin=USER, gate-behind-worktree strategy from #165), then `exec`s `claude attach <short-id>` — single purpose session per call (not 3 panes)
- **`resume_session`**: attaches directly if `surface_ref` is live in the daemon; falls back to a new `spawn_bg` with `--resume <claude_session_id>` for dead sessions
- **Detach hint** printed before attach: "Detach with Ctrl+Z. Do NOT use Ctrl+D (terminates the daemon session in all attached terminals)"
- Removes deleted helpers: `_build_pane_args`, `_create_all_purpose_sessions`, `_spawn_session_surface`, `_notify_sibling` (cmux sibling notification not applicable to native sessions — `--notify` now emits a warning)
- `FakeNativeDaemonClient` gains `spawn_extra_args` list alongside `spawn_calls` for test assertions on `--resume` passthrough
- All 947 tests pass; zero ruff/mypy violations

## Respawn policy

Per spike findings (ADR-0000 Phase A), auto-respawn is acceptable for USER sessions because `claude attach` is the management primitive — if a session crashes and respawns, the user re-attaches. No upstream CLI flag needed.

## Out of scope

- Removing `MultiplexerAdapter` from `reconcile`, `dispatch`, `doctor`, `orchestrate` → Phase D (#167, now unblocked)
- Deleting `cmux.py`, `tmux.py` → Phase F (#119)

## Test plan

- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run mypy src/` — zero errors
- [x] `uv run pytest tests/ -v` — 947/947 pass
- New tests: `TestIsNativeSurfaceRef`, `TestStartSession` (7 tests), `TestStartWorktreeClient`, `TestResumeSession` (9 tests including live/dead/resume-flag paths), `test_start_session_reaps_phantom_before_existing_check`

Closes #166
Unblocks #167

🤖 Generated with [Claude Code](https://claude.ai/claude-code)