### PR TITLE
feat(parser): promote ambiguities/premises statuses to v4 closed enum (#191)

### DIFF
--- a/docs/headless-contract.md
+++ b/docs/headless-contract.md
@@ -86,7 +86,7 @@ The skill emits **exactly one** sentinel block per invocation. If the parser fin
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 4,
   "ticket_id": "GEN-1234",
   "status": "shipped",
   "stage_reached": "stage5_post_create",
@@ -127,9 +127,9 @@ The skill emits **exactly one** sentinel block per invocation. If the parser fin
 
 | Field | Type | Notes |
 |---|---|---|
-| `schema_version` | int | Currently `2` (legacy `1` still accepted during the rollout window). Bump rules in §8. |
+| `schema_version` | int | Currently `4` (legacy `1`, `2`, `3` accepted during the rollout window). Bump rules in §8. |
 | `ticket_id` | string | Linear ID, or synthetic for free-text invocations. |
-| `status` | string enum | See §4. |
+| `status` | string enum | See §4. Closed set; parsers MUST treat unknown values as §6 (5) errors. |
 | `stage_reached` | string enum | Pipeline-stage marker. Closed set: `stage1_pre_flight`, `stage1_plan`, `stage2_impl`, `stage3_review`, `stage4a_merge_gate`, `stage4b_pr_create`, `stage5_post_create`. Pre-flight exits (e.g. already-satisfied tickets) use `stage1_pre_flight`. Producer and parser must keep this list in lockstep — adding a stage is a `schema_version` bump (see §8). |
 | `scope.tier` | `"small"` \| `"large"` | Per the Guard Matrix in `commands/auto-dev.md`. |
 | `scope.files` | int | File count touched (or planned, if exited pre-impl). |
@@ -168,6 +168,8 @@ The `status` field is a closed set. Consumers MUST treat unknown statuses as a p
 | `forbidden_area` | `--forbidden` constraint matched a planned file; ticket rejected before impl started. |
 | `blocked` | Unrecoverable error mid-pipeline; see `blocker` field for details. |
 | `no_op` | Pre-flight detected the ticket already satisfied (or otherwise not work-bearing); no plan, no branch, no PR. Introduced at `schema_version=2`. Rationale: terse, neutral wording — does not presume the cause (already-merged dupe, invalid ticket, code already covers it). The actor (skill / cw) decides what to do via `next_actions` (typically `close_issue_as_completed`). Emitted at `schema_version=3` with `stage_reached='stage1_pre_flight'` and `plan_source='none'`. (During the rollout window, parsers also accept this shape under `schema_version=2`.) |
+| `ambiguities_pending_resolution` | Planning halted because the ambiguity scan surfaced clarifying questions that exceed the auto-resolve threshold; no branch created. The `ambiguities` array is non-empty. Introduced at `schema_version=4`. |
+| `premises_pending_verification` | Planning halted because the Plan Soundness Reviewer flagged unverified premises; no branch created. The `premises` array is non-empty. Promoted from §4.4 interim state at `schema_version=4`. |
 
 ### 4.2 `blocker.reason` (when `status = "blocked"`)
 
@@ -233,23 +235,30 @@ Advisory only. cw acts on these without parsing prose.
 | `user_approve_review` | `status = review_pending_approval` | Notify user that a branch is pushed for review. |
 | `resolve_merge_gate` | `status = merge_gate_blocked` | Notify user that the prior pipeline PR must merge first. The user then manually re-invokes `/auto-dev` for this ticket; no automatic re-dispatch exists. |
 | `close_issue_as_completed` | `status = no_op` | Close the ticket as already completed (the work was a no-op because the system is already in the desired state). Consumer chooses how to close — Linear "Done", GitHub `gh issue close --reason completed`, etc. |
+| `user_resolve_ambiguities` | `status = ambiguities_pending_resolution` | Notify user that the ambiguity scan surfaced questions requiring human disposition. The `ambiguities` array holds the structured questions. Re-dispatch the ticket after answers are recorded on the issue. |
+| `user_verify_premises` | `status = premises_pending_verification` | Notify user that one or more premises must be verified before the plan can proceed. The `premises` array holds the structured entries. Re-dispatch after verification results are recorded on the issue. |
 
-Empty list for terminal-reject (`scope_exceeded`, `forbidden_area`, `blocked`). For `shipped`, `next_actions` always contains `wait_for_ci`. `next_actions` is otherwise an open vocabulary — parsers MUST pass unknown actions through unchanged (do not act on them, do not reject the payload).
+Empty list for terminal-reject (`scope_exceeded`, `forbidden_area`, `blocked`). For `shipped`, `next_actions` always contains `wait_for_ci`. For `ambiguities_pending_resolution` and `premises_pending_verification`, `next_actions` is non-empty. `next_actions` is otherwise an open vocabulary — parsers MUST pass unknown actions through unchanged (do not act on them, do not reject the payload).
 
-### 4.4 Recognized intermediate statuses (not in closed enum)
+### 4.4 `ambiguities` and `premises` payload arrays (v4)
 
-The producer emits two additional `status` values that fall outside the §4.1 closed enum. They represent **pre-dispatch human-attention** outcomes — the run halted before producing a branch because the planning agents surfaced something a human must disposition (a premise to verify, an ambiguity to resolve). They are observed in dogfood today; they are NOT in the closed enum because the routing semantics (treat as advisory pre-dispatch context, not a terminal pipeline outcome) differ from the canonical statuses.
+Both `ambiguities_pending_resolution` and `premises_pending_verification` (§4.1) carry structured context arrays at the top level of the sentinel payload.
 
-| Status | Meaning | Payload signal |
+| Field | Status | Notes |
 |---|---|---|
-| `premises_pending_verification` | The Plan Soundness Reviewer flagged premises the orchestrator could not auto-verify; the run halted with the premises listed for human disposition. | `premises` array is non-empty. Each entry carries at minimum a description of the premise (key may be `premise` or `claim`) and producer-supplied verification context (any of `verify_by` / `plan_depends_on_it_for` / `evidence_in_ticket` / `how_to_verify` / `verified` / `resolution`). Consumers MUST tolerate missing keys — the shape is producer-driven and not yet stabilized. |
-| `ambiguities_pending_resolution` | Ambiguity scan returned items that exceeded the auto-resolve threshold; the run halted with the ambiguities listed for human disposition. | `ambiguities` array is non-empty. Each entry typically carries `question`, `plan_assumption`, `alternatives`, `why_it_matters`, `ticket_evidence`; treat all keys as best-effort. |
+| `ambiguities` | `ambiguities_pending_resolution` | Non-empty list of ambiguity entries. Each entry typically carries `question`, `plan_assumption`, `alternatives`, `why_it_matters`, `ticket_evidence`; **treat all keys as best-effort** (§4.4 / A3 decision, issue #191). |
+| `premises` | `premises_pending_verification` | Non-empty list of premise entries. Each entry carries at minimum a description (key may be `premise` or `claim`) and producer-supplied verification context (any of `verify_by` / `plan_depends_on_it_for` / `evidence_in_ticket` / `how_to_verify` / `verified` / `resolution`); **treat all keys as best-effort**. |
 
-**Parser behavior:** §6 (5) applies — unknown `status` values route through synthetic `BlockedResult` with `reason=status_unknown`. The producer's literal status string is preserved in `blocker.details` (`got status='<value>'; surface verbatim, do not auto-route`). Consumers that need the full payload re-extract the sentinel block via `extract_block` and read it as raw JSON.
+**Cross-field invariants (enforced by parser):**
+- `status='ambiguities_pending_resolution'` requires `ambiguities` non-empty (A5).
+- `status='premises_pending_verification'` requires `premises` non-empty (A5).
+- Both statuses require `next_actions` non-empty (A2).
+- Both statuses prohibit `branch` (pre-branch, A4) and require `scope.lines_actual=null` (pre-impl, A4).
+- Both statuses require `schema_version >= 4` (A1).
 
-**Consumer guidance:** Skills that want to handle these (e.g. `/cw-followup`, `/cw-validate-result`) MUST NOT key off the typed `result.status` — they should re-parse the raw sentinel block, recognize the two values, and route via the `premises` / `ambiguities` arrays directly. Treat the arrays as the first-class signal; the `status` string is the producer's label for the same condition.
+**Consumer guidance:** Key off `result.status` directly — these are now canonical statuses. Route `user_resolve_ambiguities` / `user_verify_premises` via `next_actions`. The `ambiguities` and `premises` arrays hold the structured entries for human presentation.
 
-**Promotion to v4 (future):** Promoting either to a canonical status is a `schema_version` bump per §8 (closed-enum addition rule). When that happens, the cross-field invariants are obvious from the table above (e.g. `status='ambiguities_pending_resolution'` requires `ambiguities` non-empty). Tracked in #191.
+**Migration note:** Before v4, these values were emitted by the producer but not recognized by the parser — they routed through synthetic `BlockedResult` with `reason=status_unknown`. Skills that previously keyed off `extract_block` raw JSON (`/cw-followup`, `/cw-validate-result`) can now use the typed `result.status` directly. The `result.ambiguities` / `result.premises` fields carry the same data that was previously accessed via raw JSON. Promoted via #191.
 
 ---
 
@@ -304,7 +313,7 @@ The skill can fail to emit a complete sentinel block. cw must handle:
 2. **Opening sentinel present, closing sentinel missing** — skill crashed mid-emit. Same handling as (1).
 3. **Block present but JSON does not parse** — skill bug. Same handling as (1); include the raw block in `details`.
 4. **`schema_version` higher than parser supports** — skill upgraded ahead of cw. Surface verbatim and refuse to act on `next_actions`; do not auto-merge or auto-route.
-5. **Unknown `status` value** — same as (4). Two producer-emitted values (`premises_pending_verification`, `ambiguities_pending_resolution`) are recognized as pre-dispatch human-attention states; see §4.4 for consumer-side handling.
+5. **Unknown `status` value** — same as (4). The closed enum in §4.1 covers all recognized values including `ambiguities_pending_resolution` and `premises_pending_verification` (promoted to canonical status in v4 via #191). Any value outside this set routes through `reason=status_unknown`.
 6. **Multiple complete sentinel blocks in one invocation's stdout** — skill bug (the contract is exactly one per invocation; see §3.1). Same handling as (1), with `reason: "multiple_result_blocks"` and `details` containing the count and the LAST block's raw payload.
 
 Parser must NEVER act on a partial parse — if any of the above fire, treat the run as blocked and require human attention.
@@ -321,7 +330,7 @@ Until then, cw must treat all non-terminal exits as fully manual recovery: the u
 
 ## 8. Versioning
 
-`schema_version: 3` is the current contract. Parsers also accept `schema_version: 1` and `schema_version: 2` during the rollout window.
+`schema_version: 4` is the current contract. Parsers also accept `schema_version: 1`, `2`, and `3` during the rollout window.
 
 **Version history:**
 
@@ -330,6 +339,7 @@ Until then, cw must treat all non-terminal exits as fully manual recovery: the u
 | 1 | Initial contract. |
 | 2 | Added `no_op` status (§4.1) and `close_issue_as_completed` advisory action (§4.3). v1-tagged payloads with `status=no_op` are rejected as `validation_failed`. |
 | 3 | Added `stage1_pre_flight` value to `stage_reached` enum (§3.3) and `none` value to `plan_source` enum (§3.3). Used together for pre-flight no_op exits. Parsers also accept this pair under v2 as a one-time rollout exception (the skill emitted them at v2 before the parser caught up — see #103). Also added `github_issue_existing` to `plan_source` (the post-Linear analog of `linear_existing`; treated identically). Accepted under v2 and v3 — same rollout-exception treatment, since the producer emits this value at v2 today (see #190). |
+| 4 | Promoted `ambiguities_pending_resolution` and `premises_pending_verification` from §4.4 interim states (not in closed enum) to canonical `Status` values (§4.1). Added `ambiguities` and `premises` top-level fields with cross-field invariants (non-empty when corresponding status is set, §4.4). Added `user_resolve_ambiguities` and `user_verify_premises` to §4.3 vocabulary. v3-tagged payloads with either new status are rejected as `validation_failed`. Tracked in #191. |
 
 **Bump required when:**
 - Any field is removed or renamed.

--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -30,9 +30,11 @@ _log = logging.getLogger(__name__)
 
 # v1 is the legacy shape; v2 adds the `no_op` status; v3 adds the
 # `stage1_pre_flight` stage_reached value and `none` plan_source (used
-# together for pre-flight no_op exits). All are accepted during the rollout
-# window — see docs/headless-contract.md §8.
-SUPPORTED_SCHEMA_VERSIONS: frozenset[int] = frozenset({1, 2, 3})
+# together for pre-flight no_op exits); v4 promotes
+# `ambiguities_pending_resolution` and `premises_pending_verification` to
+# canonical closed-enum statuses (issue #191). All are accepted during the
+# rollout window — see docs/headless-contract.md §8.
+SUPPORTED_SCHEMA_VERSIONS: frozenset[int] = frozenset({1, 2, 3, 4})
 
 _OPEN_SENTINEL = "<<<AUTO_DEV_RESULT"
 _CLOSE_SENTINEL = "AUTO_DEV_RESULT>>>"
@@ -60,11 +62,18 @@ Status = Literal[
     "forbidden_area",
     "blocked",
     "no_op",
+    "ambiguities_pending_resolution",
+    "premises_pending_verification",
 ]
 # Statuses introduced after v1. Emitting one under schema_version=1 is a
 # producer bug — it would silently degrade for downstream tools that key off
 # the version field.
 _V2_STATUSES: frozenset[str] = frozenset({"no_op"})
+# Statuses introduced in v4 (issue #191). Emitting under schema_version<4 is
+# a producer bug.
+_V4_STATUSES: frozenset[str] = frozenset(
+    {"ambiguities_pending_resolution", "premises_pending_verification"}
+)
 # NOTE: stage1_pre_flight (StageReached) and "none" (PlanSource) are NOT
 # gated by schema_version. Spec §8 says enum additions require a version
 # bump (v3), and v3 IS the official home for these values, BUT the producer
@@ -178,7 +187,14 @@ _TERMINAL_REJECT_STATUSES: frozenset[Status] = frozenset(
     {"scope_exceeded", "forbidden_area", "blocked"},
 )
 _PRE_BRANCH_STATUSES: frozenset[Status] = frozenset(
-    {"plan_pending_approval", "scope_exceeded", "forbidden_area", "no_op"},
+    {
+        "plan_pending_approval",
+        "scope_exceeded",
+        "forbidden_area",
+        "no_op",
+        "ambiguities_pending_resolution",
+        "premises_pending_verification",
+    },
 )
 # Pre-flight + blocked is a retry/escalation shape, not a terminal reject —
 # next_actions must signal the recovery verb. The Origin Sync block (#226)
@@ -192,7 +208,7 @@ _PRE_FLIGHT_BLOCKED_NEXT_ACTIONS: frozenset[str] = frozenset(
 class AutoDevResult(BaseModel):
     """Parsed sentinel block. All cross-field invariants from §3-§5 enforced."""
 
-    schema_version: Literal[1, 2, 3]
+    schema_version: Literal[1, 2, 3, 4]
     ticket_id: str
     status: Status
     stage_reached: StageReached
@@ -208,6 +224,11 @@ class AutoDevResult(BaseModel):
     friction_highlights: list[str] = Field(default_factory=list)
     blocker: Blocker | None = None
     next_actions: list[str] = Field(default_factory=list)
+    # v4: populated when status is ambiguities_pending_resolution or
+    # premises_pending_verification. Entry shapes are best-effort per §4.4 —
+    # all keys optional, tolerate producer-side key-name drift.
+    ambiguities: list[dict[str, Any]] = Field(default_factory=list)
+    premises: list[dict[str, Any]] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def _check_invariants(self) -> AutoDevResult:
@@ -216,6 +237,14 @@ class AutoDevResult(BaseModel):
         if self.schema_version < 2 and self.status in _V2_STATUSES:
             msg = (
                 f"status={self.status!r} requires schema_version>=2, "
+                f"got {self.schema_version}"
+            )
+            raise ValueError(msg)
+
+        # §8 v4-introduced statuses cannot ride on a pre-v4-tagged payload.
+        if self.schema_version < 4 and self.status in _V4_STATUSES:
+            msg = (
+                f"status={self.status!r} requires schema_version>=4, "
                 f"got {self.schema_version}"
             )
             raise ValueError(msg)
@@ -336,6 +365,26 @@ class AutoDevResult(BaseModel):
             msg = (
                 f"next_actions must be empty for terminal-reject status "
                 f"{self.status!r}, got {self.next_actions!r}"
+            )
+            raise ValueError(msg)
+
+        # §4.3 (A2) v4 pending statuses require non-empty next_actions.
+        if self.status in _V4_STATUSES and not self.next_actions:
+            msg = f"next_actions must be non-empty when status is {self.status!r}"
+            raise ValueError(msg)
+
+        # §4.4 (A5) cross-field array invariants: arrays must be non-empty
+        # when their corresponding status is set (empty array is a producer bug
+        # — nothing for the consumer to act on).
+        if self.status == "ambiguities_pending_resolution" and not self.ambiguities:
+            msg = (
+                "ambiguities must be non-empty when "
+                "status='ambiguities_pending_resolution'"
+            )
+            raise ValueError(msg)
+        if self.status == "premises_pending_verification" and not self.premises:
+            msg = (
+                "premises must be non-empty when status='premises_pending_verification'"
             )
             raise ValueError(msg)
 
@@ -464,6 +513,8 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
         "forbidden_area",
         "blocked",
         "no_op",
+        "ambiguities_pending_resolution",
+        "premises_pending_verification",
     }:
         return BlockedResult(
             blocker=Blocker(

--- a/tests/test_auto_dev_result.py
+++ b/tests/test_auto_dev_result.py
@@ -278,6 +278,92 @@ def _blocked_payload() -> dict[str, Any]:
     }
 
 
+def _ambiguities_pending_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 4,
+        "ticket_id": "GEN-ambig",
+        "status": "ambiguities_pending_resolution",
+        "stage_reached": "stage1_plan",
+        "scope": {
+            "tier": "small",
+            "files": 3,
+            "lines_estimate": 80,
+            "lines_actual": None,
+            "forbidden_touched": False,
+        },
+        "plan_source": "generated",
+        "branch": None,
+        "worktree_path": None,
+        "fork_point_sha": None,
+        "commits": [],
+        "pr": None,
+        "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+        "health": {
+            "lowest_agent_confidence": "HIGH",
+            "any_incomplete_risk": False,
+            "shortcuts": [],
+            "recommendation": "PROCEED",
+            "downgrade_applied": False,
+            "fix_loop_escalated": False,
+        },
+        "friction_highlights": [],
+        "blocker": None,
+        "ambiguities": [
+            {
+                "question": "Should the enum be open or closed?",
+                "plan_assumption": "closed",
+                "alternatives": ["open"],
+                "why_it_matters": "affects consumer contract",
+                "ticket_evidence": "option 1 in the ticket",
+            }
+        ],
+        "premises": [],
+        "next_actions": ["user_resolve_ambiguities"],
+    }
+
+
+def _premises_pending_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 4,
+        "ticket_id": "GEN-premise",
+        "status": "premises_pending_verification",
+        "stage_reached": "stage1_plan",
+        "scope": {
+            "tier": "small",
+            "files": 2,
+            "lines_estimate": 40,
+            "lines_actual": None,
+            "forbidden_touched": False,
+        },
+        "plan_source": "github_issue_existing",
+        "branch": None,
+        "worktree_path": None,
+        "fork_point_sha": None,
+        "commits": [],
+        "pr": None,
+        "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+        "health": {
+            "lowest_agent_confidence": "HIGH",
+            "any_incomplete_risk": False,
+            "shortcuts": [],
+            "recommendation": "PROCEED",
+            "downgrade_applied": False,
+            "fix_loop_escalated": False,
+        },
+        "friction_highlights": [],
+        "blocker": None,
+        "ambiguities": [],
+        "premises": [
+            {
+                "claim": "The existing PR #198 codified a deliberate decision",
+                "plan_depends_on_it_for": "deciding whether to override §4.4",
+                "how_to_verify": "read PR #198 body",
+            }
+        ],
+        "next_actions": ["user_verify_premises"],
+    }
+
+
 def _wrap_sentinel(payload: dict[str, Any]) -> str:
     body = json.dumps(payload)
     return f"some narrative\n<<<AUTO_DEV_RESULT\n{body}\nAUTO_DEV_RESULT>>>\n"
@@ -299,6 +385,8 @@ def _wrap_sentinel(payload: dict[str, Any]) -> str:
         _forbidden_area_payload,
         _blocked_payload,
         _no_op_payload,
+        _ambiguities_pending_payload,
+        _premises_pending_payload,
     ],
 )
 class TestStatusRoundTrips:
