### PR TITLE
fix(spawn): use explicit None check for permission_mode; fix FlakyDaemon annotation

### DIFF
--- a/src/cw/native_daemon.py
+++ b/src/cw/native_daemon.py
@@ -61,7 +61,12 @@ class NativeDaemonClient(Protocol):
     """Protocol for interacting with the Claude background daemon."""
 
     def spawn_bg(
-        self, *, cwd: Path, prompt: str, extra_args: list[str] | None = None
+        self,
+        *,
+        cwd: Path,
+        prompt: str,
+        extra_args: list[str] | None = None,
+        permission_mode: str | None = None,
     ) -> str:
         """Spawn a backgrounded Claude session in *cwd* running *prompt*.
 
@@ -71,6 +76,9 @@ class NativeDaemonClient(Protocol):
         An empty or falsy *prompt* is omitted from the command so the
         session starts idle (tempo=blocked), ready for the user's first
         message.
+
+        *permission_mode* overrides ``_DEFAULT_PERMISSION_MODE`` for the
+        spawned session. Pass ``None`` to use the default (``"auto"``).
 
         Returns the 8-char short session id. Raises :class:`CwError` on
         spawn failure or unparseable stdout.
@@ -102,15 +110,24 @@ class RealNativeDaemonClient:
         self._roster_path: Path = roster_path or _ROSTER_PATH
 
     def spawn_bg(
-        self, *, cwd: Path, prompt: str, extra_args: list[str] | None = None
+        self,
+        *,
+        cwd: Path,
+        prompt: str,
+        extra_args: list[str] | None = None,
+        permission_mode: str | None = None,
     ) -> str:
-        """Invoke ``claude --bg --permission-mode auto`` and parse short id.
+        """Invoke ``claude --bg --permission-mode <mode>`` and parse short id.
 
         *extra_args* are inserted after ``--permission-mode <mode>`` and
         before *prompt*. An empty *prompt* is omitted so the session starts
         idle (tempo=blocked), ready for the user's first message.
+
+        *permission_mode* overrides the default (``"auto"``). Pass ``None``
+        to use the default.
         """
-        cmd = ["claude", "--bg", "--permission-mode", _DEFAULT_PERMISSION_MODE]
+        mode = permission_mode or _DEFAULT_PERMISSION_MODE
+        cmd = ["claude", "--bg", "--permission-mode", mode]
         if extra_args:
             cmd.extend(extra_args)
         if prompt:
@@ -195,17 +212,24 @@ class FakeNativeDaemonClient:
         self._counter = 0
         self.spawn_calls: list[tuple[Path, str]] = []
         self.spawn_extra_args: list[list[str] | None] = []
+        self.spawn_permission_modes: list[str | None] = []
         self.stop_calls: list[str] = []
         self._live: set[str] = set()
 
     def spawn_bg(
-        self, *, cwd: Path, prompt: str, extra_args: list[str] | None = None
+        self,
+        *,
+        cwd: Path,
+        prompt: str,
+        extra_args: list[str] | None = None,
+        permission_mode: str | None = None,
     ) -> str:
         """Record call, register a deterministic short id, return it."""
         self._counter += 1
         short_id = f"{self._counter:08x}"
         self.spawn_calls.append((cwd, prompt))
         self.spawn_extra_args.append(extra_args)
+        self.spawn_permission_modes.append(permission_mode)
         self._live.add(short_id)
         return short_id
 

--- a/src/cw/native_daemon.py
+++ b/src/cw/native_daemon.py
@@ -126,7 +126,7 @@ class RealNativeDaemonClient:
         *permission_mode* overrides the default (``"auto"``). Pass ``None``
         to use the default.
         """
-        mode = permission_mode or _DEFAULT_PERMISSION_MODE
+        mode = _DEFAULT_PERMISSION_MODE if permission_mode is None else permission_mode
         cmd = ["claude", "--bg", "--permission-mode", mode]
         if extra_args:
             cmd.extend(extra_args)

--- a/src/cw/spawn.py
+++ b/src/cw/spawn.py
@@ -135,6 +135,8 @@ def spawn_create_impl(
     parent: str | None = None,
     ticket_id: str | None = None,
     headless: bool = False,
+    extra_args: list[str] | None = None,
+    permission_mode: str | None = None,
 ) -> str:
     """Create a daemon-spawned session via the native Claude background daemon.
 
@@ -189,15 +191,18 @@ def spawn_create_impl(
         headless=headless,
     )
 
-    extra_args: list[str] | None = None
+    final_extra: list[str] = []
     if client.worker_model:
-        extra_args = ["--model", client.worker_model]
+        final_extra.extend(["--model", client.worker_model])
+    if extra_args:
+        final_extra.extend(extra_args)
 
     daemon = native_daemon or get_native_daemon_client()
     sess.surface_ref = daemon.spawn_bg(
         cwd=worktree,
         prompt=prompt,
-        extra_args=extra_args,
+        extra_args=final_extra or None,
+        permission_mode=permission_mode,
     )
 
     if parent_session is not None:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1069,7 +1069,12 @@ class _RaisingNativeDaemon(FakeNativeDaemonClient):
         self._exc = exc
 
     def spawn_bg(
-        self, *, cwd: Path, prompt: str, extra_args: list[str] | None = None
+        self,
+        *,
+        cwd: Path,
+        prompt: str,
+        extra_args: list[str] | None = None,
+        permission_mode: str | None = None,
     ) -> str:
         self.spawn_calls.append((cwd, prompt))
         raise self._exc

--- a/tests/test_native_daemon.py
+++ b/tests/test_native_daemon.py
@@ -178,6 +178,33 @@ class TestRealNativeDaemonClientSpawn:
         # Verbatim AC2 substring (lowercase 'r') must appear in the message.
         assert "run `claude --dangerously-skip-permissions` once" in str(exc_info.value)
 
