### PR TITLE
fix(dev-queue): add CANCELLED status to prevent dispatcher race on spawn close (#317)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -29,6 +29,7 @@ from cw.config import (
 from cw.daemon import run_watcher_tick
 from cw.dev_queue import (
     add_ticket,
+    cancel_ticket,
     clear_tickets,
     dev_queue_lock,
     list_tickets,
@@ -1374,6 +1375,36 @@ def dev_queue_remove(tickets: tuple[str, ...], client: str, remove_all: bool) ->
         click.echo(f"Removed {ticket} from {client} dev-queue.")
 
 
+@dev_queue.command(name="cancel")
+@click.argument("tickets", nargs=-1, required=True)
+@click.option("--client", "-c", "client", required=True, help="Client name")
+@handle_errors
+def dev_queue_cancel(tickets: tuple[str, ...], client: str) -> None:
+    """Cancel dev-queue task(s) and stop any running session."""
+    state = load_state()
+    daemon = get_native_daemon_client()
+    for ticket in tickets:
+        store = load_dev_queue()
+        old_session_id = next(
+            (
+                t.session_id
+                for t in store.tasks
+                if t.ticket_id == ticket and t.client == client
+            ),
+            None,
+        )
+        cancel_ticket(ticket, client)
+        if old_session_id is not None:
+            sess = state.find_by_name_or_id(old_session_id)
+            if (
+                sess is not None
+                and sess.surface_ref is not None
+                and sess.origin is SessionOrigin.DAEMON
+            ):
+                daemon.stop(sess.surface_ref)
+        click.echo(f"Cancelled {ticket} in {client} dev-queue.")
+
+
 @dev_queue.command(name="clear")
 @click.option("--client", "-c", "client", required=True, help="Client name")
 @click.option(
@@ -1412,9 +1443,12 @@ def dev_queue_status(client: str | None) -> None:
             by_client[task.client] = []
         by_client[task.client].append(task)
 
-    header = f"{'CLIENT':<20} {'PENDING':>7}  {'RUNNING':>7}  {'COMPLETED':>9}  TICKETS"
+    header = (
+        f"{'CLIENT':<20} {'PENDING':>7}  {'RUNNING':>7}  {'COMPLETED':>9}"
+        f"  {'CANCELLED':>9}  TICKETS"
+    )
     click.echo(header)
-    click.echo("-" * 70)
+    click.echo("-" * 82)
     for client_name in clients_seen:
         client_tasks = by_client[client_name]
         pending_tasks = [t for t in client_tasks if t.status == QueueItemStatus.PENDING]
@@ -1422,10 +1456,13 @@ def dev_queue_status(client: str | None) -> None:
         completed_tasks = [
             t for t in client_tasks if t.status == QueueItemStatus.COMPLETED
         ]
+        cancelled_tasks = [
+            t for t in client_tasks if t.status == QueueItemStatus.CANCELLED
+        ]
         ticket_ids = ", ".join(t.ticket_id for t in client_tasks)
         click.echo(
             f"{client_name:<20} {len(pending_tasks):>7}  {len(running_tasks):>7}"
-            f"  {len(completed_tasks):>9}  {ticket_ids}"
+            f"  {len(completed_tasks):>9}  {len(cancelled_tasks):>9}  {ticket_ids}"
         )
 
 
@@ -1839,6 +1876,25 @@ def _spawn_close_impl(
                 sess.id,
                 sess.surface_ref,
             )
+
+    # For DAEMON sessions, atomically cancel any RUNNING TicketTask that owns
+    # this session so revert_completed_silent_tasks cannot revert it to PENDING
+    # and the dispatcher cannot re-spawn the same ticket in the same tick.
+    # (See GitHub issue #317.)
+    if sess.origin is SessionOrigin.DAEMON:
+        with dev_queue_lock():
+            store = load_dev_queue()
+            changed = False
+            for task in store.tasks:
+                if (
+                    task.session_id == sess.id
+                    and task.status == QueueItemStatus.RUNNING
+                ):
+                    task.status = QueueItemStatus.CANCELLED
+                    task.session_id = None
+                    changed = True
+            if changed:
+                save_dev_queue(store)
 
     sess.status = SessionStatus.COMPLETED
     sess.completed_at = datetime.now(UTC)

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -29,6 +29,7 @@ from cw.config import (
 from cw.daemon import run_watcher_tick
 from cw.dev_queue import (
     add_ticket,
+    cancel_task_for_session,
     cancel_ticket,
     clear_tickets,
     dev_queue_lock,
@@ -1384,24 +1385,16 @@ def dev_queue_cancel(tickets: tuple[str, ...], client: str) -> None:
     state = load_state()
     daemon = get_native_daemon_client()
     for ticket in tickets:
-        store = load_dev_queue()
-        old_session_id = next(
-            (
-                t.session_id
-                for t in store.tasks
-                if t.ticket_id == ticket and t.client == client
-            ),
-            None,
-        )
-        cancel_ticket(ticket, client)
-        if old_session_id is not None:
-            sess = state.find_by_name_or_id(old_session_id)
-            if (
-                sess is not None
-                and sess.surface_ref is not None
-                and sess.origin is SessionOrigin.DAEMON
-            ):
-                daemon.stop(sess.surface_ref)
+        cleared_session_ids = cancel_ticket(ticket, client)
+        for old_session_id in cleared_session_ids:
+            if old_session_id is not None:
+                sess = state.find_by_name_or_id(old_session_id)
+                if (
+                    sess is not None
+                    and sess.surface_ref is not None
+                    and sess.origin is SessionOrigin.DAEMON
+                ):
+                    daemon.stop(sess.surface_ref)
         click.echo(f"Cancelled {ticket} in {client} dev-queue.")
 
 
@@ -1882,19 +1875,7 @@ def _spawn_close_impl(
     # and the dispatcher cannot re-spawn the same ticket in the same tick.
     # (See GitHub issue #317.)
     if sess.origin is SessionOrigin.DAEMON:
-        with dev_queue_lock():
-            store = load_dev_queue()
-            changed = False
-            for task in store.tasks:
-                if (
-                    task.session_id == sess.id
-                    and task.status == QueueItemStatus.RUNNING
-                ):
-                    task.status = QueueItemStatus.CANCELLED
-                    task.session_id = None
-                    changed = True
-            if changed:
-                save_dev_queue(store)
+        cancel_task_for_session(sess.id)
 
     sess.status = SessionStatus.COMPLETED
     sess.completed_at = datetime.now(UTC)

--- a/src/cw/dev_queue.py
+++ b/src/cw/dev_queue.py
@@ -161,6 +161,34 @@ def remove_ticket(ticket_id: str, client: str, *, remove_all: bool = False) -> N
         save_dev_queue(store)
 
 
+def cancel_ticket(ticket_id: str, client: str) -> None:
+    """Mark a TicketTask as CANCELLED, clearing its session_id.
+
+    Raises CwError when no task matches (ticket_id + client).  Already-CANCELLED
+    tasks are silently skipped (idempotent).  Acquires the file lock atomically.
+    """
+    with _lock():
+        store = load_dev_queue()
+        matches = [
+            t for t in store.tasks if t.ticket_id == ticket_id and t.client == client
+        ]
+        if not matches:
+            msg = (
+                f"No dev-queue task found for ticket '{ticket_id}'"
+                f" in client '{client}'."
+            )
+            raise CwError(msg)
+        changed = False
+        for task in matches:
+            if task.status == QueueItemStatus.CANCELLED:
+                continue
+            task.status = QueueItemStatus.CANCELLED
+            task.session_id = None
+            changed = True
+        if changed:
+            save_dev_queue(store)
+
+
 def clear_tickets(client: str, status: QueueItemStatus | None = None) -> int:
     """Remove all TicketTasks for *client*, optionally filtered by *status*.
 

--- a/src/cw/dev_queue.py
+++ b/src/cw/dev_queue.py
@@ -161,11 +161,11 @@ def remove_ticket(ticket_id: str, client: str, *, remove_all: bool = False) -> N
         save_dev_queue(store)
 
 
-def cancel_ticket(ticket_id: str, client: str) -> None:
+def cancel_ticket(ticket_id: str, client: str) -> list[str | None]:
     """Mark a TicketTask as CANCELLED, clearing its session_id.
 
-    Raises CwError when no task matches (ticket_id + client).  Already-CANCELLED
-    tasks are silently skipped (idempotent).  Acquires the file lock atomically.
+    Returns the list of session_ids that were cleared (one per cancelled task).
+    Raises CwError when no task matches. Idempotent for already-CANCELLED tasks.
     """
     with _lock():
         store = load_dev_queue()
@@ -178,15 +178,36 @@ def cancel_ticket(ticket_id: str, client: str) -> None:
                 f" in client '{client}'."
             )
             raise CwError(msg)
+        cleared: list[str | None] = []
         changed = False
         for task in matches:
             if task.status == QueueItemStatus.CANCELLED:
                 continue
+            cleared.append(task.session_id)
             task.status = QueueItemStatus.CANCELLED
             task.session_id = None
             changed = True
         if changed:
             save_dev_queue(store)
+    return cleared
+
+
+def cancel_task_for_session(session_id: str) -> bool:
+    """Mark the RUNNING TicketTask that owns *session_id* as CANCELLED.
+
+    Returns True if a task was cancelled, False if none matched.
+    Used by _spawn_close_impl to atomically preempt the dispatcher before
+    the session is marked COMPLETED. See GitHub issue #317.
+    """
+    with _lock():
+        store = load_dev_queue()
+        for task in store.tasks:
+            if task.session_id == session_id and task.status == QueueItemStatus.RUNNING:
+                task.status = QueueItemStatus.CANCELLED
+                task.session_id = None
+                save_dev_queue(store)
+                return True
+    return False
 
 
 def clear_tickets(client: str, status: QueueItemStatus | None = None) -> int:

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -47,6 +47,7 @@ class QueueItemStatus(StrEnum):
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
+    CANCELLED = "cancelled"
 
 
 # Schema versions for persisted state. Bump when making a breaking change
@@ -187,6 +188,9 @@ class DevQueueStore(BaseModel):
 
     def completed(self) -> list[TicketTask]:
         return [t for t in self.tasks if t.status == QueueItemStatus.COMPLETED]
+
+    def cancelled(self) -> list[TicketTask]:
+        return [t for t in self.tasks if t.status == QueueItemStatus.CANCELLED]
 
     def by_client(self, client: str) -> list[TicketTask]:
         return [t for t in self.tasks if t.client == client]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3625,3 +3625,118 @@ class TestOrchestratorStart:
         assert "--dangerously-load-development-channels" in extra
         assert _ORCHESTRATOR_CHANNEL in extra
         assert daemon.spawn_permission_modes[0] == "acceptEdits"
+
+
+# ---------------------------------------------------------------------------
+# TestSpawnCloseTaskCancellation — issue #317
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnCloseTaskCancellation:
+    """_spawn_close_impl must atomically CANCEL the owning RUNNING TicketTask."""
+
+    def _make_daemon_session(
+        self, tmp_path: Path, sess_id: str = "close-sess-1"
+    ) -> Session:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir(parents=True, exist_ok=True)
+        sess = Session(
+            id=sess_id,
+            name=f"test-client/auto-dev/{sess_id}",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            workspace_path=workspace,
+            status=SessionStatus.ACTIVE,
+            surface_ref="fake-ref",
+        )
+        state = load_state()
+        state.sessions.append(sess)
+        save_state(state)
+        return sess
+
+    def test_spawn_close_cancels_running_task(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """DAEMON session + RUNNING task with session_id → after close → CANCELLED."""
+        from cw.cli import _spawn_close_impl
+        from cw.dev_queue import load_dev_queue, save_dev_queue
+        from cw.models import DevQueueStore, QueueItemStatus, TicketTask
+        from cw.native_daemon import FakeNativeDaemonClient
+
+        sess = self._make_daemon_session(tmp_path)
+        task = TicketTask(
+            ticket_id="CLOSE-1",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+            session_id=sess.id,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        daemon = FakeNativeDaemonClient()
+        _spawn_close_impl(session_id=sess.id, native_daemon=daemon)
+
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "CLOSE-1")
+        assert t.status == QueueItemStatus.CANCELLED
+        assert t.session_id is None
+
+    def test_spawn_close_user_origin_does_not_touch_task(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """USER-origin session close → RUNNING task is NOT cancelled."""
+        from cw.cli import _spawn_close_impl
+        from cw.dev_queue import load_dev_queue, save_dev_queue
+        from cw.models import DevQueueStore, QueueItemStatus, TicketTask
+        from cw.native_daemon import FakeNativeDaemonClient
+
+        workspace = tmp_path / "workspace2"
+        workspace.mkdir(parents=True, exist_ok=True)
+        sess = Session(
+            id="user-close-sess",
+            name="test-client/auto-dev/user-close-sess",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.USER,
+            workspace_path=workspace,
+            status=SessionStatus.ACTIVE,
+            surface_ref=None,
+        )
+        state = load_state()
+        state.sessions.append(sess)
+        save_state(state)
+
+        task = TicketTask(
+            ticket_id="USER-CLOSE-1",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+            session_id=sess.id,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        daemon = FakeNativeDaemonClient()
+        _spawn_close_impl(session_id=sess.id, native_daemon=daemon)
+
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "USER-CLOSE-1")
+        assert t.status == QueueItemStatus.RUNNING
+
+    def test_spawn_close_no_task_for_session_is_ok(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """DAEMON session with no matching task → close succeeds without error."""
+        from cw.cli import _spawn_close_impl
+        from cw.dev_queue import save_dev_queue
+        from cw.models import DevQueueStore
+        from cw.native_daemon import FakeNativeDaemonClient
+
+        sess = self._make_daemon_session(tmp_path, sess_id="no-task-sess")
+        save_dev_queue(DevQueueStore(tasks=[]))
+
+        daemon = FakeNativeDaemonClient()
+        # Should not raise.
+        _spawn_close_impl(session_id=sess.id, native_daemon=daemon)
+
+        state = load_state()
+        updated = next(s for s in state.sessions if s.id == sess.id)
+        assert updated.status == SessionStatus.COMPLETED

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -13,6 +13,7 @@ from cw.cli import main
 from cw.config import load_orchestrator_config
 from cw.dev_queue import (
     add_ticket,
+    cancel_task_for_session,
     cancel_ticket,
     clear_tickets,
     list_tickets,
@@ -912,11 +913,51 @@ class TestCancelTicket:
             session_id="sess-abc",
         )
         save_dev_queue(DevQueueStore(tasks=[task]))
-        cancel_ticket("TKT-C2", "genhealth")
+        cleared = cancel_ticket("TKT-C2", "genhealth")
         store = load_dev_queue()
         t = next(t for t in store.tasks if t.ticket_id == "TKT-C2")
         assert t.status == QueueItemStatus.CANCELLED
         assert t.session_id is None
+        # cancel_ticket returns the cleared session_ids atomically
+        assert cleared == ["sess-abc"]
+
+    def test_cancel_returns_cleared_session_id(self, tmp_dev_queue: Path) -> None:
+        """cancel_ticket returns the cleared session_id list atomically."""
+        task = TicketTask(
+            ticket_id="TKT-RET",
+            client="genhealth",
+            status=QueueItemStatus.RUNNING,
+            session_id="sess-xyz",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+        cleared = cancel_ticket("TKT-RET", "genhealth")
+        assert cleared == ["sess-xyz"]
+
+    def test_cancel_pending_task_returns_none_session_id(
+        self, tmp_dev_queue: Path
+    ) -> None:
+        """PENDING tasks have session_id=None; cancel_ticket returns [None]."""
+        task = TicketTask(
+            ticket_id="TKT-PRET",
+            client="genhealth",
+            status=QueueItemStatus.PENDING,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+        cleared = cancel_ticket("TKT-PRET", "genhealth")
+        assert cleared == [None]
+
+    def test_cancel_already_cancelled_returns_empty_list(
+        self, tmp_dev_queue: Path
+    ) -> None:
+        """Already-CANCELLED tasks are skipped; cancel_ticket returns []."""
+        task = TicketTask(
+            ticket_id="TKT-ARET",
+            client="genhealth",
+            status=QueueItemStatus.CANCELLED,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+        cleared = cancel_ticket("TKT-ARET", "genhealth")
+        assert cleared == []
 
     def test_cancel_nonexistent_raises_cwerror(self, tmp_dev_queue: Path) -> None:
         save_dev_queue(DevQueueStore(tasks=[]))
@@ -953,6 +994,48 @@ class TestCancelTicket:
         other_task = next(t for t in store.tasks if t.client == "other-client")
         assert gh_task.status == QueueItemStatus.CANCELLED
         assert other_task.status == QueueItemStatus.PENDING
+
+
+# ---------------------------------------------------------------------------
+# TestCancelTaskForSession
+# ---------------------------------------------------------------------------
+
+
+class TestCancelTaskForSession:
+    def test_cancels_running_task_by_session_id(self, tmp_dev_queue: Path) -> None:
+        task = TicketTask(
+            ticket_id="SID-1",
+            client="genhealth",
+            status=QueueItemStatus.RUNNING,
+            session_id="sess-001",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+        result = cancel_task_for_session("sess-001")
+        assert result is True
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "SID-1")
+        assert t.status == QueueItemStatus.CANCELLED
+        assert t.session_id is None
+
+    def test_returns_false_when_no_match(self, tmp_dev_queue: Path) -> None:
+        save_dev_queue(DevQueueStore(tasks=[]))
+        result = cancel_task_for_session("nonexistent-sess")
+        assert result is False
+
+    def test_ignores_non_running_task(self, tmp_dev_queue: Path) -> None:
+        """Only RUNNING tasks are cancelled; PENDING/COMPLETED are ignored."""
+        task = TicketTask(
+            ticket_id="SID-2",
+            client="genhealth",
+            status=QueueItemStatus.PENDING,
+            session_id="sess-002",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+        result = cancel_task_for_session("sess-002")
+        assert result is False
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "SID-2")
+        assert t.status == QueueItemStatus.PENDING
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -13,6 +13,7 @@ from cw.cli import main
 from cw.config import load_orchestrator_config
 from cw.dev_queue import (
     add_ticket,
+    cancel_ticket,
     clear_tickets,
     list_tickets,
     load_dev_queue,
@@ -884,3 +885,102 @@ class TestCLIDevQueueClear:
         )
         assert result.exit_code != 0
         assert "Invalid value" in result.output or "invalid choice" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TestCancelTicket
+# ---------------------------------------------------------------------------
+
+
+class TestCancelTicket:
+    def test_cancel_pending_task_marks_cancelled(self, tmp_dev_queue: Path) -> None:
+        task = TicketTask(
+            ticket_id="TKT-C1", client="genhealth", status=QueueItemStatus.PENDING
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+        cancel_ticket("TKT-C1", "genhealth")
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "TKT-C1")
+        assert t.status == QueueItemStatus.CANCELLED
+        assert t.session_id is None
+
+    def test_cancel_running_task_marks_cancelled(self, tmp_dev_queue: Path) -> None:
+        task = TicketTask(
+            ticket_id="TKT-C2",
+            client="genhealth",
+            status=QueueItemStatus.RUNNING,
+            session_id="sess-abc",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+        cancel_ticket("TKT-C2", "genhealth")
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "TKT-C2")
+        assert t.status == QueueItemStatus.CANCELLED
+        assert t.session_id is None
+
+    def test_cancel_nonexistent_raises_cwerror(self, tmp_dev_queue: Path) -> None:
+        save_dev_queue(DevQueueStore(tasks=[]))
+        pattern = "No dev-queue task found for ticket 'TKT-MISS' in client 'genhealth'"
+        with pytest.raises(CwError, match=pattern):
+            cancel_ticket("TKT-MISS", "genhealth")
+
+    def test_cancel_already_cancelled_is_idempotent(self, tmp_dev_queue: Path) -> None:
+        task = TicketTask(
+            ticket_id="TKT-C3",
+            client="genhealth",
+            status=QueueItemStatus.CANCELLED,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+        # Should not raise
+        cancel_ticket("TKT-C3", "genhealth")
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "TKT-C3")
+        assert t.status == QueueItemStatus.CANCELLED
+
+    def test_cancel_does_not_affect_other_client(self, tmp_dev_queue: Path) -> None:
+        tasks = [
+            TicketTask(
+                ticket_id="TKT-X", client="genhealth", status=QueueItemStatus.PENDING
+            ),
+            TicketTask(
+                ticket_id="TKT-X", client="other-client", status=QueueItemStatus.PENDING
+            ),
+        ]
+        save_dev_queue(DevQueueStore(tasks=tasks))
+        cancel_ticket("TKT-X", "genhealth")
+        store = load_dev_queue()
+        gh_task = next(t for t in store.tasks if t.client == "genhealth")
+        other_task = next(t for t in store.tasks if t.client == "other-client")
+        assert gh_task.status == QueueItemStatus.CANCELLED
+        assert other_task.status == QueueItemStatus.PENDING
+
+
+# ---------------------------------------------------------------------------
+# TestCLIDevQueueCancel
+# ---------------------------------------------------------------------------
+
+
+class TestCLIDevQueueCancel:
+    def test_cancel_pending_task_via_cli(self, tmp_dev_queue: Path) -> None:
+        task = TicketTask(
+            ticket_id="CLI-C1", client="genhealth", status=QueueItemStatus.PENDING
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["dev-queue", "cancel", "CLI-C1", "--client", "genhealth"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Cancelled CLI-C1" in result.output
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "CLI-C1")
+        assert t.status == QueueItemStatus.CANCELLED
+
+    def test_cancel_nonexistent_errors(self, tmp_dev_queue: Path) -> None:
+        save_dev_queue(DevQueueStore(tasks=[]))
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["dev-queue", "cancel", "CLI-MISS", "--client", "genhealth"]
+        )
+        assert result.exit_code != 0
+        assert "No dev-queue task found" in result.output

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1602,3 +1602,82 @@ class TestDispatchDoesNotTouchMainCheckout:
         assert len(tasks) == 1
         assert tasks[0].status == QueueItemStatus.PENDING
         assert tasks[0].attempts == 1
+
+
+# ---------------------------------------------------------------------------
+# Race regression: spawn close cancels task so dispatcher cannot re-spawn
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnCloseRaceRegression:
+    def test_spawn_close_prevents_respawn_via_cancelled_status(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """_spawn_close_impl CANCELS the task; dispatch_tick does not re-spawn it.
+
+        Regression test for GitHub issue #317.  Setup:
+        1. One DAEMON ACTIVE session with a RUNNING TicketTask that has its
+           session_id stamped.
+        2. _spawn_close_impl is called (simulates `cw spawn close`).
+        3. A subsequent dispatch_tick must NOT spawn a new session for the
+           now-CANCELLED task.
+        """
+        from cw.cli import _spawn_close_impl
+        from cw.config import CwState, save_state
+        from cw.models import SessionPurpose
+
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        # Build a DAEMON ACTIVE session.
+        workspace = sample_client_config.workspace_path
+        sess = Session(
+            id="race-sess-1",
+            name="test-client/auto-dev/RACE-1",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            workspace_path=workspace,
+            status=SessionStatus.ACTIVE,
+            surface_ref="fake-surface-ref",
+        )
+        save_state(CwState(sessions=[sess]))
+
+        # Matching RUNNING TicketTask.
+        task = TicketTask(
+            ticket_id="RACE-1",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+            session_id="race-sess-1",
+        )
+        from cw.dev_queue import save_dev_queue
+        from cw.models import DevQueueStore
+
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        # Stub out daemon.stop so it doesn't error on the fake surface_ref.
+        daemon = FakeNativeDaemonClient()
+
+        # Call _spawn_close_impl — should CANCEL the task atomically.
+        _spawn_close_impl(session_id="race-sess-1", native_daemon=daemon)
+
+        # Verify the task is CANCELLED.
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "RACE-1")
+        assert t.status == QueueItemStatus.CANCELLED, (
+            f"Expected CANCELLED after spawn close, got {t.status}"
+        )
+
+        # Now dispatch_tick should NOT re-spawn (CANCELLED != PENDING).
+        spawned = dispatch_tick(simple_config, native_daemon=daemon)
+        assert spawned == 0, (
+            f"Dispatcher should not re-spawn a CANCELLED task, got {spawned}"
+        )
+
+        # Still CANCELLED — not reverted to PENDING.
+        store2 = load_dev_queue()
+        t2 = next(t for t in store2.tasks if t.ticket_id == "RACE-1")
+        assert t2.status == QueueItemStatus.CANCELLED

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1218,3 +1218,31 @@ def test_revert_stalled_uses_per_session_budget(
 
     assert "per-sess-small" in reverted
     assert sess.status == SessionStatus.TIMED_OUT
+
+
+# ---------------------------------------------------------------------------
+# CANCELLED task skipped by revert_completed_silent_tasks
+# ---------------------------------------------------------------------------
+
+
+def test_revert_completed_silent_tasks_skips_cancelled_task(
+    tmp_config_dir: Path,
+) -> None:
+    """DAEMON COMPLETED session + CANCELLED task → no revert, task stays CANCELLED."""
+    sess = _mk_daemon_completed_session("comp-sess-cancel")
+    save_state(CwState(sessions=[sess]))
+
+    task = TicketTask(
+        ticket_id="TKT-CANCEL",
+        client="client-a",
+        status=QueueItemStatus.CANCELLED,
+        session_id=None,
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    reverted = revert_completed_silent_tasks()
+    assert reverted == []
+
+    store = load_dev_queue()
+    t = next(t for t in store.tasks if t.ticket_id == "TKT-CANCEL")
+    assert t.status == QueueItemStatus.CANCELLED


### PR DESCRIPTION
## Summary

- Fixes #317
- Root cause: `_spawn_close_impl` left TicketTask RUNNING; `revert_completed_silent_tasks` reverted it to PENDING; dispatcher re-spawned
- Fix: `CANCELLED` tombstone status; `cancel_task_for_session()` called atomically in `_spawn_close_impl`; new `cw dev-queue cancel` command
- Test coverage: 7 files, 413+120 lines

## Commits

- feat(dev-queue): add CANCELLED status to prevent dispatcher race on spawn close
- fix(dev-queue): resolve TOCTOU race and DRY violation in cancel logic

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it