### PR TITLE
feat(pr-channel): durable persist-on-emit with cursor replay (#139)

### DIFF
--- a/src/cw/cw_pr_events_server.py
+++ b/src/cw/cw_pr_events_server.py
@@ -16,6 +16,8 @@ from starlette.applications import Starlette
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Mount, Route
 
+from cw.config import state_dir
+
 if TYPE_CHECKING:
     from starlette.requests import Request
 
@@ -52,7 +54,7 @@ _subscribers: list[queue.SimpleQueue[dict[str, Any]]] = []
 
 _file_lock = threading.Lock()
 _cursors: dict[str, int] = {}
-_event_offset: int = 0
+_event_offset: list[int] = [0]
 
 
 def subscribe() -> queue.SimpleQueue[dict[str, Any]]:
@@ -73,53 +75,51 @@ def unsubscribe(q: queue.SimpleQueue[dict[str, Any]]) -> None:
 
 def _append_event(notification: dict[str, Any]) -> None:
     """Persist notification to channel-events.jsonl with a monotonic offset."""
-    from cw.config import state_dir  # noqa: PLC0415
-
-    global _event_offset  # noqa: PLW0603
     with _file_lock:
         path = state_dir() / "channel-events.jsonl"
         path.parent.mkdir(parents=True, exist_ok=True)
-        record = {**notification, "offset": _event_offset}
+        record = {**notification, "offset": _event_offset[0]}
         with path.open("a") as f:
             f.write(json.dumps(record) + "\n")
             f.flush()
-        _event_offset += 1
+        _event_offset[0] += 1
 
 
 def _read_events_from_offset(from_offset: int) -> list[dict[str, Any]]:
     """Read all events with offset >= from_offset from channel-events.jsonl."""
-    from cw.config import state_dir  # noqa: PLC0415
-
-    path = state_dir() / "channel-events.jsonl"
-    if not path.exists():
-        return []
-    results: list[dict[str, Any]] = []
-    for raw_line in path.read_text().splitlines():
-        stripped = raw_line.strip()
-        if not stripped:
-            continue
-        try:
-            record: dict[str, Any] = json.loads(stripped)
-        except json.JSONDecodeError:
-            logger.warning(
-                "channel-events.jsonl: skipping malformed line: %r", stripped
-            )
-            continue
-        if record.get("offset", -1) >= from_offset:
-            results.append(record)
-    return results
+    with _file_lock:
+        path = state_dir() / "channel-events.jsonl"
+        if not path.exists():
+            return []
+        results: list[dict[str, Any]] = []
+        for raw_line in path.read_text().splitlines():
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            try:
+                record: dict[str, Any] = json.loads(stripped)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "channel-events.jsonl: skipping malformed line: %r", stripped
+                )
+                continue
+            if record.get("offset", -1) >= from_offset:
+                results.append(record)
+        return results
 
 
 def _load_cursors() -> dict[str, int]:
     """Load per-subscriber cursors from disk."""
-    from cw.config import state_dir  # noqa: PLC0415
-
     with _file_lock:
         path = state_dir() / "channel-cursors.json"
         if not path.exists():
             return {}
         try:
-            return json.loads(path.read_text())  # type: ignore[no-any-return]
+            data = json.loads(path.read_text())
+            if not isinstance(data, dict):
+                logger.warning("channel-cursors.json: unexpected shape, ignoring")
+                return {}
+            return {str(k): int(v) for k, v in data.items()}
         except json.JSONDecodeError:
             logger.warning("channel-cursors.json: corrupt, ignoring")
             return {}
@@ -127,8 +127,6 @@ def _load_cursors() -> dict[str, int]:
 
 def _load_offset_from_file() -> int:
     """Determine current offset from channel-events.jsonl on disk."""
-    from cw.config import state_dir  # noqa: PLC0415
-
     with _file_lock:
         path = state_dir() / "channel-events.jsonl"
         if not path.exists():
@@ -161,8 +159,6 @@ def subscribe_with_cursor(client_id: str) -> queue.SimpleQueue[dict[str, Any]]:
 
 def ack_offset(client_id: str, offset: int) -> None:
     """Advance the per-subscriber cursor and persist to disk."""
-    from cw.config import state_dir  # noqa: PLC0415
-
     with _file_lock:
         _cursors[client_id] = offset
         path = state_dir() / "channel-cursors.json"
