### PR TITLE
feat(agents): add cw-orchestrator subagent that routes channel events

### DIFF
--- a/.claude/agents/cw-orchestrator.md
+++ b/.claude/agents/cw-orchestrator.md
@@ -1,0 +1,24 @@
+---
+name: cw-orchestrator
+description: React to <channel source="cw-pr-events"> events and route PR work
+tools: Bash(cw orchestrate *), Bash(cw dev-queue *), Bash(gh pr view *), Read, Write
+---
+
+You are the cw orchestrator session. PR events arrive as
+`<channel source="cw-pr-events" event_type=... pr_number=... repo=... role=...>` tags.
+Inside the tag body is a JSON payload with shape `{repo, pr_number, event_type, payload}`.
+
+## Decision table
+
+| event_type            | Action                                                                     |
+|-----------------------|----------------------------------------------------------------------------|
+| `pr.ci_failed`        | run: `cw dev-queue add <pr_number> -c <client>` then `cw dev-queue run --once` |
+| `pr.review_received`  | run: `cw dev-queue add <pr_number> -c <client>` then `cw dev-queue run --once` |
+| `pr.mergeable`        | log only (no spawn)                                                        |
+| `pr.merged`           | run: `cw orchestrate retire`                                               |
+
+The dispatch path handles worktree creation, branch checkout, and prompt
+generation. Dedup before dispatch via `cw dev-queue status -c <client>` —
+if the ticket already shows PENDING or RUNNING, skip.
+
+If a channel event body fails to parse as JSON, log to stderr and continue.

--- a/tests/test_orchestrator_skill.py
+++ b/tests/test_orchestrator_skill.py
@@ -1,0 +1,28 @@
+"""Structural smoke tests for the cw-orchestrator subagent definition."""
+
+from pathlib import Path
+
+AGENT_FILE = Path(__file__).parent.parent / ".claude" / "agents" / "cw-orchestrator.md"
+
+
+def test_orchestrator_agent_file_exists() -> None:
+    assert AGENT_FILE.exists(), f"{AGENT_FILE} not found"
+
+
+def test_orchestrator_agent_frontmatter_valid() -> None:
+    content = AGENT_FILE.read_text()
+    assert "name: cw-orchestrator" in content
+    assert "description:" in content
+    assert "tools:" in content  # agents/ convention (NOT allowed-tools:)
+    assert "allowed-tools:" not in content
+
+
+def test_orchestrator_agent_decision_table_covers_known_events() -> None:
+    content = AGENT_FILE.read_text()
+    for event in ["pr.ci_failed", "pr.review_received", "pr.mergeable", "pr.merged"]:
+        assert event in content, f"Event '{event}' missing from decision table"
+
+
+def test_orchestrator_agent_dedup_command_documented() -> None:
+    content = AGENT_FILE.read_text()
+    assert "cw dev-queue status" in content, "Dedup command not documented"


### PR DESCRIPTION
## Summary

- feat(agents): add cw-orchestrator subagent that routes channel events (#115 split 3/4) (#296)

Adds `.claude/agents/cw-orchestrator.md` — a subagent definition that subscribes to PR channel events and routes them to the correct handler based on event type (review requested, CI complete, merge, etc.). Includes a test file validating the agent file structure, frontmatter, decision table coverage, and dedup command documentation.

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors (PR files clean; pre-existing errors in test_atomic.py and test_adapter_protocol.py are on main)
- [ ] pytest — 4/4 pass (test_orchestrator_skill.py)
- [ ] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it