### PR TITLE
docs(adr): ADR-0003 Stop-hook completion + ADR-0004 stage events

### DIFF
--- a/docs/adr/0003-stop-hook-canonical-completion-signal.md
+++ b/docs/adr/0003-stop-hook-canonical-completion-signal.md
@@ -1,0 +1,135 @@
+# Stop hook is the canonical worker-completion signal
+
+**Status:** Accepted
+**Driven by:** #147 (inject Stop hook for direct completion signal),
+#165 (origin-aware Stop hook + safe `settings.local.json` write),
+#176 (Layer 1 transcript backstop + JSONL sentinel detector),
+#151 (defer when `background_tasks` pending),
+#184 (`cw signal-stop` CLI surface),
+#225 (last-result capture for headless DAEMON sessions).
+**Builds on:** [ADR-0000](0000-native-supervisor-migration.md) — `claude --bg`
+is the daemon-spawn primitive; the wrapper subprocess is no longer in the
+process chain for DAEMON-origin sessions.
+
+## Decision
+
+A daemon-spawned worker signals completion by invoking `cw signal-stop` from
+a Stop hook that cw injects into the worktree before spawn. The hook is the
+canonical signal; the `wrapper.py` sentinel-buffer parse is the legacy
+interactive-pane fallback; `reconcile.py`'s crashed-pane sweep is the
+catch-all backstop. These three layers MUST be considered in this priority
+order — new completion behavior belongs in the Stop hook path.
+
+## Invariant
+
+For every DAEMON-origin Session created by `cw.spawn.spawn_create_impl`:
+
+1. `spawn._write_hook_context` MUST land both files under `<worktree>/.claude/`
+   before the daemon is asked to spawn the worker:
+   - `settings.local.json` configuring a Stop hook → `cw signal-stop`.
+   - `cw-context.json` carrying `session_id`, `session_name`, `client`,
+     `purpose`, `ticket_id`, and `headless`.
+2. `cw signal-stop` MUST be idempotent. A session already in `COMPLETED`,
+   `IDLE`, or `TIMED_OUT` is a no-op.
+3. `cw signal-stop` MUST defer (silent return, no state I/O) when the hook
+   payload's `background_tasks` list is non-empty. Completing here would
+   orphan an in-flight `run_in_background: true` subagent; the Stop hook
+   fires again on the next turn boundary once the background work drains.
+4. When `cw-context.json.headless == true` AND `origin == DAEMON`, the Stop
+   hook MUST NOT transition to `COMPLETED` unless the `<<<AUTO_DEV_RESULT`
+   sentinel is present in Claude's session transcript. Under wall-clock
+   budget → defer. Over budget → transition to `TIMED_OUT` (loud,
+   retry-eligible), revert the owning `TicketTask` from RUNNING → PENDING,
+   and `claude stop` the daemon session.
+5. For `origin == USER` sessions, the Stop hook transitions `ACTIVE → IDLE`
+   only — it MUST NOT emit `SESSION_COMPLETED` (no `TicketTask` to retire)
+   and MUST NOT call `native_daemon.stop`. The `_write_hook_context` path
+   refuses to clobber a pre-existing `settings.local.json` (raises
+   `HookContextConflictError`); USER worktrees may carry user-managed
+   settings.
+
+## What this means for callers
+
+- **`cw.spawn`** is the only place that writes `cw-context.json` and
+  `settings.local.json` for DAEMON sessions. Any future spawn entry point
+  (USER-origin `claude --bg`, future supervisor flows) MUST route through
+  `_write_hook_context` with the correct `origin`. Direct
+  `settings.local.json` writes outside spawn are forbidden — they break the
+  USER-origin safety guarantee.
+- **`cw.cli.signal_stop`** is the single entry point for the hook. The
+  layered model (idempotency → `background_tasks` defer → USER carve-out →
+  headless transcript backstop → COMPLETED transition) is encoded here in
+  this order. New completion semantics belong in this function, not in
+  callers reading `last_result`.
+- **`cw.reconcile`** MUST NOT reap sessions whose status is already
+  `TIMED_OUT` (carve-out introduced by #176 Layer 1) and MUST honor parked
+  statuses (per [ADR-0001](0001-parked-tasks-pin-their-session.md)). The
+  reconciler stays the backstop for genuinely crashed processes; it does
+  not race the Stop hook on healthy exits.
+- **`cw.wrapper.signal_completed`** remains the buffer-parse fallback for
+  interactive panes that still run under `cw run-claude`. DAEMON-origin
+  spawns bypass the wrapper entirely (ADR-0000) — wrapper parse never
+  fires for them. New work targeting DAEMON sessions MUST NOT depend on
+  wrapper-side capture.
+
+## What this means for producers
+
+- The `/auto-dev` skill MUST emit its `<<<AUTO_DEV_RESULT…>>>` sentinel
+  before its final agent turn ends. The Stop hook's Layer-1 transcript
+  walk (`_parse_sentinel_from_transcript`) reads from
+  `~/.claude/projects/<encoded-cwd>/<claude-session-id>.jsonl`; the
+  sentinel must be in that JSONL before the turn ends or the budget gate
+  trips.
+- Any skill that schedules `run_in_background: true` subagents MUST allow
+  the parent's turn to end normally — do not `claude stop` from within the
+  subagent. The Stop hook's `background_tasks` defer relies on the natural
+  turn cycle to fire again once the subagent's result arrives as the
+  parent's next turn.
+
+## Consequences
+
+- `<worktree>/.claude/cw-context.json` becomes a per-worktree identity
+  artifact that the worker reads from its own filesystem. Worktrees are no
+  longer disposable mid-session — clobbering or relocating one breaks the
+  Stop hook for that session. Accepted: the worktree was already the
+  source of truth post-ADR-0000; the artifact just makes the dependency
+  explicit.
+- `signal_stop` in `cli.py` is ~210 lines including comments. Each
+  deferral / branch covers an independent failure mode (subagent orphan,
+  USER-origin noise, headless silent-success) documented inline. Folding
+  the branches would couple invariants whose failure modes are unrelated.
+- A user who deletes `<worktree>/.claude/settings.local.json` after spawn
+  disables the hook for that session. cw treats this as user error:
+  reconcile will eventually mark the session CRASHED and revert its
+  `TicketTask` to PENDING. No silent recovery, but also no silent wedge.
+- For headless sessions, capture of the parsed sentinel into
+  `Session.last_result` moved from `wrapper.signal_completed` into
+  `signal_stop` itself (#225). Consumers reading `last_result`
+  (`consume_completed_sessions`, `/cw-followup`) work unchanged; only the
+  capture site changed.
+
+## Alternatives considered
+
+- **Continue parsing the wrapper buffer for daemon sessions.** Rejected.
+  `claude --bg` runs the worker under the per-user supervisor (ADR-0000),
+  so there is no `cw run-claude` in the process chain — the buffer does
+  not exist. An out-of-process tail of supervisor stdout was prototyped
+  (issue #133) and rejected as fragile under ANSI/streaming edge cases
+  later confirmed by #203.
+- **Poll `claude agents --json` for completion status.** Rejected as the
+  canonical signal: it reports `idle`/`completed`/`failed`, which is
+  *liveness*, not *outcome*. It cannot tell `shipped` from `no_op` from
+  `blocked` — those live in the sentinel. Used inside reconcile as the
+  liveness backstop, but not the primary signal.
+- **Pass identity via env vars to the worker instead of `cw-context.json`.**
+  Rejected. `claude --bg` does not propagate the caller's environment to
+  the supervisor-owned process (issue #133); a filesystem artifact is the
+  only reliable channel.
+- **Fold the three deferral guards into one.** Rejected. Idempotency,
+  `background_tasks`, and headless-budget catch independent failure modes.
+  Folding `background_tasks` into the headless backstop, for example,
+  would orphan subagents in non-headless DAEMON sessions.
+
+## Referenced by
+
+- #147, #151, #165, #176, #184, #225, ADR-0002

--- a/docs/adr/0004-stage-events-on-orchestrator-bus.md
+++ b/docs/adr/0004-stage-events-on-orchestrator-bus.md
@@ -1,0 +1,97 @@
+# Stage-transition events on the orchestrator event bus
+
+**Status:** Accepted
+**Driven by:** #173 (event taxonomy + `last_stage` derivation), #213 (rollup PR)
+**Builds on:** [`docs/headless-contract.md`](../headless-contract.md) §10
+(stage event taxonomy), [`docs/events.md`](../events.md) (event-bus
+storage and CLI).
+
+## Decision
+
+The `/auto-dev` skill emits `stage.entered` and `stage.errored` events on
+the existing orchestrator event bus (`OrchestratorEventType.STAGE_ENTERED`
+/ `STAGE_ERRORED`) at each stage boundary while running headless. cw
+consumers derive a per-session `last_stage` by walking `STAGE_ENTERED`
+events only — `STAGE_ERRORED` is observability-only and never redefines
+the current stage.
+
+## Invariant
+
+For every event recorded with type `STAGE_ENTERED` or `STAGE_ERRORED`:
+
+1. The `payload.stage` value MUST be one of the closed enum in
+   [headless-contract §10.2](../headless-contract.md#102-stage-identifiers-closed-enum)
+   (`s0_intake` … `done`). Unknown stages are a producer bug; consumers
+   that gate on stage MUST tolerate them by treating the event as
+   `last_stage = None` rather than crashing.
+2. `STAGE_ERRORED.payload.error_kind` is an *open* enum — consumers MUST
+   accept unknown values without crashing.
+3. `cw.orchestrate._derive_last_stage_by_session` MUST ignore
+   `STAGE_ERRORED` when computing `last_stage`. A transient `agent_block`
+   that the skill later recovers from MUST NOT displace the real current
+   stage in the operator-facing rollup.
+4. `last_stage` is a *render-time derivation*, NOT a persisted field on
+   the `Session`. The event log is the source of truth. If events are
+   pruned, `last_stage` correctly reverts to `None`.
+
+## What this means for callers
+
+- **`cw orchestrate status`** (CLI text) and **`cw orchestrate watch`**
+  (TUI) read `SessionSummary.last_stage`, which is populated from
+  `_derive_last_stage_by_session` at status-snapshot time. Both surfaces
+  must tolerate `None` (sessions with no stage events render as `—`).
+- **Future stage-aware surfaces** (e.g. a notification when
+  `s3_review_complete` is reached, or a dashboard heatmap) MUST consume
+  `STAGE_ENTERED` from the event log via `read_events` + cursor
+  advancement, identical to how the daemon already consumes PR events.
+  They MUST NOT cache stage state on the Session model.
+
+## What this means for producers
+
+- The `/auto-dev` skill (in `mattwwarren/global-claude`) MUST emit
+  `stage.entered` at each transition, with `session_id` set to
+  `$CW_SESSION_ID` and `ticket_id` matching the run. Emission goes
+  through `cw event record stage.entered --payload '…'` — see
+  [headless-contract §10.4](../headless-contract.md#104-producer-invocation).
+- `stage.errored` is reserved for transient setbacks (agent_block, parse
+  failure) that do NOT end the run. A run-ending failure still emits the
+  canonical `<<<AUTO_DEV_RESULT` sentinel with `status: blocked` per §3 —
+  stage events do not replace the sentinel.
+
+## Consequences
+
+- The event log grows linearly with stage transitions: ~10 stages × 1
+  transition each × N daily tickets. Well below the PR-event volume the
+  bus already carries; no pruning needed in the foreseeable horizon.
+- A producer that lies about its `prev_stage` (emits `s4_pr_created`
+  immediately after `s0_intake`) is accepted by the consumer — the enum
+  is validated, the sequence is not. Worth it: enforcing sequence in cw
+  would require duplicating the skill's state machine across repos.
+- The producer lives in `global-claude` while the consumer lives in cw.
+  Any change to the stage enum (§10.2) requires coordinated PRs in both
+  repos. The closed enum is the only schema field with this constraint;
+  payload additions (e.g. new optional fields) are non-breaking.
+
+## Alternatives considered
+
+- **Dedicated stage channel separate from the orchestrator bus.**
+  Rejected. The bus already handles correlation IDs, cursors, and
+  multi-consumer reads; a parallel channel would duplicate infrastructure
+  for a small event volume.
+- **Persist `last_stage` directly on the `Session` model.** Rejected.
+  Stage transitions arrive from the headless worker out-of-process.
+  Updating the Session each transition either requires the producer to
+  hold a state-write capability (defeats the event-log model) or a
+  consumer bridge that writes events → state (defeats the
+  derive-at-render simplicity). Render-time derivation keeps `state.json`
+  small and stage logic in one place.
+- **Use `STAGE_ERRORED` to update `last_stage`.** Rejected. A producer
+  that hits a transient block at `s2_impl_started` and recovers would
+  briefly render as "errored at s2" before re-entering — confusing for
+  operators glancing at the dashboard. `STAGE_ERRORED` belongs in
+  `recent_events` and `cw event tail --type stage.errored` for
+  diagnosis, not in the current-stage rollup.
+
+## Referenced by
+
+- #173, #213

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,7 +45,8 @@ When an ADR is superseded, edit the old one's status line — don't delete it.
 | [0000](0000-native-supervisor-migration.md) | Migrate session lifecycle to `claude --bg` + supervisor | Accepted |
 | [0001](0001-parked-tasks-pin-their-session.md) | Parked tasks pin their Session | Accepted |
 | [0002](0002-blocker-retry-policy-pair.md) | Blocker carries an explicit retry policy | Accepted |
+| [0003](0003-stop-hook-canonical-completion-signal.md) | Stop hook is the canonical worker-completion signal | Accepted |
+| [0004](0004-stage-events-on-orchestrator-bus.md) | Stage-transition events on the orchestrator event bus | Accepted |
 
 ADR-0000 is the foundational record — the trajectory it captures is
-assumed as ground truth by every subsequent ADR. Future ADRs start
-at 0002 and number sequentially.
+assumed as ground truth by every subsequent ADR.

--- a/docs/events.md
+++ b/docs/events.md
@@ -142,6 +142,46 @@ A monitored PR was merged.
 }
 ```
 
+### `stage.entered`
+
+The headless `/auto-dev` worker entered a new stage of its pipeline. Used
+by `cw orchestrate status` / `watch` to derive a per-session `last_stage`
+display. Producer contract is in
+[`headless-contract.md` §10](headless-contract.md#10-stage-event-taxonomy-producer-contract);
+the invariant that `STAGE_ERRORED` does not redefine `last_stage` is
+captured in [ADR-0004](adr/0004-stage-events-on-orchestrator-bus.md).
+
+```json
+{
+  "session_id": "<str>",
+  "ticket_id": "<str>",
+  "stage": "s2_impl_started",
+  "prev_stage": "s1_plan_reviewed",
+  "started_at": "2026-05-23T13:01:42Z"
+}
+```
+
+`stage` and `prev_stage` MUST match the closed enum in headless-contract
+§10.2 (`s0_intake` … `done`).
+
+### `stage.errored`
+
+The headless `/auto-dev` worker hit a transient error inside a stage. The
+worker may recover and continue. Visible in `cw event tail` and
+`recent_events`; deliberately does NOT update `last_stage` (per ADR-0004).
+
+```json
+{
+  "session_id": "<str>",
+  "ticket_id": "<str>",
+  "stage": "s2_impl_started",
+  "error_kind": "agent_block",
+  "started_at": "2026-05-23T13:04:11Z"
+}
+```
+
+`error_kind` is an open enum — consumers MUST tolerate unknown values.
+
 ## CLI
 
 ### Record an event


### PR DESCRIPTION
## Summary

Documentation sweep — captures two architectural decisions made during the recent
rapid-development phase that weren't yet codified as ADRs, and brings `docs/events.md`
back in sync with the code.

- **ADR-0003: Stop hook is the canonical worker-completion signal**
  - Establishes the 3-layer detection model: Stop hook (canonical) → wrapper-buffer
    sentinel parse (legacy interactive fallback) → reconcile crashed-pane sweep (backstop).
  - Captures sub-invariants: idempotency guard, `background_tasks` deferral,
    headless-transcript backstop, USER-vs-DAEMON origin behavior.
  - Folds in `cw-context.json` as the per-worktree identity artifact.
  - Cites driving issues: #147, #151, #165, #176, #184, #225.

- **ADR-0004: Stage-transition events on the orchestrator event bus**
  - Establishes the `stage.entered` / `stage.errored` taxonomy and the
    "STAGE_ERRORED does not redefine `last_stage`" invariant.
  - Closes the loop with `headless-contract.md` §10 (producer side) and
    `_derive_last_stage_by_session` (consumer side).
  - Cites #173 and #213.

- **`docs/events.md` sync**
  - Adds missing `stage.entered` and `stage.errored` sections; was out-of-sync
    after the #173/#213 merges landed the event types in code without doc updates.

- **ADR README index** gains the two new entries; drops the stale
  "future ADRs start at 0002" sentence.

## Test plan

- [x] Docs-only diff — no code touched
- [x] Pre-commit hooks (pytest) passed on commit + push
- [x] Internal links checked: ADR-0003 → ADR-0000/0001, ADR-0004 → headless-contract §10,
      events.md → ADR-0004 and headless-contract §10
- [x] Invariants verified against current code (cli.py:signal_stop, spawn.py,
      orchestrate.py:_derive_last_stage_by_session, models.py STAGE_*)

Generated with [Claude Code](https://claude.com/claude-code)