@@ -219,6 +215,10 @@ async def handle_post_ack(request: Request) -> Response:
         return JSONResponse({"error": msg}, status_code=400)
     ack_offset(req.client_id, req.offset)
     return JSONResponse({"status": "ok"})
+
+
+_cursors.update(_load_cursors())
+_event_offset[0] = _load_offset_from_file()
 
 
 def make_app() -> Starlette:

--- a/src/cw/cw_pr_events_server.py
+++ b/src/cw/cw_pr_events_server.py
@@ -8,6 +8,7 @@ import logging
 import os
 import queue
 import threading
+import urllib.parse
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field, field_validator
@@ -41,8 +42,17 @@ class PREventRequest(BaseModel):
         return v
 
 
+class AckRequest(BaseModel):
+    client_id: str
+    offset: int
+
+
 _lock = threading.Lock()
 _subscribers: list[queue.SimpleQueue[dict[str, Any]]] = []
+
+_file_lock = threading.Lock()
+_cursors: dict[str, int] = {}
+_event_offset: int = 0
 
 
 def subscribe() -> queue.SimpleQueue[dict[str, Any]]:
@@ -61,9 +71,109 @@ def unsubscribe(q: queue.SimpleQueue[dict[str, Any]]) -> None:
     logger.info("pr-events subscriber removed, total=%d", len(_subscribers))
 
 
+def _append_event(notification: dict[str, Any]) -> None:
+    """Persist notification to channel-events.jsonl with a monotonic offset."""
+    from cw.config import state_dir  # noqa: PLC0415
+
+    global _event_offset  # noqa: PLW0603
+    with _file_lock:
+        path = state_dir() / "channel-events.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = {**notification, "offset": _event_offset}
+        with path.open("a") as f:
+            f.write(json.dumps(record) + "\n")
+            f.flush()
+        _event_offset += 1
+
+
+def _read_events_from_offset(from_offset: int) -> list[dict[str, Any]]:
+    """Read all events with offset >= from_offset from channel-events.jsonl."""
+    from cw.config import state_dir  # noqa: PLC0415
+
+    path = state_dir() / "channel-events.jsonl"
+    if not path.exists():
+        return []
+    results: list[dict[str, Any]] = []
+    for raw_line in path.read_text().splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        try:
+            record: dict[str, Any] = json.loads(stripped)
+        except json.JSONDecodeError:
+            logger.warning(
+                "channel-events.jsonl: skipping malformed line: %r", stripped
+            )
+            continue
+        if record.get("offset", -1) >= from_offset:
+            results.append(record)
+    return results
+
+
+def _load_cursors() -> dict[str, int]:
+    """Load per-subscriber cursors from disk."""
+    from cw.config import state_dir  # noqa: PLC0415
+
+    with _file_lock:
+        path = state_dir() / "channel-cursors.json"
+        if not path.exists():
+            return {}
+        try:
+            return json.loads(path.read_text())  # type: ignore[no-any-return]
+        except json.JSONDecodeError:
+            logger.warning("channel-cursors.json: corrupt, ignoring")
+            return {}
+
+
+def _load_offset_from_file() -> int:
+    """Determine current offset from channel-events.jsonl on disk."""
+    from cw.config import state_dir  # noqa: PLC0415
+
+    with _file_lock:
+        path = state_dir() / "channel-events.jsonl"
+        if not path.exists():
+            return 0
+        max_offset = -1
+        for raw_line in path.read_text().splitlines():
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            try:
+                record: dict[str, Any] = json.loads(stripped)
+                offset = record.get("offset", -1)
+                if isinstance(offset, int) and offset > max_offset:
+                    max_offset = offset
+            except json.JSONDecodeError:
+                continue
+        return max_offset + 1
+
+
+def subscribe_with_cursor(client_id: str) -> queue.SimpleQueue[dict[str, Any]]:
+    """Subscribe and replay any missed events since the client's last cursor."""
+    q = subscribe()  # acquires+releases _lock (FIRST)
+    with _file_lock:  # acquires+releases _file_lock (AFTER)
+        cursor = _cursors.get(client_id, 0)
+    missed = _read_events_from_offset(cursor)
+    for record in missed:
+        q.put_nowait(record)
+    return q
+
+
+def ack_offset(client_id: str, offset: int) -> None:
+    """Advance the per-subscriber cursor and persist to disk."""
+    from cw.config import state_dir  # noqa: PLC0415
+
+    with _file_lock:
+        _cursors[client_id] = offset
+        path = state_dir() / "channel-cursors.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(_cursors))
+
+
 def broadcast(notification: dict[str, Any]) -> None:
     """Fan-out notification to all subscriber queues."""
