### PR TITLE
fix(reconcile): 30s spawn grace window prevents same-tick phantom reaping (#271)

### DIFF
--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import json
 import subprocess
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from cw.config import load_state, save_state
@@ -64,6 +64,16 @@ AUTO_DEV_LABEL_PREFIX = "auto-dev/"
 # 626 lines) hit the 30-min cap mid-implementation. Per-ticket / per-tier
 # override mechanism tracked in #265.
 HEADLESS_TIMEOUT_SECONDS = 3600  # 60 minutes
+
+
+# Grace window for a newly-spawned session to register with the daemon
+# (`claude agents --json`). `claude --bg` spawn → daemon roster registration
+# is async; reconciliation that runs in the same dispatch tick as the spawn
+# would otherwise see the session as a phantom and reap it within 1 second.
+# 30 seconds is comfortably above observed registration latency (~0.3-1.5s
+# in dogfooding 2026-05-26) while still bounding how long a genuinely dead
+# session can hide. See GitHub issue #271.
+SPAWN_GRACE_SECONDS = 30
 
 
 # Only these two statuses imply "the daemon should have a live session".
@@ -114,20 +124,27 @@ class ReconcileReport:
 def compute_drift(
     state: CwState,
     native_live: set[str],
+    *,
+    now: datetime | None = None,
 ) -> ReconcileReport:
     """Return a report naming sessions whose surface is no longer live.
 
     An ACTIVE or IDLE session is phantom when:
     - it has a ``surface_ref`` (None means it was never spawned), AND
-    - that ref is not in *native_live*.
+    - that ref is not in *native_live*, AND
+    - its ``started_at`` is older than :data:`SPAWN_GRACE_SECONDS` ago
+      (newly-spawned sessions are still registering with the daemon).
 
     *native_live* is the set of short session IDs reported by
     ``claude agents --json``; callers obtain it via :func:`_claude_agents_json`.
+
+    *now* is injected for testability; defaults to ``datetime.now(UTC)``.
 
     This function does not mutate state. It also does not distinguish
     "backend reports zero live entries" from "backend is unreachable";
     that guard lives in :func:`reconcile`.
     """
+    cutoff = (now or datetime.now(UTC)) - timedelta(seconds=SPAWN_GRACE_SECONDS)
     phantoms: list[str] = []
     for session in state.sessions:
         if session.status not in _LIVE_STATUSES:
@@ -135,6 +152,8 @@ def compute_drift(
         if session.surface_ref is None:
             continue
         if session.surface_ref in native_live:
+            continue
+        if session.started_at > cutoff:
             continue
         phantoms.append(session.id)
     return ReconcileReport(phantom_session_ids=phantoms)
@@ -314,7 +333,7 @@ def reconcile() -> ReconcileReport:
     if _looks_like_daemon_outage(state, daemon_errored, native_live):
         return ReconcileReport(reverted_ticket_ids=stalled_reverted)
 
-    drift = compute_drift(state, native_live)
+    drift = compute_drift(state, native_live, now=now)
     if not drift.phantom_session_ids:
         # No phantom sessions to reap, but still run the TIMED_OUT and
         # COMPLETED-silent sweeps so any tasks whose sessions completed or

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2473,6 +2473,10 @@ class TestShowStatus:
                     status=SessionStatus.ACTIVE,
                     workspace_path=sample_client.workspace_path,
                     surface_ref="impl",
+                    # started_at older than SPAWN_GRACE_SECONDS so reconcile
+                    # treats this session as eligible for phantom-reaping
+                    # (the grace window protects only freshly-spawned sessions).
+                    started_at=datetime(2026, 4, 19, tzinfo=UTC),
                 )
             ]
         )
@@ -2841,6 +2845,9 @@ def test_display_status_reconciles_phantom_active_sessions(
                     status=SessionStatus.ACTIVE,
                     workspace_path=sample_client.workspace_path,
                     surface_ref="gone",
+                    # Older than SPAWN_GRACE_SECONDS so the spawn-grace
+                    # window doesn't protect this from phantom-reaping.
+                    started_at=datetime(2026, 4, 19, tzinfo=UTC),
                 ),
             ]
         )

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -911,6 +912,10 @@ def test_dispatch_tick_reconciles_phantoms_before_counting(
                     status=SessionStatus.ACTIVE,
                     workspace_path=sample_client_config.workspace_path,
                     surface_ref="dead",
+                    # started_at older than SPAWN_GRACE_SECONDS so this
+                    # session is eligible for phantom-reaping rather
+                    # than protected by the grace window.
+                    started_at=datetime(2026, 4, 19, tzinfo=UTC),
                 ),
             ]
         )
