### PR TITLE
fix(sentinel): map short-form stage_reached aliases to canonical full-form values (#292)

### DIFF
--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -24,7 +24,7 @@ import logging
 import re
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 _log = logging.getLogger(__name__)
 
@@ -96,6 +96,27 @@ StageReached = Literal[
     "stage4b_pr_create",
     "stage5_post_create",
 ]
+# Short-form stage codes emitted by the auto-dev producer's resume-detection
+# substates (e.g. ``s5_ci_pending`` instead of ``stage5_post_create``).
+# ``AutoDevResult._normalize_stage_reached`` maps these to their nearest
+# full-form canonical equivalent before Pydantic validates the Literal.
+# Unknown values pass through unchanged and fail the Literal check loudly.
+# See issue #292 for the root-cause analysis.
+_STAGE_REACHED_ALIASES: dict[str, str] = {
+    "pre_flight": "stage1_pre_flight",
+    "s1_drafting": "stage1_plan",
+    "s1_pending_ambiguity_resolution": "stage1_plan",
+    "s1_pending_human_approval": "stage1_plan",
+    "s1_plan_approved": "stage1_plan",
+    "s2_implementing": "stage2_impl",
+    "s3_review_pending": "stage3_review",
+    "s3_fix_loop": "stage3_review",
+    "s4_pr_open": "stage5_post_create",
+    "s5_ci_pending": "stage5_post_create",
+    "s5_ci_passed": "stage5_post_create",
+    "s5_ci_failed": "stage5_post_create",
+    "merged": "stage5_post_create",
+}
 ScopeTier = Literal["small", "large"]
 PlanSource = Literal[
     "linear_existing",
@@ -229,6 +250,13 @@ class AutoDevResult(BaseModel):
     # all keys optional, tolerate producer-side key-name drift.
     ambiguities: list[dict[str, Any]] = Field(default_factory=list)
     premises: list[dict[str, Any]] = Field(default_factory=list)
+
+    @field_validator("stage_reached", mode="before")
+    @classmethod
+    def _normalize_stage_reached(cls, v: object) -> object:
+        if isinstance(v, str) and v in _STAGE_REACHED_ALIASES:
+            return _STAGE_REACHED_ALIASES[v]
+        return v
 
     @model_validator(mode="after")
     def _check_invariants(self) -> AutoDevResult:

--- a/tests/test_auto_dev_result.py
+++ b/tests/test_auto_dev_result.py
@@ -1110,3 +1110,90 @@ class TestV4StatusPromotion:
         result = parse_stdout(_wrap_sentinel(p))
         assert isinstance(result, AutoDevResult)
         assert result.status == "shipped"
+
+
+class TestStageReachedAliases:
+    """Short-form stage_reached aliases from the producer map to full-form values.
+
+    Issue #292: producer occasionally emits resume-detection substates
+    (``s5_ci_pending``, ``merged``, etc.) instead of canonical full-form
+    values. The ``_normalize_stage_reached`` field_validator maps them so
+    otherwise-valid sentinels don't fail with ``validation_failed``.
+    """
+
+    # Each tuple: (alias, expected_canonical, payload_factory)
+    # The payload_factory must return a payload whose status/scope are
+    # compatible with the expected_canonical stage.
+    @pytest.mark.parametrize(
+        ("alias", "expected"),
+        [
+            # pre-flight
+            ("pre_flight", "stage1_pre_flight"),
+            # Stage 1 substates
+            ("s1_drafting", "stage1_plan"),
+            ("s1_pending_ambiguity_resolution", "stage1_plan"),
+            ("s1_pending_human_approval", "stage1_plan"),
+            ("s1_plan_approved", "stage1_plan"),
+            # Stage 2
+            ("s2_implementing", "stage2_impl"),
+            # Stage 3
+            ("s3_review_pending", "stage3_review"),
+            ("s3_fix_loop", "stage3_review"),
+            # Stage 4 / 5 (PR created or later)
+            ("s4_pr_open", "stage5_post_create"),
+            ("s5_ci_pending", "stage5_post_create"),
+            ("s5_ci_passed", "stage5_post_create"),
+            ("s5_ci_failed", "stage5_post_create"),
+            ("merged", "stage5_post_create"),
+        ],
+    )
+    def test_short_form_aliases_normalize(self, alias: str, expected: str) -> None:
+        payload_for: dict[str, Any] = {
+            "stage1_pre_flight": _no_op_payload(),
+            "stage1_plan": _plan_pending_payload(),
+            "stage2_impl": _blocked_payload(),
+            "stage3_review": _review_pending_payload(),
+            "stage5_post_create": _shipped_payload(),
+        }
+        p = payload_for[expected]
+        p["stage_reached"] = alias
+        result = AutoDevResult.model_validate(p)
+        assert result.stage_reached == expected
+
+    @pytest.mark.parametrize("bad", ["stagee5", "", "stage_1", "s6_unknown", "MERGED"])
+    def test_misspelled_stage_still_rejects(self, bad: str) -> None:
+        p = _shipped_payload()
+        p["stage_reached"] = bad
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(p)
+
+    def test_full_form_values_pass_through_unchanged(self) -> None:
+        # Existing canonical values must not be mangled by the normalizer
+        for full_form, payload_fn in [
+            ("stage1_pre_flight", _no_op_payload),
+            ("stage1_plan", _plan_pending_payload),
+            ("stage2_impl", _blocked_payload),
+            ("stage3_review", _review_pending_payload),
+            ("stage4a_merge_gate", _merge_gate_payload),
+            ("stage5_post_create", _shipped_payload),
+        ]:
+            p = payload_fn()
+            result = AutoDevResult.model_validate(p)
+            assert result.stage_reached == full_form
+
+    def test_parse_stdout_shipped_with_s5_ci_pending(self) -> None:
+        # Regression for issue #292: producer emitted s5_ci_pending in a shipped
+        # sentinel; the task was left PENDING despite the PR being merged.
+        p = _shipped_payload()
+        p["stage_reached"] = "s5_ci_pending"
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "shipped"
+        assert result.stage_reached == "stage5_post_create"
+
+    def test_parse_stdout_shipped_with_merged(self) -> None:
+        p = _shipped_payload()
+        p["stage_reached"] = "merged"
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.stage_reached == "stage5_post_create"


### PR DESCRIPTION
## Summary

- fix(sentinel): map short-form stage_reached aliases to canonical full-form values (#292)

Adds a `field_validator` on `AutoDevResult.stage_reached` (mode=before) that normalises the 13 short-form resume-detection substates the producer occasionally emits (`s5_ci_pending`, `merged`, `s4_pr_open`, etc.) to their canonical `StageReached` Literal equivalents. Unknown/misspelled values pass through unchanged and still fail the Literal check loudly.

Closes #292.

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate (1038 passed, 2 skipped)
- [ ] `TestStageReachedAliases` covers all 13 known aliases, 5 misspelled-stage rejection cases, full-form pass-through, and two `parse_stdout` integration regression tests for the exact observed failure (`s5_ci_pending` and `merged` in shipped sentinels)

🤖 Shipped via /prep-pr + project /ship-it