+    def test_spawn_bg_permission_mode_override(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """permission_mode override replaces _DEFAULT_PERMISSION_MODE in cmd."""
+        captured: dict[str, object] = {}
+
+        def fake_run(args: Sequence[str], **kwargs: object) -> _FakeCompleted:
+            captured["args"] = list(args)
+            return _FakeCompleted(stdout="backgrounded · a1b2c3d4\n")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        client = RealNativeDaemonClient()
+
+        client.spawn_bg(
+            cwd=tmp_path, prompt="do it", permission_mode="bypassPermissions"
+        )
+
+        args = captured["args"]
+        assert isinstance(args, list)
+        assert args[:5] == [
+            "claude",
+            "--bg",
+            "--permission-mode",
+            "bypassPermissions",
+            "do it",
+        ]
+
 
 class TestRealNativeDaemonClientRoster:
     """list_live_session_short_ids reads roster.json."""

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -57,9 +57,19 @@ class _ScriptedDaemon(FakeNativeDaemonClient):
         self._payload = output_payload
 
     def spawn_bg(
-        self, *, cwd: Path, prompt: str, extra_args: list[str] | None = None
+        self,
+        *,
+        cwd: Path,
+        prompt: str,
+        extra_args: list[str] | None = None,
+        permission_mode: str | None = None,
     ) -> str:
-        short_id = super().spawn_bg(cwd=cwd, prompt=prompt, extra_args=extra_args)
+        short_id = super().spawn_bg(
+            cwd=cwd,
+            prompt=prompt,
+            extra_args=extra_args,
+            permission_mode=permission_mode,
+        )
         from cw.config import DEV_PLAN_OUTPUT_DIR
 
         prompts = sorted(DEV_PLAN_OUTPUT_DIR.glob("prompt-*.txt"))

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -325,7 +325,12 @@ class TestStartSession:
 
         class FlakyDaemon(FakeNativeDaemonClient):
             def spawn_bg(
-                self, *, cwd: object, prompt: object, extra_args: object = None
+                self,
+                *,
+                cwd: object,
+                prompt: object,
+                extra_args: object = None,
+                permission_mode: object = None,
             ) -> str:
                 msg = "simulated daemon failure"
                 raise CwError(msg)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -330,7 +330,7 @@ class TestStartSession:
                 cwd: object,
                 prompt: object,
                 extra_args: object = None,
-                permission_mode: object = None,
+                permission_mode: str | None = None,
             ) -> str:
                 msg = "simulated daemon failure"
                 raise CwError(msg)

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -347,6 +347,117 @@ class TestSpawnCreateImplWorkerModel:
         ]
 
 
+class TestSpawnCreateImplExtraArgsPermissionMode:
+    """Tests for extra_args and permission_mode on spawn_create_impl (issue #294)."""
+
+    def test_spawn_create_impl_passes_extra_args(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """Caller-provided extra_args reach spawn_bg."""
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        daemon = FakeNativeDaemonClient()
+        worktree = make_git_repo("worktree-extra-args")
+
+        spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt="Do the thing.",
+            label=None,
+            native_daemon=daemon,
+            extra_args=["--resume", "abc12345"],
+        )
+
+        assert daemon.spawn_extra_args[0] == ["--resume", "abc12345"]
+
+    def test_spawn_create_impl_merges_worker_model_and_extra_args(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """worker_model args come first, then caller extra_args."""
+        from cw.spawn import spawn_create_impl
+
+        workspace = tmp_path / "workspace" / "merged"
+        workspace.mkdir(parents=True)
+        client = ClientConfig(
+            name="merged",
+            workspace_path=workspace,
+            default_branch="main",
+            worker_model="claude-sonnet-4-6-20251015",
+        )
+        daemon = FakeNativeDaemonClient()
+        worktree = make_git_repo("worktree-merged-args")
+
+        spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt="Do the thing.",
+            label=None,
+            native_daemon=daemon,
+            extra_args=["--resume", "abc12345"],
+        )
+
+        assert daemon.spawn_extra_args[0] == [
+            "--model",
+            "claude-sonnet-4-6-20251015",
+            "--resume",
+            "abc12345",
+        ]
+
+    def test_spawn_create_impl_passes_permission_mode(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """Non-None permission_mode propagates to spawn_bg."""
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        daemon = FakeNativeDaemonClient()
+        worktree = make_git_repo("worktree-permission-mode")
+
+        spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt="Do the thing.",
+            label=None,
+            native_daemon=daemon,
+            permission_mode="bypassPermissions",
+        )
+
+        assert daemon.spawn_permission_modes[0] == "bypassPermissions"
+
+    def test_spawn_create_impl_permission_mode_default_is_none(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """permission_mode defaults to None (spawn_bg uses _DEFAULT_PERMISSION_MODE)."""
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        daemon = FakeNativeDaemonClient()
+        worktree = make_git_repo("worktree-permission-default")
+
+        spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt="Do the thing.",
+            label=None,
+            native_daemon=daemon,
+        )
+
+        assert daemon.spawn_permission_modes[0] is None
+
+
 class TestValidateWorktree:
     """Tests for the _validate_worktree pre-flight gate (issue #186).
 


### PR DESCRIPTION
## Summary

- fix(spawn): use explicit None check for permission_mode; fix FlakyDaemon annotation
- feat(spawn): add extra_args + permission_mode to spawn_create_impl/spawn_bg (#294)

Closes #294

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors (src/)
- [ ] pytest — 1043 passed, 2 skipped
- [ ] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it