@@ -987,6 +992,8 @@ def test_crash_revert_respawn_rejects_old_event_completes_new(
                     status=SessionStatus.ACTIVE,
                     workspace_path=sample_client_config.workspace_path,
                     surface_ref="dead",
+                    # Older than SPAWN_GRACE_SECONDS — phantom-eligible.
+                    started_at=datetime(2026, 4, 19, tzinfo=UTC),
                 ),
             ]
         )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -101,6 +101,9 @@ def test_run_doctor_reap_flag_reconciles_and_reports(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """run_doctor(reap=True) invokes reconcile and reports reaped sessions."""
+    from datetime import UTC
+    from datetime import datetime as _dt
+
     from cw.config import load_state, save_state
     from cw.doctor import run_doctor
     from cw.models import CwState, Session, SessionPurpose, SessionStatus
@@ -116,6 +119,8 @@ def test_run_doctor_reap_flag_reconciles_and_reports(
                     status=SessionStatus.ACTIVE,
                     workspace_path=sample_client.workspace_path,
                     surface_ref="gone",
+                    # Older than SPAWN_GRACE_SECONDS — phantom-eligible.
+                    started_at=_dt(2026, 4, 19, tzinfo=UTC),
                 ),
             ]
         )

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import subprocess
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -30,6 +30,7 @@ from cw.models import (
 from cw.native_daemon import FakeNativeDaemonClient
 from cw.reconcile import (
     HEADLESS_TIMEOUT_SECONDS,
+    SPAWN_GRACE_SECONDS,
     _claude_agents_json,
     compute_drift,
     reconcile,
@@ -43,6 +44,7 @@ def _mk_session(
     sid: str,
     surface_ref: str | None,
     status: SessionStatus = SessionStatus.ACTIVE,
+    started_at: datetime | None = None,
 ) -> Session:
     return Session(
         id=sid,
@@ -54,7 +56,9 @@ def _mk_session(
             name="client-a", workspace_path=Path("/tmp/ws")
         ).workspace_path,
         surface_ref=surface_ref,
-        started_at=datetime(2026, 4, 19, tzinfo=UTC),
+        started_at=(
+            started_at if started_at is not None else datetime(2026, 4, 19, tzinfo=UTC)
+        ),
     )
 
 
@@ -150,6 +154,40 @@ def test_compute_drift_native_daemon_live_set_counts_as_alive() -> None:
     )
     report = compute_drift(state, native_live)
     assert report.phantom_session_ids == ["native-dead"]
+
+
+def test_compute_drift_spawn_grace_window_protects_fresh_sessions() -> None:
+    """Sessions younger than SPAWN_GRACE_SECONDS are not reaped as phantom.
+
+    Regression test for #271: ``claude --bg`` spawn → daemon roster
+    registration is async. A reconcile call in the same dispatch tick as
+    the spawn would otherwise see the not-yet-registered session as a
+    phantom and reap it within 1 second. Real-world latency observed
+    2026-05-26: 0.3-1.5s between spawn and roster registration.
+    """
+    now = datetime(2026, 5, 26, 12, 0, 0, tzinfo=UTC)
+    fresh = _mk_session("fresh", "fresh-ref", started_at=now - timedelta(seconds=2))
+    old = _mk_session("old", "old-ref", started_at=now - timedelta(seconds=120))
+    state = CwState(sessions=[fresh, old])
+
+    # native_live is empty (both refs missing from daemon roster)
+    report = compute_drift(state, set(), now=now)
+
+    # Only the old one is reaped; the fresh one is in the grace window.
+    assert report.phantom_session_ids == ["old"]
+
+
+def test_compute_drift_grace_expires_after_spawn_grace_seconds() -> None:
+    """A session just past SPAWN_GRACE_SECONDS is eligible for phantom-reaping."""
+    now = datetime(2026, 5, 26, 12, 0, 0, tzinfo=UTC)
+    just_expired = _mk_session(
+        "expired",
+        "expired-ref",
+        started_at=now - timedelta(seconds=SPAWN_GRACE_SECONDS + 1),
+    )
+    state = CwState(sessions=[just_expired])
+    report = compute_drift(state, set(), now=now)
+    assert report.phantom_session_ids == ["expired"]
 
 
 def test_compute_drift_empty_live_set_from_both_backends_is_reconciled() -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1273,6 +1273,9 @@ def test_start_session_reaps_phantom_before_existing_check(
         f"    workspace_path: {sample_client.workspace_path}\n"
     )
 
+    from datetime import UTC
+    from datetime import datetime as _dt
+
     save_state(
         CwState(
             sessions=[
@@ -1284,6 +1287,8 @@ def test_start_session_reaps_phantom_before_existing_check(
                     status=SessionStatus.ACTIVE,
                     workspace_path=sample_client.workspace_path,
                     surface_ref="gone-ref",
+                    # Older than SPAWN_GRACE_SECONDS — phantom-eligible.
+                    started_at=_dt(2026, 4, 19, tzinfo=UTC),
                 ),
             ]
         )


### PR DESCRIPTION
## Summary

Closes #271. Adds a 30-second grace window in `compute_drift()` so newly-spawned sessions are not reaped as phantoms before the daemon has registered them in its `claude agents --json` roster.

## Root cause

PR #269 (multiplexer-removal Phase D) switched `reconcile()` from the multiplexer adapter to `claude agents --json` as the sole liveness oracle. But `claude --bg` spawn → daemon registration is async — registration takes ~0.3-1.5s in observed dogfooding. Any dispatch tick that called both `reconcile()` and `spawn_create_impl()` saw the just-spawned session as a phantom and immediately reaped it as crashed.

## Real-world impact (today)

Three parallel-dispatch sessions all reaped within 1.156 seconds of spawn:

```
02:33:42.284Z  session.spawned     session_id=acbdb591  ticket=265
02:33:43.440Z  session.completed   session_id=acbdb591  ticket=265  crashed=True  (1.156s)
02:37:49.818Z  session.spawned     session_id=b7fdde25  ticket=265
02:37:50.700Z  session.completed   session_id=b7fdde25  ticket=265  crashed=True  (0.882s)
02:37:50.365Z  session.spawned     session_id=5b31480f  ticket=270
02:37:50.700Z  session.completed   session_id=5b31480f  ticket=270  crashed=True  (0.335s)
```

Meanwhile the actual claude sessions completed normally and emitted valid sentinels — cw just stopped tracking them.

## Fix

`compute_drift()` skips any session whose `started_at` is within `SPAWN_GRACE_SECONDS = 30`. Caller passes `now` for testability; `reconcile()` threads its own `now` through.

```python
SPAWN_GRACE_SECONDS = 30

def compute_drift(
    state: CwState,
    native_live: set[str],
    *,
    now: datetime | None = None,
) -> ReconcileReport:
    cutoff = (now or datetime.now(UTC)) - timedelta(seconds=SPAWN_GRACE_SECONDS)
    phantoms: list[str] = []
    for session in state.sessions:
        ...
        if session.started_at > cutoff:
            continue  # protected by grace window
        phantoms.append(session.id)
    return ReconcileReport(phantom_session_ids=phantoms)
```

## Test coverage

- `test_compute_drift_spawn_grace_window_protects_fresh_sessions` — fresh session not reaped, old session is
- `test_compute_drift_grace_expires_after_spawn_grace_seconds` — boundary test at grace+1s

Six existing phantom-reaping tests updated to set `started_at` explicitly to a pre-grace-window time so they still exercise the phantom path.

## Acceptance from #271

- [x] Single dispatch: spawn, observe session reaches Stop hook emission without phantom-reap
- [x] Regression test added — fresh-spawn case
- [x] `_looks_like_daemon_outage` still fires when N≥2 long-lived sessions disappear simultaneously (unchanged)
- [ ] Parallel dispatch verified end-to-end (will validate after this lands by re-dispatching #265 + #270)
- [ ] cw event for normal completion has `claude_session_id` and `crashed: false` (will verify post-merge)

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest tests/` — 1022 / 1022 pass
- [ ] CI confirms above
- [ ] Post-merge dogfood: re-dispatch #265 + #270 in parallel, verify both reach Stage 1 sentinel without phantom-reap

🤖 Generated by [Claude Code](https://claude.com/claude-code)