### PR TITLE
feat(pr-channel): connect daemon to cw-pr-events channel server (#114)

### DIFF
--- a/src/cw/daemon.py
+++ b/src/cw/daemon.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import http.client
 import json
 import logging
 import os
 import time
-import urllib.request
+import urllib.parse
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
@@ -183,11 +184,11 @@ def _post_to_channel(
             "payload": payload,
         }
     ).encode()
-    req = urllib.request.Request(  # noqa: S310
-        url, data=body, headers={"Content-Type": "application/json"}, method="POST"
-    )
+    parsed = urllib.parse.urlparse(url)
+    conn = http.client.HTTPConnection(parsed.netloc, timeout=2)
     try:
-        urllib.request.urlopen(req, timeout=2)  # noqa: S310
+        conn.request("POST", parsed.path, body, {"Content-Type": "application/json"})
+        conn.getresponse()
     except Exception:  # noqa: BLE001
         # Best-effort: channel server may not be running; never block PR watching.
         # Justification: (1) failure modes are connection refused/timeout/HTTP error,
@@ -200,6 +201,8 @@ def _post_to_channel(
             event_type,
             exc_info=True,
         )
+    finally:
+        conn.close()
 
 
 def watch_prs_for_client(

--- a/src/cw/daemon.py
+++ b/src/cw/daemon.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
+import urllib.request
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
@@ -162,6 +164,44 @@ def _all_threads_addressed(thread_status: dict[str, Any]) -> bool:
     )
 
 
+_DEFAULT_CHANNEL_URL = "http://127.0.0.1:8788/pr-event"
+
+
+def _post_to_channel(
+    event_type: str,
+    repo: str,
+    pr_number: int,
+    payload: dict[str, Any],
+) -> None:
+    """Post a PR event to the channel server. Best-effort: logs on failure."""
+    url = os.environ.get("CW_PR_EVENTS_URL", _DEFAULT_CHANNEL_URL)
+    body = json.dumps(
+        {
+            "repo": repo,
+            "pr_number": pr_number,
+            "event_type": event_type,
+            "payload": payload,
+        }
+    ).encode()
+    req = urllib.request.Request(  # noqa: S310
+        url, data=body, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    try:
+        urllib.request.urlopen(req, timeout=2)  # noqa: S310
+    except Exception:  # noqa: BLE001
+        # Best-effort: channel server may not be running; never block PR watching.
+        # Justification: (1) failure modes are connection refused/timeout/HTTP error,
+        # (2) logged at debug with exc_info=True for traceability,
+        # (3) non-critical — PR watching must continue regardless,
+        # (4) tests verify resilience (test_channel_server_down_does_not_raise).
+        logger.debug(
+            "_post_to_channel failed url=%s event_type=%s",
+            url,
+            event_type,
+            exc_info=True,
+        )
+
+
 def watch_prs_for_client(
     client: ClientConfig,
     snapshot: WatcherSnapshot,
@@ -223,6 +263,9 @@ def watch_prs_for_client(
                     },
                 )
                 events.append(event)
+                _post_to_channel(
+                    "merged", repo, pr_number, {"status": status, "role": role}
+                )
                 new_snapshot.pr_states[pr_key] = status
                 continue
 
@@ -247,6 +290,12 @@ def watch_prs_for_client(
                     },
                 )
                 events.append(event)
+                _post_to_channel(
+                    "review_received",
+                    repo,
+                    pr_number,
+                    {"unresolved_threads": unresolved_now, "role": role},
+                )
                 new_snapshot.review_prs.add(pr_key)
 
             # --- PR_MERGEABLE: all threads addressed (and we've seen review before) ---
@@ -267,6 +316,7 @@ def watch_prs_for_client(
                     },
                 )
                 events.append(event)
+                _post_to_channel("mergeable", repo, pr_number, {"role": role})
                 new_snapshot.mergeable_prs.add(pr_key)
 
             # --- PR_CI_FAILED: delta_findings mention CI failure ---
@@ -286,6 +336,12 @@ def watch_prs_for_client(
                     },
                 )
                 events.append(event)
