### PR TITLE
refactor(daemon): remove respond_to_pr_events from watcher tick + deprecate cw daemon

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -1264,7 +1264,8 @@ def daemon(once: bool) -> None:
     """
     click.echo(
         "Note: cw daemon's PR-dispatch role is deprecated as of 0.11. "
-        "Use `cw orchestrator-start` to run the channel-based orchestrator. "
+        "The channel-based orchestrator (cw orchestrator-start, arriving in #115b) "
+        "will replace this dispatch role. "
         "The PR watcher loop (this command's other role) is still required.",
         err=True,
     )

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -1262,6 +1262,12 @@ def daemon(once: bool) -> None:
     Single tick (e.g. from cron):
       cw daemon --once
     """
+    click.echo(
+        "Note: cw daemon's PR-dispatch role is deprecated as of 0.11. "
+        "Use `cw orchestrator-start` to run the channel-based orchestrator. "
+        "The PR watcher loop (this command's other role) is still required.",
+        err=True,
+    )
     run_watcher_tick(once=once)
 
 

--- a/src/cw/daemon.py
+++ b/src/cw/daemon.py
@@ -371,8 +371,9 @@ def run_watcher_tick(*, once: bool = False) -> None:
             _events, updated_snapshot = watch_prs_for_client(client, snapshot)
             _save_snapshot(client_name, updated_snapshot)
 
-        # As of 2026-05-26 the orchestrator skill (cw-orchestrator.md) replaces the
-        # in-daemon dispatch role of pr_responder.respond_to_pr_events().
+        # As of 2026-05-26 the orchestrator skill
+        # (see .claude/agents/cw-orchestrator.md) replaces the in-daemon
+        # dispatch role of pr_responder.respond_to_pr_events().
         # The watcher loop continues to detect PRs and post events into the
         # cw-pr-events channel; the orchestrator session (spawn with
         # `cw orchestrator-start`) consumes the channel and routes spawns.

--- a/src/cw/daemon.py
+++ b/src/cw/daemon.py
@@ -24,7 +24,7 @@ from cw.config import (
 from cw.events import record_event
 from cw.models import OrchestratorEventType, SessionStatus
 from cw.orchestrate import retire_merged_prs
-from cw.pr_responder import clear_completed_pr_sessions, respond_to_pr_events
+from cw.pr_responder import clear_completed_pr_sessions
 
 logger = logging.getLogger(__name__)
 
@@ -371,10 +371,13 @@ def run_watcher_tick(*, once: bool = False) -> None:
             _events, updated_snapshot = watch_prs_for_client(client, snapshot)
             _save_snapshot(client_name, updated_snapshot)
 
-        # Respond to queued PR events and clean up completed dispatch records
+        # As of 2026-05-26 the orchestrator skill (cw-orchestrator.md) replaces the
+        # in-daemon dispatch role of pr_responder.respond_to_pr_events().
+        # The watcher loop continues to detect PRs and post events into the
+        # cw-pr-events channel; the orchestrator session (spawn with
+        # `cw orchestrator-start`) consumes the channel and routes spawns.
         state = load_state()
         clear_completed_pr_sessions(state)
-        respond_to_pr_events()
 
         # Retire merged PRs: close sessions, drop dispatch entries, emit events.
         try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,6 +192,16 @@ class TestCli:
             assert result.exit_code != 0
             assert "Test error message" in result.output
 
+    def test_daemon_once_emits_deprecation_warning(self) -> None:
+        """cw daemon --once prints deprecation warning (via click.echo err=True)."""
+        runner = CliRunner()
+        with patch("cw.cli.run_watcher_tick"):
+            result = runner.invoke(main, ["daemon", "--once"])
+        assert result.exit_code == 0
+        assert "Note: cw daemon's PR-dispatch role is deprecated as of 0.11." in (
+            result.output
+        )
+
 
 class TestUpgradeWorkers:
     def test_happy_path(self) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -547,28 +547,18 @@ class TestChannelPosting:
 
 
 def test_run_watcher_tick_does_not_call_respond_to_pr_events() -> None:
-    """respond_to_pr_events must NOT be called from run_watcher_tick.
+    """respond_to_pr_events must NOT be imported or called in run_watcher_tick.
 
     The orchestrator skill (cw-orchestrator.md) replaced the in-daemon
-    dispatch role of pr_responder.respond_to_pr_events().  This is a
-    regression guard so the removal stays removed.
+    dispatch role of pr_responder.respond_to_pr_events(). This regression
+    guard ensures the import stays removed.
     """
-    from cw.daemon import run_watcher_tick
+    import importlib
 
-    with (
-        patch("cw.daemon.load_orchestrator_config") as mock_config,
-        patch("cw.daemon.load_clients", return_value={}),
-        patch("cw.daemon.load_state") as mock_state,
-        patch("cw.daemon._load_throttle") as mock_throttle,
-        patch("cw.daemon._save_throttle"),
-        patch("cw.daemon.clear_completed_pr_sessions"),
-        patch("cw.daemon.retire_merged_prs"),
-        patch("cw.pr_responder.respond_to_pr_events") as mock_respond,
-    ):
-        mock_config.return_value = MagicMock(tick_interval_seconds=1)
-        mock_state.return_value = MagicMock()
-        mock_throttle.return_value = MagicMock()
+    import cw.daemon
 
-        run_watcher_tick(once=True)
-
-    mock_respond.assert_not_called()
+    importlib.reload(cw.daemon)
+    assert not hasattr(cw.daemon, "respond_to_pr_events"), (
+        "respond_to_pr_events must not be imported in cw.daemon — "
+        "the orchestrator skill replaced its dispatch role"
+    )

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -539,3 +539,36 @@ class TestChannelPosting:
             _post_to_channel("merged", "owner/repo", 1, {})
 
         assert captured_netlocs == ["custom-host:9999"]
+
+
+# ---------------------------------------------------------------------------
+# run_watcher_tick regression guard
+# ---------------------------------------------------------------------------
+
+
+def test_run_watcher_tick_does_not_call_respond_to_pr_events() -> None:
+    """respond_to_pr_events must NOT be called from run_watcher_tick.
+
+    The orchestrator skill (cw-orchestrator.md) replaced the in-daemon
+    dispatch role of pr_responder.respond_to_pr_events().  This is a
+    regression guard so the removal stays removed.
+    """
+    from cw.daemon import run_watcher_tick
+
+    with (
+        patch("cw.daemon.load_orchestrator_config") as mock_config,
+        patch("cw.daemon.load_clients", return_value={}),
+        patch("cw.daemon.load_state") as mock_state,
+        patch("cw.daemon._load_throttle") as mock_throttle,
+        patch("cw.daemon._save_throttle"),
+        patch("cw.daemon.clear_completed_pr_sessions"),
+        patch("cw.daemon.retire_merged_prs"),
+        patch("cw.pr_responder.respond_to_pr_events") as mock_respond,
+    ):
+        mock_config.return_value = MagicMock(tick_interval_seconds=1)
+        mock_state.return_value = MagicMock()
+        mock_throttle.return_value = MagicMock()
+
+        run_watcher_tick(once=True)
+
+    mock_respond.assert_not_called()


### PR DESCRIPTION
## Summary

- refactor(daemon): remove respond_to_pr_events from watcher tick + deprecate cw daemon
- fix(daemon): address review findings — deprecation warning and regression guard

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it