### PR TITLE
fix(sentinel): strip code-fence wrapper before json.loads in parse_stdout

### DIFF
--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -436,6 +436,19 @@ def _tail(text: str, lines: int = _TAIL_LINES) -> str:
     return "\n".join(text.splitlines()[-lines:])
 
 
+def _strip_code_fence(raw: str) -> str:
+    """Strip a markdown code fence wrapper from a sentinel block payload.
+
+    Only strips known-safe language specs (json or plain). Unknown specs
+    (e.g. typescript) and missing closing fences are left for json.loads
+    to reject loudly.
+    """
+    for prefix in ("```json\n", "```\n"):
+        if raw.startswith(prefix) and raw.endswith("\n```"):
+            return raw[len(prefix) : -4]
+    return raw
+
+
 def extract_block(text: str) -> str | None:
     """Return the JSON text inside the LAST complete sentinel pair, or None.
 
@@ -483,7 +496,7 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
             blocker=Blocker(stage="unknown", reason=reason, details=details),
         )
 
-    raw_block = matches[0].group(1)
+    raw_block = _strip_code_fence(matches[0].group(1))
 
     # §6 (3) JSON does not parse.
     try:

--- a/tests/test_auto_dev_result.py
+++ b/tests/test_auto_dev_result.py
@@ -522,6 +522,54 @@ class TestSentinelFraming:
 
 
 # ---------------------------------------------------------------------------
+# Code-fence stripping
+# ---------------------------------------------------------------------------
+
+
+class TestCodeFenceStripping:
+    """parse_stdout must handle code-fence-wrapped JSON payloads."""
+
+    def test_json_fence_parses_same_as_raw(self) -> None:
+        """```json\n...\n``` wrapper produces same AutoDevResult as raw JSON."""
+        payload = _shipped_payload()
+        body = json.dumps(payload)
+        text = (
+            f"narrative\n<<<AUTO_DEV_RESULT\n```json\n{body}\n```\nAUTO_DEV_RESULT>>>\n"
+        )
+        result = parse_stdout(text)
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "shipped"
+
+    def test_plain_fence_parses_same_as_raw(self) -> None:
+        """```\n...\n``` (no language specifier) also parses."""
+        payload = _shipped_payload()
+        body = json.dumps(payload)
+        text = f"narrative\n<<<AUTO_DEV_RESULT\n```\n{body}\n```\nAUTO_DEV_RESULT>>>\n"
+        result = parse_stdout(text)
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "shipped"
+
+    def test_misformed_fence_wrong_language_fails(self) -> None:
+        """Unknown language spec (typescript) is NOT stripped; json.loads rejects it."""
+        payload = _shipped_payload()
+        body = json.dumps(payload)
+        sentinel = "<<<AUTO_DEV_RESULT\n```typescript\n"
+        text = f"narrative\n{sentinel}{body}\n```\nAUTO_DEV_RESULT>>>\n"
+        result = parse_stdout(text)
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "no_result_emitted"
+
+    def test_misformed_fence_no_closing_fails(self) -> None:
+        """```json\n... without closing ``` is NOT stripped — json.loads rejects it."""
+        payload = _shipped_payload()
+        body = json.dumps(payload)
+        text = f"narrative\n<<<AUTO_DEV_RESULT\n```json\n{body}\nAUTO_DEV_RESULT>>>\n"
+        result = parse_stdout(text)
+        assert isinstance(result, BlockedResult)
+        assert result.blocker.reason == "no_result_emitted"
+
+
+# ---------------------------------------------------------------------------
 # Cross-field invariants (per the owner's comment + §3-§5)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- fix(auto_dev_result): strip code-fence wrapper before json.loads in parse_stdout

Fixes #303 — when Claude agents emit the sentinel JSON payload wrapped in a markdown code fence (` ```json ... ``` `), `parse_stdout` was passing the raw fenced string directly to `json.loads`, which raised `JSONDecodeError` and left the task in PENDING state. This PR adds a pre-parse strip step that detects and unwraps ` ```json ``` ` or ` ``` ``` ` fences before decoding, matching the sentinel extraction logic already present for the outer `<sentinel>` block.

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate (117 tests in test_auto_dev_result.py, including 4 new TestCodeFenceStripping cases)
- [ ] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it