### PR TITLE
fix(pr-channel): prevent 307 redirect on bare /sse path

### DIFF
--- a/src/cw/cw_pr_events_channel.py
+++ b/src/cw/cw_pr_events_channel.py
@@ -99,7 +99,7 @@ def run_proxy(client_id: str | None = None) -> None:
     base_url = os.environ.get("CW_PR_EVENTS_BASE_URL", _DEFAULT_BASE_URL)
     if client_id is None:
         client_id = os.environ.get("CW_PR_EVENTS_CLIENT_ID", socket.gethostname())
-    sse_url = f"{base_url}/sse?client_id={urllib.parse.quote(client_id)}"
+    sse_url = f"{base_url}/sse/?client_id={urllib.parse.quote(client_id)}"
 
     mcp_server: Server = Server("cw-pr-events")
     init_options = mcp_server.create_initialization_options(

--- a/src/cw/cw_pr_events_server.py
+++ b/src/cw/cw_pr_events_server.py
@@ -230,10 +230,30 @@ _cursors.update(_load_cursors())
 _event_offset[0] = _load_offset_from_file()
 
 
+class _SSESlashMiddleware:
+    """Rewrite bare /sse → /sse/ at ASGI scope level.
+
+    Starlette's Mount("/sse") regex requires a trailing slash to produce a
+    FULL match.  Without this rewrite, a GET /sse request falls through to
+    the redirect_slashes handler and returns a 307.  We normalise the path
+    internally so neither the client nor the router needs to care which form
+    was used.
+    """
+
+    def __init__(self, app: Any) -> None:
+        self._app = app
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        if scope.get("type") == "http" and scope.get("path") == "/sse":
+            scope = dict(scope, path="/sse/")
+        await self._app(scope, receive, send)
+
+
 def make_app() -> Starlette:
     """Build and return the Starlette ASGI app with MCP SSE + /pr-event route."""
     try:
         from starlette.applications import Starlette  # noqa: PLC0415
+        from starlette.middleware import Middleware  # noqa: PLC0415
         from starlette.routing import Mount, Route  # noqa: PLC0415
     except ImportError as exc:
         raise ImportError(_MCP_EXTRA_MSG) from exc
@@ -291,14 +311,17 @@ def make_app() -> Starlette:
             finally:
                 unsubscribe(q)
 
-    return Starlette(
+    app = Starlette(
         routes=[
             Mount("/sse", app=_sse_asgi),
             Mount("/messages", app=sse.handle_post_message),
             Route("/pr-event", handle_post_pr_event, methods=["POST"]),
             Route("/ack", handle_post_ack, methods=["POST"]),
-        ]
+        ],
+        middleware=[Middleware(_SSESlashMiddleware)],
     )
+    app.router.redirect_slashes = False
+    return app
 
 
 def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> None:

--- a/tests/test_cw_pr_events_channel.py
+++ b/tests/test_cw_pr_events_channel.py
@@ -398,6 +398,14 @@ class TestRunProxyEnvVars:
         params = urllib.parse.parse_qs(parsed.query)
         assert params.get("client_id") == [socket.gethostname()]
 
+    def test_sse_url_uses_trailing_slash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SSE URL must use /sse/ to connect directly, not /sse which redirects."""
+        monkeypatch.delenv("CW_PR_EVENTS_BASE_URL", raising=False)
+        monkeypatch.delenv("CW_PR_EVENTS_CLIENT_ID", raising=False)
+        url = self._invoke_proxy_capture_url(monkeypatch)
+        parsed = urllib.parse.urlparse(url)
+        assert parsed.path == "/sse/", f"Expected /sse/ path, got {parsed.path!r}"
+
 
 # ---------------------------------------------------------------------------
 # CLI

--- a/tests/test_cw_pr_events_channel.py
+++ b/tests/test_cw_pr_events_channel.py
@@ -322,10 +322,6 @@ class TestRelayUpstream:
 # ---------------------------------------------------------------------------
 
 
-def _build_expected_sse_url(base: str, client_id: str) -> str:
-    return f"{base}/sse?client_id={urllib.parse.quote(client_id)}"
-
-
 class TestRunProxyEnvVars:
     def _invoke_proxy_capture_url(
         self,
@@ -362,13 +358,17 @@ class TestRunProxyEnvVars:
         monkeypatch.delenv("CW_PR_EVENTS_BASE_URL", raising=False)
         monkeypatch.delenv("CW_PR_EVENTS_CLIENT_ID", raising=False)
         url = self._invoke_proxy_capture_url(monkeypatch)
-        assert url.startswith(f"{_DEFAULT_BASE_URL}/sse")
+        parsed = urllib.parse.urlparse(url)
+        assert parsed.scheme + "://" + parsed.netloc == _DEFAULT_BASE_URL
+        assert parsed.path == "/sse/"
 
     def test_custom_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CW_PR_EVENTS_BASE_URL", "http://example.com:9999")
         monkeypatch.delenv("CW_PR_EVENTS_CLIENT_ID", raising=False)
         url = self._invoke_proxy_capture_url(monkeypatch)
-        assert url.startswith("http://example.com:9999/sse")
+        parsed = urllib.parse.urlparse(url)
+        assert parsed.netloc == "example.com:9999"
+        assert parsed.path == "/sse/"
 
     def test_custom_client_id_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("CW_PR_EVENTS_BASE_URL", raising=False)

--- a/tests/test_cw_pr_events_server.py
+++ b/tests/test_cw_pr_events_server.py
@@ -598,3 +598,85 @@ class TestLazyStarlette:
 
         with pytest.raises(ImportError, match=r"channel server requires \[mcp\] extra"):
             _server_mod.serve()
+
+
+class TestSSERouting:
+    """Regression: /sse must not 307-redirect (issue #305).
+
+    TestClient hangs on live SSE connections so tests are structural/unit-level.
+    """
+
+    def test_app_redirect_slashes_disabled(self) -> None:
+        """make_app() disables Starlette's default redirect_slashes to stop /sse→307."""
+        app = make_app()
+        assert not app.router.redirect_slashes
+
+    def test_sse_slash_middleware_rewrites_bare_path(self) -> None:
+        """_SSESlashMiddleware rewrites /sse (no trailing slash) → /sse/."""
+        import asyncio
+
+        from cw.cw_pr_events_server import _SSESlashMiddleware
+
+        captured: list[str] = []
+
+        async def _capture(scope: object, receive: object, send: object) -> None:
+            assert isinstance(scope, dict)
+            captured.append(scope["path"])
+
+        mw = _SSESlashMiddleware(_capture)
+
+        async def _run() -> None:
+            await mw(
+                {"type": "http", "path": "/sse", "query_string": b"client_id=t"},
+                None,
+                None,
+            )
+
+        asyncio.run(_run())
+        assert captured == ["/sse/"]
+
+    def test_sse_slash_middleware_leaves_slash_path_unchanged(self) -> None:
+        """_SSESlashMiddleware leaves /sse/ (already has trailing slash) untouched."""
+        import asyncio
+
+        from cw.cw_pr_events_server import _SSESlashMiddleware
+
+        captured: list[str] = []
+
+        async def _capture(scope: object, receive: object, send: object) -> None:
+            assert isinstance(scope, dict)
+            captured.append(scope["path"])
+
+        mw = _SSESlashMiddleware(_capture)
+
+        async def _run() -> None:
+            await mw(
+                {"type": "http", "path": "/sse/", "query_string": b"client_id=t"},
+                None,
+                None,
+            )
+
+        asyncio.run(_run())
+        assert captured == ["/sse/"]
+
+    def test_sse_slash_middleware_ignores_other_paths(self) -> None:
+        """_SSESlashMiddleware does not rewrite non-/sse paths."""
+        import asyncio
+
+        from cw.cw_pr_events_server import _SSESlashMiddleware
+
+        captured: list[str] = []
+
+        async def _capture(scope: object, receive: object, send: object) -> None:
+            assert isinstance(scope, dict)
+            captured.append(scope["path"])
+
+        mw = _SSESlashMiddleware(_capture)
+
+        async def _run() -> None:
+            for path in ["/ack", "/pr-event", "/messages"]:
+                scope = {"type": "http", "path": path, "query_string": b""}
+                await mw(scope, None, None)
+
+        asyncio.run(_run())
+        assert captured == ["/ack", "/pr-event", "/messages"]


### PR DESCRIPTION
## Summary

- Starlette's `Mount("/sse")` compiles to `^/sse/(?P<path>.*)$` — requires trailing slash for a full match. Without it, `GET /sse` falls through to the `redirect_slashes` handler and returns a 307. The MCP SSE client (`mcp.client.sse.sse_client`) does not follow redirects, so the SSE connection was never established.
- Added `_SSESlashMiddleware`: pure ASGI middleware that rewrites `scope["path"]` from `/sse` to `/sse/` before routing — transparent internal rewrite, no HTTP redirect visible to clients.
- Set `app.router.redirect_slashes = False` to suppress the 307 entirely.
- Updated `cw_pr_events_channel.py` SSE URL to `/sse/?` (was `/sse?`) for defense-in-depth.
- Regression tests use structural assertions and `asyncio.run()`-based middleware unit tests (`TestClient` hangs on live SSE connections).

## Test plan

- [x] `test_app_redirect_slashes_disabled` — `make_app()` sets `redirect_slashes = False`
- [x] `test_sse_slash_middleware_rewrites_bare_path` — `/sse` → `/sse/` rewrite verified
- [x] `test_sse_slash_middleware_leaves_slash_path_unchanged` — `/sse/` passes through unchanged
- [x] `test_sse_slash_middleware_ignores_other_paths` — `/ack`, `/pr-event`, `/messages` not rewritten
- [x] `test_sse_url_uses_trailing_slash` — channel proxy constructs `/sse/` URL
- [x] `test_default_base_url` / `test_custom_base_url` — tightened to assert `parsed.path == "/sse/"` (was loose `startswith`)
- [x] All 1133 tests pass, ruff clean, mypy clean

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)