### PR TITLE
ci(nightly,release): install [mcp] extra so pr-events tests run

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
         run: uv python install 3.13
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --dev --extra mcp
 
       - name: Install cmux
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: brew install tmux
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --dev --extra mcp
 
       - name: Verify version matches tag
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #282 which added `--extra mcp` to `ci.yml`. `nightly.yml` and `release.yml` both run pytest and would hit the same `ModuleNotFoundError: No module named 'starlette'` failure on their next run without this change.

## Test plan

- [x] Local: `uv sync --dev --extra mcp` succeeds
- [x] Local: `uv run pytest tests/test_cw_pr_events_server.py` passes (21/21)
- [ ] Nightly workflow next run is green
- [ ] Release workflow validated on next tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)