### PR TITLE
fix(server): lazy-import starlette so cw_pr_events_server loads without [mcp] extra

### DIFF
--- a/src/cw/cw_pr_events_server.py
+++ b/src/cw/cw_pr_events_server.py
@@ -12,17 +12,21 @@ import urllib.parse
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field, field_validator
-from starlette.applications import Starlette
-from starlette.responses import JSONResponse, Response
-from starlette.routing import Mount, Route
 
 from cw.atomic import atomic_write_text
 from cw.config import state_dir
 
 if TYPE_CHECKING:
+    from starlette.applications import Starlette
     from starlette.requests import Request
+    from starlette.responses import Response
 
 logger = logging.getLogger(__name__)
+
+_MCP_EXTRA_MSG = (
+    "channel server requires [mcp] extra; "
+    "run 'uv pip install cw[mcp]' or 'uv sync --extra mcp'"
+)
 
 DEFAULT_PORT = 8788
 DEFAULT_HOST = "127.0.0.1"
@@ -194,6 +198,8 @@ def _build_notification(event: PREventRequest) -> dict[str, Any]:
 
 async def handle_post_pr_event(request: Request) -> Response:
     """Handle POST /pr-event: validate JSON body and broadcast MCP notification."""
+    from starlette.responses import JSONResponse  # noqa: PLC0415
+
     try:
         body = await request.json()
         event = PREventRequest.model_validate(body)
@@ -207,6 +213,8 @@ async def handle_post_pr_event(request: Request) -> Response:
 
 async def handle_post_ack(request: Request) -> Response:
     """Handle POST /ack: advance per-subscriber cursor."""
+    from starlette.responses import JSONResponse  # noqa: PLC0415
+
     try:
         body = await request.json()
         req = AckRequest.model_validate(body)
@@ -224,6 +232,11 @@ _event_offset[0] = _load_offset_from_file()
 
 def make_app() -> Starlette:
     """Build and return the Starlette ASGI app with MCP SSE + /pr-event route."""
+    try:
+        from starlette.applications import Starlette  # noqa: PLC0415
+        from starlette.routing import Mount, Route  # noqa: PLC0415
+    except ImportError as exc:
+        raise ImportError(_MCP_EXTRA_MSG) from exc
     import anyio  # noqa: PLC0415
     from mcp.server import Server  # noqa: PLC0415
     from mcp.server.sse import SseServerTransport  # noqa: PLC0415

--- a/tests/test_cw_pr_events_server.py
+++ b/tests/test_cw_pr_events_server.py
@@ -548,3 +548,53 @@ class TestLoadOffsetFromFile:
             f.write("bad-json\n")
         result = _load_offset_from_file()
         assert result == 1
+
+
+class TestLazyStarlette:
+    """Verify starlette is not required at module-load time (lazy-import contract)."""
+
+    def test_module_import_does_not_require_starlette(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import importlib
+        import sys
+
+        # Block starlette sub-modules to simulate the [mcp] extra being absent
+        for key in (
+            "starlette",
+            "starlette.applications",
+            "starlette.responses",
+            "starlette.routing",
+            "starlette.requests",
+        ):
+            monkeypatch.setitem(sys.modules, key, None)
+
+        server_mod_name = "cw.cw_pr_events_server"
+        original_mod = sys.modules.pop(server_mod_name, None)
+        try:
+            mod = importlib.import_module(server_mod_name)
+            assert mod is not None
+        finally:
+            sys.modules.pop(server_mod_name, None)
+            if original_mod is not None:
+                sys.modules[server_mod_name] = original_mod
+
+    def test_make_app_raises_clear_importerror_without_starlette(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+
+        monkeypatch.setitem(sys.modules, "starlette.applications", None)
+
+        with pytest.raises(ImportError, match=r"channel server requires \[mcp\] extra"):
+            _server_mod.make_app()
+
+    def test_serve_raises_clear_importerror_without_starlette(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+
+        monkeypatch.setitem(sys.modules, "starlette.applications", None)
+
+        with pytest.raises(ImportError, match=r"channel server requires \[mcp\] extra"):
+            _server_mod.serve()


### PR DESCRIPTION
## Summary

- Removes top-level `from starlette...` imports that caused `ModuleNotFoundError` on `import cw.cw_pr_events_server` without the `[mcp]` extra
- Defers starlette imports to `make_app()` (with a clear `ImportError` + install hint) and the two handler functions, matching the existing lazy-import pattern for `mcp`/`anyio`/`uvicorn`
- Moves starlette type annotations to `TYPE_CHECKING` block (no runtime cost)
- Adds `TestLazyStarlette` with 3 regression tests: module loads without starlette, `make_app()` raises clear error, `serve()` raises clear error

## Test plan

- [x] `uv run pytest tests/test_cw_pr_events_server.py -v` — 52/52 pass
- [x] `uv run ruff check` — clean
- [x] `uv run mypy` — clean
- [x] New `TestLazyStarlette::test_module_import_does_not_require_starlette` — passes (blocks starlette in sys.modules, reimports module, verifies no ImportError)
- [x] New `TestLazyStarlette::test_make_app_raises_clear_importerror_without_starlette` — passes
- [x] New `TestLazyStarlette::test_serve_raises_clear_importerror_without_starlette` — passes

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)