### PR TITLE
chore(lint): enable ICN + ISC + INP + SLOT + YTT + PYI ruff rules (#236)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,12 @@ select = [
     "TRY",  # tryceratops (exception handling)
     "LOG",  # flake8-logging (logger.exception vs error+exc_info, extra= misuse)
     "G",    # flake8-logging-format (no f-strings/format in log calls; use lazy %)
+    "ICN",  # flake8-import-conventions (canonical aliases, e.g. import pandas as pd)
+    "ISC",  # flake8-implicit-str-concat (accidental adjacent-string concat in lists)
+    "INP",  # flake8-no-pep420 (require __init__.py; no implicit namespace packages)
+    "SLOT", # flake8-slots (require __slots__ on str/tuple/namedtuple subclasses)
+    "YTT",  # flake8-2020 (sys.version_info index gotchas)
+    "PYI",  # flake8-pyi (stub-file hygiene; no .pyi files in tree today)
 ]
 ignore = [
     "T201",  # print() is our UI output mechanism (via click.echo, but also direct)

--- a/src/cw/exceptions.py
+++ b/src/cw/exceptions.py
@@ -6,9 +6,13 @@ from __future__ import annotations
 class CwError(Exception):
     """Base exception for all cw errors."""
 
+    __slots__ = ()
+
 
 class WorktreeError(CwError):
     """Error from git worktree operations."""
+
+    __slots__ = ()
 
 
 class HookContextConflictError(CwError):
@@ -20,6 +24,8 @@ class HookContextConflictError(CwError):
     (Phase C of multiplexer-removal) route this to a clean failure mode
     rather than overwriting.
     """
+
+    __slots__ = ()
 
 
 class DisclaimerNotAcceptedError(CwError):
@@ -38,3 +44,5 @@ class DisclaimerNotAcceptedError(CwError):
     to accept the disclaimer (persisted to ``~/.claude/settings.json`` as
     ``skipDangerousModePermissionPrompt: true``).
     """
+
+    __slots__ = ()


### PR DESCRIPTION
## Summary

Closes #236. Tier 1 #5 of #230 — bundled low-friction defensive rule additions.

Append six defensive flake8 plugin families to `[tool.ruff.lint] select`:

- `ICN`  flake8-import-conventions  (canonical aliases, e.g. `import pandas as pd`)
- `ISC`  flake8-implicit-str-concat (accidental adjacent-string concat in lists)
- `INP`  flake8-no-pep420           (require `__init__.py`)
- `SLOT` flake8-slots               (str/tuple/namedtuple subclasses)
- `YTT`  flake8-2020                (`sys.version_info` index gotchas)
- `PYI`  flake8-pyi                 (stub-file hygiene; no `.pyi` today)

All six pre-flight clean against `src/` and `tests/` — this is forward-guard against future regressions, not a violation cleanup.

Also add `__slots__ = ()` to the four `Exception` subclasses in `src/cw/exceptions.py` (`CwError`, `WorktreeError`, `HookContextConflictError`, `DisclaimerNotAcceptedError`) per the resolved Ambiguity 1 on the ticket.

**Note (discovery during impl pre-flight):** Ruff's `SLOT` rule only fires on `str`/`tuple`/`namedtuple` subclasses — not on `Exception` subclasses. The 4 `__slots__ = ()` additions are therefore defensive (per the explicit user resolution), not rule-enforced. Trivial 4-line addition; safe (Exception's C-level slots for `args`/`__traceback__`/`__cause__` are unaffected by empty `__slots__` on Python subclasses).

## Premises verified pre-flight

- `find . -name "*.pyi"` — empty
- `uv run ruff check --select ICN src/ tests/` — clean
- `uv run ruff check --select ICN,ISC,INP,SLOT,YTT,PYI src/ tests/` — clean

## Test plan

- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run mypy src/` — 29 files clean
- [x] `uv run pytest tests/ -v` — 963 passed
- [x] `uv run pre-commit run --all-files` — passed (ruff, ruff-format, mypy, pytest, diff-cover ≥ 90%)

🤖 Shipped via /auto-dev --headless on #236 (Stage 1 plan + Stage 1f spec/soundness review + Stage 2 impl + Stage 3 code-quality/sysadmin/PM review, all NO_ISSUES).