### PR TITLE
feat(cli): add cw orchestrator-start command (#295)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -1929,6 +1929,54 @@ def spawn_close(session_id: str) -> None:
     click.echo(f"Closed session: {session_id}")
 
 
+def _resolve_client(client_name: str | None) -> ClientConfig:
+    """Resolve --client to a ClientConfig, defaulting to the first configured client."""
+    clients = load_clients()
+    if client_name:
+        return get_client(client_name)
+    if not clients:
+        msg = "No clients configured. Add one to ~/.config/cw/clients.yaml."
+        raise CwError(msg)
+    return next(iter(clients.values()))
+
+
+@main.command(name="orchestrator-start")
+@click.option("--name", default="cw-orchestrator", help="Session label.")
+@click.option(
+    "--client",
+    default=None,
+    help="Client to scope the orchestrator to. Defaults to first configured client.",
+)
+@handle_errors
+def orchestrator_start(
+    name: str,
+    client: str | None,
+    native_daemon: NativeDaemonClient | None = None,
+) -> None:
+    """Spawn a long-running cw orchestrator session driven by the cw-pr-events channel.
+
+    The session listens for PR events emitted by cw daemon and reacts via
+    the cw-orchestrator agent skill.
+    """
+    client_cfg = _resolve_client(client)
+    extra_args = [
+        "--agent",
+        "cw-orchestrator",
+        "--dangerously-load-development-channels",
+        "server:cw-pr-events",
+    ]
+    session_id = spawn_create_impl(
+        client=client_cfg,
+        worktree=client_cfg.workspace_path,
+        prompt="You are the cw orchestrator session. Wait for channel events.",
+        label=name,
+        extra_args=extra_args,
+        permission_mode="acceptEdits",
+        native_daemon=native_daemon,
+    )
+    click.echo(f"Spawned orchestrator session: {session_id}")
+
+
 @main.group(name="pr-channel")
 def pr_channel() -> None:
     """PR channel server: push MCP notifications to subscribed Claude sessions."""

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -1929,6 +1929,10 @@ def spawn_close(session_id: str) -> None:
     click.echo(f"Closed session: {session_id}")
 
 
+_ORCHESTRATOR_AGENT = "cw-orchestrator"
+_ORCHESTRATOR_CHANNEL = "server:cw-pr-events"
+
+
 def _resolve_client(client_name: str | None) -> ClientConfig:
     """Resolve --client to a ClientConfig, defaulting to the first configured client."""
     clients = load_clients()
@@ -1941,7 +1945,7 @@ def _resolve_client(client_name: str | None) -> ClientConfig:
 
 
 @main.command(name="orchestrator-start")
-@click.option("--name", default="cw-orchestrator", help="Session label.")
+@click.option("--name", default=_ORCHESTRATOR_AGENT, help="Session label.")
 @click.option(
     "--client",
     default=None,
@@ -1961,9 +1965,9 @@ def orchestrator_start(
     client_cfg = _resolve_client(client)
     extra_args = [
         "--agent",
-        "cw-orchestrator",
+        _ORCHESTRATOR_AGENT,
         "--dangerously-load-development-channels",
-        "server:cw-pr-events",
+        _ORCHESTRATOR_CHANNEL,
     ]
     session_id = spawn_create_impl(
         client=client_cfg,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3502,44 +3502,46 @@ class TestDevQueueAddTimeout:
 # ---------------------------------------------------------------------------
 
 
+def _write_clients_yaml_for_test(
+    tmp_config_dir: Path,
+    clients: list[tuple[str, str]],
+) -> None:
+    """Write a minimal clients.yaml with the given (name, workspace_path) tuples."""
+    config_dir = tmp_config_dir / ".config" / "cw"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    lines = ["clients:\n"]
+    for name, ws in clients:
+        lines.append(f"  {name}:\n")
+        lines.append(f"    workspace_path: {ws}\n")
+    (config_dir / "clients.yaml").write_text("".join(lines))
+
+
+def _make_git_workspace_for_test(tmp_path: Path, name: str) -> Path:
+    """Create a minimal git repo suitable for spawn_create_impl's _validate_worktree."""
+    import os
+    import subprocess
+
+    repo = tmp_path / name
+    repo.mkdir(parents=True, exist_ok=True)
+    clean_env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+    def _git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            check=True,
+            env=clean_env,
+        )
+
+    _git("init", "-b", "main")
+    _git("config", "user.email", "t@t.com")
+    _git("config", "user.name", "t")
+    _git("commit", "--allow-empty", "-m", "init")
+    return repo
+
+
 class TestOrchestratorStart:
     """Tests for ``cw orchestrator-start`` command."""
-
-    def _write_clients_yaml(
-        self,
-        tmp_config_dir: Path,
-        clients: list[tuple[str, str]],
-    ) -> None:
-        config_dir = tmp_config_dir / ".config" / "cw"
-        config_dir.mkdir(parents=True, exist_ok=True)
-        lines = ["clients:\n"]
-        for name, ws in clients:
-            lines.append(f"  {name}:\n")
-            lines.append(f"    workspace_path: {ws}\n")
-        (config_dir / "clients.yaml").write_text("".join(lines))
-
-    def _make_git_workspace(self, tmp_path: Path, name: str) -> Path:
-        """Create a minimal git repo suitable for _validate_worktree."""
-        import os
-        import subprocess
-
-        repo = tmp_path / name
-        repo.mkdir(parents=True, exist_ok=True)
-        clean_env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
-
-        def _git(*args: str) -> None:
-            subprocess.run(
-                ["git", "-C", str(repo), *args],
-                capture_output=True,
-                check=True,
-                env=clean_env,
-            )
-
-        _git("init", "-b", "main")
-        _git("config", "user.email", "t@t.com")
-        _git("config", "user.name", "t")
-        _git("commit", "--allow-empty", "-m", "init")
-        return repo
 
     def test_orchestrator_start_with_explicit_client_spawns_session(
         self, tmp_config_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -3547,8 +3549,8 @@ class TestOrchestratorStart:
         """cw orchestrator-start --client mytest spawns a session and prints its id."""
         from cw.native_daemon import FakeNativeDaemonClient
 
-        ws = self._make_git_workspace(tmp_path, "ws-explicit")
-        self._write_clients_yaml(tmp_config_dir, [("mytest", str(ws))])
+        ws = _make_git_workspace_for_test(tmp_path, "ws-explicit")
+        _write_clients_yaml_for_test(tmp_config_dir, [("mytest", str(ws))])
         daemon = FakeNativeDaemonClient()
         monkeypatch.setattr("cw.spawn.get_native_daemon_client", lambda: daemon)
 
@@ -3574,7 +3576,7 @@ class TestOrchestratorStart:
         """--client unknown-name exits with error mentioning the unknown name."""
         ws = tmp_path / "ws-unknown"
         ws.mkdir()
-        self._write_clients_yaml(tmp_config_dir, [("real-client", str(ws))])
+        _write_clients_yaml_for_test(tmp_config_dir, [("real-client", str(ws))])
 
         runner = CliRunner()
         result = runner.invoke(main, ["orchestrator-start", "--client", "unknown-name"])
@@ -3588,8 +3590,8 @@ class TestOrchestratorStart:
         """Without --client, command uses the first configured client."""
         from cw.native_daemon import FakeNativeDaemonClient
 
-        ws = self._make_git_workspace(tmp_path, "ws-default")
-        self._write_clients_yaml(tmp_config_dir, [("first-client", str(ws))])
+        ws = _make_git_workspace_for_test(tmp_path, "ws-default")
+        _write_clients_yaml_for_test(tmp_config_dir, [("first-client", str(ws))])
         daemon = FakeNativeDaemonClient()
         monkeypatch.setattr("cw.spawn.get_native_daemon_client", lambda: daemon)
 
@@ -3604,10 +3606,11 @@ class TestOrchestratorStart:
         self, tmp_config_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """extra_args contain --agent and --dangerously-load-development-channels."""
+        from cw.cli import _ORCHESTRATOR_AGENT, _ORCHESTRATOR_CHANNEL
         from cw.native_daemon import FakeNativeDaemonClient
 
-        ws = self._make_git_workspace(tmp_path, "ws-args")
-        self._write_clients_yaml(tmp_config_dir, [("args-client", str(ws))])
+        ws = _make_git_workspace_for_test(tmp_path, "ws-args")
+        _write_clients_yaml_for_test(tmp_config_dir, [("args-client", str(ws))])
         daemon = FakeNativeDaemonClient()
         monkeypatch.setattr("cw.spawn.get_native_daemon_client", lambda: daemon)
 
@@ -3618,7 +3621,7 @@ class TestOrchestratorStart:
         assert daemon.spawn_extra_args[0] is not None
         extra = daemon.spawn_extra_args[0]
         assert "--agent" in extra
-        assert "cw-orchestrator" in extra
+        assert _ORCHESTRATOR_AGENT in extra
         assert "--dangerously-load-development-channels" in extra
-        assert "server:cw-pr-events" in extra
+        assert _ORCHESTRATOR_CHANNEL in extra
         assert daemon.spawn_permission_modes[0] == "acceptEdits"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3495,3 +3495,130 @@ class TestDevQueueAddTimeout:
         task = next((t for t in store.tasks if t.ticket_id == "GEN-456"), None)
         assert task is not None
         assert task.headless_timeout_override is None
+
+
+# ---------------------------------------------------------------------------
+# TestOrchestratorStart (GitHub issue #295)
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorStart:
+    """Tests for ``cw orchestrator-start`` command."""
+
+    def _write_clients_yaml(
+        self,
+        tmp_config_dir: Path,
+        clients: list[tuple[str, str]],
+    ) -> None:
+        config_dir = tmp_config_dir / ".config" / "cw"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        lines = ["clients:\n"]
+        for name, ws in clients:
+            lines.append(f"  {name}:\n")
+            lines.append(f"    workspace_path: {ws}\n")
+        (config_dir / "clients.yaml").write_text("".join(lines))
+
+    def _make_git_workspace(self, tmp_path: Path, name: str) -> Path:
+        """Create a minimal git repo suitable for _validate_worktree."""
+        import os
+        import subprocess
+
+        repo = tmp_path / name
+        repo.mkdir(parents=True, exist_ok=True)
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+        def _git(*args: str) -> None:
+            subprocess.run(
+                ["git", "-C", str(repo), *args],
+                capture_output=True,
+                check=True,
+                env=clean_env,
+            )
+
+        _git("init", "-b", "main")
+        _git("config", "user.email", "t@t.com")
+        _git("config", "user.name", "t")
+        _git("commit", "--allow-empty", "-m", "init")
+        return repo
+
+    def test_orchestrator_start_with_explicit_client_spawns_session(
+        self, tmp_config_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """cw orchestrator-start --client mytest spawns a session and prints its id."""
+        from cw.native_daemon import FakeNativeDaemonClient
+
+        ws = self._make_git_workspace(tmp_path, "ws-explicit")
+        self._write_clients_yaml(tmp_config_dir, [("mytest", str(ws))])
+        daemon = FakeNativeDaemonClient()
+        monkeypatch.setattr("cw.spawn.get_native_daemon_client", lambda: daemon)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["orchestrator-start", "--client", "mytest"])
+
+        assert result.exit_code == 0, result.output
+        assert len(daemon.spawn_calls) == 1
+
+    def test_orchestrator_start_no_clients_raises_clickexception(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """When no clients are configured, command exits with error."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["orchestrator-start"])
+
+        assert result.exit_code != 0
+        assert "No clients configured" in result.output
+
+    def test_orchestrator_start_unknown_client_raises_clickexception(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """--client unknown-name exits with error mentioning the unknown name."""
+        ws = tmp_path / "ws-unknown"
+        ws.mkdir()
+        self._write_clients_yaml(tmp_config_dir, [("real-client", str(ws))])
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["orchestrator-start", "--client", "unknown-name"])
+
+        assert result.exit_code != 0
+        assert "unknown-name" in result.output
+
+    def test_orchestrator_start_defaults_to_first_client_when_omitted(
+        self, tmp_config_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without --client, command uses the first configured client."""
+        from cw.native_daemon import FakeNativeDaemonClient
+
+        ws = self._make_git_workspace(tmp_path, "ws-default")
+        self._write_clients_yaml(tmp_config_dir, [("first-client", str(ws))])
+        daemon = FakeNativeDaemonClient()
+        monkeypatch.setattr("cw.spawn.get_native_daemon_client", lambda: daemon)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["orchestrator-start"])
+
+        assert result.exit_code == 0, result.output
+        assert len(daemon.spawn_calls) == 1
+        assert daemon.spawn_calls[0][0] == ws
+
+    def test_orchestrator_start_passes_correct_extra_args_to_spawn_create_impl(
+        self, tmp_config_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """extra_args contain --agent and --dangerously-load-development-channels."""
+        from cw.native_daemon import FakeNativeDaemonClient
+
+        ws = self._make_git_workspace(tmp_path, "ws-args")
+        self._write_clients_yaml(tmp_config_dir, [("args-client", str(ws))])
+        daemon = FakeNativeDaemonClient()
+        monkeypatch.setattr("cw.spawn.get_native_daemon_client", lambda: daemon)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["orchestrator-start", "--client", "args-client"])
+
+        assert result.exit_code == 0, result.output
+        assert daemon.spawn_extra_args[0] is not None
+        extra = daemon.spawn_extra_args[0]
+        assert "--agent" in extra
+        assert "cw-orchestrator" in extra
+        assert "--dangerously-load-development-channels" in extra
+        assert "server:cw-pr-events" in extra
+        assert daemon.spawn_permission_modes[0] == "acceptEdits"


### PR DESCRIPTION
## Summary

- Adds `cw orchestrator-start` CLI command that spawns a long-running orchestrator session attached to the `cw-pr-events` MCP channel
- New `_resolve_client` helper defaults to the first configured client when `--client` is omitted
- Passes `--agent cw-orchestrator` and `--dangerously-load-development-channels server:cw-pr-events` as extra_args with `permission_mode="acceptEdits"`
- 5 tests covering: explicit client spawn, no-clients error, unknown-client error, default-client selection, and extra-args/permission-mode verification

Closes #295

## Test plan

- [ ] `cw orchestrator-start --help` shows `--name` and `--client` options
- [ ] `cw orchestrator-start` with no clients exits with "No clients configured" error
- [ ] `cw orchestrator-start --client unknown` exits with error mentioning the name
- [ ] `uv run pytest tests/test_cli.py::TestOrchestratorStart` — all 5 pass
- [ ] `uv run ruff check src/ tests/` — clean
- [ ] `uv run mypy src/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)