-    with _lock:
+    _append_event(notification)  # FIRST: persist (file_lock only)
+    with _lock:  # THEN: get subscribers
         subs = list(_subscribers)
     for s in subs:
         s.put_nowait(notification)
@@ -98,6 +208,19 @@ async def handle_post_pr_event(request: Request) -> Response:
     return JSONResponse({"status": "ok"})
 
 
+async def handle_post_ack(request: Request) -> Response:
+    """Handle POST /ack: advance per-subscriber cursor."""
+    try:
+        body = await request.json()
+        req = AckRequest.model_validate(body)
+    except (ValueError, TypeError) as exc:
+        msg = str(exc)
+        logger.warning("ack rejected: %s", msg)
+        return JSONResponse({"error": msg}, status_code=400)
+    ack_offset(req.client_id, req.offset)
+    return JSONResponse({"status": "ok"})
+
+
 def make_app() -> Starlette:
     """Build and return the Starlette ASGI app with MCP SSE + /pr-event route."""
     import anyio  # noqa: PLC0415
@@ -114,7 +237,12 @@ def make_app() -> Starlette:
     ) -> None:
         async with sse.connect_sse(scope, receive, send) as streams:
             read_stream, write_stream = streams
-            q = subscribe()
+            query = urllib.parse.parse_qs(scope.get("query_string", b"").decode())
+            client_id_list = query.get("client_id", [])
+            if client_id_list:
+                q = subscribe_with_cursor(client_id_list[0])
+            else:
+                q = subscribe()
             try:
                 async with anyio.create_task_group() as tg:
                     tg.start_soon(
@@ -154,6 +282,7 @@ def make_app() -> Starlette:
             Mount("/sse", app=_sse_asgi),
             Mount("/messages", app=sse.handle_post_message),
             Route("/pr-event", handle_post_pr_event, methods=["POST"]),
+            Route("/ack", handle_post_ack, methods=["POST"]),
         ]
     )
 

--- a/src/cw/cw_pr_events_server.py
+++ b/src/cw/cw_pr_events_server.py
@@ -16,6 +16,7 @@ from starlette.applications import Starlette
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Mount, Route
 
+from cw.atomic import atomic_write_text
 from cw.config import state_dir
 
 if TYPE_CHECKING:
@@ -163,7 +164,7 @@ def ack_offset(client_id: str, offset: int) -> None:
         _cursors[client_id] = offset
         path = state_dir() / "channel-cursors.json"
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(_cursors))
+        atomic_write_text(path, json.dumps(_cursors))
 
 
 def broadcast(notification: dict[str, Any]) -> None:

--- a/tests/test_cw_pr_events_server.py
+++ b/tests/test_cw_pr_events_server.py
@@ -486,3 +486,65 @@ class TestDurableReplay:
             assert {item["offset"] for item in items} == {0, 1, 2, 3, 4}
         finally:
             unsubscribe(q)