@@ -881,3 +969,144 @@ class TestPlanSourceGitHubIssueExisting:
         assert isinstance(result, AutoDevResult)
         assert result.plan_source == "github_issue_existing"
         assert result.status == "no_op"
+
+
+class TestV4StatusPromotion:
+    def test_ambiguities_pending_parses_at_v4(self) -> None:
+        result = parse_stdout(_wrap_sentinel(_ambiguities_pending_payload()))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "ambiguities_pending_resolution"
+        assert result.schema_version == 4
+
+    def test_premises_pending_parses_at_v4(self) -> None:
+        result = parse_stdout(_wrap_sentinel(_premises_pending_payload()))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "premises_pending_verification"
+        assert result.schema_version == 4
+
+    def test_ambiguities_pending_rejected_at_v3(self) -> None:
+        # v4-gated status must not parse under schema_version=3
+        p = _ambiguities_pending_payload()
+        p["schema_version"] = 3
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "validation_failed"
+
+    def test_premises_pending_rejected_at_v3(self) -> None:
+        p = _premises_pending_payload()
+        p["schema_version"] = 3
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "validation_failed"
+
+    def test_v4_schema_accepted(self) -> None:
+        p = _ambiguities_pending_payload()
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.schema_version == 4
+
+    def test_v5_schema_rejected(self) -> None:
+        p = _ambiguities_pending_payload()
+        p["schema_version"] = 5
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "schema_version_unsupported"
+
+    # A5 — empty arrays rejected via cross-field validator
+    def test_empty_ambiguities_rejected(self) -> None:
+        p = _ambiguities_pending_payload()
+        p["ambiguities"] = []
+        with pytest.raises(ValidationError, match="ambiguities"):
+            AutoDevResult.model_validate(p)
+
+    def test_empty_premises_rejected(self) -> None:
+        p = _premises_pending_payload()
+        p["premises"] = []
+        with pytest.raises(ValidationError, match="premises"):
+            AutoDevResult.model_validate(p)
+
+    # A2 — next_actions must be non-empty
+    def test_ambiguities_empty_next_actions_rejected(self) -> None:
+        p = _ambiguities_pending_payload()
+        p["next_actions"] = []
+        with pytest.raises(ValidationError, match="next_actions"):
+            AutoDevResult.model_validate(p)
+
+    def test_premises_empty_next_actions_rejected(self) -> None:
+        p = _premises_pending_payload()
+        p["next_actions"] = []
+        with pytest.raises(ValidationError, match="next_actions"):
+            AutoDevResult.model_validate(p)
+
+    # A4 — pre-branch status: branch must be null
+    def test_ambiguities_rejects_branch(self) -> None:
+        p = _ambiguities_pending_payload()
+        p["branch"] = "dev/sneak"
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_premises_rejects_branch(self) -> None:
+        p = _premises_pending_payload()
+        p["branch"] = "dev/sneak"
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    # A4 — lines_actual must be null (pre-impl exit)
+    def test_ambiguities_rejects_lines_actual(self) -> None:
+        p = _ambiguities_pending_payload()
+        p["scope"]["lines_actual"] = 50
+        with pytest.raises(ValidationError, match="lines_actual"):
+            AutoDevResult.model_validate(p)
+
+    def test_premises_rejects_lines_actual(self) -> None:
+        p = _premises_pending_payload()
+        p["scope"]["lines_actual"] = 30
+        with pytest.raises(ValidationError, match="lines_actual"):
+            AutoDevResult.model_validate(p)
+
+    # A3 — entry fields are all optional (best-effort)
+    def test_ambiguities_entry_with_minimal_keys_accepted(self) -> None:
+        p = _ambiguities_pending_payload()
+        p["ambiguities"] = [{"question": "only question provided"}]
+        result = AutoDevResult.model_validate(p)
+        assert len(result.ambiguities) == 1
+
+    def test_premises_entry_with_minimal_keys_accepted(self) -> None:
+        p = _premises_pending_payload()
+        p["premises"] = [{"claim": "minimal premise"}]
+        result = AutoDevResult.model_validate(p)
+        assert len(result.premises) == 1
+
+    def test_premises_entry_with_alternate_key_shapes_accepted(self) -> None:
+        # Producer uses various key names; parser must tolerate any shape
+        p = _premises_pending_payload()
+        p["premises"] = [
+            {
+                "premise": "alternate key",
+                "verify_by": "read the doc",
+                "verified": False,
+            }
+        ]
+        result = AutoDevResult.model_validate(p)
+        assert len(result.premises) == 1
+
+    def test_round_trip_preserves_ambiguities(self) -> None:
+        p = _ambiguities_pending_payload()
+        result = AutoDevResult.model_validate(p)
+        dumped = result.model_dump(mode="json")
+        assert dumped["status"] == "ambiguities_pending_resolution"
+        assert len(dumped["ambiguities"]) == 1
+
+    def test_round_trip_preserves_premises(self) -> None:
+        p = _premises_pending_payload()
+        result = AutoDevResult.model_validate(p)
+        dumped = result.model_dump(mode="json")
+        assert dumped["status"] == "premises_pending_verification"
+        assert len(dumped["premises"]) == 1
+
+    def test_existing_statuses_unaffected_by_v4_addition(self) -> None:
+        # Regression guard: shipped (v1 payload) still parses under v4-aware parser
+        p = _shipped_payload()
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "shipped"


