### PR TITLE
fix(reconcile): bump IDLE_WATCHDOG_SECONDS default 300→900 (#340 stopgap)

### DIFF
--- a/config/CONFIG_REFERENCE.md
+++ b/config/CONFIG_REFERENCE.md
@@ -185,11 +185,11 @@ headless_timeout_by_tier:
 # Per-tier idle-watchdog budgets (seconds). After this window of silence
 # (no terminal sentinel emitted), a DAEMON session is flagged as
 # BLOCKED_ON_USER and a push notification fires. Large-tier sessions can
-# legitimately stall >5min on slow test runs or mypy before emitting any
+# legitimately stall on slow test runs or mypy before emitting any
 # sentinel. Sessions whose scope_hint is unknown fall back to the global
-# IDLE_WATCHDOG_SECONDS (300s). See GitHub issue #326.
+# IDLE_WATCHDOG_SECONDS (900s). See GitHub issues #326, #340.
 idle_watchdog_by_tier:
-  large: 600    # 10 min — large-tier sessions may stall on slow builds
+  large: 1800   # 30 min — large-tier sessions may stall on slow builds
 ```
 
 Override a single ticket's budget at enqueue time:

--- a/docs/headless-contract.md
+++ b/docs/headless-contract.md
@@ -386,8 +386,8 @@ When bumping, update this doc, `commands/auto-dev.md`, and the cw parser in lock
 
 3. **Watchdog** — `reconcile()` finds a DAEMON RUNNING session with no `last_result`, surface still live in the native daemon, and `(now - started_at) > budget`. `flag_silently_idle_daemon_sessions` fires. The budget follows a three-level lookup via `resolve_idle_watchdog_budget`:
    - **Per-ticket** (`TicketTask.idle_watchdog_override`) — explicit escape hatch; beats everything.
-   - **Per-tier** (`OrchestratorConfig.idle_watchdog_by_tier[task.scope_hint]`) — keyed by `TicketTask.scope_hint` (e.g., `"large": 600`). Default config ships `{"large": 600}` so large-tier sessions, which can legitimately stall >5min on slow tests/mypy, get a 10-minute window.
-   - **Global fallback** (`IDLE_WATCHDOG_SECONDS = 300`) — used when no task is found or scope_hint is unset.
+   - **Per-tier** (`OrchestratorConfig.idle_watchdog_by_tier[task.scope_hint]`) — keyed by `TicketTask.scope_hint` (e.g., `"large": 1800`). Default config ships `{"large": 1800}` so large-tier sessions, which can legitimately stall on slow tests/mypy, get a 30-minute window.
+   - **Global fallback** (`IDLE_WATCHDOG_SECONDS = 900`) — used when no task is found or scope_hint is unset. NB: on first dispatch attempt `scope_hint` is always `None` (only retries inherit it from the prior sentinel), so attempt 1 always uses this fallback.
 
 ### SESSION_NEEDS_ATTENTION Event
 

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -234,11 +234,11 @@ class OrchestratorConfig(BaseModel):
         default_factory=lambda: {"small": 1800, "large": 5400}
     )
     # Per-tier idle-watchdog budgets (seconds). Keyed by TicketTask.scope_hint;
-    # unknown tiers fall back to IDLE_WATCHDOG_SECONDS (300s). Large-tier
-    # sessions can legitimately stall >5min on slow tests/mypy before emitting
-    # any sentinel. See GitHub issue #326.
+    # unknown tiers fall back to IDLE_WATCHDOG_SECONDS (900s). Large-tier
+    # sessions can legitimately stall longer on slow tests/mypy before emitting
+    # any sentinel. See GitHub issues #326, #340.
     idle_watchdog_by_tier: dict[str, int] = Field(
-        default_factory=lambda: {"large": 600}
+        default_factory=lambda: {"large": 1800}
     )
 
     @model_validator(mode="before")

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -68,12 +68,15 @@ AUTO_DEV_LABEL_PREFIX = "auto-dev/"
 # override mechanism tracked in #265.
 HEADLESS_TIMEOUT_SECONDS = 3600  # 60 minutes
 
-# Watchdog budget for DAEMON RUNNING sessions that emit no sentinel at all.
-# These are sessions whose wrapper process exited before any AUTO_DEV_RESULT
-# block was written — typically because the child self-backgrounded a subagent
-# and exited early (GitHub #105, #121). After this window, reconcile flags
-# them as BLOCKED_ON_USER and fires a push notification.
-IDLE_WATCHDOG_SECONDS = 300  # 5 minutes
+# Watchdog budget for DAEMON RUNNING sessions that have not yet emitted any
+# AUTO_DEV_RESULT sentinel. Fires on time elapsed alone — no liveness signal
+# is read from the worker's transcript (GitHub #340 tracks the deeper fix).
+# Set generous enough to cover legitimate small-tier work (parser change +
+# tests + skill doc routinely takes 10-20 min wall time). Per-tier overrides
+# in OrchestratorConfig.idle_watchdog_by_tier take precedence; per-ticket
+# TicketTask.idle_watchdog_override beats both. After this window, reconcile
+# flags the session as BLOCKED_ON_USER and fires a push notification.
+IDLE_WATCHDOG_SECONDS = 900  # 15 minutes
 
 # Paused-status value written to SESSION_NEEDS_ATTENTION events for sessions
 # the watchdog flags (no sentinel ever emitted, daemon surface still live).

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1264,7 +1264,7 @@ def test_flag_silently_idle_daemon_sessions_transitions_past_budget(
 ) -> None:
     """DAEMON ACTIVE + no last_result + started >IDLE_WATCHDOG → BLOCKED_ON_USER."""
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    now = datetime(2026, 1, 1, 0, 10, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
     assert (now - started_at).total_seconds() > IDLE_WATCHDOG_SECONDS
 
     sess = Session(
@@ -1375,7 +1375,7 @@ def test_flag_silently_idle_daemon_sessions_leaves_under_budget_alone(
     tmp_config_dir: Path,
     tmp_path: Path,
 ) -> None:
-    """Session started <5min ago → not flagged."""
+    """Session started under the watchdog budget → not flagged."""
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
     now = datetime(2026, 1, 1, 0, 1, 0, tzinfo=UTC)
     assert (now - started_at).total_seconds() < IDLE_WATCHDOG_SECONDS
@@ -1476,7 +1476,7 @@ def test_reconcile_includes_silently_idle_in_report(
 ) -> None:
     """reconcile() calls watchdog and includes BLOCKED_ON_USER ticket in report."""
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    now = datetime(2026, 1, 1, 0, 10, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
     assert (now - started_at).total_seconds() > IDLE_WATCHDOG_SECONDS
 
     # The daemon returns this session as live (surface still registered).
@@ -1557,12 +1557,12 @@ def test_flag_silently_idle_daemon_sessions_respects_large_tier_override(
     tmp_config_dir: Path,
     tmp_path: Path,
 ) -> None:
-    """Large-tier task at 400s: > default 300s but < tier 600s → not flagged."""
+    """Large-tier task at 1200s: > default 900s but < tier 1800s → not flagged."""
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    now = datetime(2026, 1, 1, 0, 6, 40, tzinfo=UTC)  # 400 seconds elapsed
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)  # 1200 seconds elapsed
     elapsed = (now - started_at).total_seconds()
-    assert elapsed > IDLE_WATCHDOG_SECONDS  # 400 > 300 — would flag without override
-    assert elapsed < 600  # but under the large-tier override
+    assert elapsed > IDLE_WATCHDOG_SECONDS  # 1200 > 900 — would flag without override
+    assert elapsed < 1800  # but under the large-tier override
 
     sess = Session(
         id="tier-silent",
@@ -1589,7 +1589,7 @@ def test_flag_silently_idle_daemon_sessions_respects_large_tier_override(
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
-    config = OrchestratorConfig(idle_watchdog_by_tier={"large": 600})
+    config = OrchestratorConfig(idle_watchdog_by_tier={"large": 1800})
     blocked = flag_silently_idle_daemon_sessions(
         state, now=now, native_live={"live-ref"}, config=config
     )
@@ -1611,10 +1611,10 @@ def test_flag_silently_idle_daemon_sessions_respects_per_ticket_override(
 ) -> None:
     """idle_watchdog_override on task beats both tier and global defaults."""
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    now = datetime(2026, 1, 1, 0, 10, 0, tzinfo=UTC)  # 600s elapsed
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)  # 1200s elapsed
     elapsed = (now - started_at).total_seconds()
-    assert elapsed > IDLE_WATCHDOG_SECONDS  # 600 > 300 default
-    assert elapsed < 900  # under the per-ticket override
+    assert elapsed > IDLE_WATCHDOG_SECONDS  # 1200 > 900 default
+    assert elapsed < 1500  # under the per-ticket override
 
     sess = Session(
         id="ticket-silent",
@@ -1637,7 +1637,7 @@ def test_flag_silently_idle_daemon_sessions_respects_per_ticket_override(
         client="client-a",
         status=QueueItemStatus.RUNNING,
         session_id="ticket-silent",
-        idle_watchdog_override=900,
+        idle_watchdog_override=1500,
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 


### PR DESCRIPTION
## Summary

Stopgap fix for #340. The silent-stall watchdog fires on time elapsed alone — it never reads the worker's transcript to check liveness. With the previous 300s budget, even legitimate small-tier work routinely tripped a false positive.

**Today's manifestation (#337 / PR #339):**

| time (UTC) | event |
|---|---|
| 01:46:45 | worker spawned for #337 |
| 01:51:41 | **watchdog fires** (elapsed=296s > 300s, surface alive, no sentinel yet) — session COMPLETED + queue task BLOCKED_ON_USER |
| 02:00:23 | worker opens PR #339 |
| 02:00:46 | worker emits `shipped` sentinel (cw isn't listening anymore) |
| 02:01:32 | PR #339 merged to main |

Worker was alive and productive the whole time. Operator had to manually `cw dev-queue remove 337` to clean up the orphaned queue task.

## Changes

- `IDLE_WATCHDOG_SECONDS`: `300` → `900` (global fallback / attempt-1 default)
- `idle_watchdog_by_tier['large']`: `600` → `1800` (keep large > global)
- Updated affected tests, comments, and docs (`headless-contract.md`, `CONFIG_REFERENCE.md`)

## What this doesn't fix

The underlying class of bug — incomplete liveness detection. The watchdog still has no idea whether the worker is actively writing to its transcript. Tracked properly in #340 as the transcript-mtime liveness check. This PR is the stopgap (option B from the ticket).

## Test plan

- [x] `uv run ruff check` — zero violations
- [x] `uv run mypy src/` — zero type errors
- [x] `uv run pytest tests/ -q` — 1228 passed (54 reconcile tests pass with updated elapsed values)

Related: #340 (defense ticket), #326 / #331 (per-tier override), #337 (the false-positive trigger today)