+
+
+class TestLoadCursors:
+    def test_returns_empty_for_missing_file(self) -> None:
+        from cw.cw_pr_events_server import _load_cursors
+
+        result = _load_cursors()
+        assert result == {}
+
+    def test_returns_persisted_cursors(self) -> None:
+        from cw.config import state_dir
+        from cw.cw_pr_events_server import _load_cursors
+
+        path = state_dir() / "channel-cursors.json"
+        path.write_text(json.dumps({"sub-x": 5, "sub-y": 12}))
+        result = _load_cursors()
+        assert result == {"sub-x": 5, "sub-y": 12}
+
+    def test_returns_empty_on_corrupt_file(self) -> None:
+        from cw.config import state_dir
+        from cw.cw_pr_events_server import _load_cursors
+
+        path = state_dir() / "channel-cursors.json"
+        path.write_text("not-json")
+        result = _load_cursors()
+        assert result == {}
+
+
+class TestLoadOffsetFromFile:
+    def test_returns_zero_for_missing_file(self) -> None:
+        from cw.cw_pr_events_server import _load_offset_from_file
+
+        result = _load_offset_from_file()
+        assert result == 0
+
+    def test_returns_max_offset_plus_one(self) -> None:
+        from cw.cw_pr_events_server import _append_event, _load_offset_from_file
+
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "a", "title": "a"}
+        )
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "b", "title": "b"}
+        )
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "c", "title": "c"}
+        )
+        result = _load_offset_from_file()
+        assert result == 3
+
+    def test_skips_malformed_lines(self) -> None:
+        from cw.config import state_dir
+        from cw.cw_pr_events_server import _append_event, _load_offset_from_file
+
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "a", "title": "a"}
+        )
+        path = state_dir() / "channel-events.jsonl"
+        with path.open("a") as f:
+            f.write("bad-json\n")
+        result = _load_offset_from_file()
+        assert result == 1

--- a/tests/test_cw_pr_events_server.py
+++ b/tests/test_cw_pr_events_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import queue
+import threading
 from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
@@ -26,6 +27,7 @@ from cw.cw_pr_events_server import (  # noqa: E402
     make_app,
     serve,
     subscribe,
+    subscribe_with_cursor,
     unsubscribe,
 )
 
@@ -38,6 +40,18 @@ def _reset_subscribers() -> Generator[None]:
     yield
     with _server_mod._lock:
         _server_mod._subscribers.clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_channel_state() -> Generator[None]:
+    """Reset durable-replay in-memory state between tests."""
+    with _server_mod._file_lock:
+        _server_mod._cursors.clear()
+        _server_mod._event_offset = 0
+    yield
+    with _server_mod._file_lock:
+        _server_mod._cursors.clear()
+        _server_mod._event_offset = 0
 
 
 class TestPREventPayloadValidation:
@@ -196,3 +210,279 @@ class TestCLIPrChannel:
             result = runner.invoke(main, ["pr-channel", "serve", "--port", "9123"])
         assert result.exit_code == 0
         mock_serve.assert_called_once_with(host="127.0.0.1", port=9123)
