### PR TITLE
chore(lint): enable LOG + G ruff rules (logging correctness)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,8 @@ select = [
     "BLE",  # flake8-blind-except
     "EM",   # flake8-errmsg
     "TRY",  # tryceratops (exception handling)
+    "LOG",  # flake8-logging (logger.exception vs error+exc_info, extra= misuse)
+    "G",    # flake8-logging-format (no f-strings/format in log calls; use lazy %)
 ]
 ignore = [
     "T201",  # print() is our UI output mechanism (via click.echo, but also direct)


### PR DESCRIPTION
## Summary

- chore(lint): enable LOG + G ruff rules (logging correctness)

Closes #233.

## Test plan

- [x] ruff check src/ tests/ — zero violations
- [x] mypy src/ — zero type errors (29 source files)
- [x] pytest tests/ — 950 passed
- [x] pre-commit (touched files) — clean
- [x] diff-cover ≥ 90% on patch (verified by pre-push hook)

Note: `mypy .` (whole repo) surfaces 8 pre-existing errors in test files (test_session.py, test_dispatch.py, test_plan.py) that exist on `main` and are unrelated to this change. The ticket's gate is `mypy src/` which is clean.

🤖 Shipped via /prep-pr + project /ship-it