### PR DESCRIPTION
## Summary

- Promotes `ambiguities_pending_resolution` and `premises_pending_verification` from §4.4 interim advisory states to canonical `Status` enum values
- Schema bump v3→v4 with `_V4_STATUSES` gate (statuses require `schema_version>=4` — honoring §8 closed-enum versioning rule)
- Adds `ambiguities` and `premises` fields to `AutoDevResult` with cross-field invariants: non-empty arrays required (A5), non-empty `next_actions` required (A2), both join `_PRE_BRANCH_STATUSES` (A4)
- All entry fields in both arrays are `dict[str, Any]` — best-effort per §4.4 / A3 decision
- Updates `docs/headless-contract.md`: §4.1 (new status rows), §4.3 (new vocabulary), §4.4 (rewrites "interim" section to document promoted arrays + cross-field invariants + migration note), §6(5), §8 (v4 history entry)

Closes #191.

## Decisions implemented (from ticket's Decisions comment)
- **A1**: `_V4_STATUSES` gate
- **A2**: non-empty `next_actions` required; added `user_resolve_ambiguities` / `user_verify_premises` to §4.3
- **A3**: all entry fields optional (best-effort)
- **A4**: `_PRE_BRANCH_STATUSES` extended; `branch=null`, `lines_actual=null` enforced via existing invariants
- **A5**: empty array cross-field validator rejects producer bugs

## Test plan
- [ ] `uv run pytest tests/test_auto_dev_result.py -v` — 92 tests, all pass
- [ ] `uv run pytest tests/ -q` — 1002 tests, all pass
- [ ] `uv run ruff check src/ tests/` — zero violations
- [ ] `uv run mypy src/` — zero errors
- [ ] New `TestV4StatusPromotion` class exercises all A1–A5 decisions (both positive and negative paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)