+                _post_to_channel(
+                    "ci_failed",
+                    repo,
+                    pr_number,
+                    {"findings_count": len(delta_findings), "role": role},
+                )
                 new_snapshot.ci_fail_prs.add(pr_key)
 
     return events, new_snapshot

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock, patch
+from urllib.error import URLError
 
 import pytest
 
 from cw.daemon import (
     ThrottleStore,
     WatcherSnapshot,
+    _post_to_channel,
     watch_prs_for_client,
 )
 from cw.models import (
@@ -432,3 +435,110 @@ class TestThrottleStore:
         store.mark_dispatched("client", "owner/repo#3", "author", "sess003")
         # "reviewer" role is different from "author"
         assert not store.is_throttled("client", "owner/repo#3", "reviewer", state)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _post_to_channel
+# ---------------------------------------------------------------------------
+
+
+class TestChannelPosting:
+    """Tests for the best-effort HTTP channel posting helper."""
+
+    def test_merged_posts_correct_payload(self) -> None:
+        """merged event_type sends correct JSON body to channel server."""
+        captured: list[dict[str, Any]] = []
+
+        def fake_urlopen(req: Any, timeout: int = 0) -> MagicMock:
+            captured.append(json.loads(req.data))
+            return MagicMock()
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            _post_to_channel(
+                "merged",
+                "owner/my-repo",
+                42,
+                {"status": "complete", "role": "author"},
+            )
+
+        assert len(captured) == 1
+        assert captured[0]["event_type"] == "merged"
+        assert captured[0]["repo"] == "owner/my-repo"
+        assert captured[0]["pr_number"] == 42
+        assert captured[0]["payload"] == {"status": "complete", "role": "author"}
+
+    def test_ci_failed_posts_correct_payload(self) -> None:
+        """ci_failed event_type sends correct JSON body to channel server."""
+        captured: list[dict[str, Any]] = []
+
+        def fake_urlopen(req: Any, timeout: int = 0) -> MagicMock:
+            captured.append(json.loads(req.data))
+            return MagicMock()
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            _post_to_channel(
+                "ci_failed", "owner/repo", 7, {"findings_count": 3, "role": "author"}
+            )
+
+        assert captured[0]["event_type"] == "ci_failed"
+        assert captured[0]["pr_number"] == 7
+
+    def test_review_received_posts_correct_payload(self) -> None:
+        """review_received event_type sends correct JSON body."""
+        captured: list[dict[str, Any]] = []
+
+        def fake_urlopen(req: Any, timeout: int = 0) -> MagicMock:
+            captured.append(json.loads(req.data))
+            return MagicMock()
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            _post_to_channel(
+                "review_received",
+                "owner/repo",
+                5,
+                {"unresolved_threads": 2, "role": "author"},
+            )
+
+        assert captured[0]["event_type"] == "review_received"
+        assert captured[0]["payload"]["unresolved_threads"] == 2
+
+    def test_mergeable_posts_correct_payload(self) -> None:
+        """mergeable event_type sends correct JSON body."""
+        captured: list[dict[str, Any]] = []
+
+        def fake_urlopen(req: Any, timeout: int = 0) -> MagicMock:
+            captured.append(json.loads(req.data))
+            return MagicMock()
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            _post_to_channel("mergeable", "owner/repo", 3, {"role": "author"})
+
+        assert captured[0]["event_type"] == "mergeable"
+
+    def test_channel_server_down_does_not_raise(self) -> None:
+        """URLError from unreachable server is silently swallowed."""
+        err_msg = "Connection refused"
+
+        def raise_url_error(req: Any, timeout: int = 0) -> None:
+            raise URLError(err_msg)
+
+        # Must not raise — best-effort design
+        with patch("cw.daemon.urllib.request.urlopen", raise_url_error):
+            _post_to_channel("merged", "owner/repo", 1, {})
+
+    def test_cw_pr_events_url_env_var_overrides_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CW_PR_EVENTS_URL env var controls the POST destination."""
+        custom_url = "http://custom-host:9999/pr-event"
+        monkeypatch.setenv("CW_PR_EVENTS_URL", custom_url)
+        captured_urls: list[str] = []
+
+        def fake_urlopen(req: Any, timeout: int = 0) -> MagicMock:
+            captured_urls.append(req.full_url)
+            return MagicMock()
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            _post_to_channel("merged", "owner/repo", 1, {})
+
+        assert captured_urls == [custom_url]

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -523,7 +523,7 @@ class TestChannelPosting:
             raise URLError(err_msg)
 
         # Must not raise — best-effort design
-        with patch("cw.daemon.urllib.request.urlopen", raise_url_error):
+        with patch("urllib.request.urlopen", raise_url_error):
             _post_to_channel("merged", "owner/repo", 1, {})
 
     def test_cw_pr_events_url_env_var_overrides_default(

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
-from urllib.error import URLError
 
 import pytest
 
@@ -448,12 +447,12 @@ class TestChannelPosting:
     def test_merged_posts_correct_payload(self) -> None:
         """merged event_type sends correct JSON body to channel server."""
         captured: list[dict[str, Any]] = []
+        mock_conn = MagicMock()
+        mock_conn.request.side_effect = lambda _m, _p, body, _h: captured.append(
+            json.loads(body)
+        )
 
-        def fake_urlopen(req: Any, timeout: int = 0) -> MagicMock:
-            captured.append(json.loads(req.data))
-            return MagicMock()
-
-        with patch("urllib.request.urlopen", fake_urlopen):
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
             _post_to_channel(
                 "merged",
                 "owner/my-repo",
@@ -470,12 +469,12 @@ class TestChannelPosting:
     def test_ci_failed_posts_correct_payload(self) -> None:
         """ci_failed event_type sends correct JSON body to channel server."""
         captured: list[dict[str, Any]] = []
+        mock_conn = MagicMock()
+        mock_conn.request.side_effect = lambda _m, _p, body, _h: captured.append(
+            json.loads(body)
+        )
 
-        def fake_urlopen(req: Any, timeout: int = 0) -> MagicMock:
-            captured.append(json.loads(req.data))
-            return MagicMock()
-
-        with patch("urllib.request.urlopen", fake_urlopen):
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
             _post_to_channel(
                 "ci_failed", "owner/repo", 7, {"findings_count": 3, "role": "author"}
             )
@@ -486,12 +485,12 @@ class TestChannelPosting:
     def test_review_received_posts_correct_payload(self) -> None:
         """review_received event_type sends correct JSON body."""
         captured: list[dict[str, Any]] = []
+        mock_conn = MagicMock()
+        mock_conn.request.side_effect = lambda _m, _p, body, _h: captured.append(
+            json.loads(body)
+        )
 
-        def fake_urlopen(req: Any, timeout: int = 0) -> MagicMock:
-            captured.append(json.loads(req.data))
-            return MagicMock()
-
-        with patch("urllib.request.urlopen", fake_urlopen):
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
             _post_to_channel(
                 "review_received",
                 "owner/repo",
@@ -505,25 +504,23 @@ class TestChannelPosting:
     def test_mergeable_posts_correct_payload(self) -> None:
         """mergeable event_type sends correct JSON body."""
         captured: list[dict[str, Any]] = []
+        mock_conn = MagicMock()
+        mock_conn.request.side_effect = lambda _m, _p, body, _h: captured.append(
+            json.loads(body)
+        )
 
-        def fake_urlopen(req: Any, timeout: int = 0) -> MagicMock:
-            captured.append(json.loads(req.data))
-            return MagicMock()
-
-        with patch("urllib.request.urlopen", fake_urlopen):
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
             _post_to_channel("mergeable", "owner/repo", 3, {"role": "author"})
 
         assert captured[0]["event_type"] == "mergeable"
 
     def test_channel_server_down_does_not_raise(self) -> None:
-        """URLError from unreachable server is silently swallowed."""
-        err_msg = "Connection refused"
-
-        def raise_url_error(req: Any, timeout: int = 0) -> None:
-            raise URLError(err_msg)
+        """OSError from unreachable server is silently swallowed."""
+        mock_conn = MagicMock()
+        mock_conn.request.side_effect = OSError("Connection refused")
 
         # Must not raise — best-effort design
-        with patch("urllib.request.urlopen", raise_url_error):
+        with patch("http.client.HTTPConnection", return_value=mock_conn):
             _post_to_channel("merged", "owner/repo", 1, {})
 
     def test_cw_pr_events_url_env_var_overrides_default(
@@ -532,13 +529,13 @@ class TestChannelPosting:
         """CW_PR_EVENTS_URL env var controls the POST destination."""
         custom_url = "http://custom-host:9999/pr-event"
         monkeypatch.setenv("CW_PR_EVENTS_URL", custom_url)
-        captured_urls: list[str] = []
+        captured_netlocs: list[str] = []
 
-        def fake_urlopen(req: Any, timeout: int = 0) -> MagicMock:
-            captured_urls.append(req.full_url)
+        def fake_connection(netloc: str, timeout: int = 0) -> MagicMock:
+            captured_netlocs.append(netloc)
             return MagicMock()
 
-        with patch("urllib.request.urlopen", fake_urlopen):
+        with patch("http.client.HTTPConnection", fake_connection):
             _post_to_channel("merged", "owner/repo", 1, {})
 
-        assert captured_urls == [custom_url]
+        assert captured_netlocs == ["custom-host:9999"]


### PR DESCRIPTION
## Summary

- Adds `_post_to_channel()` helper to `daemon.py` that POSTs PR events to the `cw-pr-events` channel server (already built in #282/#284) via `http.client.HTTPConnection`
- Wires all four delta-detection paths (`merged`, `review_received`, `mergeable`, `ci_failed`) in `watch_prs_for_client()` to call the helper after each `record_event()` call
- Channel server URL defaults to `http://127.0.0.1:8788/pr-event`; overridable via `CW_PR_EVENTS_URL` env var
- Best-effort by design: all HTTP errors are caught and logged at DEBUG; PR watching is never blocked if the channel server is down
- Switched from `urllib.request` to `http.client` to avoid bandit S310 without a noqa suppression

## Test plan

- [x] `TestChannelPosting` class (6 tests) covers all four event types, server-down resilience, and env var URL override
- [x] `uv run pytest tests/ -q` — 1017 passed, 1 skipped
- [x] `uv run ruff check` — zero violations
- [x] `uv run mypy src/` — zero type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)