### PR TITLE
chore(lint): enable ASYNC ruff rule (async correctness) (#235)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ select = [
     "TCH",  # flake8-type-checking
     "PERF", # perflint
     "FURB", # refurb
+    "ASYNC", # flake8-async (blocking calls in async def, time.sleep vs asyncio.sleep)
     "BLE",  # flake8-blind-except
     "EM",   # flake8-errmsg
     "TRY",  # tryceratops (exception handling)


### PR DESCRIPTION
## Summary

- chore(lint): enable ASYNC ruff rule (async correctness)

Closes #235. Tier 1 #4 of #230.

## What changed

Adds `ASYNC` (flake8-async) to `[tool.ruff.lint] select` in `pyproject.toml`. The rule catches blocking calls inside `async def` (e.g., `time.sleep` instead of `asyncio.sleep`).

Pre-flight `uv run ruff check src/ tests/ --select=ASYNC` returned zero violations — most blocking I/O is in sync code already, per the ticket's expectation. No per-file ignores added, no code refactored.

Placed before `BLE` to keep the loose correctness-cluster grouping in the select list (matches the family-grouping pattern used by recent ruff-enable PRs).

## Test plan

- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run mypy src/` — zero errors (29 files)
- [x] `uv run pytest tests/ -v` — 963 passed
- [x] `uv run pre-commit run --all-files` — clean (ruff/format/mypy/pytest/diff-cover all passed)

🤖 Shipped via /auto-dev (headless) + /prep-pr + project /ship-it