### PR TITLE
feat(reconcile): sweep stalled headless DAEMON sessions to TIMED_OUT (#185)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -75,7 +75,7 @@ from cw.queue import (
     peek_next,
     remove_item,
 )
-from cw.reconcile import reconcile
+from cw.reconcile import HEADLESS_TIMEOUT_SECONDS, reconcile
 from cw.session import (
     background_all_sessions,
     background_session,
@@ -87,12 +87,6 @@ from cw.spawn import spawn_create_impl
 from cw.tui import DetailLevel
 from cw.tui import watch as tui_watch
 from cw.wrapper import run_claude_wrapper, signal_idle
-
-# Wall-clock budget for headless daemon sessions before signal_stop transitions
-# them to TIMED_OUT instead of deferring. After this many seconds without a
-# sentinel the session is considered stalled; dev-queue retries via reconcile.
-# See GitHub issue #176 Layer 1.
-HEADLESS_TIMEOUT_SECONDS = 1800  # 30 minutes
 
 
 def handle_errors[F: Callable[..., object]](fn: F) -> F:

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -35,6 +35,7 @@ targets.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -53,7 +54,7 @@ from cw.native_daemon import get_native_daemon_client
 
 if TYPE_CHECKING:
     from cw.cmux import MultiplexerAdapter
-    from cw.models import CwState
+    from cw.models import CwState, Session
     from cw.native_daemon import NativeDaemonClient
 
 
@@ -63,6 +64,11 @@ if TYPE_CHECKING:
 # here (not in ``cw.dispatch``) to avoid a circular import — ``cw.dispatch``
 # imports :func:`reconcile` from this module.
 AUTO_DEV_LABEL_PREFIX = "auto-dev/"
+
+# Wall-clock budget for headless daemon sessions. Mirrors the constant in
+# cli.py signal_stop; cli.py imports this value so there is a single source
+# of truth. See GitHub issue #185.
+HEADLESS_TIMEOUT_SECONDS = 1800  # 30 minutes
 
 
 # Only these two statuses imply "the multiplexer should have a surface".
@@ -194,6 +200,101 @@ def _looks_like_backend_outage(
     )
 
 
+def _is_headless(session: Session) -> bool:
+    """Return True if session's worktree has a headless cw-context.json.
+
+    Fail-open: returns False when worktree_path is None, or when the context
+    file is missing or unreadable — a deleted worktree must not be falsely
+    flagged as headless. Mirrors cli.py signal_stop at line 1003-1005.
+    """
+    if session.worktree_path is None:
+        return False
+    context_path = session.worktree_path / ".claude" / "cw-context.json"
+    try:
+        context = json.loads(context_path.read_text())
+        return bool(context.get("headless")) if isinstance(context, dict) else False
+    except (OSError, json.JSONDecodeError):
+        return False
+
+
+def revert_stalled_headless_sessions(
+    state: CwState, *, now: datetime, budget_seconds: int
+) -> list[str]:
+    """Transition stalled headless DAEMON sessions past budget to TIMED_OUT.
+
+    Passive backstop complementing signal_stop's Stop-hook-driven check.
+    signal_stop can only fire at Claude turn boundaries; a session whose agent
+    stalled mid-turn (classifier denial, OOM, long subagent chain) produces no
+    further Stop firings and would sit ACTIVE forever without this sweep.
+
+    Runs unconditionally before the outage guard so a transient backend hiccup
+    does not delay enforcement of the wall-clock budget. The sweep is purely
+    time-based; surface liveness is irrelevant.
+
+    Calls save_state(state) when any sessions are transitioned — callers must
+    not assume state is unchanged on return. On the phantom-handling path in
+    reconcile(), save_state is called again at line 271; this double-save is
+    benign because save_state is idempotent over identical content.
+
+    Returns the list of ticket IDs whose TicketTask was reverted to PENDING.
+    See GitHub issue #185.
+    """
+    pending: list[tuple[Session, str | None]] = []
+    for session in state.sessions:
+        if session.status is not SessionStatus.ACTIVE:
+            continue
+        if session.origin is not SessionOrigin.DAEMON:
+            continue
+        if not _is_headless(session):
+            continue
+        elapsed = (now - session.started_at).total_seconds()
+        if elapsed < budget_seconds:
+            continue
+        ticket_id = ticket_id_for_session(session.name)
+        session.status = SessionStatus.TIMED_OUT
+        session.completed_at = now
+        session.completed_reason = CompletionReason.TIMED_OUT
+        pending.append((session, ticket_id))
+
+    if not pending:
+        return []
+
+    save_state(state)
+
+    ticket_ids_to_revert = [tid for _, tid in pending if tid]
+    reverted: list[str] = []
+    if ticket_ids_to_revert:
+        ticket_id_set = set(ticket_ids_to_revert)
+        with dev_queue_lock():
+            store = load_dev_queue()
+            for task in store.tasks:
+                if (
+                    task.ticket_id in ticket_id_set
+                    and task.status == QueueItemStatus.RUNNING
+                ):
+                    task.status = QueueItemStatus.PENDING
+                    task.session_id = None
+                    reverted.append(task.ticket_id)
+            if reverted:
+                save_dev_queue(store)
+
+    for session, ticket_id in pending:
+        payload: dict[str, object] = {
+            "session_id": session.id,
+            "session_name": session.name,
+            "client": session.client,
+            "ticket_id": ticket_id,
+            "claude_session_id": session.claude_session_id,
+            "elapsed_seconds": (now - session.started_at).total_seconds(),
+            "last_assistant_message_excerpt": "",
+        }
+        record_event(OrchestratorEventType.SESSION_TIMED_OUT, payload)
+        if session.surface_ref is not None:
+            get_native_daemon_client().stop(session.surface_ref)
+
+    return reverted
+
+
 def reconcile(
     adapter: MultiplexerAdapter | None = None,
     native_daemon: NativeDaemonClient | None = None,
@@ -224,10 +325,20 @@ def reconcile(
     """
     daemon = native_daemon or get_native_daemon_client()
     state = load_state()
+    now = datetime.now(UTC)
+
+    # Passive budget sweep: catches headless DAEMON sessions whose agent
+    # stalled mid-turn and produced no further Stop hook firings. Runs before
+    # the outage guard so a backend hiccup does not delay budget enforcement.
+    # See GitHub issue #185.
+    stalled_reverted = revert_stalled_headless_sessions(
+        state, now=now, budget_seconds=HEADLESS_TIMEOUT_SECONDS
+    )
+
     tmux_live = adapter.list_surfaces() if adapter is not None else set()
     native_live = daemon.list_live_session_short_ids()
     if _looks_like_backend_outage(state, tmux_live, native_live):
-        return ReconcileReport()
+        return ReconcileReport(reverted_ticket_ids=stalled_reverted)
 
     drift = compute_drift(state, adapter, daemon)
     if not drift.phantom_session_ids:
@@ -236,15 +347,14 @@ def reconcile(
         # timed out without reverting their queue task are recovered.
         timed_out_ticket_ids = revert_timed_out_tasks()
         completed_silent_ticket_ids = revert_completed_silent_tasks()
-        return ReconcileReport(
-            reverted_ticket_ids=list(
-                dict.fromkeys(timed_out_ticket_ids + completed_silent_ticket_ids)
+        all_reverted = list(
+            dict.fromkeys(
+                stalled_reverted + timed_out_ticket_ids + completed_silent_ticket_ids
             )
         )
+        return ReconcileReport(reverted_ticket_ids=all_reverted)
 
     phantom_set = set(drift.phantom_session_ids)
-    now = datetime.now(UTC)
-
     ticket_ids_to_revert: list[str] = []
     pending_events: list[dict[str, object]] = []
     phantom_names: list[str] = []
@@ -299,7 +409,12 @@ def reconcile(
     timed_out_ticket_ids = revert_timed_out_tasks()
     completed_silent_ticket_ids = revert_completed_silent_tasks()
     all_reverted = list(
-        dict.fromkeys(reverted + timed_out_ticket_ids + completed_silent_ticket_ids)
+        dict.fromkeys(
+            stalled_reverted
+            + reverted
+            + timed_out_ticket_ids
+            + completed_silent_ticket_ids
+        )
     )
 
     return ReconcileReport(

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -233,7 +233,7 @@ def revert_stalled_headless_sessions(
 
     Calls save_state(state) when any sessions are transitioned — callers must
     not assume state is unchanged on return. On the phantom-handling path in
-    reconcile(), save_state is called again at line 271; this double-save is
+    reconcile(), save_state is called again at line 381; this double-save is
     benign because save_state is idempotent over identical content.
 
     Returns the list of ticket IDs whose TicketTask was reverted to PENDING.
@@ -241,7 +241,7 @@ def revert_stalled_headless_sessions(
     """
     pending: list[tuple[Session, str | None]] = []
     for session in state.sessions:
-        if session.status is not SessionStatus.ACTIVE:
+        if session.status not in _LIVE_STATUSES:
             continue
         if session.origin is not SessionOrigin.DAEMON:
             continue

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -33,6 +33,7 @@ from cw.reconcile import (
     HEADLESS_TIMEOUT_SECONDS,
     compute_drift,
     reconcile,
+    revert_completed_silent_tasks,
     revert_stalled_headless_sessions,
     revert_timed_out_tasks,
 )
@@ -519,8 +520,6 @@ def test_revert_completed_silent_tasks_happy_path(
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
-    from cw.reconcile import revert_completed_silent_tasks
-
     reverted = revert_completed_silent_tasks()
     assert "TKT-CS1" in reverted
 
@@ -546,8 +545,6 @@ def test_revert_completed_silent_tasks_skips_user_origin(
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
-    from cw.reconcile import revert_completed_silent_tasks
-
     reverted = revert_completed_silent_tasks()
     assert reverted == []
 
@@ -572,8 +569,6 @@ def test_revert_completed_silent_tasks_skips_non_completed(
         save_state(CwState(sessions=[sess]))
         save_dev_queue(DevQueueStore(tasks=[task]))
 
-        from cw.reconcile import revert_completed_silent_tasks
-
         reverted = revert_completed_silent_tasks()
         assert reverted == [], f"Expected no revert for status={status}"
 
@@ -593,8 +588,6 @@ def test_revert_completed_silent_tasks_skips_unmatched_session(
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
-    from cw.reconcile import revert_completed_silent_tasks
-
     reverted = revert_completed_silent_tasks()
     assert reverted == []
 
@@ -609,8 +602,6 @@ def test_revert_completed_silent_tasks_returns_empty_when_no_match(
     """No matching sessions → returns empty list."""
     save_state(CwState(sessions=[]))
     save_dev_queue(DevQueueStore(tasks=[]))
-
-    from cw.reconcile import revert_completed_silent_tasks
 
     reverted = revert_completed_silent_tasks()
     assert reverted == []
@@ -726,8 +717,6 @@ def test_reconcile_calls_timed_out_then_completed_silent(
     )
     save_dev_queue(dev_store)
 
-    from cw.reconcile import revert_completed_silent_tasks, revert_timed_out_tasks
-
     # Call helpers independently to assert each reverts only the right task.
     to_reverted = revert_timed_out_tasks()
     assert "TKT-IND-TO" in to_reverted
@@ -842,6 +831,28 @@ def test_revert_stalled_headless_sessions_leaves_under_budget_alone(
 
     assert reverted == []
     assert sess.status == SessionStatus.ACTIVE
+
+
+def test_revert_stalled_headless_sessions_catches_idle_sessions(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """IDLE headless DAEMON session past budget → TIMED_OUT (not ACTIVE-only)."""
+    worktree = tmp_path / "wt-idle"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("idle-stalled", worktree, started_at)
+    sess.status = SessionStatus.IDLE
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    reverted = revert_stalled_headless_sessions(
+        state, now=now, budget_seconds=HEADLESS_TIMEOUT_SECONDS
+    )
+
+    assert reverted == []  # no matching ticket task
+    assert sess.status == SessionStatus.TIMED_OUT
 
 
 def test_revert_stalled_headless_sessions_skips_non_daemon(

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+import freezegun
 
 from cw.cmux import FakeCmuxAdapter
+
+if TYPE_CHECKING:
+    import pytest
 from cw.config import load_state, save_state
 from cw.dev_queue import load_dev_queue, save_dev_queue
 from cw.events import read_events
@@ -23,7 +29,13 @@ from cw.models import (
     TicketTask,
 )
 from cw.native_daemon import FakeNativeDaemonClient
-from cw.reconcile import compute_drift, reconcile, revert_timed_out_tasks
+from cw.reconcile import (
+    HEADLESS_TIMEOUT_SECONDS,
+    compute_drift,
+    reconcile,
+    revert_stalled_headless_sessions,
+    revert_timed_out_tasks,
+)
 
 
 def _mk_session(
@@ -724,3 +736,268 @@ def test_reconcile_calls_timed_out_then_completed_silent(
     cs_reverted = revert_completed_silent_tasks()
     assert "TKT-IND-CS" in cs_reverted
     assert "TKT-IND-TO" not in cs_reverted
+
+
+# ---------------------------------------------------------------------------
+# revert_stalled_headless_sessions tests (GitHub issue #185)
+# ---------------------------------------------------------------------------
+
+
+def _mk_headless_daemon_session(
+    sid: str,
+    worktree: Path,
+    started_at: datetime,
+    surface_ref: str | None = "fake-short-id",
+) -> Session:
+    """Build a headless DAEMON ACTIVE session with a cw-context.json."""
+    sess = Session(
+        id=sid,
+        name=f"client-a/auto-dev/{sid}",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=ClientConfig(
+            name="client-a", workspace_path=Path("/tmp/ws")
+        ).workspace_path,
+        worktree_path=worktree,
+        surface_ref=surface_ref,
+        started_at=started_at,
+    )
+    context_dir = worktree / ".claude"
+    context_dir.mkdir(parents=True, exist_ok=True)
+    (context_dir / "cw-context.json").write_text(
+        '{"headless": true, "session_id": "' + sid + '"}'
+    )
+    return sess
+
+
+def test_revert_stalled_headless_sessions_transitions_past_budget(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """Session past budget → TIMED_OUT, task reverted, event emitted."""
+    worktree = tmp_path / "wt-stalled"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 31, 0, tzinfo=UTC)
+    assert (now - started_at).total_seconds() > HEADLESS_TIMEOUT_SECONDS
+
+    sess = _mk_headless_daemon_session("stalled-1", worktree, started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    task = TicketTask(
+        ticket_id="stalled-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="stalled-1",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    reverted = revert_stalled_headless_sessions(
+        state, now=now, budget_seconds=HEADLESS_TIMEOUT_SECONDS
+    )
+
+    assert "stalled-1" in reverted
+    assert sess.status == SessionStatus.TIMED_OUT
+    assert sess.completed_reason == CompletionReason.TIMED_OUT
+    assert sess.completed_at == now
+
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "stalled-1")
+    assert s.status == SessionStatus.TIMED_OUT
+
+    store = load_dev_queue()
+    t = next(t for t in store.tasks if t.ticket_id == "stalled-1")
+    assert t.status == QueueItemStatus.PENDING
+    assert t.session_id is None
+
+    events = read_events(
+        consumer="test-stalled-1",
+        event_types=[OrchestratorEventType.SESSION_TIMED_OUT],
+    )
+    assert len(events) == 1
+    payload = events[0].payload
+    assert payload["session_id"] == "stalled-1"
+    assert payload["elapsed_seconds"] >= HEADLESS_TIMEOUT_SECONDS
+
+
+def test_revert_stalled_headless_sessions_leaves_under_budget_alone(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """Session under budget → unchanged."""
+    worktree = tmp_path / "wt-under"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 10, 0, tzinfo=UTC)
+    assert (now - started_at).total_seconds() < HEADLESS_TIMEOUT_SECONDS
+
+    sess = _mk_headless_daemon_session("under-budget", worktree, started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    reverted = revert_stalled_headless_sessions(
+        state, now=now, budget_seconds=HEADLESS_TIMEOUT_SECONDS
+    )
+
+    assert reverted == []
+    assert sess.status == SessionStatus.ACTIVE
+
+
+def test_revert_stalled_headless_sessions_skips_non_daemon(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """USER-origin session past budget → unchanged."""
+    worktree = tmp_path / "wt-user"
+    worktree.mkdir(parents=True, exist_ok=True)
+    context_dir = worktree / ".claude"
+    context_dir.mkdir(parents=True, exist_ok=True)
+    (context_dir / "cw-context.json").write_text('{"headless": true}')
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+
+    sess = Session(
+        id="user-sess",
+        name="client-a/user-sess",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.USER,
+        status=SessionStatus.ACTIVE,
+        workspace_path=ClientConfig(
+            name="client-a", workspace_path=Path("/tmp/ws")
+        ).workspace_path,
+        worktree_path=worktree,
+        started_at=started_at,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    reverted = revert_stalled_headless_sessions(
+        state, now=now, budget_seconds=HEADLESS_TIMEOUT_SECONDS
+    )
+
+    assert reverted == []
+    assert sess.status == SessionStatus.ACTIVE
+
+
+def test_revert_stalled_headless_sessions_fail_open_missing_context(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """Session with no cw-context.json → fail-open, not transitioned."""
+    worktree = tmp_path / "wt-nocontext"
+    worktree.mkdir(parents=True, exist_ok=True)
+    # Deliberately do NOT write cw-context.json
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+
+    sess = Session(
+        id="no-ctx",
+        name="client-a/auto-dev/no-ctx",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=ClientConfig(
+            name="client-a", workspace_path=Path("/tmp/ws")
+        ).workspace_path,
+        worktree_path=worktree,
+        started_at=started_at,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    reverted = revert_stalled_headless_sessions(
+        state, now=now, budget_seconds=HEADLESS_TIMEOUT_SECONDS
+    )
+
+    assert reverted == []
+    assert sess.status == SessionStatus.ACTIVE
+
+
+def test_revert_stalled_headless_sessions_skips_none_worktree_path(
+    tmp_config_dir: Path,
+) -> None:
+    """DAEMON session with worktree_path=None → treated as not headless."""
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+
+    sess = _mk_session("no-wt", surface_ref="some-ref")
+    sess.origin = SessionOrigin.DAEMON
+    sess.started_at = started_at
+    assert sess.worktree_path is None
+
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    reverted = revert_stalled_headless_sessions(
+        state, now=now, budget_seconds=HEADLESS_TIMEOUT_SECONDS
+    )
+
+    assert reverted == []
+    assert sess.status == SessionStatus.ACTIVE
+
+
+def test_revert_stalled_headless_sessions_stops_daemon_surface(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stalled session has surface_ref → get_native_daemon_client().stop() called."""
+    worktree = tmp_path / "wt-stop"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+
+    daemon = FakeNativeDaemonClient()
+    short_id = daemon.spawn_bg(cwd=tmp_path, prompt="seed")
+    monkeypatch.setattr("cw.reconcile.get_native_daemon_client", lambda: daemon)
+
+    sess = _mk_headless_daemon_session(
+        "stop-me", worktree, started_at, surface_ref=short_id
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    revert_stalled_headless_sessions(
+        state, now=now, budget_seconds=HEADLESS_TIMEOUT_SECONDS
+    )
+
+    assert short_id in daemon.stop_calls
+
+
+def test_reconcile_includes_stalled_reverts_in_report(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """reconcile() surfaces stalled-session reverts in ReconcileReport."""
+    worktree = tmp_path / "wt-rec"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+
+    daemon = FakeNativeDaemonClient()
+    short_id = daemon.spawn_bg(cwd=tmp_path, prompt="seed")
+
+    sess = _mk_headless_daemon_session(
+        "rec-stalled", worktree, started_at, surface_ref=short_id
+    )
+    save_state(CwState(sessions=[sess]))
+
+    task = TicketTask(
+        ticket_id="rec-stalled",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="rec-stalled",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    adapter = FakeCmuxAdapter()
+    with freezegun.freeze_time(now):
+        report = reconcile(adapter, daemon)
+
+    assert "rec-stalled" in report.reverted_ticket_ids
+    store = load_dev_queue()
+    t = next(t for t in store.tasks if t.ticket_id == "rec-stalled")
+    assert t.status == QueueItemStatus.PENDING


### PR DESCRIPTION
## Summary

- Adds `revert_stalled_headless_sessions()` to `reconcile.py` — a time-based sweep that transitions headless DAEMON sessions past the 30-minute wall-clock budget to `TIMED_OUT` without relying on the Stop hook
- Moves `HEADLESS_TIMEOUT_SECONDS` from `cli.py` to `reconcile.py` as the single source of truth (cli.py imports it)
- Sweep runs before the outage guard so a backend hiccup doesn't delay enforcement; reads `<worktree>/.claude/cw-context.json` and fails open on missing/unreadable files
- Reverts RUNNING dev-queue tasks to PENDING for retry; emits `SESSION_TIMED_OUT` events matching the `signal_stop` payload shape; calls `claude stop <short_id>` best-effort
- Catches both ACTIVE and IDLE headless sessions (via `_LIVE_STATUSES`)
- 8 new tests in `test_reconcile.py` (34 total)

Fixes #185

## Test plan

- [ ] `uv run pytest tests/test_reconcile.py -v` — 34 passed
- [ ] `uv run ruff check src/cw/reconcile.py src/cw/cli.py tests/test_reconcile.py` — zero violations
- [ ] `uv run mypy src/cw/reconcile.py src/cw/cli.py` — zero errors
- [ ] Pre-commit hooks (ruff, mypy, pytest, diff-cover) — all pass on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)