### PR TITLE
feat(spawn): pin per-client worker model on claude --bg (#248)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,21 @@ cw list
 | **sonnet** | Default - implementation, reviews, planning, multi-file analysis |
 | **opus** | Only when explicitly requested or Sonnet fails on complex reasoning |
 
+### Per-client worker pinning
+
+Each client can pin the model used by autonomous workers (auto-dev,
+dispatch) via the `worker_model` field in `clients.yaml`. When set, `cw`
+forwards `--model <worker_model>` to `claude --bg` from two chokepoints:
+
+- `src/cw/spawn.py:spawn_create_impl` — initial DAEMON spawn (auto-dev
+  worker creation).
+- `src/cw/session.py:resume_session` — DAEMON-origin resume of a dead
+  surface (re-spawn path).
+
+USER-origin sessions (interactive `cw start` / `cw resume`) always inherit
+the operator's logged-in default model and ignore `worker_model`. See
+`config/CONFIG_REFERENCE.md` for the cost-control example.
+
 ## Agent Spawning Decision Tree
 
 **Default: Work directly unless clear reason to spawn.**

--- a/config/CONFIG_REFERENCE.md
+++ b/config/CONFIG_REFERENCE.md
@@ -46,6 +46,7 @@ State is stored at `~/.local/share/cw/` (or `$XDG_DATA_HOME/cw/`).
 | `auto_purposes` | list | `[idea, impl, debt]` | Session purposes to auto-start with `cw start` |
 | `purpose_prompts` | dict | `{}` | Custom prompts per session purpose |
 | `worktree_base` | path | *none* | Base directory for git worktree isolation |
+| `worker_model` | string \| null | `null` | Pin the model for DAEMON-origin worker spawns (auto-dev). Forwarded as `--model <id>` to `claude --bg` from both initial spawn and DAEMON-origin resume. USER-origin sessions (interactive `cw start` / `cw resume`) always inherit the operator's logged-in default model. Opaque string — no validation. |
 | `repo_path` | path | *none** | Shared repo path (worktree mode) |
 | `branch` | string | *none** | Branch name (worktree mode) |
 
@@ -137,6 +138,31 @@ clients:
     branch: feature-a
     worktree_base: /home/user/worktrees
 ```
+
+### Cost Control — Pin Worker Model
+
+`worker_model` constrains the model used by autonomous workers (auto-dev,
+dispatch, planner) without affecting your interactive sessions:
+
+```yaml
+clients:
+  thrifty-project:
+    workspace_path: /home/user/projects/thrifty-project
+    default_branch: main
+    # Workers run on Sonnet (cheaper than Opus) for auto-dev tasks.
+    # Interactive `cw start thrifty-project` still uses your default model.
+    worker_model: claude-sonnet-4-6-20251015
+
+  exploratory-project:
+    workspace_path: /home/user/projects/exploratory-project
+    default_branch: main
+    # Workers pinned to Haiku — fast/cheap for simple debt tickets.
+    worker_model: claude-haiku-4-5-20251001
+```
+
+Scope: forwarded as `--model <id>` to `claude --bg` from both
+`spawn_create_impl` (initial DAEMON spawn) and `resume_session` (DAEMON-origin
+resume of a dead surface). USER-origin sessions ignore this field.
 
 ## Managing Configuration
 

--- a/config/clients.example.yaml
+++ b/config/clients.example.yaml
@@ -17,6 +17,7 @@ clients:
   #   auto_purposes: [impl, idea, debt]    # which sessions auto-start (default: [idea, impl, debt])
   #   notifications: true                   # desktop notifications on session events
   #   auto_background_threshold: 50         # auto-background after N conversation turns
+  #   worker_model: claude-sonnet-4-6-20251015  # pin Sonnet for auto-dev workers
   #   purpose_prompts:                      # override default session prompts
   #     impl: "Custom implementation instructions..."
   #     idea: "Custom ideation instructions..."

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -306,6 +306,13 @@ class ClientConfig(BaseModel):
         default_factory=lambda: list(DEFAULT_AUTO_PURPOSES),
     )
     purpose_prompts: dict[str, str] = Field(default_factory=dict)
+    # When set, ``cw`` passes ``--model <worker_model>`` to ``claude --bg``
+    # for DAEMON-origin spawns (auto-dev workers, including resume re-spawns
+    # in :func:`cw.session.resume_session`). Opaque string — no validation;
+    # user is responsible for matching Anthropic's published model ids.
+    # Default ``None`` inherits the user's logged-in default model.
+    # See issue #248.
+    worker_model: str | None = None
     auto_background_threshold: int | None = None
     notifications: bool = False
     cmux_workspace: str | None = None

--- a/src/cw/session.py
+++ b/src/cw/session.py
@@ -388,7 +388,7 @@ def resume_session(
         # spawn_create_impl chokepoint. USER-origin sessions inherit the
         # operator's default model (issue #248).
         if session.origin == SessionOrigin.DAEMON and client.worker_model:
-            extra_args = (extra_args or []) + ["--model", client.worker_model]
+            extra_args = [*extra_args, "--model", client.worker_model]
 
         click.echo(
             f"Session {session.name} not live in daemon;"

--- a/src/cw/session.py
+++ b/src/cw/session.py
@@ -384,6 +384,12 @@ def resume_session(
         if session.claude_session_id:
             extra_args = ["--resume", session.claude_session_id]
 
+        # Forward client.worker_model for DAEMON-origin resume, mirroring the
+        # spawn_create_impl chokepoint. USER-origin sessions inherit the
+        # operator's default model (issue #248).
+        if session.origin == SessionOrigin.DAEMON and client.worker_model:
+            extra_args = (extra_args or []) + ["--model", client.worker_model]
+
         click.echo(
             f"Session {session.name} not live in daemon;"
             " spawning new background session..."

--- a/src/cw/spawn.py
+++ b/src/cw/spawn.py
@@ -189,8 +189,16 @@ def spawn_create_impl(
         headless=headless,
     )
 
+    extra_args: list[str] | None = None
+    if client.worker_model:
+        extra_args = ["--model", client.worker_model]
+
     daemon = native_daemon or get_native_daemon_client()
-    sess.surface_ref = daemon.spawn_bg(cwd=worktree, prompt=prompt)
+    sess.surface_ref = daemon.spawn_bg(
+        cwd=worktree,
+        prompt=prompt,
+        extra_args=extra_args,
+    )
 
     if parent_session is not None:
         sess.parent_session_id = parent_session.id

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -124,6 +124,35 @@ class TestLoadClients:
         result = load_clients()
         assert result["acme"].auto_purposes == DEFAULT_AUTO_PURPOSES
 
+    def test_load_clients_with_worker_model(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        ws_dir = tmp_path / "ws"
+        ws_dir.mkdir()
+        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
+        clients_file.write_text(
+            "clients:\n"
+            "  acme:\n"
+            f"    workspace_path: {ws_dir}\n"
+            "    worker_model: claude-sonnet-4-6-20251015\n"
+        )
+        result = load_clients()
+        assert result["acme"].worker_model == "claude-sonnet-4-6-20251015"
+
+    def test_default_worker_model_is_none_when_unset(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        ws_dir = tmp_path / "ws"
+        ws_dir.mkdir()
+        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
+        clients_file.write_text(f"clients:\n  acme:\n    workspace_path: {ws_dir}\n")
+        result = load_clients()
+        assert result["acme"].worker_model is None
+
 
 class TestLoadWorktreeClients:
     def test_worktree_client_from_yaml(

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1079,7 +1079,9 @@ class _RaisingNativeDaemon(FakeNativeDaemonClient):
         super().__init__()
         self._exc = exc
 
-    def spawn_bg(self, *, cwd: Path, prompt: str) -> str:
+    def spawn_bg(
+        self, *, cwd: Path, prompt: str, extra_args: list[str] | None = None
+    ) -> str:
         self.spawn_calls.append((cwd, prompt))
         raise self._exc
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -232,6 +232,28 @@ class TestClientConfig:
         # Explicit workspace_path is preserved
         assert c.workspace_path == Path("/explicit/path")
 
+    def test_worker_model_defaults_to_none(self) -> None:
+        c = ClientConfig(name="test", workspace_path=Path("/dev/null"))
+        assert c.worker_model is None
+
+    def test_worker_model_accepts_opaque_string(self) -> None:
+        c = ClientConfig(
+            name="test",
+            workspace_path=Path("/dev/null"),
+            worker_model="claude-sonnet-4-6-20251015",
+        )
+        assert c.worker_model == "claude-sonnet-4-6-20251015"
+
+    def test_worker_model_round_trip(self) -> None:
+        original = ClientConfig(
+            name="test",
+            workspace_path=Path("/dev/null"),
+            worker_model="claude-haiku-4-5-20251001",
+        )
+        data = original.model_dump(mode="json")
+        restored = ClientConfig.model_validate(data)
+        assert restored.worker_model == "claude-haiku-4-5-20251001"
+
 
 class TestCwState:
     def test_empty_state(self) -> None:

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -56,8 +56,10 @@ class _ScriptedDaemon(FakeNativeDaemonClient):
         super().__init__()
         self._payload = output_payload
 
-    def spawn_bg(self, *, cwd: Path, prompt: str) -> str:
-        short_id = super().spawn_bg(cwd=cwd, prompt=prompt)
+    def spawn_bg(
+        self, *, cwd: Path, prompt: str, extra_args: list[str] | None = None
+    ) -> str:
+        short_id = super().spawn_bg(cwd=cwd, prompt=prompt, extra_args=extra_args)
         from cw.config import DEV_PLAN_OUTPUT_DIR
 
         prompts = sorted(DEV_PLAN_OUTPUT_DIR.glob("prompt-*.txt"))

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -589,14 +589,20 @@ class TestBackgroundSession:
 
 class TestResumeSession:
     def _write_clients_file(
-        self, tmp_config_dir: Path, sample_client: ClientConfig
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        worker_model: str | None = None,
     ) -> None:
         clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
-        clients_file.write_text(
+        body = (
             f"clients:\n"
             f"  test-client:\n"
             f"    workspace_path: {sample_client.workspace_path}\n"
         )
+        if worker_model is not None:
+            body += f"    worker_model: {worker_model}\n"
+        clients_file.write_text(body)
 
     def test_live_session_attaches_directly(
         self,
@@ -705,6 +711,121 @@ class TestResumeSession:
         # Verify --resume <uuid> was passed as extra_args
         extra = mock_native_daemon.spawn_extra_args[0]
         assert extra == ["--resume", "550e8400-e29b-41d4-a716-446655440000"]
+
+    def test_resume_daemon_session_with_worker_model_pins_model(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """DAEMON-origin resume of a dead surface forwards --model from client."""
+        self._write_clients_file(
+            tmp_config_dir,
+            sample_client,
+            worker_model="claude-sonnet-4-6-20251015",
+        )
+        monkeypatch.setattr("cw.session._attach_session", _noop)
+
+        state = CwState(
+            sessions=[
+                Session(
+                    id="resumewm1",
+                    name="test-client/impl",
+                    client="test-client",
+                    purpose=SessionPurpose.IMPL,
+                    origin=SessionOrigin.DAEMON,
+                    status=SessionStatus.BACKGROUNDED,
+                    workspace_path=sample_client.workspace_path,
+                    surface_ref="deadbeef",
+                    claude_session_id="550e8400-e29b-41d4-a716-446655440000",
+                )
+            ]
+        )
+        save_state(state)
+
+        resume_session("test-client/impl", native_daemon=mock_native_daemon)
+
+        assert mock_native_daemon.spawn_extra_args[0] == [
+            "--resume",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "--model",
+            "claude-sonnet-4-6-20251015",
+        ]
+
+    def test_resume_daemon_session_no_worker_model_omits_model_flag(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Regression guard: DAEMON resume without worker_model only has --resume."""
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
+
+        state = CwState(
+            sessions=[
+                Session(
+                    id="resumewm2",
+                    name="test-client/impl",
+                    client="test-client",
+                    purpose=SessionPurpose.IMPL,
+                    origin=SessionOrigin.DAEMON,
+                    status=SessionStatus.BACKGROUNDED,
+                    workspace_path=sample_client.workspace_path,
+                    surface_ref="deadbeef",
+                    claude_session_id="550e8400-e29b-41d4-a716-446655440000",
+                )
+            ]
+        )
+        save_state(state)
+
+        resume_session("test-client/impl", native_daemon=mock_native_daemon)
+
+        assert mock_native_daemon.spawn_extra_args[0] == [
+            "--resume",
+            "550e8400-e29b-41d4-a716-446655440000",
+        ]
+
+    def test_resume_user_session_never_pins_model(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """USER-origin resume ignores client.worker_model (operator default wins)."""
+        self._write_clients_file(
+            tmp_config_dir,
+            sample_client,
+            worker_model="claude-sonnet-4-6-20251015",
+        )
+        monkeypatch.setattr("cw.session._attach_session", _noop)
+
+        state = CwState(
+            sessions=[
+                Session(
+                    id="resumewm3",
+                    name="test-client/impl",
+                    client="test-client",
+                    purpose=SessionPurpose.IMPL,
+                    origin=SessionOrigin.USER,
+                    status=SessionStatus.BACKGROUNDED,
+                    workspace_path=sample_client.workspace_path,
+                    surface_ref="deadbeef",
+                    claude_session_id="550e8400-e29b-41d4-a716-446655440000",
+                )
+            ]
+        )
+        save_state(state)
+
+        resume_session("test-client/impl", native_daemon=mock_native_daemon)
+
+        assert mock_native_daemon.spawn_extra_args[0] == [
+            "--resume",
+            "550e8400-e29b-41d4-a716-446655440000",
+        ]
 
     def test_no_handoff_warns(
         self,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -324,7 +324,7 @@ class TestStartSession:
         pre_state = load_state()
 
         class FlakyDaemon(FakeNativeDaemonClient):
-            def spawn_bg(  # type: ignore[override]
+            def spawn_bg(
                 self, *, cwd: object, prompt: object, extra_args: object = None
             ) -> str:
                 msg = "simulated daemon failure"

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -253,6 +253,101 @@ class TestSpawnCreate:
         assert daemon.spawn_calls == []
 
 
+class TestSpawnCreateImplWorkerModel:
+    """Tests for ClientConfig.worker_model forwarding through spawn_create_impl
+    to ``claude --bg`` via ``extra_args`` (issue #248).
+    """
+
+    def test_spawn_create_impl_with_worker_model_pins_model(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """When worker_model is set, spawn_bg gets --model <id> as extra_args."""
+        from cw.spawn import spawn_create_impl
+
+        workspace = tmp_path / "workspace" / "acme"
+        workspace.mkdir(parents=True)
+        client = ClientConfig(
+            name="acme",
+            workspace_path=workspace,
+            default_branch="main",
+            worker_model="claude-sonnet-4-6-20251015",
+        )
+        daemon = FakeNativeDaemonClient()
+        worktree = make_git_repo("worktree-worker-model")
+
+        spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt="Do the thing.",
+            label=None,
+            native_daemon=daemon,
+        )
+
+        assert daemon.spawn_extra_args[0] == [
+            "--model",
+            "claude-sonnet-4-6-20251015",
+        ]
+
+    def test_spawn_create_impl_no_worker_model_omits_model_flag(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """When worker_model is unset, extra_args is None (no --model flag)."""
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        daemon = FakeNativeDaemonClient()
+        worktree = make_git_repo("worktree-no-worker-model")
+
+        spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt="Do the thing.",
+            label=None,
+            native_daemon=daemon,
+        )
+
+        assert daemon.spawn_extra_args[0] is None
+
+    def test_spawn_create_impl_worker_model_haiku_passes_through_opaque(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """worker_model is opaque — any string is threaded verbatim."""
+        from cw.spawn import spawn_create_impl
+
+        workspace = tmp_path / "workspace" / "thrifty"
+        workspace.mkdir(parents=True)
+        client = ClientConfig(
+            name="thrifty",
+            workspace_path=workspace,
+            default_branch="main",
+            worker_model="claude-haiku-4-5-20251001",
+        )
+        daemon = FakeNativeDaemonClient()
+        worktree = make_git_repo("worktree-haiku-pinned")
+
+        spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt="Do the thing.",
+            label=None,
+            native_daemon=daemon,
+        )
+
+        assert daemon.spawn_extra_args[0] == [
+            "--model",
+            "claude-haiku-4-5-20251001",
+        ]
+
+
 class TestValidateWorktree:
     """Tests for the _validate_worktree pre-flight gate (issue #186).
 


### PR DESCRIPTION
## Summary
- Adds optional `worker_model: str | None = None` to `ClientConfig` — opt-in per client.
- When set, `cw` forwards `--model <id>` to `claude --bg` via the existing `spawn_bg(extra_args=...)` channel.
- Two chokepoints covered: `spawn_create_impl` (initial DAEMON spawn) AND `resume_session` (DAEMON-origin re-spawn). USER-origin paths unchanged.
- Docs in `CLAUDE.md`, `config/CONFIG_REFERENCE.md`, `config/clients.example.yaml`.

## Decisions (from plan-phase ambiguity scan)
1. Option B (--model CLI flag) over Option A (env var) — smaller diff given existing `extra_args` plumbing.
2. Default `None` (opt-in) — no silent behavior change for existing configs.
3. Resume path covered — Plan Soundness Reviewer flagged silent-drop on respawn (elevated to MUST_FIX).
4. `pr_responder.py` out of scope — different spawn mechanism (`claude --print` via multiplexer). Follow-up ticket pending.
5. No model-id validation — opaque string; `claude --bg` errors at runtime on typo.

## Test plan
- [x] All 961 tests pass (`uv run pytest tests/ -v`)
- [x] Ruff clean (`uv run ruff check src/ tests/`)
- [x] Mypy clean (`uv run mypy src/`)
- [x] Pre-push diff-cover at 90% (hook passes)
- [x] 8 new tests cover: field defaults, YAML round-trip, spawn pinning, spawn omission, opaque-string passthrough, DAEMON resume pinning, DAEMON resume omission, USER-origin carve-out

Closes #248