### PR TITLE
feat(pr-channel): add stdio MCP channel proxy with capability declaration

### DIFF
--- a/config/cw-pr-events.mcp.json.example
+++ b/config/cw-pr-events.mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "cw-pr-events": {
+      "command": "cw",
+      "args": ["pr-channel", "proxy", "--client-id", "your-session-id"],
+      "env": {
+        "CW_PR_EVENTS_BASE_URL": "http://127.0.0.1:8788"
+      }
+    }
+  }
+}

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -1927,6 +1927,15 @@ def pr_channel() -> None:
     """PR channel server: push MCP notifications to subscribed Claude sessions."""
 
 
+@pr_channel.command(name="proxy")
+@click.option("--client-id", default=None, help="Unique client ID for cursor tracking.")
+def pr_channel_proxy(client_id: str | None) -> None:
+    """Start the MCP stdio proxy for cw-pr-events (add to .mcp.json)."""
+    from cw.cw_pr_events_channel import run_proxy  # noqa: PLC0415
+
+    run_proxy(client_id=client_id)
+
+
 @pr_channel.command(name="serve")
 @click.option("--port", default=8788, type=int, show_default=True)
 @click.option("--host", default="127.0.0.1", show_default=True)

--- a/src/cw/cw_pr_events_channel.py
+++ b/src/cw/cw_pr_events_channel.py
@@ -1,0 +1,101 @@
+"""MCP stdio proxy: forwards cw-pr-events SSE notifications to Claude."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import urllib.parse
+from typing import Any, cast
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "http://127.0.0.1:8788"
+_NOTIFICATION_TYPE = "cw-pr-event"
+
+# MCP types — deferred-import inside functions per project convention
+# (avoids hard dep at module load; mcp is an optional extra)
+
+
+def _extract_payload(session_msg: Any) -> dict[str, Any] | None:
+    """Extract {repo, pr_number, event_type, payload} from upstream SSE msg.
+
+    Returns None for non-PR-event messages (type guard, not error).
+    """
+    from mcp.types import JSONRPCNotification  # noqa: PLC0415
+
+    root = session_msg.message.root
+    if not isinstance(root, JSONRPCNotification):
+        return None
+    params = root.params or {}
+    data = params.get("data")
+    if data is None:
+        return None
+    if data.get("notification_type") != _NOTIFICATION_TYPE:
+        return None
+    raw = data.get("message")
+    if raw is None:
+        return None
+    try:
+        return cast("dict[str, Any]", json.loads(raw))
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def _build_outbound_notification(data: dict[str, Any]) -> Any:
+    """Build a SessionMessage to emit on the stdio MCP connection."""
+    from mcp.shared.message import SessionMessage  # noqa: PLC0415
+    from mcp.types import JSONRPCMessage, JSONRPCNotification  # noqa: PLC0415
+
+    return SessionMessage(
+        message=JSONRPCMessage(
+            JSONRPCNotification(
+                jsonrpc="2.0",
+                method="notifications/message",
+                params={
+                    "level": "info",
+                    "logger": "cw-pr-events",
+                    "data": data,
+                },
+            )
+        )
+    )
+
+
+async def _relay_upstream(sse_read: Any, stdio_write: Any) -> None:
+    """Read from SSE stream, write PR-event notifications to stdio."""
+    async for item in sse_read:
+        if isinstance(item, Exception):
+            logger.debug("sse read error: %s", item)
+            continue
+        payload = _extract_payload(item)
+        if payload is None:
+            continue
+        outbound = _build_outbound_notification(payload)
+        await stdio_write.send(outbound)
+
+
+def run_proxy(client_id: str | None = None) -> None:
+    """Start the stdio MCP proxy. Blocks until the SSE connection closes."""
+    import anyio  # noqa: PLC0415
+    from mcp.client.sse import sse_client  # noqa: PLC0415
+    from mcp.server.stdio import stdio_server  # noqa: PLC0415
+
+    base_url = os.environ.get("CW_PR_EVENTS_BASE_URL", _DEFAULT_BASE_URL)
+    if client_id is None:
+        client_id = os.environ.get("CW_PR_EVENTS_CLIENT_ID", socket.gethostname())
+    sse_url = f"{base_url}/sse?client_id={urllib.parse.quote(client_id)}"
+
+    async def _main() -> None:
+        async with (
+            sse_client(sse_url) as (sse_read, _sse_write),
+            stdio_server() as (_stdio_read, stdio_write),
+        ):
+            await _relay_upstream(sse_read, stdio_write)
+
+    anyio.run(_main)
+
+
+if __name__ == "__main__":
+    run_proxy()

--- a/src/cw/cw_pr_events_channel.py
+++ b/src/cw/cw_pr_events_channel.py
@@ -12,6 +12,8 @@ from typing import Any, cast
 logger = logging.getLogger(__name__)
 
 _DEFAULT_BASE_URL = "http://127.0.0.1:8788"
+# Intentionally not imported from cw_pr_events_server to avoid triggering
+# module-level I/O (_cursors.update/_event_offset init) at import time.
 _NOTIFICATION_TYPE = "cw-pr-event"
 
 # MCP types — deferred-import inside functions per project convention
@@ -43,6 +45,21 @@ def _extract_payload(session_msg: Any) -> dict[str, Any] | None:
         return None
 
 
+def _build_meta(data: dict[str, Any]) -> dict[str, str]:
+    """Build the meta dict for notifications/claude/channel params."""
+    payload = data.get("payload") or {}
+    meta: dict[str, str] = {
+        "event_type": str(data.get("event_type", "")),
+        "pr_number": str(data.get("pr_number", "")),
+        "repo": str(data.get("repo", "")),
+    }
+    if "role" in payload:
+        meta["role"] = str(payload["role"])
+    if "client" in payload:
+        meta["client"] = str(payload["client"])
+    return {k: v for k, v in meta.items() if v}
+
+
 def _build_outbound_notification(data: dict[str, Any]) -> Any:
     """Build a SessionMessage to emit on the stdio MCP connection."""
     from mcp.shared.message import SessionMessage  # noqa: PLC0415
@@ -52,12 +69,8 @@ def _build_outbound_notification(data: dict[str, Any]) -> Any:
         message=JSONRPCMessage(
             JSONRPCNotification(
                 jsonrpc="2.0",
-                method="notifications/message",
-                params={
-                    "level": "info",
-                    "logger": "cw-pr-events",
-                    "data": data,
-                },
+                method="notifications/claude/channel",
+                params={"content": json.dumps(data), "meta": _build_meta(data)},
             )
         )
     )
@@ -80,6 +93,7 @@ def run_proxy(client_id: str | None = None) -> None:
     """Start the stdio MCP proxy. Blocks until the SSE connection closes."""
     import anyio  # noqa: PLC0415
     from mcp.client.sse import sse_client  # noqa: PLC0415
+    from mcp.server import Server  # noqa: PLC0415
     from mcp.server.stdio import stdio_server  # noqa: PLC0415
 
     base_url = os.environ.get("CW_PR_EVENTS_BASE_URL", _DEFAULT_BASE_URL)
@@ -87,12 +101,19 @@ def run_proxy(client_id: str | None = None) -> None:
         client_id = os.environ.get("CW_PR_EVENTS_CLIENT_ID", socket.gethostname())
     sse_url = f"{base_url}/sse?client_id={urllib.parse.quote(client_id)}"
 
+    mcp_server: Server = Server("cw-pr-events")
+    init_options = mcp_server.create_initialization_options(
+        experimental_capabilities={"claude/channel": {}},
+    )
+
     async def _main() -> None:
         async with (
             sse_client(sse_url) as (sse_read, _sse_write),
-            stdio_server() as (_stdio_read, stdio_write),
+            stdio_server() as (stdio_read, stdio_write),
+            anyio.create_task_group() as tg,
         ):
-            await _relay_upstream(sse_read, stdio_write)
+            tg.start_soon(mcp_server.run, stdio_read, stdio_write, init_options)
+            tg.start_soon(_relay_upstream, sse_read, stdio_write)
 
     anyio.run(_main)
 

--- a/tests/test_cw_pr_events_channel.py
+++ b/tests/test_cw_pr_events_channel.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import socket
 import urllib.parse
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from click.testing import CliRunner
@@ -247,7 +247,7 @@ class TestRelayUpstream:
             await send_out.aclose()
 
             try:
-                return await recv_out.receive()
+                return cast("SessionMessage", await recv_out.receive())
             except anyio.EndOfStream:
                 return None
 
@@ -345,11 +345,11 @@ class TestRunProxyEnvVars:
         class _StopEarly(Exception):  # noqa: N818
             pass
 
-        @asynccontextmanager  # type: ignore[arg-type]
-        async def _fake_sse_client(url: str, **_kw: Any) -> Any:  # type: ignore[misc]
+        @asynccontextmanager
+        async def _fake_sse_client(url: str, **_kw: Any) -> Any:
             captured.append(url)
             raise _StopEarly
-            yield  # type: ignore[misc]
+            yield
 
         monkeypatch.setattr(_sse_mod, "sse_client", _fake_sse_client)
 

--- a/tests/test_cw_pr_events_channel.py
+++ b/tests/test_cw_pr_events_channel.py
@@ -1,0 +1,353 @@
+"""Tests for cw_pr_events_channel: payload extraction, notification building, relay."""
+
+from __future__ import annotations
+
+import json
+import socket
+import urllib.parse
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+starlette = pytest.importorskip(
+    "starlette", reason="requires mcp extras: pip install 'cw[mcp]'"
+)
+
+from mcp.shared.message import SessionMessage  # noqa: E402
+from mcp.types import JSONRPCMessage, JSONRPCNotification, JSONRPCResponse  # noqa: E402
+
+from cw.cw_pr_events_channel import (  # noqa: E402
+    _DEFAULT_BASE_URL,
+    _NOTIFICATION_TYPE,
+    _build_outbound_notification,
+    _extract_payload,
+    _relay_upstream,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session_message(
+    repo: str,
+    pr_number: int,
+    event_type: str,
+    payload: dict[str, Any] | None = None,
+) -> SessionMessage:
+    """Build a SessionMessage matching the server's _build_notification + SSE format."""
+    inner = json.dumps(
+        {
+            "repo": repo,
+            "pr_number": pr_number,
+            "event_type": event_type,
+            "payload": payload or {},
+        }
+    )
+    notif = JSONRPCNotification(
+        jsonrpc="2.0",
+        method="notifications/message",
+        params={
+            "level": "info",
+            "logger": "cw-pr-events",
+            "data": {
+                "notification_type": _NOTIFICATION_TYPE,
+                "message": inner,
+                "title": f"PR #{pr_number}: {event_type}",
+            },
+        },
+    )
+    return SessionMessage(message=JSONRPCMessage(notif))
+
+
+# ---------------------------------------------------------------------------
+# _extract_payload
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPayload:
+    def test_valid_cw_pr_event(self) -> None:
+        msg = _make_session_message("owner/repo", 42, "ci_failed", {"key": "val"})
+        result = _extract_payload(msg)
+        assert result is not None
+        assert result["repo"] == "owner/repo"
+        assert result["pr_number"] == 42
+        assert result["event_type"] == "ci_failed"
+        assert result["payload"] == {"key": "val"}
+
+    def test_non_notification_root(self) -> None:
+        response = JSONRPCResponse(jsonrpc="2.0", id=1, result={})
+        msg = SessionMessage(message=JSONRPCMessage(response))
+        assert _extract_payload(msg) is None
+
+    def test_notification_type_mismatch(self) -> None:
+        notif = JSONRPCNotification(
+            jsonrpc="2.0",
+            method="notifications/message",
+            params={
+                "level": "info",
+                "logger": "cw-pr-events",
+                "data": {
+                    "notification_type": "not-a-pr-event",
+                    "message": json.dumps({"repo": "x", "pr_number": 1}),
+                },
+            },
+        )
+        msg = SessionMessage(message=JSONRPCMessage(notif))
+        assert _extract_payload(msg) is None
+
+    def test_missing_data_key(self) -> None:
+        notif = JSONRPCNotification(
+            jsonrpc="2.0",
+            method="notifications/message",
+            params={"level": "info"},
+        )
+        msg = SessionMessage(message=JSONRPCMessage(notif))
+        assert _extract_payload(msg) is None
+
+    def test_malformed_json_in_message(self) -> None:
+        notif = JSONRPCNotification(
+            jsonrpc="2.0",
+            method="notifications/message",
+            params={
+                "level": "info",
+                "logger": "cw-pr-events",
+                "data": {
+                    "notification_type": _NOTIFICATION_TYPE,
+                    "message": "not-json",
+                },
+            },
+        )
+        msg = SessionMessage(message=JSONRPCMessage(notif))
+        assert _extract_payload(msg) is None
+
+    def test_missing_message_key(self) -> None:
+        notif = JSONRPCNotification(
+            jsonrpc="2.0",
+            method="notifications/message",
+            params={
+                "level": "info",
+                "data": {
+                    "notification_type": _NOTIFICATION_TYPE,
+                },
+            },
+        )
+        msg = SessionMessage(message=JSONRPCMessage(notif))
+        assert _extract_payload(msg) is None
+
+
+# ---------------------------------------------------------------------------
+# _build_outbound_notification
+# ---------------------------------------------------------------------------
+
+
+class TestBuildOutboundNotification:
+    def _data(self) -> dict[str, Any]:
+        return {"repo": "owner/repo", "pr_number": 5, "event_type": "merged"}
+
+    def test_returns_session_message(self) -> None:
+        result = _build_outbound_notification(self._data())
+        assert isinstance(result, SessionMessage)
+
+    def test_root_is_json_rpc_notification(self) -> None:
+        result = _build_outbound_notification(self._data())
+        assert isinstance(result.message.root, JSONRPCNotification)
+
+    def test_method_is_notifications_message(self) -> None:
+        result = _build_outbound_notification(self._data())
+        assert result.message.root.method == "notifications/message"
+
+    def test_data_preserved(self) -> None:
+        data = self._data()
+        result = _build_outbound_notification(data)
+        params = result.message.root.params or {}
+        assert params["data"] == data
+
+
+# ---------------------------------------------------------------------------
+# _relay_upstream
+# ---------------------------------------------------------------------------
+
+
+class TestRelayUpstream:
+    def test_valid_message_forwarded(self) -> None:
+        import anyio
+
+        msg = _make_session_message("owner/repo", 10, "review_received")
+
+        async def _run() -> SessionMessage | None:
+            send_in, recv_in = anyio.create_memory_object_stream[Any](max_buffer_size=5)
+            send_out, recv_out = anyio.create_memory_object_stream[Any](
+                max_buffer_size=5
+            )
+            await send_in.send(msg)
+            await send_in.aclose()
+
+            await _relay_upstream(recv_in, send_out)
+            await send_out.aclose()
+
+            try:
+                return await recv_out.receive()
+            except anyio.EndOfStream:
+                return None
+
+        result = anyio.run(_run)
+        assert result is not None
+        assert isinstance(result, SessionMessage)
+        root = result.message.root
+        assert isinstance(root, JSONRPCNotification)
+        params = root.params or {}
+        assert params["data"]["repo"] == "owner/repo"
+
+    def test_exception_skipped(self) -> None:
+        import anyio
+
+        exc = Exception("sse error")
+
+        async def _run() -> int:
+            send_in, recv_in = anyio.create_memory_object_stream[Any](max_buffer_size=5)
+            send_out, recv_out = anyio.create_memory_object_stream[Any](
+                max_buffer_size=5
+            )
+            await send_in.send(exc)
+            await send_in.aclose()
+
+            await _relay_upstream(recv_in, send_out)
+            await send_out.aclose()
+
+            count = 0
+            async for _ in recv_out:
+                count += 1
+            return count
+
+        count = anyio.run(_run)
+        assert count == 0
+
+    def test_non_pr_event_skipped(self) -> None:
+        import anyio
+
+        notif = JSONRPCNotification(
+            jsonrpc="2.0",
+            method="notifications/message",
+            params={"data": {"notification_type": "other"}},
+        )
+        msg = SessionMessage(message=JSONRPCMessage(notif))
+
+        async def _run() -> int:
+            send_in, recv_in = anyio.create_memory_object_stream[Any](max_buffer_size=5)
+            send_out, recv_out = anyio.create_memory_object_stream[Any](
+                max_buffer_size=5
+            )
+            await send_in.send(msg)
+            await send_in.aclose()
+
+            await _relay_upstream(recv_in, send_out)
+            await send_out.aclose()
+
+            count = 0
+            async for _ in recv_out:
+                count += 1
+            return count
+
+        count = anyio.run(_run)
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# run_proxy: env var / URL construction
+#
+# Strategy: patch anyio.run to call a real async runner that intercepts
+# sse_client at the mcp.client.sse module level before the deferred import.
+# ---------------------------------------------------------------------------
+
+
+def _build_expected_sse_url(base: str, client_id: str) -> str:
+    return f"{base}/sse?client_id={urllib.parse.quote(client_id)}"
+
+
+class TestRunProxyEnvVars:
+    def _invoke_proxy_capture_url(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        client_id: str | None = None,
+    ) -> str:
+        """Invoke run_proxy, capturing the SSE URL via sse_client patch."""
+        import contextlib
+        from contextlib import asynccontextmanager
+
+        import mcp.client.sse as _sse_mod
+
+        from cw.cw_pr_events_channel import run_proxy
+
+        captured: list[str] = []
+
+        class _StopEarly(Exception):  # noqa: N818
+            pass
+
+        @asynccontextmanager  # type: ignore[arg-type]
+        async def _fake_sse_client(url: str, **_kw: Any) -> Any:  # type: ignore[misc]
+            captured.append(url)
+            raise _StopEarly
+            yield  # type: ignore[misc]
+
+        monkeypatch.setattr(_sse_mod, "sse_client", _fake_sse_client)
+
+        with contextlib.suppress(_StopEarly, RuntimeError):
+            run_proxy(client_id=client_id)
+
+        return captured[0] if captured else ""
+
+    def test_default_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CW_PR_EVENTS_BASE_URL", raising=False)
+        monkeypatch.delenv("CW_PR_EVENTS_CLIENT_ID", raising=False)
+        url = self._invoke_proxy_capture_url(monkeypatch)
+        assert url.startswith(f"{_DEFAULT_BASE_URL}/sse")
+
+    def test_custom_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CW_PR_EVENTS_BASE_URL", "http://example.com:9999")
+        monkeypatch.delenv("CW_PR_EVENTS_CLIENT_ID", raising=False)
+        url = self._invoke_proxy_capture_url(monkeypatch)
+        assert url.startswith("http://example.com:9999/sse")
+
+    def test_custom_client_id_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CW_PR_EVENTS_BASE_URL", raising=False)
+        monkeypatch.setenv("CW_PR_EVENTS_CLIENT_ID", "my-custom-id")
+        url = self._invoke_proxy_capture_url(monkeypatch)
+        parsed = urllib.parse.urlparse(url)
+        params = urllib.parse.parse_qs(parsed.query)
+        assert params.get("client_id") == ["my-custom-id"]
+
+    def test_client_id_param_overrides_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CW_PR_EVENTS_BASE_URL", raising=False)
+        monkeypatch.setenv("CW_PR_EVENTS_CLIENT_ID", "env-id")
+        url = self._invoke_proxy_capture_url(monkeypatch, client_id="explicit-id")
+        parsed = urllib.parse.urlparse(url)
+        params = urllib.parse.parse_qs(parsed.query)
+        assert params.get("client_id") == ["explicit-id"]
+
+    def test_default_client_id_is_hostname(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CW_PR_EVENTS_BASE_URL", raising=False)
+        monkeypatch.delenv("CW_PR_EVENTS_CLIENT_ID", raising=False)
+        url = self._invoke_proxy_capture_url(monkeypatch)
+        parsed = urllib.parse.urlparse(url)
+        params = urllib.parse.parse_qs(parsed.query)
+        assert params.get("client_id") == [socket.gethostname()]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_pr_channel_proxy_help(self) -> None:
+        from cw.cli import main
+
+        result = CliRunner().invoke(main, ["pr-channel", "proxy", "--help"])
+        assert result.exit_code == 0
+        assert "--client-id" in result.output

--- a/tests/test_cw_pr_events_channel.py
+++ b/tests/test_cw_pr_events_channel.py
@@ -20,6 +20,7 @@ from mcp.types import JSONRPCMessage, JSONRPCNotification, JSONRPCResponse  # no
 from cw.cw_pr_events_channel import (  # noqa: E402
     _DEFAULT_BASE_URL,
     _NOTIFICATION_TYPE,
+    _build_meta,
     _build_outbound_notification,
     _extract_payload,
     _relay_upstream,
@@ -138,6 +139,64 @@ class TestExtractPayload:
 
 
 # ---------------------------------------------------------------------------
+# _build_meta
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMeta:
+    def test_basic_fields(self) -> None:
+        data = {"repo": "owner/repo", "pr_number": 42, "event_type": "ci_failed"}
+        meta = _build_meta(data)
+        assert meta["repo"] == "owner/repo"
+        assert meta["pr_number"] == "42"
+        assert meta["event_type"] == "ci_failed"
+
+    def test_empty_values_omitted(self) -> None:
+        # Empty string values must be filtered out; missing keys produce empty strings.
+        data = {
+            "repo": "",
+            "event_type": "merged",
+        }  # pr_number absent → str("") omitted
+        meta = _build_meta(data)
+        assert "repo" not in meta
+        assert "pr_number" not in meta
+        assert meta["event_type"] == "merged"
+
+    def test_pr_number_as_string(self) -> None:
+        data = {"repo": "r/r", "pr_number": 99, "event_type": "opened"}
+        meta = _build_meta(data)
+        assert isinstance(meta["pr_number"], str)
+        assert meta["pr_number"] == "99"
+
+    def test_role_from_payload(self) -> None:
+        data = {
+            "repo": "r/r",
+            "pr_number": 1,
+            "event_type": "review",
+            "payload": {"role": "author"},
+        }
+        meta = _build_meta(data)
+        assert meta["role"] == "author"
+
+    def test_client_from_payload(self) -> None:
+        data = {
+            "repo": "r/r",
+            "pr_number": 1,
+            "event_type": "review",
+            "payload": {"client": "acme"},
+        }
+        meta = _build_meta(data)
+        assert meta["client"] == "acme"
+
+    def test_missing_payload(self) -> None:
+        data = {"repo": "r/r", "pr_number": 5, "event_type": "merged"}
+        meta = _build_meta(data)
+        assert "role" not in meta
+        assert "client" not in meta
+        assert meta["repo"] == "r/r"
+
+
+# ---------------------------------------------------------------------------
 # _build_outbound_notification
 # ---------------------------------------------------------------------------
 
@@ -154,15 +213,15 @@ class TestBuildOutboundNotification:
         result = _build_outbound_notification(self._data())
         assert isinstance(result.message.root, JSONRPCNotification)
 
-    def test_method_is_notifications_message(self) -> None:
+    def test_method_is_notifications_claude_channel(self) -> None:
         result = _build_outbound_notification(self._data())
-        assert result.message.root.method == "notifications/message"
+        assert result.message.root.method == "notifications/claude/channel"
 
     def test_data_preserved(self) -> None:
         data = self._data()
         result = _build_outbound_notification(data)
         params = result.message.root.params or {}
-        assert params["data"] == data
+        assert json.loads(params["content"]) == data
 
 
 # ---------------------------------------------------------------------------
@@ -197,8 +256,9 @@ class TestRelayUpstream:
         assert isinstance(result, SessionMessage)
         root = result.message.root
         assert isinstance(root, JSONRPCNotification)
+        assert root.method == "notifications/claude/channel"
         params = root.params or {}
-        assert params["data"]["repo"] == "owner/repo"
+        assert json.loads(params["content"])["repo"] == "owner/repo"
 
     def test_exception_skipped(self) -> None:
         import anyio


### PR DESCRIPTION
## Summary

- feat(pr-channel): add stdio MCP channel proxy
- fix(pr-channel): declare claude/channel capability; use notifications/claude/channel method
- fix(test): resolve mypy errors in test_cw_pr_events_channel

## Test plan

- [x] ruff check — zero violations
- [x] mypy — zero type errors (no new errors vs main baseline)
- [x] pytest — 1091 passed
- [ ] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it