### PR TITLE
fix(reconcile): match short-id surface_ref against UUID-prefix sessionId (#271 follow-up)

### DIFF
--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -321,8 +321,14 @@ def reconcile() -> ReconcileReport:
     )
 
     try:
+        # `claude agents --json` returns sessionId as a full UUID
+        # (e.g. "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"). cw's surface_ref
+        # is the 8-char short id (prefix of the UUID) — same shape
+        # `claude --bg` returns at spawn. Normalize to short id for
+        # comparison; otherwise reconcile sees every native session as a
+        # phantom because UUID != short-id.
         native_live = {
-            sid
+            sid[:8]
             for a in _claude_agents_json()
             if isinstance(sid := a.get("sessionId"), str)
         }

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -156,6 +156,39 @@ def test_compute_drift_native_daemon_live_set_counts_as_alive() -> None:
     assert report.phantom_session_ids == ["native-dead"]
 
 
+def test_reconcile_matches_short_id_against_full_uuid_session_id(
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real `claude agents --json` returns sessionId as a full UUID; cw's
+    surface_ref is the 8-char short id. Reconcile must normalize by slicing
+    the UUID to its first 8 chars so the live-set comparison matches.
+
+    Regression test for the second bug in #271 — the FakeNativeDaemonClient
+    returns short ids, masking the mismatch in compute_drift unit tests.
+    Without this fix, every real daemon session looks phantom and gets
+    reaped right after the spawn grace window expires.
+    """
+    full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
+    short_id = full_uuid[:8]
+
+    # Session in cw state with the short-id surface_ref (Phase C format).
+    state = CwState(sessions=[_mk_session("alive-with-uuid-daemon", short_id)])
+    save_state(state)
+
+    # Real daemon shape: sessionId is the full UUID.
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": full_uuid}],
+    )
+
+    report = reconcile()
+    assert report.phantom_session_ids == [], (
+        "Session whose short-id surface_ref is the prefix of a live "
+        "daemon UUID must not be reaped as phantom"
+    )
+
+
 def test_compute_drift_spawn_grace_window_protects_fresh_sessions() -> None:
     """Sessions younger than SPAWN_GRACE_SECONDS are not reaped as phantom.
 
@@ -309,13 +342,16 @@ def test_reconcile_noop_when_no_phantoms(
     tmp_config_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    live_ref = "alive-short-id"
-    sess = _mk_session("alive", live_ref)
+    # Use a realistic 8-char short id matching cw's _is_native_surface_ref
+    # contract (the daemon would return the full UUID; we'd slice to 8).
+    short_id = "abcd1234"
+    full_uuid = f"{short_id}-1111-2222-3333-444455556666"
+    sess = _mk_session("alive", short_id)
     save_state(CwState(sessions=[sess]))
 
     monkeypatch.setattr(
         "cw.reconcile._claude_agents_json",
-        lambda: [{"sessionId": live_ref}],
+        lambda: [{"sessionId": full_uuid}],
     )
     report = reconcile()
     assert report.phantom_session_ids == []


### PR DESCRIPTION
## Summary

Second regression from #269 multiplexer removal: `claude agents --json` returns sessionId as a full UUID, but cw stores surface_ref as the 8-char short id. The reconcile comparison never matched, so every native daemon session looked phantom right after the spawn grace window from #272 expired.

## Repro

After #272 (30s grace window) landed and was installed, parallel dispatch of #265 + #270 showed:

```
spawned 11:23:31  exited 11:23:58  (#265 — 26.2s; just inside grace window)
spawned 11:23:32  exited 11:24:03  (#270 — 30.4s; just past grace window)
```

Inspection of `claude agents --json` showed both sessions still running with full UUID sessionIds (`04bf1c48-6b3a-401b-bc3a-...`, `a41c898e-4159-4ea0-...`). cw's `surface_ref` for those cw sessions was `04bf1c48` and `a41c898e` — the UUID prefixes.

The comparison `surface_ref in {full_uuid, ...}` always returned False.

## Why unit tests missed it

`FakeNativeDaemonClient.spawn_bg()` returns short ids (8-char). Real `claude agents --json` returns full UUIDs. The existing `test_compute_drift_native_daemon_live_set_counts_as_alive` used the fake, so the mismatch wasn't visible.

## Fix

```python
# Normalize to short id for comparison
native_live = {
    sid[:8]  # was: sid
    for a in _claude_agents_json()
    if isinstance(sid := a.get("sessionId"), str)
}
```

`sid[:8]` is safe — `_is_native_surface_ref` enforces 8-char lowercase hex for the short id, and Python string slicing returns the whole string when the source is shorter. Legacy non-UUID surface_refs still match (they're already 8 chars).

## Test coverage

New `test_reconcile_matches_short_id_against_full_uuid_session_id` — feeds a full UUID through the real-shape path and asserts the session with the 8-char prefix surface_ref is NOT reaped.

Updated `test_reconcile_noop_when_no_phantoms` to use realistic UUID-vs-short-id shapes (previously used 14-char ad-hoc ref that hid the bug).

## Acceptance

- [x] Real UUID sessionId matched against 8-char surface_ref
- [x] All 1023 tests pass locally
- [x] `_is_native_surface_ref` contract (8-char hex) preserved
- [ ] CI confirms above
- [ ] Post-merge: re-dispatch #265 + #270 + #246, verify no phantom-reap

🤖 Generated by [Claude Code](https://claude.com/claude-code)