### PR TITLE
chore(release): cut 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.11.2] — 2026-05-28
+
+Patch release with two reliability fixes for the dev-queue dispatch path,
+surfaced during the 2026-05-28 dogfood wave.
+
+- **Code-fenced sentinel parsing** (#337 → PR #339): `parse_stdout` now
+  tolerates AUTO_DEV_RESULT JSON wrapped in a Markdown code fence (```` ```json ````)
+  when the explicit `<<<AUTO_DEV_RESULT ... AUTO_DEV_RESULT>>>` markers are
+  absent. Previously the dispatcher treated such sessions as no-sentinel and
+  spawned wasteful att2/att3 retries on already-shipped work. Closes #336
+  (downstream consequence — silently_idle hangs after the parser returned None).
+- **Watchdog default bump** (#340 stopgap → PR #341): `IDLE_WATCHDOG_SECONDS`
+  raised from `300` → `900` (15 min), `idle_watchdog_by_tier['large']` from
+  `600` → `1800`. The previous 300s budget false-positively flagged active
+  small-tier workers (#337 itself took 14 min wall time and tripped the
+  watchdog at 5 min). The deeper fix — transcript-mtime liveness detection
+  — remains open under #340.
+
 ## [0.11.1] — 2026-05-27
 
 Patch release covering #129's BLOCKED_ON_USER producer + watchdog and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-workspace"
-version = "0.11.1"
+version = "0.11.2"
 description = "Multi-session workspace orchestrator for Claude Code"
 readme = "README.md"
 authors = [

--- a/src/cw/__init__.py
+++ b/src/cw/__init__.py
@@ -1,3 +1,3 @@
 """claude-workspace: Multi-session workspace orchestrator for Claude Code."""
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "claude-workspace"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Patch release with two reliability fixes for the dev-queue dispatch path, surfaced during the 2026-05-28 dogfood wave.

## Themes

- **#337 / PR #339** — dispatcher tolerates code-fenced JSON sentinels (worker-side AUTO_DEV_RESULT format drift). Also closes #336 as a downstream consequence (silently_idle hang after parser returned None).
- **#340 stopgap / PR #341** — `IDLE_WATCHDOG_SECONDS` default `300` → `900` (15 min) and `idle_watchdog_by_tier['large']` `600` → `1800` (30 min). Stops the watchdog from false-positively flagging legitimate small-tier work. Deeper transcript-mtime liveness check remains open under #340.

## Still open from prior wave

- #340 — proper fix (transcript-mtime liveness detection); this release ships the stopgap only.

## Test plan

- [x] `uv run ruff check` — passes (pre-push hook)
- [x] `uv run mypy` — passes
- [x] `uv run pytest` — 1228 passed
- [ ] CI green
- [ ] Release workflow runs on tag push (post-merge)