### PR TITLE
chore(headless): bump HEADLESS_TIMEOUT_SECONDS 30→60 min

### DIFF
--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -68,7 +68,11 @@ AUTO_DEV_LABEL_PREFIX = "auto-dev/"
 # Wall-clock budget for headless daemon sessions. Mirrors the constant in
 # cli.py signal_stop; cli.py imports this value so there is a single source
 # of truth. See GitHub issue #185.
-HEADLESS_TIMEOUT_SECONDS = 1800  # 30 minutes
+#
+# Bumped 30 → 60 min on 2026-05-25 after ticket #215 (tier=large, 11 files,
+# 626 lines) hit the 30-min cap mid-implementation. Per-ticket / per-tier
+# override mechanism tracked in #265.
+HEADLESS_TIMEOUT_SECONDS = 3600  # 60 minutes
 
 
 # Only these two statuses imply "the multiplexer should have a surface".

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -945,7 +945,7 @@ class TestSignalStop:
         a session that orphaned (Stop fires, no sentinel, bg_tasks empty)
         must NOT silently transition to COMPLETED.
         """
-        # Seed session started 31 minutes ago (past the 30-min budget).
+        # Seed session started 61 minutes ago (past the 60-min budget).
         import datetime as dt
 
         from cw.cli import HEADLESS_TIMEOUT_SECONDS
@@ -954,7 +954,7 @@ class TestSignalStop:
         from cw.native_daemon import FakeNativeDaemonClient
 
         started_at = dt.datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-        hook_time = dt.datetime(2026, 1, 1, 0, 31, 0, tzinfo=UTC)
+        hook_time = dt.datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
         assert (hook_time - started_at).total_seconds() > HEADLESS_TIMEOUT_SECONDS
 
         workspace = tmp_path / "workspace"

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -768,7 +768,7 @@ def test_revert_stalled_headless_sessions_transitions_past_budget(
     """Session past budget → TIMED_OUT, task reverted, event emitted."""
     worktree = tmp_path / "wt-stalled"
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    now = datetime(2026, 1, 1, 0, 31, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
     assert (now - started_at).total_seconds() > HEADLESS_TIMEOUT_SECONDS
 
     sess = _mk_headless_daemon_session("stalled-1", worktree, started_at)


### PR DESCRIPTION
## Summary

Bumps the Layer-1 headless wall-clock budget from 30 minutes to 60 minutes to unblock tier=large tickets that legitimately need longer Stage-2 implementation time.

Triggered by #215 (11 files, 626 lines) hitting the 30-min cap mid-implementation while the Implementation subagent was still actively working. The session was making progress, not stalled — but the constant treated it the same as a runaway.

The structural fix is per-tier / per-ticket override (filed as #265); this PR is the immediate workaround.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest tests/` — 1002 tests pass
- [x] Test fixtures using `now = started_at + 31min` updated to `+61min` so past-budget assertions still hold

## Related

- #265 — per-tier / per-ticket override (the proper fix)
- #185 / PR #260 — added the Layer-1 sweep
- #215 — first observed budget mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)