### PR TITLE
refactor(phase-d): drop MultiplexerAdapter from reconcile/dispatch/doctor/orchestrate (#167)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import json
+import logging
 import subprocess
 import sys
 from collections.abc import Callable
@@ -16,7 +17,6 @@ from click.shell_completion import CompletionItem
 
 from cw import __version__
 from cw.auto_dev_result import AutoDevResult, BlockedResult, extract_block, parse_stdout
-from cw.cmux import CmuxAdapter, get_cmux_adapter
 from cw.config import (
     get_client,
     init_client,
@@ -421,20 +421,16 @@ def _display_sessions() -> None:
 
 
 def _check_and_mark_dead_sessions() -> list[str]:
-    """Reconcile state with the live multiplexer and return reaped session names.
+    """Reconcile state with the native daemon and return reaped session names.
 
     Cheap passive reconciliation: called from every read path (``cw status``,
     ``cw list``, ``cw start``). The reconciler is idempotent and returns an
     empty list when nothing changed. :func:`cw.reconcile.reconcile` refuses
-    to mass-reap when both backends report empty live sets while active
-    sessions still have surface refs (backend-outage guard), so this helper
+    to mass-reap when the daemon is unreachable or the roster is empty while
+    active sessions still have surface refs (outage guard), so this helper
     is safe to run on every read path.
     """
-    try:
-        adapter = get_cmux_adapter()
-    except CwError:
-        return []
-    report = reconcile(adapter, get_native_daemon_client())
+    report = reconcile()
     return list(report.phantom_session_names)
 
 
@@ -1583,8 +1579,7 @@ def orchestrate_status(as_json: bool) -> None:
 @handle_errors
 def orchestrate_retire() -> None:
     """Run a single PR-retirement pass and print retired session IDs."""
-    adapter = get_cmux_adapter()
-    retired = retire_merged_prs(adapter=adapter)
+    retired = retire_merged_prs()
     if not retired:
         click.echo("No sessions retired.")
         return
@@ -1763,16 +1758,14 @@ def _spawn_create_impl(
 def _spawn_close_impl(
     *,
     session_id: str,
-    adapter: CmuxAdapter,
     native_daemon: NativeDaemonClient | None = None,
 ) -> None:
     """Close a daemon-spawned session.
 
-    Routes the underlying-backend close call based on session origin: a
-    DAEMON-origin session was spawned via ``claude --bg`` and is stopped
-    via the native daemon, while a USER-origin session lives in the
-    multiplexer and is closed via the adapter. Separated from the Click
-    command so tests can inject both clients directly.
+    DAEMON-origin sessions are stopped via the native daemon client.
+    USER-origin sessions with a legacy ``surface_ref`` are logged and
+    skipped — the multiplexer adapter has been removed. Separated from
+    the Click command so tests can inject the daemon client directly.
     """
     state = load_state()
     sess = state.find_by_name_or_id(session_id)
@@ -1788,7 +1781,11 @@ def _spawn_close_impl(
             daemon = native_daemon or get_native_daemon_client()
             daemon.stop(sess.surface_ref)
         else:
-            adapter.close(sess.surface_ref)
+            logging.getLogger(__name__).warning(
+                "Session %s has legacy surface_ref %r; skipping surface close",
+                sess.id,
+                sess.surface_ref,
+            )
 
     sess.status = SessionStatus.COMPLETED
     sess.completed_at = datetime.now(UTC)
@@ -1869,24 +1866,11 @@ def spawn(
 def spawn_close(session_id: str) -> None:
     """Close a spawned session by session ID.
 
-    Calls adapter.close on the associated surface and marks the session
-    as COMPLETED.
+    Stops the session via the native daemon and marks it as COMPLETED.
 
     \b
     Example:
       cw spawn close abc12345
     """
-    # Validate session exists before acquiring the adapter (adapter may fail on
-    # non-macOS when cmux is not installed).
-    state = load_state()
-    sess = state.find_by_name_or_id(session_id)
-    if sess is None:
-        not_found_msg = f"Session '{session_id}' not found."
-        raise CwError(not_found_msg)
-    if sess.status == SessionStatus.COMPLETED:
-        already_done_msg = f"Session '{session_id}' is already completed."
-        raise CwError(already_done_msg)
-
-    adapter = get_cmux_adapter()
-    _spawn_close_impl(session_id=session_id, adapter=adapter)
+    _spawn_close_impl(session_id=session_id)
     click.echo(f"Closed session: {session_id}")

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -7,7 +7,6 @@ import time
 from typing import TYPE_CHECKING
 
 from cw.auto_dev_result import AutoDevResult, parse_stdout
-from cw.cmux import get_cmux_adapter
 from cw.config import load_clients, load_orchestrator_config, load_state, save_state
 from cw.dev_queue import dev_queue_lock, load_dev_queue, load_plan, save_dev_queue
 from cw.events import advance_cursor, read_events, record_event
@@ -23,7 +22,6 @@ from cw.spawn import spawn_create_impl
 from cw.worktree import create_worktree, is_main_behind_origin
 
 if TYPE_CHECKING:
-    from cw.cmux import CmuxAdapter
     from cw.models import OrchestratorConfig, TicketTask
     from cw.native_daemon import NativeDaemonClient
 
@@ -74,7 +72,6 @@ def _claim_next_pending(
 
 def dispatch_tick(
     config: OrchestratorConfig,
-    adapter: CmuxAdapter | None = None,
     *,
     use_plan: bool = False,
     parent: str | None = None,
@@ -89,7 +86,6 @@ def dispatch_tick(
 
     Args:
         config: Orchestrator config (per-client caps, tick interval).
-        adapter: Optional CmuxAdapter for testing.
         use_plan: If True, respect the persisted DispatchPlan ordering.
         parent: Optional parent session ID. When set, every spawned
             worker is linked to it (``parent_session_id`` +
@@ -100,15 +96,13 @@ def dispatch_tick(
     Returns:
         Number of sessions spawned during this tick.
     """
-    resolved_adapter = adapter or get_cmux_adapter()
     resolved_native_daemon = native_daemon or get_native_daemon_client()
     try:
-        reconcile(resolved_adapter, resolved_native_daemon)
+        reconcile()
     except Exception:  # noqa: BLE001
         # Sanctioned broad-catch per PYTHON-PATTERNS.md:316-331 (4-part justification):
-        # 1. Adapter surface: reconcile() calls adapter.list_surfaces() and
-        #    native-daemon roster I/O — backend-specific failure modes
-        #    (tmux server crash, JSON roster corruption, OSError on stale socket).
+        # 1. reconcile() calls ``claude agents --json`` and native-daemon roster
+        #    I/O — failure modes include subprocess crash and JSON decode errors.
         # 2. Logging: _log.exception captures the full traceback with exc_info.
         # 3. Non-critical: reconcile is best-effort housekeeping. Skipping a tick
         #    just means phantoms get reaped on the next dispatch_tick.
@@ -387,7 +381,6 @@ def run_dispatch_loop(
     *,
     max_parallel: int | None = None,
     once: bool = False,
-    adapter: CmuxAdapter | None = None,
     use_plan: bool = False,
     parent: str | None = None,
     native_daemon: NativeDaemonClient | None = None,
@@ -397,8 +390,6 @@ def run_dispatch_loop(
     Args:
         max_parallel: If set, override all per-client caps with this value.
         once: If True, run a single tick and return immediately.
-        adapter: Optional CmuxAdapter for testing.  Defaults to
-            ``get_cmux_adapter()`` at call time.
         use_plan: If True, load the persisted DispatchPlan and use its
             ordering to claim tasks.  Falls back to enqueue order when no
             plan is found (load_plan returns None).
@@ -407,8 +398,7 @@ def run_dispatch_loop(
             caller's session.
         native_daemon: Optional NativeDaemonClient for testing. Defaults
             to ``get_native_daemon_client()`` at call time. Used for
-            spawning dispatched workers and the native side of
-            reconcile.
+            spawning dispatched workers.
     """
     config = load_orchestrator_config()
 
@@ -417,14 +407,12 @@ def run_dispatch_loop(
         overridden: dict[str, int] = dict.fromkeys(clients, max_parallel)
         config = config.model_copy(update={"per_client_max_parallel": overridden})
 
-    resolved_adapter = adapter or get_cmux_adapter()
     resolved_native_daemon = native_daemon or get_native_daemon_client()
 
     while True:
         consume_completed_sessions()
         dispatch_tick(
             config,
-            adapter=resolved_adapter,
             use_plan=use_plan,
             parent=parent,
             native_daemon=resolved_native_daemon,

--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -1,9 +1,8 @@
 """cw doctor preflight — report environment health in one place.
 
-When a user's environment doesn't satisfy the chosen backend (no tmux,
-cmux daemon not running, state file corrupted), every cw command fails
-deep in an adapter with a cryptic error. `cw doctor` is the one place
-to find out *what* is wrong before you start a session.
+When the environment is missing required binaries or the state file is
+corrupted, every cw command fails with a cryptic error. `cw doctor` is
+the one place to find out *what* is wrong before starting a session.
 
 Returns structured results so the CLI can format them and tests can
 assert on specific checks.
@@ -12,17 +11,15 @@ assert on specific checks.
 from __future__ import annotations
 
 import json
-import shutil
 import subprocess
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 from pydantic import ValidationError
 
 from cw import __version__
-from cw.cmux import _resolve_backend_name, get_cmux_adapter
 from cw.config import (
     clients_file,
     load_clients,
@@ -32,9 +29,11 @@ from cw.config import (
 )
 from cw.dev_queue import load_dev_queue
 from cw.exceptions import CwError
-from cw.models import BackendName, CwState, Session
 from cw.native_daemon import _ROSTER_PATH
 from cw.reconcile import reconcile
+
+if TYPE_CHECKING:
+    from cw.models import CwState, Session
 
 
 @dataclass(frozen=True)
@@ -52,7 +51,6 @@ class DoctorReport:
     """Aggregated output from :func:`run_doctor`."""
 
     version: str
-    backend: BackendName
     checks: list[CheckResult] = field(default_factory=list)
 
     @property
@@ -65,10 +63,6 @@ class DoctorReport:
         return all(c.ok and not c.warn for c in self.checks)
 
 
-_CMUX_SOCKET_PATH = (
-    Path.home() / "Library" / "Application Support" / "cmux" / "cmux.sock"
-)
-
 # Path to Claude Code user settings — read for the disclaimer-acceptance flag.
 _CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 
@@ -77,37 +71,6 @@ _MIN_CLAUDE_VERSION = (2, 1, 139)
 
 # Number of components (major.minor.patch) required in a version string.
 _VERSION_PARTS = 3
-
-
-def _check_backend_binary(backend: BackendName) -> CheckResult:
-    """Check whether the chosen backend's binary/daemon is reachable."""
-    if backend is BackendName.TMUX:
-        path = shutil.which("tmux")
-        if path:
-            return CheckResult("tmux on PATH", ok=True, detail=path)
-        return CheckResult(
-            "tmux on PATH",
-            ok=False,
-            detail="tmux not found; install via brew/apt or set CW_BACKEND=cmux",
-        )
-    if backend is BackendName.CMUX:
-        if sys.platform != "darwin":
-            return CheckResult(
-                "cmux daemon",
-                ok=False,
-                detail=f"cmux requires macOS; running on {sys.platform}",
-            )
-        if _CMUX_SOCKET_PATH.exists():
-            return CheckResult(
-                "cmux daemon socket", ok=True, detail=str(_CMUX_SOCKET_PATH)
-            )
-        return CheckResult(
-            "cmux daemon socket",
-            ok=False,
-            detail=f"not found at {_CMUX_SOCKET_PATH}; is cmux running?",
-        )
-    # fake backend needs no binary
-    return CheckResult("fake backend (no binary required)", ok=True, detail="")
 
 
 def _check_config_file() -> CheckResult:
@@ -260,15 +223,7 @@ def _check_linkage(state: CwState) -> list[CheckResult]:
 def _check_reconcile() -> CheckResult:
     """Run reconciliation and describe the outcome as a check result."""
     try:
-        adapter = get_cmux_adapter()
-    except CwError as exc:
-        return CheckResult(
-            "reconciliation",
-            ok=False,
-            detail=f"adapter unavailable: {exc}",
-        )
-    try:
-        reconcile_report = reconcile(adapter)
+        reconcile_report = reconcile()
     except CwError as exc:
         return CheckResult(
             "reconciliation",
@@ -292,17 +247,14 @@ def _check_reconcile() -> CheckResult:
 def run_doctor(*, reap: bool = False) -> DoctorReport:
     """Run every preflight check and return a populated report.
 
-    When *reap* is True, also run multiplexer/state reconciliation and
-    append a ``reconciliation`` check summarising the number of reaped
-    sessions and reverted tickets.
+    When *reap* is True, also run state reconciliation and append a
+    ``reconciliation`` check summarising the number of reaped sessions and
+    reverted tickets.
 
     Linkage drift checks (parent/worker reference integrity) are always run,
     independent of the *reap* flag.
     """
-    backend = _resolve_backend_name()
-    report = DoctorReport(version=__version__, backend=backend)
-    report.checks.append(CheckResult("resolved backend", ok=True, detail=backend.value))
-    report.checks.append(_check_backend_binary(backend))
+    report = DoctorReport(version=__version__)
     report.checks.append(_check_config_file())
     report.checks.append(_check_orchestrator_config())
     state_check, link_state = _check_state_file()

--- a/src/cw/orchestrate.py
+++ b/src/cw/orchestrate.py
@@ -4,8 +4,7 @@ This module closes the loop on the orchestrator pipeline:
 
 * :func:`retire_merged_prs` consumes ``pr.merged`` events, removes the PR
   from review-monitor's persisted state, marks correlated sessions as
-  ``COMPLETED`` (reason ``HANDOFF``), closes their cmux surfaces, and
-  emits ``session.completed`` events.
+  ``COMPLETED`` (reason ``HANDOFF``), and emits ``session.completed`` events.
 
 * :func:`orchestrator_status` returns a snapshot of the orchestrator's
   current state -- pending dev-queue tickets, running sessions, monitored
@@ -31,7 +30,6 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
-from cw.cmux import get_cmux_adapter
 from cw.config import load_state, review_monitor_dir, save_state
 from cw.dev_queue import load_dev_queue
 from cw.events import advance_cursor, read_events, record_event
@@ -53,8 +51,6 @@ from cw.pr_responder import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-    from cw.cmux import CmuxAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -143,21 +139,22 @@ def _sessions_for_pr(
 
 def _close_session(
     sess: Session,
-    adapter: CmuxAdapter,
     *,
     pr_number: int,
     repo: str,
 ) -> None:
-    """Close a session: mark COMPLETED, close surface, emit event."""
+    """Close a session: mark COMPLETED and emit event.
+
+    Multiplexer surface close is intentionally omitted: the native daemon
+    manages session lifetime.  Legacy ``surface_ref`` values on existing
+    records are logged and skipped rather than passed to a now-removed adapter.
+    """
     if sess.surface_ref is not None:
-        try:
-            adapter.close(sess.surface_ref)
-        except Exception:
-            logger.exception(
-                "Failed to close cmux surface %s for session %s",
-                sess.surface_ref,
-                sess.id,
-            )
+        logger.warning(
+            "Session %s has legacy surface_ref %r; skipping surface close",
+            sess.id,
+            sess.surface_ref,
+        )
 
     sess.status = SessionStatus.COMPLETED
     sess.completed_reason = CompletionReason.HANDOFF
@@ -175,7 +172,6 @@ def _close_session(
 
 
 def retire_merged_prs(
-    adapter: CmuxAdapter | None = None,
     *,
     runner: Callable[[list[str]], subprocess.CompletedProcess[str]] | None = None,
 ) -> list[str]:
@@ -186,8 +182,8 @@ def retire_merged_prs(
     1. Invoke ``review_monitor.py complete`` to remove the PR from
        monitoring state.
     2. Look up sessions correlated to the PR via :class:`PRDispatchRecord`.
-    3. Close each session's cmux surface, mark it ``COMPLETED`` with
-       reason ``HANDOFF``, and emit a ``session.completed`` event.
+    3. Mark each session ``COMPLETED`` with reason ``HANDOFF`` and emit a
+       ``session.completed`` event.
     4. Drop the dispatch record entries so subsequent ticks see no
        lingering correlation.
 
@@ -195,8 +191,6 @@ def retire_merged_prs(
     no new ``pr.merged`` events is a no-op.
 
     Args:
-        adapter: CmuxAdapter for surface close calls.  Defaults to
-            :func:`cw.cmux.get_cmux_adapter`.
         runner: Optional subprocess runner override (for tests).
 
     Returns:
@@ -212,10 +206,6 @@ def retire_merged_prs(
     state = load_state()
     dispatch_record = load_dispatch_record()
     retired: list[str] = []
-    # Resolve the adapter lazily — only when we actually have a session to
-    # close. On Linux, `get_cmux_adapter()` crashes at instantiation, so
-    # `retire_merged_prs` with no matching sessions must not trigger it.
-    resolved_adapter: CmuxAdapter | None = adapter
 
     for event in events:
         payload = event.payload
@@ -261,11 +251,8 @@ def retire_merged_prs(
                 dispatch_record.active.pop(dispatch_key, None)
                 continue
 
-            if resolved_adapter is None:
-                resolved_adapter = get_cmux_adapter()
             _close_session(
                 sess,
-                resolved_adapter,
                 pr_number=pr_number,
                 repo=repo,
             )

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -1,28 +1,20 @@
-"""Reconcile cw session state with live worker backends.
+"""Reconcile cw session state with the native Claude daemon.
 
-A cw session is "live" if its ``surface_ref`` is registered with at least
-one backend that supplies a liveness oracle. Today there are two:
-
-- the multiplexer (tmux/cmux/fake) for interactive sessions and legacy
-  daemon-via-tmux paths;
-- the native Claude background daemon for dispatched workers spawned via
-  ``claude --bg`` (see GitHub issue #150).
-
-:func:`compute_drift` unions both backends' live sets and returns a
-:class:`ReconcileReport` naming the sessions whose ``surface_ref``
-appears in neither. :func:`reconcile` applies the report.
+A cw session is "live" if its ``surface_ref`` appears in the roster
+returned by ``claude agents --json``. :func:`compute_drift` checks the
+live set and returns a :class:`ReconcileReport` naming sessions whose
+``surface_ref`` is absent. :func:`reconcile` applies the report.
 
 The split is deliberate: ``compute_drift`` is pure and testable in
 isolation; ``reconcile`` does the side-effecting work (state mutation,
 event emission, dev-queue revert).
 
-Transient-outage safety: ``reconcile`` refuses to mutate state when
-*both* backends report zero live entries but the persisted state still
-contains ACTIVE/IDLE sessions with surface refs. A temporary multiplexer
-hiccup, or a missing/unreadable native roster, would otherwise
-irreversibly mark every session as CRASHED. ``compute_drift`` stays pure
-and does not apply this guard — callers that want drift-without-side-
-effects still get the full phantom list.
+Transient-outage safety: ``reconcile`` refuses to mutate state when the
+daemon cannot be reached (``_claude_agents_json`` raises
+``CalledProcessError``) or returns an empty roster while the persisted
+state still contains ACTIVE/IDLE sessions with surface refs. A transient
+daemon hiccup would otherwise irreversibly mark every session as CRASHED.
+``compute_drift`` stays pure and does not apply this guard.
 
 Race note: ``reconcile`` does ``load_state → mutate → save_state`` without
 a dedicated ``sessions.json`` file lock. This matches every other
@@ -36,6 +28,7 @@ targets.
 from __future__ import annotations
 
 import json
+import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -53,9 +46,7 @@ from cw.models import (
 from cw.native_daemon import get_native_daemon_client
 
 if TYPE_CHECKING:
-    from cw.cmux import MultiplexerAdapter
     from cw.models import CwState, Session
-    from cw.native_daemon import NativeDaemonClient
 
 
 # Session-name prefix for DAEMON sessions spawned by the dispatch loop. The
@@ -75,8 +66,8 @@ AUTO_DEV_LABEL_PREFIX = "auto-dev/"
 HEADLESS_TIMEOUT_SECONDS = 3600  # 60 minutes
 
 
-# Only these two statuses imply "the multiplexer should have a surface".
-# BACKGROUNDED sessions intentionally have no pane (that's the whole point);
+# Only these two statuses imply "the daemon should have a live session".
+# BACKGROUNDED sessions intentionally have no surface (that's the whole point);
 # COMPLETED is terminal. Both are ignored by reconciliation.
 _LIVE_STATUSES: frozenset[SessionStatus] = frozenset(
     {
@@ -85,18 +76,20 @@ _LIVE_STATUSES: frozenset[SessionStatus] = frozenset(
     }
 )
 
-# Shell process names indicating a pane's foreground process is an idle
-# shell — claude (or ``cw run-claude``) has exited and the pane is back
-# at the prompt. A session whose ``pane_current_command`` is in this
-# set is treated as a zombie phantom even though the pane itself still
-# exists. See GitHub issue #144.
-# Known limitation: a user who manually attaches to a cw pane and drops
-# to a subshell will also match this predicate and be reaped on the
-# next reconcile tick. cw auto-spawn does not produce this pattern in
-# normal use.
-_IDLE_SHELL_COMMANDS: frozenset[str] = frozenset(
-    {"bash", "zsh", "sh", "fish", "dash", "tcsh", "ksh"}
-)
+
+def _claude_agents_json() -> list[dict[str, object]]:
+    """Call ``claude agents --json`` and return the parsed list.
+
+    Raises ``subprocess.CalledProcessError`` when the daemon is not running.
+    """
+    proc = subprocess.run(
+        ["claude", "agents", "--json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(proc.stdout)
+    return data if isinstance(data, list) else []
 
 
 @dataclass(frozen=True)
@@ -120,52 +113,26 @@ class ReconcileReport:
 
 def compute_drift(
     state: CwState,
-    adapter: MultiplexerAdapter | None = None,
-    native_daemon: NativeDaemonClient | None = None,
+    native_live: set[str],
 ) -> ReconcileReport:
     """Return a report naming sessions whose surface is no longer live.
 
     An ACTIVE or IDLE session is phantom when:
     - it has a ``surface_ref`` (None means it was never spawned), AND
-    - that ref is not in the multiplexer's live set, AND
-    - that ref is not in the native daemon's live set.
+    - that ref is not in *native_live*.
 
-    The two backends are unioned so a daemon-origin session with a short
-    Claude session id passes liveness via the roster, while an
-    interactive session with a tmux pane ref passes via the adapter.
-
-    *adapter* is optional. When ``None``, the multiplexer side of the union
-    is treated as empty; only the native daemon oracle is consulted. Phase D
-    will drop the adapter parameter entirely once the multiplexer is removed
-    from all call sites.
+    *native_live* is the set of short session IDs reported by
+    ``claude agents --json``; callers obtain it via :func:`_claude_agents_json`.
 
     This function does not mutate state. It also does not distinguish
     "backend reports zero live entries" from "backend is unreachable";
     that guard lives in :func:`reconcile`.
     """
-    daemon = native_daemon or get_native_daemon_client()
-    tmux_live = adapter.list_surfaces() if adapter is not None else set()
-    native_live = daemon.list_live_session_short_ids()
-    # Second-pass zombie filter: panes that exist but whose foreground
-    # process is a bare shell are not actually live cw sessions. An empty
-    # command map means the backend can't enumerate — skip the filter
-    # (fail-open) rather than risk false-positive reaping.
-    surface_commands = (
-        adapter.list_live_surface_commands() if adapter is not None else {}
-    )
-    zombie_refs: set[str] = set()
-    if surface_commands:
-        zombie_refs = {
-            ref for ref, cmd in surface_commands.items() if cmd in _IDLE_SHELL_COMMANDS
-        }
-
     phantoms: list[str] = []
     for session in state.sessions:
         if session.status not in _LIVE_STATUSES:
             continue
         if session.surface_ref is None:
-            continue
-        if session.surface_ref in tmux_live and session.surface_ref not in zombie_refs:
             continue
         if session.surface_ref in native_live:
             continue
@@ -181,23 +148,26 @@ def ticket_id_for_session(session_name: str) -> str | None:
     return None
 
 
-def _looks_like_backend_outage(
-    state: CwState, tmux_live: set[str], native_live: set[str]
+def _looks_like_daemon_outage(
+    state: CwState,
+    daemon_errored: bool,
+    native_live: set[str],
 ) -> bool:
-    """True when both backends are empty and the state still has live refs.
+    """True when the daemon appears unreachable and the state still has live refs.
 
-    If either backend returned a non-empty set, treat its absence on the
-    other as "the other backend has nothing live", not an outage — the
-    common case is dispatch using only the native daemon while the
-    multiplexer is idle (or vice versa).
+    Fires when:
+    - the daemon subprocess raised ``CalledProcessError`` (*daemon_errored*), OR
+    - the daemon returned an empty roster while the persisted state has at
+      least one ACTIVE/IDLE session with a ``surface_ref``.
 
-    If both backends are empty *and* the persisted state has at least one
-    ACTIVE/IDLE session that was once given a surface_ref, assume the
-    backends are unreachable rather than "somehow every session died at
-    once". Aborting here is the difference between a 5-second restart and
-    permanent data loss.
+    In either case, assume the daemon is transiently unreachable rather than
+    "somehow every session died at once". Aborting here is the difference
+    between a 5-second restart and permanent data loss.
+
+    When *native_live* is non-empty the daemon is clearly reachable, so
+    this returns False regardless of *daemon_errored*.
     """
-    if tmux_live or native_live:
+    if not daemon_errored and native_live:
         return False
     return any(
         s.surface_ref is not None and s.status in _LIVE_STATUSES for s in state.sessions
@@ -299,10 +269,7 @@ def revert_stalled_headless_sessions(
     return reverted
 
 
-def reconcile(
-    adapter: MultiplexerAdapter | None = None,
-    native_daemon: NativeDaemonClient | None = None,
-) -> ReconcileReport:
+def reconcile() -> ReconcileReport:
     """Apply drift reconciliation against the persisted state.
 
     Flips phantom ACTIVE/IDLE sessions to COMPLETED with
@@ -312,12 +279,8 @@ def reconcile(
     the dispatch loop will retry.
 
     Returns an empty report without mutating state when
-    :func:`_looks_like_backend_outage` matches — a transient multiplexer
-    restart (or a missing native roster) must not trigger mass-reaping.
-
-    *adapter* is optional. When ``None``, the multiplexer side is treated
-    as empty; only the native daemon oracle is consulted. Phase D will drop
-    the adapter parameter entirely.
+    :func:`_looks_like_daemon_outage` matches — a transient daemon hiccup
+    must not trigger mass-reaping.
 
     Partial-failure note: state and the dev queue are separate files. If
     ``save_state`` succeeds but the subsequent dev-queue update raises,
@@ -327,24 +290,31 @@ def reconcile(
     only be recovered by explicit operator action. This is an acceptable
     tradeoff for a file-based, single-user tool.
     """
-    daemon = native_daemon or get_native_daemon_client()
     state = load_state()
     now = datetime.now(UTC)
 
     # Passive budget sweep: catches headless DAEMON sessions whose agent
     # stalled mid-turn and produced no further Stop hook firings. Runs before
-    # the outage guard so a backend hiccup does not delay budget enforcement.
+    # the outage guard so a daemon hiccup does not delay budget enforcement.
     # See GitHub issue #185.
     stalled_reverted = revert_stalled_headless_sessions(
         state, now=now, budget_seconds=HEADLESS_TIMEOUT_SECONDS
     )
 
-    tmux_live = adapter.list_surfaces() if adapter is not None else set()
-    native_live = daemon.list_live_session_short_ids()
-    if _looks_like_backend_outage(state, tmux_live, native_live):
+    try:
+        native_live = {
+            sid
+            for a in _claude_agents_json()
+            if isinstance(sid := a.get("sessionId"), str)
+        }
+        daemon_errored = False
+    except subprocess.CalledProcessError:
+        native_live = set()
+        daemon_errored = True
+    if _looks_like_daemon_outage(state, daemon_errored, native_live):
         return ReconcileReport(reverted_ticket_ids=stalled_reverted)
 
-    drift = compute_drift(state, adapter, daemon)
+    drift = compute_drift(state, native_live)
     if not drift.phantom_session_ids:
         # No phantom sessions to reap, but still run the TIMED_OUT and
         # COMPLETED-silent sweeps so any tasks whose sessions completed or

--- a/src/cw/session.py
+++ b/src/cw/session.py
@@ -82,7 +82,7 @@ def start_session(
     state = load_state()
 
     # Reap phantom sessions so we don't short-circuit on a dead "active" row.
-    reconcile(native_daemon=daemon)
+    reconcile()
     state = load_state()
 
     # Validate parent session FIRST so a bad ID always errors, even when

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,15 @@ def tmp_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         tmp_path / ".claude" / "daemon" / "roster.json",
     )
 
+    # Stub _claude_agents_json so tests don't invoke the real ``claude``
+    # binary. Tests that want specific liveness behaviour override this with
+    # their own monkeypatch.setattr call; pytest patches stack and the
+    # test-level patch wins.
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        list,
+    )
+
     return tmp_path
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2424,9 +2424,6 @@ class TestShowStatus:
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        from cw.cmux import FakeCmuxAdapter
-
-        monkeypatch.setattr("cw.cli.get_cmux_adapter", FakeCmuxAdapter)
         clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
         clients_file.write_text(
             "clients:\n"
@@ -2453,16 +2450,12 @@ class TestShowStatus:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """_check_and_mark_dead_sessions reaps sessions whose surface is gone."""
-        from cw.cmux import FakeCmuxAdapter
-
-        def _adapter_with_decoy() -> FakeCmuxAdapter:
-            # Non-empty live set prevents reconcile's outage guard from
-            # refusing to mutate state (see cw.reconcile._looks_like_backend_outage).
-            a = FakeCmuxAdapter()
-            a.spawn("decoy-ws", "echo")
-            return a
-
-        monkeypatch.setattr("cw.cli.get_cmux_adapter", _adapter_with_decoy)
+        # Non-empty live set prevents reconcile's outage guard from
+        # refusing to mutate state; "impl" ref still isn't live so phantom is reaped.
+        monkeypatch.setattr(
+            "cw.reconcile._claude_agents_json",
+            lambda: [{"sessionId": "decoy000"}],
+        )
         clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
         clients_file.write_text(
             f"clients:\n"
@@ -2834,7 +2827,6 @@ def test_display_status_reconciles_phantom_active_sessions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """`cw status` reports and reaps sessions with missing surfaces."""
-    from cw.cmux import FakeCmuxAdapter
     from cw.config import load_state, save_state
     from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
@@ -2856,12 +2848,10 @@ def test_display_status_reconciles_phantom_active_sessions(
 
     # Non-empty live set prevents the outage guard from aborting reconcile;
     # the "gone" surface_ref still isn't in the set so phantom1 is reaped.
-    def _adapter_with_decoy() -> FakeCmuxAdapter:
-        a = FakeCmuxAdapter()
-        a.spawn("decoy-ws", "echo")
-        return a
-
-    monkeypatch.setattr("cw.cli.get_cmux_adapter", _adapter_with_decoy)
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
 
     runner = CliRunner()
     result = runner.invoke(main, ["status"])

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from cw.cmux import FakeCmuxAdapter
 from cw.config import load_state, save_state
 from cw.dev_queue import add_ticket, load_dev_queue, save_dev_queue, save_plan
 from cw.dispatch import (
@@ -131,9 +130,8 @@ class TestDispatchTickSpawnsSession:
         )
         add_ticket(task)
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        spawned = dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        spawned = dispatch_tick(simple_config, native_daemon=daemon)
 
         assert spawned == 1
 
@@ -169,9 +167,8 @@ class TestDispatchTickSpawnsSession:
         _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
         add_ticket(TicketTask(ticket_id="GEN-300", client="test-client"))
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        dispatch_tick(simple_config, native_daemon=daemon)
 
         assert len(daemon.spawn_calls) == 1
         _cwd, prompt = daemon.spawn_calls[0]
@@ -202,11 +199,8 @@ class TestDispatchTickSpawnsSession:
         for i in range(2):
             add_ticket(TicketTask(ticket_id=f"GEN-{i}", client="test-client"))
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        spawned = dispatch_tick(
-            cap2_config, adapter=adapter, native_daemon=daemon, parent=parent.id
-        )
+        spawned = dispatch_tick(cap2_config, native_daemon=daemon, parent=parent.id)
         assert spawned == 2
 
         state = load_state()
@@ -235,9 +229,8 @@ class TestDispatchTickSpawnsSession:
         _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
         add_ticket(TicketTask(ticket_id="GEN-STAMP", client="test-client"))
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        dispatch_tick(simple_config, native_daemon=daemon)
 
         store = load_dev_queue()
         running = store.running()
@@ -258,11 +251,8 @@ class TestDispatchTickSpawnsSession:
         _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
         add_ticket(TicketTask(ticket_id="GEN-400", client="test-client"))
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        dispatch_tick(
-            simple_config, adapter=adapter, native_daemon=daemon
-        )  # parent omitted
+        dispatch_tick(simple_config, native_daemon=daemon)  # parent omitted
 
         state = load_state()
         worker = state.sessions[0]
@@ -288,9 +278,8 @@ class TestPerClientCapRespected:
         for i in range(3):
             add_ticket(TicketTask(ticket_id=f"GEN-{i}", client="test-client"))
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        spawned = dispatch_tick(cap2_config, adapter=adapter, native_daemon=daemon)
+        spawned = dispatch_tick(cap2_config, native_daemon=daemon)
 
         assert spawned == 2
         assert len(daemon.spawn_calls) == 2
@@ -320,9 +309,8 @@ class TestPerClientCapRespected:
         for i in range(4):
             add_ticket(TicketTask(ticket_id=f"GEN-{i}", client="test-client"))
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        spawned = dispatch_tick(config, adapter=adapter, native_daemon=daemon)
+        spawned = dispatch_tick(config, native_daemon=daemon)
 
         # default_max_parallel=3 → spawn 3, leave 1 pending.
         assert spawned == 3
@@ -348,15 +336,14 @@ class TestNoDoubleDispatch:
 
         add_ticket(TicketTask(ticket_id="GEN-200", client="test-client"))
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
 
         # First tick claims the task
-        spawned1 = dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        spawned1 = dispatch_tick(simple_config, native_daemon=daemon)
         assert spawned1 == 1
 
         # Second tick: running_count=1 >= cap=1, should skip
-        spawned2 = dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        spawned2 = dispatch_tick(simple_config, native_daemon=daemon)
         assert spawned2 == 0
 
         # Only one spawn call total
@@ -755,9 +742,8 @@ class TestDispatchTickReturnsCount:
         add_ticket(TicketTask(ticket_id="GEN-500", client="test-client"))
         add_ticket(TicketTask(ticket_id="GEN-501", client="test-client"))
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        count = dispatch_tick(cap2_config, adapter=adapter, native_daemon=daemon)
+        count = dispatch_tick(cap2_config, native_daemon=daemon)
 
         assert count == 2
 
@@ -770,9 +756,8 @@ class TestDispatchTickReturnsCount:
         """Empty queue returns 0."""
         _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        count = dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        count = dispatch_tick(simple_config, native_daemon=daemon)
 
         assert count == 0
 
@@ -800,10 +785,9 @@ class TestDispatchTickReturnsCount:
         # Enqueue a task
         add_ticket(TicketTask(ticket_id="GEN-600", client="test-client"))
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
         # cap=1, running=1 => should not spawn
-        count = dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        count = dispatch_tick(simple_config, native_daemon=daemon)
 
         assert count == 0
         assert len(daemon.spawn_calls) == 0
@@ -842,12 +826,9 @@ class TestDispatchTickWithPlan:
             )
         )
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
         # cap=2 => should claim C first, then A
-        spawned = dispatch_tick(
-            cap2_config, adapter=adapter, native_daemon=daemon, use_plan=True
-        )
+        spawned = dispatch_tick(cap2_config, native_daemon=daemon, use_plan=True)
         assert spawned == 2
 
         store = load_dev_queue()
@@ -866,11 +847,8 @@ class TestDispatchTickWithPlan:
         add_ticket(TicketTask(ticket_id="GEN-FIRST", client="test-client"))
         add_ticket(TicketTask(ticket_id="GEN-SECOND", client="test-client"))
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        spawned = dispatch_tick(
-            simple_config, adapter=adapter, native_daemon=daemon, use_plan=True
-        )
+        spawned = dispatch_tick(simple_config, native_daemon=daemon, use_plan=True)
         assert spawned == 1
 
         store = load_dev_queue()
@@ -895,11 +873,8 @@ class TestDispatchTickWithPlan:
             DispatchPlan(tasks=[TicketTask(ticket_id="GEN-B", client="test-client")])
         )
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        spawned = dispatch_tick(
-            cap2_config, adapter=adapter, native_daemon=daemon, use_plan=True
-        )
+        spawned = dispatch_tick(cap2_config, native_daemon=daemon, use_plan=True)
         # cap=2: claims B first (per plan), then A (fallback)
         assert spawned == 2
 
@@ -916,6 +891,7 @@ def test_dispatch_tick_reconciles_phantoms_before_counting(
     tmp_dispatch_dirs: Path,
     sample_client_config: ClientConfig,
     simple_config: OrchestratorConfig,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Phantom DAEMON sessions do not block new dispatch."""
     _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
@@ -956,13 +932,15 @@ def test_dispatch_tick_reconciles_phantoms_before_counting(
         )
     )
 
-    adapter = FakeCmuxAdapter()
     daemon = FakeNativeDaemonClient()
     # Non-empty live set bypasses reconcile's outage guard; "dead" ref still
     # isn't live so the phantom is reaped as intended.
-    adapter.spawn("decoy-ws", "echo")
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
 
-    spawned = dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+    spawned = dispatch_tick(simple_config, native_daemon=daemon)
     assert spawned == 1
 
     reloaded = load_state()
@@ -975,6 +953,7 @@ def test_crash_revert_respawn_rejects_old_event_completes_new(
     tmp_dispatch_dirs: Path,
     sample_client_config: ClientConfig,
     simple_config: OrchestratorConfig,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """End-to-end: crash → reconcile revert → respawn → consumer disambiguates.
 
@@ -1025,13 +1004,16 @@ def test_crash_revert_respawn_rejects_old_event_completes_new(
         )
     )
 
-    adapter = FakeCmuxAdapter()
-    adapter.spawn("decoy-ws", "echo")  # non-empty live set bypasses outage guard
+    # Non-empty live set bypasses outage guard; "dead" ref still isn't live.
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
     daemon = FakeNativeDaemonClient()
 
     # Step 2: tick triggers reconcile (revert + emit crashed event), then
     # claims and respawns the same ticket with a new session id.
-    spawned = dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+    spawned = dispatch_tick(simple_config, native_daemon=daemon)
     assert spawned == 1
 
     queue = load_dev_queue()
@@ -1106,7 +1088,6 @@ class TestDispatchTickSpawnErrors:
         _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
         add_ticket(TicketTask(ticket_id="GEN-149A", client="test-client"))
 
-        adapter = FakeCmuxAdapter()
         daemon = _RaisingNativeDaemon(
             subprocess.CalledProcessError(
                 returncode=1,
@@ -1116,7 +1097,7 @@ class TestDispatchTickSpawnErrors:
         )
 
         caplog.set_level(logging.ERROR, logger="cw.dispatch")
-        spawned = dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        spawned = dispatch_tick(simple_config, native_daemon=daemon)
 
         assert spawned == 0
 
@@ -1150,11 +1131,10 @@ class TestDispatchTickSpawnErrors:
         # Patch the name as imported into cw.dispatch, not the source module.
         monkeypatch.setattr("cw.dispatch.create_worktree", _boom)
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
 
         caplog.set_level(logging.ERROR, logger="cw.dispatch")
-        spawned = dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        spawned = dispatch_tick(simple_config, native_daemon=daemon)
 
         assert spawned == 0
         assert daemon.spawn_calls == []
@@ -1196,9 +1176,8 @@ class TestDispatchTickFreshnessGate:
             lambda _client: (True, "aaa", "bbb", 3),
         )
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        spawned = dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        spawned = dispatch_tick(simple_config, native_daemon=daemon)
 
         assert spawned == 0
 
@@ -1232,9 +1211,8 @@ class TestDispatchTickFreshnessGate:
             lambda _client: (True, "aaa", "bbb", 1),
         )
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        dispatch_tick(simple_config, native_daemon=daemon)
 
         events = read_events(
             consumer="test-freshness-multi",
@@ -1292,9 +1270,8 @@ class TestDispatchTickFreshnessGate:
             per_client_max_parallel={"test-client": 1, "fresh-client": 1},
         )
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        spawned = dispatch_tick(config, adapter=adapter, native_daemon=daemon)
+        spawned = dispatch_tick(config, native_daemon=daemon)
 
         assert spawned == 1  # only fresh-client
 
@@ -1321,9 +1298,8 @@ class TestDispatchTickFreshnessGate:
             lambda _client: (False, "abc", "abc", 0),
         )
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        spawned = dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        spawned = dispatch_tick(simple_config, native_daemon=daemon)
 
         assert spawned == 1
 
@@ -1354,9 +1330,8 @@ class TestDispatchTickFreshnessGate:
 
         monkeypatch.setattr("cw.dispatch.is_main_behind_origin", _counting)
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
-        dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        dispatch_tick(simple_config, native_daemon=daemon)
 
         assert call_count == 1
 
@@ -1378,11 +1353,10 @@ class TestDispatchTickFreshnessGate:
 
         monkeypatch.setattr("cw.dispatch.is_main_behind_origin", _boom)
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
 
         caplog.set_level(logging.WARNING, logger="cw.dispatch")
-        spawned = dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        spawned = dispatch_tick(simple_config, native_daemon=daemon)
 
         assert spawned == 1  # dispatch proceeded
         assert any(
@@ -1416,14 +1390,13 @@ class TestDispatchTickReconcileErrors:
         # Patch the name as imported into cw.dispatch (not cw.reconcile).
         monkeypatch.setattr("cw.dispatch.reconcile", _boom_reconcile)
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
 
         caplog.set_level(logging.ERROR, logger="cw.dispatch")
 
         # Must not raise; reconcile guard catches and logs, dispatch_tick
         # continues to the dev-queue scan and returns normally.
-        spawned = dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        spawned = dispatch_tick(simple_config, native_daemon=daemon)
 
         assert spawned == 0
         assert any(
@@ -1457,10 +1430,9 @@ class TestClaimNextPendingAttempts:
         )
         add_ticket(task)
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
 
-        dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        dispatch_tick(simple_config, native_daemon=daemon)
 
         queue = load_dev_queue()
         claimed = next(t for t in queue.tasks if t.ticket_id == "GEN-251-attempts")
@@ -1487,10 +1459,9 @@ class TestClaimNextPendingAttempts:
         store = DevQueueStore(tasks=[task])
         save_dev_queue(store)
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
 
-        dispatch_tick(simple_config, adapter=adapter, native_daemon=daemon)
+        dispatch_tick(simple_config, native_daemon=daemon)
 
         queue = load_dev_queue()
         claimed = next(t for t in queue.tasks if t.ticket_id == "GEN-251-cumulative")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -10,7 +10,6 @@ from click.testing import CliRunner
 
 from cw.cli import main
 from cw.doctor import CheckResult, DoctorReport, format_report, run_doctor
-from cw.models import BackendName
 
 if TYPE_CHECKING:
     import pytest
@@ -33,65 +32,29 @@ def _stub_claude_version_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestRunDoctorFakeBackend:
-    """When CW_BACKEND=fake the backend binary check is a no-op."""
-
-    def test_resolved_backend_is_fake(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
-    ) -> None:
-        monkeypatch.setenv("CW_BACKEND", "fake")
-        _stub_claude_version_ok(monkeypatch)
-        report = run_doctor()
-        assert report.backend is BackendName.FAKE
-        assert report.ok
+    """run_doctor returns a healthy report on the fake backend."""
 
     def test_report_includes_version(
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
-        monkeypatch.setenv("CW_BACKEND", "fake")
+        _stub_claude_version_ok(monkeypatch)
         report = run_doctor()
         assert report.version
 
-
-class TestRunDoctorTmuxBackend:
-    def test_tmux_missing_is_reported_as_failure(
+    def test_report_ok_on_fake_backend(
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
-        monkeypatch.setenv("CW_BACKEND", "tmux")
-        monkeypatch.setattr("cw.doctor.shutil.which", lambda _name: None)
-        report = run_doctor()
-        assert not report.ok
-        failing = [c for c in report.checks if not c.ok]
-        assert any("tmux" in c.name for c in failing)
-
-    def test_tmux_on_path_passes(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
-    ) -> None:
-        monkeypatch.setenv("CW_BACKEND", "tmux")
-        monkeypatch.setattr("cw.doctor.shutil.which", lambda _name: "/usr/bin/tmux")
         _stub_claude_version_ok(monkeypatch)
         report = run_doctor()
         assert report.ok
 
 
-class TestRunDoctorCmuxBackend:
-    def test_cmux_non_darwin_is_reported_as_failure(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
-    ) -> None:
-        monkeypatch.setenv("CW_BACKEND", "cmux")
-        monkeypatch.setattr("cw.doctor.sys.platform", "linux")
-        report = run_doctor()
-        assert not report.ok
-        failing = [c for c in report.checks if not c.ok]
-        assert any("cmux" in c.name for c in failing)
-
-
 class TestFormatReport:
-    def test_render_contains_ok_and_fail_markers(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
-    ) -> None:
-        monkeypatch.setenv("CW_BACKEND", "tmux")
-        monkeypatch.setattr("cw.doctor.shutil.which", lambda _name: None)
-        report = run_doctor()
+    def test_render_contains_ok_and_fail_markers(self) -> None:
+        report = DoctorReport(
+            version="0.0.0",
+            checks=[CheckResult("check-fail", ok=False, detail="broken")],
+        )
         rendered = format_report(report)
         assert "FAIL" in rendered
         assert "status: problems detected" in rendered
@@ -99,7 +62,6 @@ class TestFormatReport:
     def test_healthy_report_ends_with_healthy(
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
-        monkeypatch.setenv("CW_BACKEND", "fake")
         _stub_claude_version_ok(monkeypatch)
         report = run_doctor()
         rendered = format_report(report)
@@ -110,7 +72,6 @@ class TestDoctorCli:
     def test_cli_exit_zero_on_healthy(
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
-        monkeypatch.setenv("CW_BACKEND", "fake")
         _stub_claude_version_ok(monkeypatch)
         runner = CliRunner()
         result = runner.invoke(main, ["doctor"])
@@ -120,8 +81,14 @@ class TestDoctorCli:
     def test_cli_exit_nonzero_on_failure(
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
-        monkeypatch.setenv("CW_BACKEND", "tmux")
-        monkeypatch.setattr("cw.doctor.shutil.which", lambda _name: None)
+        # Simulate a failing check by stubbing run_doctor to return a failing report.
+        monkeypatch.setattr(
+            "cw.cli.run_doctor",
+            lambda **_kwargs: DoctorReport(
+                version="0.0.0",
+                checks=[CheckResult("check-fail", ok=False, detail="broken")],
+            ),
+        )
         runner = CliRunner()
         result = runner.invoke(main, ["doctor"])
         assert result.exit_code != 0
@@ -134,7 +101,6 @@ def test_run_doctor_reap_flag_reconciles_and_reports(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """run_doctor(reap=True) invokes reconcile and reports reaped sessions."""
-    from cw.cmux import FakeCmuxAdapter
     from cw.config import load_state, save_state
     from cw.doctor import run_doctor
     from cw.models import CwState, Session, SessionPurpose, SessionStatus
@@ -155,14 +121,12 @@ def test_run_doctor_reap_flag_reconciles_and_reports(
         )
     )
 
-    def _adapter_with_decoy() -> FakeCmuxAdapter:
-        # Non-empty live set bypasses reconcile's outage guard; "gone" still
-        # isn't live so phantom is still reaped.
-        a = FakeCmuxAdapter()
-        a.spawn("decoy-ws", "echo")
-        return a
-
-    monkeypatch.setattr("cw.doctor.get_cmux_adapter", _adapter_with_decoy)
+    # Non-empty live set bypasses reconcile's outage guard; "gone" still
+    # isn't live so phantom is still reaped.
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
 
     report = run_doctor(reap=True)
     reap_checks = [c for c in report.checks if c.name == "reconciliation"]
@@ -188,7 +152,6 @@ def test_cw_doctor_cli_reap_flag(
 
     # Force fake backend so the binary/socket check passes on every platform
     # (macOS default is cmux, whose socket does not exist in CI).
-    monkeypatch.setenv("CW_BACKEND", "fake")
     _stub_claude_version_ok(monkeypatch)
     runner = CliRunner()
     result = runner.invoke(main, ["doctor", "--reap"])
@@ -213,7 +176,6 @@ class TestCheckLinkageHealthy:
         from cw.config import save_state
         from cw.models import CwState
 
-        monkeypatch.setenv("CW_BACKEND", "fake")
         save_state(CwState(sessions=[]))
         report = run_doctor()
         linkage_checks = [c for c in report.checks if c.name.startswith("linkage/")]
@@ -230,7 +192,6 @@ class TestCheckLinkageHealthy:
         from cw.config import save_state
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
-        monkeypatch.setenv("CW_BACKEND", "fake")
         save_state(
             CwState(
                 sessions=[
@@ -268,7 +229,6 @@ class TestCheckLinkageHealthy:
         from cw.config import save_state
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
-        monkeypatch.setenv("CW_BACKEND", "fake")
         save_state(
             CwState(
                 sessions=[
@@ -321,7 +281,6 @@ class TestCheckLinkageDanglingWorker:
         from cw.config import save_state
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
-        monkeypatch.setenv("CW_BACKEND", "fake")
         save_state(
             CwState(
                 sessions=[
@@ -355,7 +314,6 @@ class TestCheckLinkageDanglingWorker:
         from cw.config import save_state
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
-        monkeypatch.setenv("CW_BACKEND", "fake")
         save_state(
             CwState(
                 sessions=[
@@ -393,7 +351,6 @@ class TestCheckLinkageDanglingParent:
         from cw.config import save_state
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
-        monkeypatch.setenv("CW_BACKEND", "fake")
         save_state(
             CwState(
                 sessions=[
@@ -428,7 +385,6 @@ class TestCheckLinkageDanglingParent:
         from cw.config import save_state
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
-        monkeypatch.setenv("CW_BACKEND", "fake")
         save_state(
             CwState(
                 sessions=[
@@ -475,7 +431,6 @@ class TestCheckLinkageAsymmetric:
         from cw.config import save_state
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
-        monkeypatch.setenv("CW_BACKEND", "fake")
         save_state(
             CwState(
                 sessions=[
@@ -516,7 +471,6 @@ class TestCheckLinkageAsymmetric:
         from cw.config import save_state
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
-        monkeypatch.setenv("CW_BACKEND", "fake")
         save_state(
             CwState(
                 sessions=[
@@ -565,7 +519,6 @@ class TestCheckLinkageAsymmetric:
         from cw.config import save_state
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
-        monkeypatch.setenv("CW_BACKEND", "fake")
         save_state(
             CwState(
                 sessions=[
@@ -608,7 +561,6 @@ class TestCheckLinkageIndependence:
         """If state.json is corrupt, linkage checks are skipped (not crashed)."""
         from cw.config import state_file
 
-        monkeypatch.setenv("CW_BACKEND", "fake")
         # Write corrupt JSON to the state file
         state_file().parent.mkdir(parents=True, exist_ok=True)
         state_file().write_text("{not valid json}")
@@ -628,7 +580,6 @@ class TestCheckLinkageIndependence:
         from cw.config import save_state
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
-        monkeypatch.setenv("CW_BACKEND", "fake")
         _stub_claude_version_ok(monkeypatch)
         save_state(
             CwState(
@@ -791,7 +742,6 @@ def test_doctor_reap_reverts_completed_silent_dev_queue_task(
     from click.testing import CliRunner
 
     from cw.cli import main
-    from cw.cmux import FakeCmuxAdapter
     from cw.config import save_state
     from cw.dev_queue import load_dev_queue, save_dev_queue
     from cw.models import (
@@ -806,7 +756,6 @@ def test_doctor_reap_reverts_completed_silent_dev_queue_task(
         TicketTask,
     )
 
-    monkeypatch.setenv("CW_BACKEND", "fake")
     _stub_claude_version_ok(monkeypatch)
 
     comp_session = Session(
@@ -831,11 +780,6 @@ def test_doctor_reap_reverts_completed_silent_dev_queue_task(
         session_id="comp-doctor-1",
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
-
-    def _fake_adapter() -> FakeCmuxAdapter:
-        return FakeCmuxAdapter()
-
-    monkeypatch.setattr("cw.doctor.get_cmux_adapter", _fake_adapter)
 
     runner = CliRunner()
     result = runner.invoke(main, ["doctor", "--reap"])
@@ -911,7 +855,6 @@ class TestRunDoctor10Checks:
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
         """run_doctor() includes bypass-disclaimer, claude-version, daemon-reachable."""
-        monkeypatch.setenv("CW_BACKEND", "fake")
         settings_path = tmp_config_dir / ".claude" / "settings.json"
         roster_path = tmp_config_dir / ".claude" / "daemon" / "roster.json"
         settings_path.parent.mkdir(parents=True, exist_ok=True)
@@ -935,7 +878,6 @@ class TestRunDoctor10Checks:
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
         """settings.json with {} → bypass-disclaimer is ok=True warn=True."""
-        monkeypatch.setenv("CW_BACKEND", "fake")
         self._monkeypatch_paths(
             monkeypatch,
             tmp_config_dir,
@@ -951,7 +893,6 @@ class TestRunDoctor10Checks:
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
         """settings.json with flag set → bypass-disclaimer ok=True warn=False."""
-        monkeypatch.setenv("CW_BACKEND", "fake")
         self._monkeypatch_paths(
             monkeypatch,
             tmp_config_dir,
@@ -967,7 +908,6 @@ class TestRunDoctor10Checks:
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
         """No roster file → daemon-reachable is ok=True warn=True."""
-        monkeypatch.setenv("CW_BACKEND", "fake")
         # Provide settings so bypass-disclaimer doesn't interfere
         self._monkeypatch_paths(
             monkeypatch,
@@ -984,7 +924,6 @@ class TestRunDoctor10Checks:
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
         """roster with supervisorPid: 12345 → daemon-reachable is ok=True warn=False."""
-        monkeypatch.setenv("CW_BACKEND", "fake")
         self._monkeypatch_paths(
             monkeypatch,
             tmp_config_dir,
@@ -1000,7 +939,6 @@ class TestRunDoctor10Checks:
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
         """roster with workers but no supervisorPid → WARN, no KeyError."""
-        monkeypatch.setenv("CW_BACKEND", "fake")
         self._monkeypatch_paths(
             monkeypatch,
             tmp_config_dir,
@@ -1016,7 +954,6 @@ class TestRunDoctor10Checks:
         self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
     ) -> None:
         """FileNotFoundError from claude binary → claude-version is ok=False."""
-        monkeypatch.setenv("CW_BACKEND", "fake")
 
         def fake_run_not_found(*_a: object, **_kw: object) -> object:
             msg = "no claude"
@@ -1040,7 +977,6 @@ def test_report_ok_unaffected_by_warn_checks() -> None:
     warn_check = CheckResult("bypass-disclaimer", ok=True, warn=True, detail="not set")
     report = DoctorReport(
         version="0.0.0",
-        backend=BackendName.FAKE,
         checks=[warn_check],
     )
     assert report.ok is True
@@ -1058,7 +994,6 @@ class TestFormatReportFooter:
         """Only OK checks (no WARN, no FAIL) → 'status: healthy'."""
         report = DoctorReport(
             version="0.0.0",
-            backend=BackendName.FAKE,
             checks=[
                 CheckResult("check-a", ok=True, warn=False, detail=""),
                 CheckResult("check-b", ok=True, warn=False, detail=""),
@@ -1071,7 +1006,6 @@ class TestFormatReportFooter:
         """Any WARN check (ok=True, warn=True) → advisory footer, not plain healthy."""
         report = DoctorReport(
             version="0.0.0",
-            backend=BackendName.FAKE,
             checks=[
                 CheckResult("bypass-disclaimer", ok=True, warn=True, detail="not set"),
                 CheckResult("check-ok", ok=True, warn=False, detail=""),
@@ -1087,7 +1021,6 @@ class TestFormatReportFooter:
         """Any FAIL check → 'status: problems detected'."""
         report = DoctorReport(
             version="0.0.0",
-            backend=BackendName.FAKE,
             checks=[
                 CheckResult("check-fail", ok=False, warn=False, detail="broken"),
             ],
@@ -1100,7 +1033,6 @@ class TestFormatReportFooter:
         """DoctorReport.clean is True only when every check is ok and not warned."""
         report = DoctorReport(
             version="0.0.0",
-            backend=BackendName.FAKE,
             checks=[CheckResult("x", ok=True, warn=False, detail="")],
         )
         assert report.clean is True
@@ -1109,7 +1041,6 @@ class TestFormatReportFooter:
         """DoctorReport.clean is False when any check has warn=True."""
         report = DoctorReport(
             version="0.0.0",
-            backend=BackendName.FAKE,
             checks=[
                 CheckResult("x", ok=True, warn=True, detail=""),
                 CheckResult("y", ok=True, warn=False, detail=""),
@@ -1121,7 +1052,6 @@ class TestFormatReportFooter:
         """DoctorReport.clean is False when any check has ok=False."""
         report = DoctorReport(
             version="0.0.0",
-            backend=BackendName.FAKE,
             checks=[CheckResult("x", ok=False, warn=False, detail="")],
         )
         assert report.clean is False

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -317,6 +317,45 @@ class TestRetireMergedPRs:
 
 
 # ---------------------------------------------------------------------------
+# CLI tests: cw orchestrate retire
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestrateRetireCli:
+    def test_no_sessions_retired(
+        self,
+        tmp_orchestrate_dirs: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """CLI prints 'No sessions retired.' when nothing was retired."""
+        monkeypatch.setattr(
+            "cw.cli.retire_merged_prs",
+            lambda **_kw: [],
+        )
+        cli_runner = CliRunner()
+        result = cli_runner.invoke(main, ["orchestrate", "retire"])
+        assert result.exit_code == 0
+        assert "No sessions retired." in result.output
+
+    def test_sessions_retired_prints_ids(
+        self,
+        tmp_orchestrate_dirs: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """CLI lists retired session IDs when sessions were retired."""
+        monkeypatch.setattr(
+            "cw.cli.retire_merged_prs",
+            lambda **_kw: ["sess-abc", "sess-def"],
+        )
+        cli_runner = CliRunner()
+        result = cli_runner.invoke(main, ["orchestrate", "retire"])
+        assert result.exit_code == 0
+        assert "Retired 2 session(s)" in result.output
+        assert "sess-abc" in result.output
+        assert "sess-def" in result.output
+
+
+# ---------------------------------------------------------------------------
 # Tests: orchestrator_status
 # ---------------------------------------------------------------------------
 

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -11,7 +11,6 @@ import pytest
 from click.testing import CliRunner
 
 from cw.cli import main
-from cw.cmux import FakeCmuxAdapter
 from cw.config import load_state, save_state
 from cw.dev_queue import add_ticket
 from cw.events import read_events, record_event
@@ -59,12 +58,6 @@ def workspace(tmp_path: Path) -> Path:
     ws = tmp_path / "workspace" / "test-project"
     ws.mkdir(parents=True)
     return ws
-
-
-@pytest.fixture
-def adapter() -> FakeCmuxAdapter:
-    """A fresh FakeCmuxAdapter for each test."""
-    return FakeCmuxAdapter()
 
 
 @pytest.fixture
@@ -173,19 +166,16 @@ class TestRetireMergedPRs:
     def test_no_events_returns_empty_list(
         self,
         tmp_orchestrate_dirs: Path,
-        adapter: FakeCmuxAdapter,
         fake_runner: tuple[list[list[str]], object],
     ) -> None:
         """When there are no pr.merged events, retirement is a no-op."""
         _calls, runner = fake_runner
-        retired = retire_merged_prs(adapter=adapter, runner=runner)  # type: ignore[arg-type]
+        retired = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
         assert retired == []
-        assert adapter.calls["close"] == []
 
     def test_retires_correlated_session(
         self,
         tmp_orchestrate_dirs: Path,
-        adapter: FakeCmuxAdapter,
         workspace: Path,
         fake_runner: tuple[list[list[str]], object],
     ) -> None:
@@ -197,7 +187,7 @@ class TestRetireMergedPRs:
         _seed_pr_merged("owner/repo", 42)
 
         calls, runner = fake_runner
-        retired = retire_merged_prs(adapter=adapter, runner=runner)  # type: ignore[arg-type]
+        retired = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
 
         # Returned list contains the session ID.
         assert retired == ["sess0001"]
@@ -216,9 +206,6 @@ class TestRetireMergedPRs:
         assert updated.completed_reason == CompletionReason.HANDOFF
         assert updated.completed_at is not None
 
-        # Cmux surface was closed.
-        assert adapter.calls["close"] == [("pane-7",)]
-
         # session.completed event was emitted.
         events = read_events(event_types=[OrchestratorEventType.SESSION_COMPLETED])
         assert len(events) == 1
@@ -231,7 +218,6 @@ class TestRetireMergedPRs:
     def test_idempotent_second_call_noop(
         self,
         tmp_orchestrate_dirs: Path,
-        adapter: FakeCmuxAdapter,
         workspace: Path,
         fake_runner: tuple[list[list[str]], object],
     ) -> None:
@@ -242,19 +228,18 @@ class TestRetireMergedPRs:
         _seed_pr_merged("owner/repo", 9)
 
         calls, runner = fake_runner
-        first = retire_merged_prs(adapter=adapter, runner=runner)  # type: ignore[arg-type]
+        first = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
         assert first == ["sess0010"]
         assert len(calls) == 1
 
         # Second call: cursor advanced, nothing left to do.
-        second = retire_merged_prs(adapter=adapter, runner=runner)  # type: ignore[arg-type]
+        second = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
         assert second == []
         assert len(calls) == 1  # no additional review-monitor invocations
 
     def test_dispatch_record_entry_removed(
         self,
         tmp_orchestrate_dirs: Path,
-        adapter: FakeCmuxAdapter,
         workspace: Path,
         fake_runner: tuple[list[list[str]], object],
     ) -> None:
@@ -265,7 +250,7 @@ class TestRetireMergedPRs:
         _seed_pr_merged("owner/repo", 11)
 
         _calls, runner = fake_runner
-        retire_merged_prs(adapter=adapter, runner=runner)  # type: ignore[arg-type]
+        retire_merged_prs(runner=runner)  # type: ignore[arg-type]
 
         from cw.pr_responder import load_dispatch_record
 
@@ -275,8 +260,6 @@ class TestRetireMergedPRs:
     def test_no_dispatch_match_only_calls_review_monitor(
         self,
         tmp_orchestrate_dirs: Path,
-        adapter: FakeCmuxAdapter,
-        workspace: Path,
         fake_runner: tuple[list[list[str]], object],
     ) -> None:
         """A merged PR with no correlated sessions still cleans monitor state."""
@@ -284,16 +267,14 @@ class TestRetireMergedPRs:
         _seed_pr_merged("owner/other", 5)
 
         calls, runner = fake_runner
-        retired = retire_merged_prs(adapter=adapter, runner=runner)  # type: ignore[arg-type]
+        retired = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
 
         assert retired == []
         assert len(calls) == 1
-        assert adapter.calls["close"] == []
 
     def test_completed_session_skipped_but_record_dropped(
         self,
         tmp_orchestrate_dirs: Path,
-        adapter: FakeCmuxAdapter,
         workspace: Path,
         fake_runner: tuple[list[list[str]], object],
     ) -> None:
@@ -304,10 +285,9 @@ class TestRetireMergedPRs:
         _seed_pr_merged("owner/repo", 14)
 
         _calls, runner = fake_runner
-        retired = retire_merged_prs(adapter=adapter, runner=runner)  # type: ignore[arg-type]
+        retired = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
 
         assert retired == []
-        assert adapter.calls["close"] == []
 
         from cw.pr_responder import load_dispatch_record
 
@@ -316,7 +296,6 @@ class TestRetireMergedPRs:
     def test_invalid_pr_number_advances_cursor(
         self,
         tmp_orchestrate_dirs: Path,
-        adapter: FakeCmuxAdapter,
         fake_runner: tuple[list[list[str]], object],
     ) -> None:
         """A pr.merged event without a usable pr_number is skipped, cursor advances."""
@@ -326,43 +305,15 @@ class TestRetireMergedPRs:
         )
 
         calls, runner = fake_runner
-        retired = retire_merged_prs(adapter=adapter, runner=runner)  # type: ignore[arg-type]
+        retired = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
 
         assert retired == []
         # review_monitor.py was NOT invoked because pr_number was invalid.
         assert calls == []
 
         # Second call is a no-op (cursor advanced).
-        retired_second = retire_merged_prs(adapter=adapter, runner=runner)  # type: ignore[arg-type]
+        retired_second = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
         assert retired_second == []
-
-    def test_no_matches_skips_platform_adapter_resolution(
-        self,
-        tmp_orchestrate_dirs: Path,
-        monkeypatch: pytest.MonkeyPatch,
-        fake_runner: tuple[list[list[str]], object],
-    ) -> None:
-        """Regression: when no session matches, the adapter factory is not called.
-
-        `RealCmuxAdapter.__init__` crashes on non-Darwin. If
-        `retire_merged_prs` eagerly called `get_cmux_adapter()` before
-        checking whether any sessions needed closing, a Linux user with
-        zero matches would crash even though no adapter work is needed.
-        """
-        from cw import orchestrate as orch
-
-        def _boom() -> None:
-            msg = "RealCmuxAdapter requires macOS"
-            raise CwError(msg)
-
-        monkeypatch.setattr(orch, "get_cmux_adapter", _boom)
-
-        save_state(CwState(sessions=[]))
-        _seed_pr_merged("owner/other", 99)
-
-        _calls, runner = fake_runner
-        retired = orch.retire_merged_prs(runner=runner)  # type: ignore[arg-type]
-        assert retired == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -30,6 +30,7 @@ from cw.models import (
 from cw.native_daemon import FakeNativeDaemonClient
 from cw.reconcile import (
     HEADLESS_TIMEOUT_SECONDS,
+    _claude_agents_json,
     compute_drift,
     reconcile,
     revert_completed_silent_tasks,
@@ -55,6 +56,44 @@ def _mk_session(
         surface_ref=surface_ref,
         started_at=datetime(2026, 4, 19, tzinfo=UTC),
     )
+
+
+def test_claude_agents_json_parses_subprocess_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_claude_agents_json parses the subprocess output and returns a list."""
+    import json as _json
+
+    fake_output = _json.dumps([{"sessionId": "abc12345"}, {"sessionId": "def67890"}])
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> object:
+        class _Result:
+            stdout = fake_output
+            returncode = 0
+
+        return _Result()
+
+    monkeypatch.setattr("cw.reconcile.subprocess.run", _fake_run)
+    result = _claude_agents_json()
+    assert result == [{"sessionId": "abc12345"}, {"sessionId": "def67890"}]
+
+
+def test_claude_agents_json_returns_empty_on_non_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_claude_agents_json returns [] when daemon output is not a list."""
+    import json as _json
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> object:
+        class _Result:
+            stdout = _json.dumps({"error": "not a list"})
+            returncode = 0
+
+        return _Result()
+
+    monkeypatch.setattr("cw.reconcile.subprocess.run", _fake_run)
+    result = _claude_agents_json()
+    assert result == []
 
 
 def test_compute_drift_empty_state_returns_empty_report() -> None:

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
+import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import freezegun
-
-from cw.cmux import FakeCmuxAdapter
 
 if TYPE_CHECKING:
     import pytest
@@ -59,24 +58,18 @@ def _mk_session(
 
 
 def test_compute_drift_empty_state_returns_empty_report() -> None:
-    adapter = FakeCmuxAdapter()
-    daemon = FakeNativeDaemonClient()
     state = CwState()
-    report = compute_drift(state, adapter, daemon)
+    report = compute_drift(state, set())
     assert report.phantom_session_ids == []
 
 
 def test_compute_drift_flags_active_session_with_missing_surface() -> None:
-    adapter = FakeCmuxAdapter()  # no surfaces
-    daemon = FakeNativeDaemonClient()
     state = CwState(sessions=[_mk_session("s1", "missing-ref")])
-    report = compute_drift(state, adapter, daemon)
+    report = compute_drift(state, set())
     assert report.phantom_session_ids == ["s1"]
 
 
 def test_compute_drift_ignores_backgrounded_completed_and_refless() -> None:
-    adapter = FakeCmuxAdapter()
-    daemon = FakeNativeDaemonClient()
     state = CwState(
         sessions=[
             _mk_session("s-bg", "ref1", status=SessionStatus.BACKGROUNDED),
@@ -84,21 +77,19 @@ def test_compute_drift_ignores_backgrounded_completed_and_refless() -> None:
             _mk_session("s-noref", None, status=SessionStatus.ACTIVE),
         ]
     )
-    report = compute_drift(state, adapter, daemon)
+    report = compute_drift(state, set())
     assert report.phantom_session_ids == []
 
 
 def test_compute_drift_respects_live_set() -> None:
-    adapter = FakeCmuxAdapter()
-    daemon = FakeNativeDaemonClient()
-    live_ref = adapter.spawn("ws", "echo hi")  # registers in live set
+    live_ref = "live-short-id"
     state = CwState(
         sessions=[
             _mk_session("alive", live_ref),
             _mk_session("dead", "gone"),
         ]
     )
-    report = compute_drift(state, adapter, daemon)
+    report = compute_drift(state, {live_ref})
     assert report.phantom_session_ids == ["dead"]
 
 
@@ -107,50 +98,50 @@ def test_compute_drift_native_daemon_live_set_counts_as_alive() -> None:
 
     Daemon-origin workers spawned via ``claude --bg`` store the short
     Claude session id as ``surface_ref``. Reconcile must consider them
-    alive via the native roster even though the multiplexer adapter has
-    no record of them.
+    alive via the native roster even though no multiplexer adapter is used.
     """
-    adapter = FakeCmuxAdapter()
     daemon = FakeNativeDaemonClient()
     native_ref = daemon.spawn_bg(cwd=Path("/tmp"), prompt="x")
+    native_live = {native_ref}
     state = CwState(
         sessions=[
             _mk_session("native-alive", native_ref),
             _mk_session("native-dead", "no-such-short-id"),
         ]
     )
-    report = compute_drift(state, adapter, daemon)
+    report = compute_drift(state, native_live)
     assert report.phantom_session_ids == ["native-dead"]
 
 
 def test_compute_drift_empty_live_set_from_both_backends_is_reconciled() -> None:
-    """Both backends empty: every ACTIVE/IDLE session with a surface_ref is
-    phantom. The reconciler trusts the backends; callers who want
-    "don't touch state when backends are down" must guard before calling.
+    """Empty live set: every ACTIVE/IDLE session with a surface_ref is
+    phantom. The reconciler trusts the backend; callers who want
+    "don't touch state when daemon is down" must guard before calling.
     """
-    adapter = FakeCmuxAdapter()
-    daemon = FakeNativeDaemonClient()
     state = CwState(
         sessions=[
             _mk_session("s1", "r1"),
             _mk_session("s2", "r2", status=SessionStatus.IDLE),
         ]
     )
-    report = compute_drift(state, adapter, daemon)
+    report = compute_drift(state, set())
     assert set(report.phantom_session_ids) == {"s1", "s2"}
 
 
 def test_reconcile_marks_phantom_completed_crashed(
     tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """reconcile flips phantom sessions to COMPLETED/CRASHED and persists."""
     state = CwState(sessions=[_mk_session("s1", "missing-ref")])
     save_state(state)
 
-    adapter = FakeCmuxAdapter()
-    daemon = FakeNativeDaemonClient()
-    adapter.spawn("ws", "echo decoy")  # keep live set non-empty to bypass outage guard
-    report = reconcile(adapter, daemon)
+    # Non-empty live set bypasses outage guard; "missing-ref" is still not live.
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
+    report = reconcile()
 
     assert report.phantom_session_ids == ["s1"]
     assert report.phantom_session_names == ["client-a/s1"]
@@ -165,6 +156,7 @@ def test_reconcile_marks_phantom_completed_crashed(
 
 def test_reconcile_reverts_daemon_session_ticket_to_pending(
     tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When a DAEMON session for a ticket is phantom, revert its task."""
     sess = _mk_session("sess-daemon", "dead-ref")
@@ -179,10 +171,12 @@ def test_reconcile_reverts_daemon_session_ticket_to_pending(
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
-    adapter = FakeCmuxAdapter()
-    daemon = FakeNativeDaemonClient()
-    adapter.spawn("ws", "echo decoy")  # non-empty live set bypasses outage guard
-    report = reconcile(adapter, daemon)
+    # Non-empty live set bypasses outage guard; "dead-ref" still isn't live.
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
+    report = reconcile()
 
     assert "TKT-1" in report.reverted_ticket_ids
     queue = load_dev_queue()
@@ -200,6 +194,7 @@ def test_reconcile_reverts_daemon_session_ticket_to_pending(
 
 def test_reconcile_clears_session_id_on_revert(
     tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Revert clears the stamped session_id so respawn gets a clean slate.
 
@@ -222,10 +217,11 @@ def test_reconcile_clears_session_id_on_revert(
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
-    adapter = FakeCmuxAdapter()
-    daemon = FakeNativeDaemonClient()
-    adapter.spawn("ws", "echo decoy")
-    reconcile(adapter, daemon)
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
+    reconcile()
 
     queue = load_dev_queue()
     assert queue.tasks[0].status == QueueItemStatus.PENDING
@@ -234,26 +230,30 @@ def test_reconcile_clears_session_id_on_revert(
 
 def test_reconcile_noop_when_no_phantoms(
     tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    adapter = FakeCmuxAdapter()
-    daemon = FakeNativeDaemonClient()
-    live_ref = adapter.spawn("ws", "echo")
+    live_ref = "alive-short-id"
     sess = _mk_session("alive", live_ref)
     save_state(CwState(sessions=[sess]))
 
-    report = reconcile(adapter, daemon)
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": live_ref}],
+    )
+    report = reconcile()
     assert report.phantom_session_ids == []
     assert report.reverted_ticket_ids == []
 
 
 def test_reconcile_refuses_to_mass_reap_on_empty_live_set(
     tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Transient backend outage: both backends empty, reconcile must abort.
+    """Daemon reachable but returns empty list: guard fires, no sessions reaped.
 
-    Without this guard, a 5-second multiplexer restart (or a missing
-    native roster) during ``cw status`` would mark every ACTIVE session
-    COMPLETED+CRASHED irreversibly.
+    When ``_claude_agents_json`` returns ``[]`` (daemon running but nothing
+    live) and state has ACTIVE/IDLE sessions with surface refs, the outage
+    guard fires and reconcile returns without mutating state.
     """
     state = CwState(
         sessions=[
@@ -263,9 +263,9 @@ def test_reconcile_refuses_to_mass_reap_on_empty_live_set(
     )
     save_state(state)
 
-    adapter = FakeCmuxAdapter()  # empty live set simulates backend outage
-    daemon = FakeNativeDaemonClient()  # native roster also empty
-    report = reconcile(adapter, daemon)
+    # Daemon reachable, empty roster → guard fires (daemon_errored=False)
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", list)
+    report = reconcile()
 
     assert report.phantom_session_ids == []
     assert report.phantom_session_names == []
@@ -279,74 +279,11 @@ def test_reconcile_refuses_to_mass_reap_on_empty_live_set(
         assert s.completed_reason is None
 
 
-def test_compute_drift_flags_idle_session_when_pane_runs_bash() -> None:
-    """Key zombie test: IDLE session whose pane command is 'bash' is flagged phantom."""
-    adapter = FakeCmuxAdapter()
-    ref = adapter.spawn("ws", "claude", "right")
-    adapter.set_pane_command(ref, "bash")
-
-    daemon = FakeNativeDaemonClient()
-    state = CwState(sessions=[_mk_session("zombie", ref, status=SessionStatus.IDLE)])
-    report = compute_drift(state, adapter, daemon)
-    assert "zombie" in report.phantom_session_ids
-
-
-def test_compute_drift_keeps_session_alive_when_pane_runs_cw() -> None:
-    """Session whose pane foreground process is 'cw' (or 'claude') is alive."""
-    adapter = FakeCmuxAdapter()
-    ref = adapter.spawn("ws", "claude", "right")
-    # Default command from spawn is "claude" — leave it unchanged.
-
-    daemon = FakeNativeDaemonClient()
-    state = CwState(sessions=[_mk_session("alive", ref, status=SessionStatus.IDLE)])
-    report = compute_drift(state, adapter, daemon)
-    assert "alive" not in report.phantom_session_ids
-
-
-def test_compute_drift_command_check_empty_does_not_falsely_reap() -> None:
-    """When list_live_surface_commands returns {} (failure), do not reap sessions
-    that are in list_surfaces — fail-open, no false-positive reaping."""
-    adapter = FakeCmuxAdapter()
-    ref = adapter.spawn("ws", "claude", "right")
-    # Simulate a backend failure via the FakeCmuxAdapter fail-mode flag.
-    adapter._commands_fail = True
-
-    daemon = FakeNativeDaemonClient()
-    state = CwState(sessions=[_mk_session("maybe-alive", ref)])
-    report = compute_drift(state, adapter, daemon)
-    # list_surfaces has ref, list_live_surface_commands returned {} → fail-open
-    assert "maybe-alive" not in report.phantom_session_ids
-
-
-def test_reconcile_reaps_bash_pane_zombie_session(
+def test_reconcile_refuses_to_mass_reap_when_daemon_errors(
     tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Full reconcile end-to-end: IDLE session with bash pane is COMPLETED+CRASHED."""
-    adapter = FakeCmuxAdapter()
-    bash_ref = adapter.spawn("ws", "claude", "right")
-    adapter.set_pane_command(bash_ref, "bash")
-    # Add a decoy live surface so outage guard doesn't fire.
-    _decoy_ref = adapter.spawn("ws", "claude", "right")
-
-    sess = _mk_session("zombie-full", bash_ref, status=SessionStatus.IDLE)
-    save_state(CwState(sessions=[sess]))
-
-    daemon = FakeNativeDaemonClient()
-    report = reconcile(adapter, daemon)
-
-    assert "zombie-full" in report.phantom_session_ids
-    reloaded = load_state()
-    s = reloaded.find_by_name_or_id("zombie-full")
-    assert s is not None
-    assert s.status == SessionStatus.COMPLETED
-    assert s.completed_reason == CompletionReason.CRASHED
-
-
-def test_reconcile_outage_guard_still_fires_on_empty_list_surfaces(
-    tmp_config_dir: Path,
-) -> None:
-    """Outage guard: when list_surfaces returns empty and state has live sessions,
-    reconcile returns empty report regardless of list_live_surface_commands content."""
+    """Daemon subprocess error: guard fires, no sessions reaped."""
     state = CwState(
         sessions=[
             _mk_session("s1", "r1"),
@@ -355,37 +292,39 @@ def test_reconcile_outage_guard_still_fires_on_empty_list_surfaces(
     )
     save_state(state)
 
-    adapter = FakeCmuxAdapter()  # empty live set → outage guard fires
-    daemon = FakeNativeDaemonClient()
-    report = reconcile(adapter, daemon)
+    def _boom() -> list[dict[str, object]]:
+        raise subprocess.CalledProcessError(1, ["claude", "agents", "--json"])
+
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", _boom)
+    report = reconcile()
 
     assert report.phantom_session_ids == []
     assert report.phantom_session_names == []
+    assert report.reverted_ticket_ids == []
 
     reloaded = load_state()
     for sid in ("s1", "s2"):
         s = reloaded.find_by_name_or_id(sid)
         assert s is not None
         assert s.status in {SessionStatus.ACTIVE, SessionStatus.IDLE}
+        assert s.completed_reason is None
 
 
-def test_reconcile_with_only_native_live_proceeds(
+def test_reconcile_with_native_live_proceeds(
     tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Non-empty native live set bypasses the outage guard even when the
-    multiplexer is empty.
+    """Non-empty live set from _claude_agents_json bypasses outage guard.
 
-    The outage guard only fires when *both* backends are empty. After the
-    issue #150 migration, dispatched workers register with the native
-    daemon and the multiplexer is empty in normal operation — so a
-    phantom must still be reaped.
+    A phantom session (surface_ref not in live set) is still reaped.
     """
     save_state(CwState(sessions=[_mk_session("dead-native", "missing-short-id")]))
 
-    adapter = FakeCmuxAdapter()  # empty
-    daemon = FakeNativeDaemonClient()
-    daemon.spawn_bg(cwd=Path("/tmp"), prompt="decoy")  # native side non-empty
-    report = reconcile(adapter, daemon)
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
+    report = reconcile()
 
     assert report.phantom_session_ids == ["dead-native"]
 
@@ -441,6 +380,7 @@ def test_reconcile_timed_out_session_reverts_dev_queue_task_to_pending(
 
 def test_reconcile_timed_out_task_revert_called_during_reconcile(
     tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """reconcile() picks up TIMED_OUT session queue revert automatically.
 
@@ -474,11 +414,11 @@ def test_reconcile_timed_out_task_revert_called_during_reconcile(
     )
     save_dev_queue(dev_store)
 
-    # Both backends empty but only TIMED_OUT sessions in state (not ACTIVE/IDLE)
-    # so the backend-outage guard doesn't trip.
-    adapter = FakeCmuxAdapter()
-    daemon = FakeNativeDaemonClient()
-    report = reconcile(adapter, daemon)
+    # No ACTIVE/IDLE sessions with surface_refs, so outage guard doesn't trip
+    # even with an empty live set. Monkeypatch _claude_agents_json to avoid
+    # subprocess.run calls in tests.
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", list)
+    report = reconcile()
 
     assert "43" in report.reverted_ticket_ids
 
@@ -609,6 +549,7 @@ def test_revert_completed_silent_tasks_returns_empty_when_no_match(
 
 def test_reconcile_merges_completed_silent_reverts_into_report(
     tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """reconcile() includes both timed-out and completed-silent reverts."""
     timed_out_session = Session(
@@ -657,9 +598,9 @@ def test_reconcile_merges_completed_silent_reverts_into_report(
     )
     save_dev_queue(dev_store)
 
-    adapter = FakeCmuxAdapter()
-    daemon = FakeNativeDaemonClient()
-    report = reconcile(adapter, daemon)
+    # No ACTIVE/IDLE sessions with surface_refs → outage guard won't trip.
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", list)
+    report = reconcile()
 
     assert "TKT-TO" in report.reverted_ticket_ids
     assert "TKT-CS" in report.reverted_ticket_ids
@@ -982,6 +923,7 @@ def test_revert_stalled_headless_sessions_stops_daemon_surface(
 def test_reconcile_includes_stalled_reverts_in_report(
     tmp_config_dir: Path,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """reconcile() surfaces stalled-session reverts in ReconcileReport."""
     worktree = tmp_path / "wt-rec"
@@ -1004,9 +946,11 @@ def test_reconcile_includes_stalled_reverts_in_report(
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
-    adapter = FakeCmuxAdapter()
+    # After revert_stalled_headless_sessions fires, session becomes TIMED_OUT,
+    # so the outage guard won't trip. Monkeypatch to avoid subprocess.run.
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", list)
     with freezegun.freeze_time(now):
-        report = reconcile(adapter, daemon)
+        report = reconcile()
 
     assert "rec-stalled" in report.reverted_ticket_ids
     store = load_dev_queue()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1289,17 +1289,19 @@ def test_start_session_reaps_phantom_before_existing_check(
         )
     )
 
-    # Inject a daemon with one live session (bypasses outage guard) but
-    # "gone-ref" is not a valid 8-char hex ref, so reconcile treats the
-    # session as phantom (non-hex refs don't appear in native_live set).
-    daemon = FakeNativeDaemonClient()
-    daemon._live.add("00000099")  # keep outage guard from firing
+    # Non-empty live set bypasses outage guard; "gone-ref" is absent so
+    # the phantom session is reaped.
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
 
     monkeypatch.setattr("cw.session._write_hook_context", _noop)
 
     attached: list[str] = []
     monkeypatch.setattr("cw.session._attach_session", attached.append)
 
+    daemon = FakeNativeDaemonClient()
     start_session(sample_client.name, "impl", native_daemon=daemon)
 
     reloaded = load_state()

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -10,7 +10,6 @@ import pytest
 from click.testing import CliRunner
 
 from cw.cli import main
-from cw.cmux import FakeCmuxAdapter
 from cw.config import load_state, save_state
 from cw.exceptions import CwError
 from cw.models import (
@@ -761,10 +760,9 @@ class TestSpawnClose:
         from cw.cli import _spawn_close_impl
 
         sess = self._seed_daemon_session(tmp_path, tmp_config_dir)
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
 
-        _spawn_close_impl(session_id=sess.id, adapter=adapter, native_daemon=daemon)
+        _spawn_close_impl(session_id=sess.id, native_daemon=daemon)
 
         state = load_state()
         closed = state.find_by_name_or_id(sess.id)
@@ -776,22 +774,20 @@ class TestSpawnClose:
     def test_daemon_close_routes_through_native_daemon(
         self, tmp_config_dir: Path, tmp_path: Path
     ) -> None:
-        """DAEMON-origin sessions get stopped via claude stop, not adapter.close."""
+        """DAEMON-origin sessions are stopped via the native daemon client."""
         from cw.cli import _spawn_close_impl
 
         sess = self._seed_daemon_session(tmp_path, tmp_config_dir)
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
 
-        _spawn_close_impl(session_id=sess.id, adapter=adapter, native_daemon=daemon)
+        _spawn_close_impl(session_id=sess.id, native_daemon=daemon)
 
         assert daemon.stop_calls == ["abc12345"]
-        assert adapter.calls["close"] == []
 
-    def test_user_origin_close_routes_through_adapter(
+    def test_user_origin_legacy_surface_ref_skipped(
         self, tmp_config_dir: Path, tmp_path: Path
     ) -> None:
-        """USER-origin sessions still close via the multiplexer adapter."""
+        """USER-origin sessions with legacy surface_ref are logged and skipped."""
         from cw.cli import _spawn_close_impl
 
         workspace = tmp_path / "workspace" / "test-client"
@@ -807,13 +803,17 @@ class TestSpawnClose:
             surface_ref="tmux-pane-7",
         )
         save_state(CwState(sessions=[sess]))
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
 
-        _spawn_close_impl(session_id="user0001", adapter=adapter, native_daemon=daemon)
+        _spawn_close_impl(session_id="user0001", native_daemon=daemon)
 
-        assert adapter.calls["close"] == [("tmux-pane-7",)]
+        # No native daemon stop (not a DAEMON session)
         assert daemon.stop_calls == []
+        # Session still marked COMPLETED
+        state = load_state()
+        closed = state.find_by_name_or_id("user0001")
+        assert closed is not None
+        assert closed.status == SessionStatus.COMPLETED
 
     def test_missing_session_raises_cw_error(
         self, tmp_config_dir: Path, tmp_path: Path
@@ -821,13 +821,10 @@ class TestSpawnClose:
         """spawn close: raises CwError when session_id not found."""
         from cw.cli import _spawn_close_impl
 
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
         error_msg = ""
         try:
-            _spawn_close_impl(
-                session_id="nonexistent", adapter=adapter, native_daemon=daemon
-            )
+            _spawn_close_impl(session_id="nonexistent", native_daemon=daemon)
         except CwError as exc:
             error_msg = str(exc)
         else:
@@ -853,13 +850,10 @@ class TestSpawnClose:
             workspace_path=workspace,
         )
         save_state(CwState(sessions=[sess]))
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
 
         with pytest.raises(CwError, match="already completed"):
-            _spawn_close_impl(
-                session_id="done1234", adapter=adapter, native_daemon=daemon
-            )
+            _spawn_close_impl(session_id="done1234", native_daemon=daemon)
 
     def test_no_surface_ref_skips_backend_close(
         self, tmp_config_dir: Path, tmp_path: Path
@@ -880,12 +874,10 @@ class TestSpawnClose:
             surface_ref=None,
         )
         save_state(CwState(sessions=[sess]))
-        adapter = FakeCmuxAdapter()
         daemon = FakeNativeDaemonClient()
 
-        _spawn_close_impl(session_id="nosurf1", adapter=adapter, native_daemon=daemon)
+        _spawn_close_impl(session_id="nosurf1", native_daemon=daemon)
 
-        assert adapter.calls["close"] == []
         assert daemon.stop_calls == []
         state = load_state()
         closed = state.find_by_name_or_id("nosurf1")


### PR DESCRIPTION
## Summary

- Phase D of multiplexer-removal: strip `MultiplexerAdapter` parameter from `reconcile`, `dispatch`, `doctor`, `orchestrate`, `cli` consumers
- Liveness checks switch to `claude agents --json` + `roster.json` workers (no more pane introspection)
- Net: **-252 lines** (379 insertions, 631 deletions) across 14 files

## Ambiguity dispositions (from session 7a2585cb premise-pending exit)

Per [resolution comment on #167](https://github.com/mattwwarren/claude-workspace/issues/167#issuecomment-4538692796) — design guidance: terminals are dead, daemon is the future. All four ambiguities resolved toward removal:

- **A1** `list_live_surface_commands`: dropped from reconcile consumers (file deletion deferred to #119)
- **A2** `_spawn_close_impl` adapter: full drop; legacy tmux refs handled via warning-and-skip
- **A3** `_check_backend_binary`: deleted outright, not renamed — `_check_daemon_reachable` already covers daemon health
- **A4** `_looks_like_daemon_outage`: new signature `(state, daemon_errored: bool, native_live: set[str])` preserving the CalledProcessError-vs-empty distinction

## Premises verified

- **P1** ✅ `claude agents --json` v2.1.150 returns the documented field set
- **P2** ✅ Phase C (#166) writes daemon short-id as `surface_ref`; `_is_native_surface_ref()` discriminates legacy refs

## Acceptance from #167

- [x] No `MultiplexerAdapter` parameter in `reconcile`, `dispatch`, `doctor`, `orchestrate`, `cli` function signatures
- [x] All call sites use `claude agents --json` and/or `roster.json` for liveness
- [x] Quality gates green (ruff, mypy, 1020 tests pass)
- [x] No regression in dispatch flow

## Out of scope

- File deletion of `cmux.py` / `tmux.py` — #119 (Phase F)
- Legacy `sessions.json` `surface_ref` migration — #119

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest tests/` — 1020 / 1020 pass
- [ ] CI confirms above

Closes #167

🤖 Generated by [Claude Code](https://claude.com/claude-code) via cw auto-dev (session 924ddfea-e70d-4851-b9d7-9d7f0a0e6c3e). Session timed out at Stage 3/4 transition; impl + tests landed on the branch, PR finalized manually.