+
+
+class TestAppendEvent:
+    def test_appends_to_jsonl_file(self) -> None:
+        from cw.config import state_dir
+        from cw.cw_pr_events_server import _append_event
+
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "m", "title": "t"}
+        )
+        path = state_dir() / "channel-events.jsonl"
+        assert path.exists()
+        lines = path.read_text().splitlines()
+        assert len(lines) == 1
+
+    def test_offset_increments_monotonically(self) -> None:
+        from cw.cw_pr_events_server import _append_event
+
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "m", "title": "t"}
+        )
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "m2", "title": "t2"}
+        )
+        assert _server_mod._event_offset == 2
+
+    def test_record_contains_offset_field(self) -> None:
+        from cw.config import state_dir
+        from cw.cw_pr_events_server import _append_event
+
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "m", "title": "t"}
+        )
+        path = state_dir() / "channel-events.jsonl"
+        record = json.loads(path.read_text().splitlines()[0])
+        assert record["offset"] == 0
+
+    def test_thread_safe_under_concurrent_appends(self) -> None:
+        from cw.config import state_dir
+        from cw.cw_pr_events_server import _append_event
+
+        def worker() -> None:
+            _append_event(
+                {"notification_type": "cw-pr-event", "message": "x", "title": "x"}
+            )
+
+        threads = [threading.Thread(target=worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        path = state_dir() / "channel-events.jsonl"
+        lines = path.read_text().splitlines()
+        assert len(lines) == 10
+        records = [json.loads(line) for line in lines]
+        offsets = {r["offset"] for r in records}
+        assert len(offsets) == 10  # all unique
+
+
+class TestReadEventsFromOffset:
+    def test_returns_empty_for_missing_file(self) -> None:
+        from cw.cw_pr_events_server import _read_events_from_offset
+
+        result = _read_events_from_offset(0)
+        assert result == []
+
+    def test_returns_all_events_from_zero(self) -> None:
+        from cw.cw_pr_events_server import _append_event, _read_events_from_offset
+
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "a", "title": "a"}
+        )
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "b", "title": "b"}
+        )
+        result = _read_events_from_offset(0)
+        assert len(result) == 2
+
+    def test_respects_offset_filter(self) -> None:
+        from cw.cw_pr_events_server import _append_event, _read_events_from_offset
+
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "a", "title": "a"}
+        )
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "b", "title": "b"}
+        )
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "c", "title": "c"}
+        )
+        result = _read_events_from_offset(1)
+        assert len(result) == 2
+        assert result[0]["offset"] == 1
+        assert result[1]["offset"] == 2
+
+    def test_skips_malformed_lines(self) -> None:
+        from cw.config import state_dir
+        from cw.cw_pr_events_server import _append_event, _read_events_from_offset
+
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "a", "title": "a"}
+        )
+        path = state_dir() / "channel-events.jsonl"
+        with path.open("a") as f:
+            f.write("not-json\n")
+        result = _read_events_from_offset(0)
+        assert len(result) == 1
+
+
+class TestSubscribeWithCursor:
+    def test_returns_queue(self) -> None:
+        q = subscribe_with_cursor("sub1")
+        assert isinstance(q, queue.SimpleQueue)
+        unsubscribe(q)
+
+    def test_replays_missed_events(self) -> None:
+        from cw.cw_pr_events_server import _append_event
+
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "a", "title": "a"}
+        )
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "b", "title": "b"}
+        )
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "c", "title": "c"}
+        )
+
+        _server_mod._cursors["sub2"] = 1
+        q = subscribe_with_cursor("sub2")
+        try:
+            items = []
+            while not q.empty():
+                items.append(q.get_nowait())
+            assert len(items) == 2
+            assert items[0]["offset"] == 1
+            assert items[1]["offset"] == 2
+        finally:
+            unsubscribe(q)
+
+    def test_no_replay_when_caught_up(self) -> None:
+        from cw.cw_pr_events_server import _append_event
+
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "a", "title": "a"}
+        )
+        _append_event(
+            {"notification_type": "cw-pr-event", "message": "b", "title": "b"}
+        )
+
+        _server_mod._cursors["sub3"] = 2
+        q = subscribe_with_cursor("sub3")
+        try:
+            assert q.empty()
+        finally:
+            unsubscribe(q)
+
+    def test_registers_for_future_events(self) -> None:
+        q = subscribe_with_cursor("sub4")
+        try:
+            broadcast(
+                {"notification_type": "cw-pr-event", "message": "future", "title": "f"}
+            )
+            item = q.get_nowait()
+            assert item["notification_type"] == "cw-pr-event"
+        finally:
+            unsubscribe(q)
+
+
+class TestAckOffset:
+    def test_persists_cursor_to_file(self) -> None:
+        from cw.config import state_dir
+        from cw.cw_pr_events_server import ack_offset
+
+        ack_offset("sub-a", 3)
+        path = state_dir() / "channel-cursors.json"
+        data = json.loads(path.read_text())
+        assert data == {"sub-a": 3}
+
+    def test_updates_in_memory_cursors(self) -> None:
+        from cw.cw_pr_events_server import ack_offset
+
+        ack_offset("sub-b", 7)
+        assert _server_mod._cursors["sub-b"] == 7
+
+    def test_overwrites_previous_cursor(self) -> None:
+        from cw.cw_pr_events_server import ack_offset
+
+        ack_offset("sub-c", 1)
+        ack_offset("sub-c", 5)
+        assert _server_mod._cursors["sub-c"] == 5
+
+
+class TestHandlePostAck:
+    def _make_client(self) -> TestClient:
+        return TestClient(make_app())
+
+    def test_valid_request_returns_ok(self) -> None:
+        client = self._make_client()
+        resp = client.post("/ack", json={"client_id": "c1", "offset": 0})
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_invalid_body_returns_400(self) -> None:
+        client = self._make_client()
+        resp = client.post("/ack", json={"client_id": "c1"})
+        assert resp.status_code == 400
+
+    def test_updates_cursor(self) -> None:
+        client = self._make_client()
+        client.post("/ack", json={"client_id": "c2", "offset": 42})
+        assert _server_mod._cursors["c2"] == 42
+
+    def test_route_registered(self) -> None:
+        app = make_app()
+        route_paths = [r.path for r in app.routes]
+        assert "/ack" in route_paths
+
+
+class TestBroadcastDurable:
+    def test_appends_to_file(self) -> None:
+        from cw.config import state_dir
+
+        broadcast({"notification_type": "cw-pr-event", "message": "m", "title": "t"})
+        path = state_dir() / "channel-events.jsonl"
+        assert path.exists()
+        lines = path.read_text().splitlines()
+        assert len(lines) == 1
+
+    def test_persists_before_subscriber_receives(self) -> None:
+        from cw.config import state_dir
+
+        # Verify file is written as part of broadcast
+        q = subscribe()
+        try:
+            broadcast(
+                {"notification_type": "cw-pr-event", "message": "m", "title": "t"}
+            )
+            # File must exist after broadcast completes
+            path = state_dir() / "channel-events.jsonl"
+            assert path.exists()
+            # Subscriber also received it
+            item = q.get_nowait()
+            assert item["notification_type"] == "cw-pr-event"
+        finally:
+            unsubscribe(q)
+
+
+class TestDurableReplay:
+    def test_five_events_survive_subscriber_restart(self) -> None:
+        """Primary acceptance criterion from ticket."""
+
+        # 1. Broadcast 5 events
+        for i in range(5):
+            broadcast(
+                {
+                    "notification_type": "cw-pr-event",
+                    "message": f"msg{i}",
+                    "title": f"t{i}",
+                }
+            )
+
+        # 2. Subscribe with cursor at 0 (no prior cursor) — simulates reconnect
+        q = subscribe_with_cursor("dispatcher")
+        try:
+            # 3. Drain queue
+            items = []
+            while not q.empty():
+                items.append(q.get_nowait())
+
+            # 4. Assert exactly 5 notifications with offsets 0-4
+            assert len(items) == 5
+            assert {item["offset"] for item in items} == {0, 1, 2, 3, 4}
+        finally:
+            unsubscribe(q)

