### PR TITLE
chore(lint): enable PTH ruff rule (pathlib enforcement) (#234)

### DIFF
--- a/.claude/skills/cw-followup/scripts/render_decisions.py
+++ b/.claude/skills/cw-followup/scripts/render_decisions.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
 from typing import Any
 
 _DECISIONS_HEADING = "## Decisions"
@@ -118,7 +119,7 @@ def render(payload: dict[str, Any], *, auto_accept: bool) -> str:
 
 def _load_payload(args: argparse.Namespace) -> dict[str, Any]:
     if args.input:
-        with open(args.input, encoding="utf-8") as handle:
+        with Path(args.input).open(encoding="utf-8") as handle:
             data = json.load(handle)
     else:
         data = json.load(sys.stdin)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ select = [
     "DTZ",  # flake8-datetimez
     "T20",  # flake8-print
     "PT",   # flake8-pytest-style
+    "PTH",  # flake8-use-pathlib
     "Q",    # flake8-quotes
     "RSE",  # flake8-raise
     "RET",  # flake8-return

--- a/src/cw/atomic.py
+++ b/src/cw/atomic.py
@@ -17,13 +17,13 @@ from pathlib import Path
 
 
 def atomic_write_text(path: Path, text: str) -> None:
-    """Write *text* to *path* atomically via a unique temp file + ``os.replace``.
+    """Write *text* to *path* atomically via a unique temp file + ``Path.replace``.
 
     The temp file is created with ``mkstemp`` in the same directory as
     *path* so the final rename stays on one filesystem. A unique temp
     name per call is required because concurrent writers (possible when
     the outer lock is advisory or absent) would otherwise race on a
-    shared temp name and one ``os.replace`` would fail with ``ENOENT``.
+    shared temp name and one ``Path.replace`` would fail with ``ENOENT``.
     """
     fd, tmp_name = tempfile.mkstemp(
         prefix=path.name + ".",

--- a/src/cw/atomic.py
+++ b/src/cw/atomic.py
@@ -13,10 +13,7 @@ from __future__ import annotations
 import contextlib
 import os
 import tempfile
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
 
 
 def atomic_write_text(path: Path, text: str) -> None:
@@ -36,9 +33,9 @@ def atomic_write_text(path: Path, text: str) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(text)
-        os.replace(tmp_name, path)
+        Path(tmp_name).replace(path)
     except BaseException:
         # Remove the temp file if the rename didn't consume it.
         with contextlib.suppress(FileNotFoundError):
-            os.unlink(tmp_name)
+            Path(tmp_name).unlink()
         raise

--- a/src/cw/wrapper.py
+++ b/src/cw/wrapper.py
@@ -135,7 +135,7 @@ def run_claude_wrapper(extra_args: tuple[str, ...]) -> None:
     session_id_env = os.environ.get("CW_SESSION_ID")
 
     claude_args = list(extra_args)
-    workspace_path = os.getcwd()
+    workspace_path = str(Path.cwd())
 
     if _is_headless(extra_args):
         returncode, captured = _run_claude_streaming(claude_args)

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -1,0 +1,49 @@
+"""Tests for cw.atomic — atomic file writing helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cw.atomic import atomic_write_text
+
+
+def test_atomic_write_text_writes_payload(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    atomic_write_text(target, '{"k": 1}')
+    assert target.read_text(encoding="utf-8") == '{"k": 1}'
+
+
+def test_atomic_write_text_cleans_temp_on_rename_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``Path.replace`` raises, the temp file must be unlinked."""
+    target = tmp_path / "state.json"
+
+    leaked: list[str] = []
+    import tempfile
+
+    real_mkstemp = tempfile.mkstemp
+
+    def capturing_mkstemp(*args: object, **kwargs: object) -> tuple[int, str]:
+        fd, name = real_mkstemp(*args, **kwargs)
+        leaked.append(name)
+        return fd, name
+
+    monkeypatch.setattr("cw.atomic.tempfile.mkstemp", capturing_mkstemp)
+
+    def failing_replace(self: Path, target_path: Path) -> Path:
+        msg = "simulated rename failure"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(Path, "replace", failing_replace)
+
+    with pytest.raises(RuntimeError, match="simulated rename failure"):
+        atomic_write_text(target, "payload")
+
+    assert leaked, "mkstemp should have been called"
+    for name in leaked:
+        assert not Path(name).exists(), f"temp file {name} should have been removed"
+    assert not target.exists()

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -23,8 +24,6 @@ def test_atomic_write_text_cleans_temp_on_rename_failure(
     target = tmp_path / "state.json"
 
     leaked: list[str] = []
-    import tempfile
-
     real_mkstemp = tempfile.mkstemp
 
     def capturing_mkstemp(*args: object, **kwargs: object) -> tuple[int, str]:


### PR DESCRIPTION
## Summary

- chore(lint): address review feedback on #234
- chore(lint): enable PTH ruff rule (pathlib enforcement)

Closes #234. Tier 1 #3 of #230.

## What changed

Adds `PTH` (flake8-use-pathlib) to `[tool.ruff.lint] select` and fixes the 4 violations across the repo:

- `src/cw/atomic.py` — `os.replace` → `Path.replace`, `os.unlink` → `Path.unlink`. Promotes the `Path` import from `TYPE_CHECKING` to runtime.
- `src/cw/wrapper.py:138` — `os.getcwd()` → `str(Path.cwd())` (preserves the `str`-typed downstream signature per the user's resolution on Ambiguity 2).
- `.claude/skills/cw-followup/scripts/render_decisions.py:121` — `open()` → `Path.open()` (full-repo scope per Ambiguity 1 — keeps `pre-commit run --all-files` clean).
- Adds `tests/test_atomic.py` covering `atomic_write_text` happy path + cleanup-on-rename-failure branch (required to satisfy the 90% diff-cover gate after touching the previously-uncovered error path).

No per-file ignores added — the PTH test noise the ticket warned about did not materialize.

Ruff 0.15.14's `--unsafe-fixes` autofix did not apply on any of the four sites in this codebase, so all rewrites are hand-applied per the plan's intended shape.

## Test plan

- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run ruff check .` — zero violations (covers `.claude/`)
- [x] `uv run mypy src/` — zero type errors (29 files)
- [x] `uv run pytest tests/ -v` — 952 passed
- [x] `uv run pre-commit run --all-files` — clean
- [x] `diff-cover --fail-under=90` — 100% (4/4 changed lines covered)

🤖 Shipped via /auto-dev (headless) + /prep-pr + project /ship-it