--- a/tests/test_cw_pr_events_server.py
+++ b/tests/test_cw_pr_events_server.py
@@ -47,11 +47,11 @@ def _reset_channel_state() -> Generator[None]:
     """Reset durable-replay in-memory state between tests."""
     with _server_mod._file_lock:
         _server_mod._cursors.clear()
-        _server_mod._event_offset = 0
+        _server_mod._event_offset[0] = 0
     yield
     with _server_mod._file_lock:
         _server_mod._cursors.clear()
-        _server_mod._event_offset = 0
+        _server_mod._event_offset[0] = 0
 
 
 class TestPREventPayloadValidation:
@@ -234,7 +234,7 @@ class TestAppendEvent:
         _append_event(
             {"notification_type": "cw-pr-event", "message": "m2", "title": "t2"}
         )
-        assert _server_mod._event_offset == 2
+        assert _server_mod._event_offset[0] == 2
 
     def test_record_contains_offset_field(self) -> None:
         from cw.config import state_dir


### PR DESCRIPTION
## Summary

- Persists every broadcast PR event to `channel-events.jsonl` with a monotonic offset before fan-out to subscribers
- `POST /ack {client_id, offset}` advances per-subscriber cursor, persisted atomically to `channel-cursors.json`
- SSE `?client_id=<id>` triggers `subscribe_with_cursor` — replays all events since the client's last acked offset on reconnect
- Module-level init loads cursors and offset from disk on server startup (no duplicate offsets or full replay after restart)

## Test plan

- [x] `TestDurableReplay.test_five_events_survive_subscriber_restart` — primary acceptance criterion
- [x] `TestAppendEvent` — offset monotonicity, thread safety, JSONL format
- [x] `TestReadEventsFromOffset` — cursor filter, malformed line skipping
- [x] `TestSubscribeWithCursor` — replay, caught-up no-op, future event delivery
- [x] `TestAckOffset` — in-memory update, disk persistence, overwrite
- [x] `TestHandlePostAck` — endpoint validation (400 on missing fields), cursor update
- [x] `TestBroadcastDurable` — file written, persist-before-deliver ordering
- [x] `TestLoadCursors` / `TestLoadOffsetFromFile` — startup recovery, corrupt file handling
- [x] All 49 tests pass: `uv run pytest tests/test_cw_pr_events_server.py -v`
- [x] `ruff check` — zero violations
- [x] `mypy` — zero type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)