### PR TITLE
feat(spawn): add `cw spawn complete` for atomic session terminal transition (#121)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -10,7 +10,7 @@ import sys
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
+from typing import cast, get_args
 
 import click
 from click.shell_completion import CompletionItem
@@ -20,6 +20,7 @@ from cw.auto_dev_result import (
     PAUSED_FOR_USER_INPUT_STATUSES,
     AutoDevResult,
     BlockedResult,
+    Status,
     extract_block,
     parse_stdout,
 )
@@ -45,7 +46,7 @@ from cw.dev_queue import (
     resolve_client,
     save_dev_queue,
 )
-from cw.dispatch import _apply_events_to_store, run_dispatch_loop
+from cw.dispatch import _DISPATCH_CONSUMER, _apply_events_to_store, run_dispatch_loop
 from cw.doctor import format_report, run_doctor
 from cw.events import advance_cursor, read_events, record_event
 from cw.exceptions import CwError, WorktreeError
@@ -1977,9 +1978,6 @@ def spawn_close(session_id: str) -> None:
     click.echo(f"Closed session: {session_id}")
 
 
-_DISPATCH_CONSUMER = "dispatch"
-
-
 def _spawn_complete_impl(
     *,
     session_id: str,
@@ -2012,19 +2010,6 @@ def _spawn_complete_impl(
 
     effective_ticket_id = ticket_id or ticket_id_for_session(sess.name)
 
-    if effective_ticket_id:
-        store = load_dev_queue()
-        for task in store.tasks:
-            if (
-                task.ticket_id == effective_ticket_id
-                and task.status == QueueItemStatus.COMPLETED
-            ):
-                already_done_task_msg = (
-                    f"Queue task for '{effective_ticket_id}' is already COMPLETED. "
-                    "Use 'cw spawn close' to close the session only."
-                )
-                raise CwError(already_done_task_msg)
-
     payload: dict[str, object] = {
         "session_id": sess.id,
         "client": sess.client,
@@ -2032,23 +2017,43 @@ def _spawn_complete_impl(
         "status": status,
         **({"ticket_id": effective_ticket_id} if effective_ticket_id else {}),
     }
-    event = record_event(OrchestratorEventType.SESSION_COMPLETED, payload)
 
     with dev_queue_lock():
         store = load_dev_queue()
+
+        # Guard: queue task already COMPLETED (inside lock — authoritative)
+        if effective_ticket_id:
+            for task in store.tasks:
+                if (
+                    task.ticket_id == effective_ticket_id
+                    and task.status == QueueItemStatus.COMPLETED
+                ):
+                    already_done_task_msg = (
+                        f"Queue task for '{effective_ticket_id}' is already COMPLETED. "
+                        "Use 'cw spawn close' to close the session only."
+                    )
+                    raise CwError(already_done_task_msg)
+
+        # Step 1: Record event (record_event uses _inbox_lock — no deadlock risk)
+        event = record_event(OrchestratorEventType.SESSION_COMPLETED, payload)
+
+        # Step 2: Apply to queue
         _apply_events_to_store(store, [event])
 
+        # Step 3: Close session state
+        sess.status = SessionStatus.COMPLETED
+        sess.completed_at = datetime.now(UTC)
+        if sess.completed_reason is None:
+            sess.completed_reason = CompletionReason.USER
+        save_state(state)
+
+    # Advance cursor after lock (advance_cursor uses inbox lock — safe)
     advance_cursor(_DISPATCH_CONSUMER, event.id)
 
+    # daemon.stop outside lock — best-effort, slow (up to 10s timeout)
     daemon = native_daemon or get_native_daemon_client()
     if sess.surface_ref is not None and sess.origin is SessionOrigin.DAEMON:
         daemon.stop(sess.surface_ref)
-
-    sess.status = SessionStatus.COMPLETED
-    sess.completed_at = datetime.now(UTC)
-    if sess.completed_reason is None:
-        sess.completed_reason = CompletionReason.USER
-    save_state(state)
 
 
 @spawn.command(name="complete")
@@ -2057,18 +2062,7 @@ def _spawn_complete_impl(
     "--status",
     "status",
     required=True,
-    type=click.Choice(
-        [
-            "shipped",
-            "no_op",
-            "plan_pending_approval",
-            "review_pending_approval",
-            "merge_gate_blocked",
-            "scope_exceeded",
-            "forbidden_area",
-            "blocked",
-        ]
-    ),
+    type=click.Choice(list(get_args(Status))),
     help="Outcome status to record (every value in auto_dev_result.Status).",
 )
 @click.option(

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -45,7 +45,7 @@ from cw.dev_queue import (
     resolve_client,
     save_dev_queue,
 )
-from cw.dispatch import run_dispatch_loop
+from cw.dispatch import _apply_events_to_store, run_dispatch_loop
 from cw.doctor import format_report, run_doctor
 from cw.events import advance_cursor, read_events, record_event
 from cw.exceptions import CwError, WorktreeError
@@ -83,7 +83,7 @@ from cw.queue import (
     peek_next,
     remove_item,
 )
-from cw.reconcile import reconcile, resolve_headless_budget
+from cw.reconcile import reconcile, resolve_headless_budget, ticket_id_for_session
 from cw.session import (
     background_all_sessions,
     background_session,
@@ -1975,6 +1975,142 @@ def spawn_close(session_id: str) -> None:
     """
     _spawn_close_impl(session_id=session_id)
     click.echo(f"Closed session: {session_id}")
+
+
+_DISPATCH_CONSUMER = "dispatch"
+
+
+def _spawn_complete_impl(
+    *,
+    session_id: str,
+    status: str,
+    ticket_id: str | None,
+    force: bool,
+    native_daemon: NativeDaemonClient | None = None,
+) -> None:
+    """Complete a daemon-spawned session atomically.
+
+    Performs three steps in sequence:
+    1. Records a session.completed event
+    2. Applies it to the dev queue inline (under dev_queue_lock)
+    3. Closes the session
+
+    Separated from the Click command so tests can inject the daemon client
+    directly.
+    """
+    state = load_state()
+    sess = state.find_by_name_or_id(session_id)
+    if sess is None:
+        msg = f"Session '{session_id}' not found."
+        raise CwError(msg)
+
+    if sess.status == SessionStatus.COMPLETED:
+        if not force:
+            msg = f"Session '{session_id}' is already completed. Use --force to no-op."
+            raise CwError(msg)
+        return
+
+    effective_ticket_id = ticket_id or ticket_id_for_session(sess.name)
+
+    if effective_ticket_id:
+        store = load_dev_queue()
+        for task in store.tasks:
+            if (
+                task.ticket_id == effective_ticket_id
+                and task.status == QueueItemStatus.COMPLETED
+            ):
+                already_done_task_msg = (
+                    f"Queue task for '{effective_ticket_id}' is already COMPLETED. "
+                    "Use 'cw spawn close' to close the session only."
+                )
+                raise CwError(already_done_task_msg)
+
+    payload: dict[str, object] = {
+        "session_id": sess.id,
+        "client": sess.client,
+        "crashed": False,
+        "status": status,
+        **({"ticket_id": effective_ticket_id} if effective_ticket_id else {}),
+    }
+    event = record_event(OrchestratorEventType.SESSION_COMPLETED, payload)
+
+    with dev_queue_lock():
+        store = load_dev_queue()
+        _apply_events_to_store(store, [event])
+
+    advance_cursor(_DISPATCH_CONSUMER, event.id)
+
+    daemon = native_daemon or get_native_daemon_client()
+    if sess.surface_ref is not None and sess.origin is SessionOrigin.DAEMON:
+        daemon.stop(sess.surface_ref)
+
+    sess.status = SessionStatus.COMPLETED
+    sess.completed_at = datetime.now(UTC)
+    if sess.completed_reason is None:
+        sess.completed_reason = CompletionReason.USER
+    save_state(state)
+
+
+@spawn.command(name="complete")
+@click.argument("session_id")
+@click.option(
+    "--status",
+    "status",
+    required=True,
+    type=click.Choice(
+        [
+            "shipped",
+            "no_op",
+            "plan_pending_approval",
+            "review_pending_approval",
+            "merge_gate_blocked",
+            "scope_exceeded",
+            "forbidden_area",
+            "blocked",
+        ]
+    ),
+    help="Outcome status to record (every value in auto_dev_result.Status).",
+)
+@click.option(
+    "--ticket-id",
+    default=None,
+    help=(
+        "Ticket ID; inferred from session name via ticket_id_for_session() if omitted."
+    ),
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help=(
+        "If session is already COMPLETED, silently succeed (no-op) instead of erroring."
+    ),
+)
+@handle_errors
+def spawn_complete(
+    session_id: str,
+    status: str,
+    ticket_id: str | None,
+    force: bool,
+) -> None:
+    """Complete a daemon-spawned session, recording its outcome atomically.
+
+    Records a session.completed event, applies it to the dev queue, and
+    closes the session in one atomic operation. Replaces the three-command
+    manual recovery sequence used when sessions are stuck.
+
+    \b
+    Example:
+      cw spawn complete abc12345 --status shipped
+      cw spawn complete abc12345 --status blocked --ticket-id GEN-42
+    """
+    _spawn_complete_impl(
+        session_id=session_id,
+        status=status,
+        ticket_id=ticket_id,
+        force=force,
+    )
+    click.echo(f"Completed session: {session_id} (status={status})")
 
 
 _ORCHESTRATOR_AGENT = "cw-orchestrator"

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -22,7 +22,12 @@ from cw.spawn import spawn_create_impl
 from cw.worktree import check_not_main_checkout, create_worktree, is_main_behind_origin
 
 if TYPE_CHECKING:
-    from cw.models import OrchestratorConfig, TicketTask
+    from cw.models import (
+        DevQueueStore,
+        OrchestratorConfig,
+        OrchestratorEvent,
+        TicketTask,
+    )
     from cw.native_daemon import NativeDaemonClient
 
 _DISPATCH_CONSUMER = "dispatch"
@@ -271,6 +276,67 @@ def dispatch_tick(
     return spawned
 
 
+def _apply_events_to_store(
+    store: DevQueueStore,
+    events: list[OrchestratorEvent],
+) -> int:
+    """Apply SESSION_COMPLETED events to an already-loaded DevQueueStore.
+
+    Caller must hold ``dev_queue_lock``. Saves the store when tasks were
+    transitioned; does NOT advance the event cursor — cursor advancement
+    is the caller's responsibility after the lock is released.
+
+    Returns the number of tasks transitioned to COMPLETED.
+    """
+    completed = 0
+    for event in events:
+        # Crashed events are emitted by reconcile only. For DAEMON
+        # sessions reconcile has already reverted the task
+        # RUNNING → PENDING; marking the task COMPLETED here would
+        # shadow that revert and (worse) match the next freshly-
+        # respawned RUNNING task for the same ticket_id, falsely
+        # retiring a still-running session. For non-DAEMON crashed
+        # sessions reconcile does not touch the queue, so a blanket
+        # skip is conservative-safe (no queue task is expected to
+        # match anyway). See GitHub issue #97.
+        if event.payload.get("crashed"):
+            continue
+        ticket_id = event.payload.get("ticket_id")
+        if not ticket_id:
+            # Fallback: recover ticket_id from the session_name for events
+            # produced before the reconciler emitted ticket_id explicitly.
+            # Drains historical RUNNING tasks whose completion events
+            # predate the producer-side fix.
+            session_name = event.payload.get("session_name")
+            if isinstance(session_name, str):
+                ticket_id = ticket_id_for_session(session_name)
+        if not ticket_id:
+            continue
+        event_session_id = event.payload.get("session_id")
+        for task in store.tasks:
+            if task.ticket_id != ticket_id:
+                continue
+            if task.status != QueueItemStatus.RUNNING:
+                continue
+            # Disambiguate stale events: when the event carries a
+            # session_id and the task has been stamped with one, they
+            # must agree. Either side missing a session_id falls back to
+            # ticket_id-only matching for backward compatibility with
+            # legacy tasks/events that predate the field.
+            if (
+                isinstance(event_session_id, str)
+                and task.session_id is not None
+                and task.session_id != event_session_id
+            ):
+                continue
+            task.status = QueueItemStatus.COMPLETED
+            completed += 1
+            break
+    if completed:
+        save_dev_queue(store)
+    return completed
+
+
 def consume_completed_sessions() -> int:
     """Process session.completed events and mark tasks COMPLETED in the queue.
 
@@ -291,54 +357,9 @@ def consume_completed_sessions() -> int:
     if not events:
         return 0
 
-    completed = 0
     with dev_queue_lock():
         store = load_dev_queue()
-        for event in events:
-            # Crashed events are emitted by reconcile only. For DAEMON
-            # sessions reconcile has already reverted the task
-            # RUNNING → PENDING; marking the task COMPLETED here would
-            # shadow that revert and (worse) match the next freshly-
-            # respawned RUNNING task for the same ticket_id, falsely
-            # retiring a still-running session. For non-DAEMON crashed
-            # sessions reconcile does not touch the queue, so a blanket
-            # skip is conservative-safe (no queue task is expected to
-            # match anyway). See GitHub issue #97.
-            if event.payload.get("crashed"):
-                continue
-            ticket_id = event.payload.get("ticket_id")
-            if not ticket_id:
-                # Fallback: recover ticket_id from the session_name for events
-                # produced before the reconciler emitted ticket_id explicitly.
-                # Drains historical RUNNING tasks whose completion events
-                # predate the producer-side fix.
-                session_name = event.payload.get("session_name")
-                if isinstance(session_name, str):
-                    ticket_id = ticket_id_for_session(session_name)
-            if not ticket_id:
-                continue
-            event_session_id = event.payload.get("session_id")
-            for task in store.tasks:
-                if task.ticket_id != ticket_id:
-                    continue
-                if task.status != QueueItemStatus.RUNNING:
-                    continue
-                # Disambiguate stale events: when the event carries a
-                # session_id and the task has been stamped with one, they
-                # must agree. Either side missing a session_id falls back to
-                # ticket_id-only matching for backward compatibility with
-                # legacy tasks/events that predate the field.
-                if (
-                    isinstance(event_session_id, str)
-                    and task.session_id is not None
-                    and task.session_id != event_session_id
-                ):
-                    continue
-                task.status = QueueItemStatus.COMPLETED
-                completed += 1
-                break
-        if completed:
-            save_dev_queue(store)
+        completed = _apply_events_to_store(store, events)
 
     # Persist sentinel-block summaries on Sessions whose completion event
     # carried captured stdout. Producer side (worker stdout capture) is

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, get_args
 
 import pytest
 from click.testing import CliRunner
 
+from cw.auto_dev_result import Status
 from cw.cli import main
 from cw.config import load_state, save_state
 from cw.exceptions import CwError
@@ -1216,19 +1217,7 @@ class TestSpawnComplete:
         )
         assert len(events) == 0
 
-    @pytest.mark.parametrize(
-        "status_value",
-        [
-            "shipped",
-            "no_op",
-            "plan_pending_approval",
-            "review_pending_approval",
-            "merge_gate_blocked",
-            "scope_exceeded",
-            "forbidden_area",
-            "blocked",
-        ],
-    )
+    @pytest.mark.parametrize("status_value", list(get_args(Status)))
     def test_status_routing_each_enum_value(
         self,
         tmp_config_dir: Path,

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -20,6 +20,7 @@ from cw.models import (
     SessionOrigin,
     SessionPurpose,
     SessionStatus,
+    TicketTask,
 )
 from cw.native_daemon import FakeNativeDaemonClient
 
@@ -48,6 +49,53 @@ def _make_prompt_file(tmp_path: Path, content: str = "Do the thing.") -> Path:
     prompt_file = tmp_path / "prompt.txt"
     prompt_file.write_text(content)
     return prompt_file
+
+
+def _seed_daemon_session(
+    tmp_path: Path,
+    tmp_config_dir: Path,
+    session_id: str = "test1234",
+    client: str = "test-client",
+    name: str | None = None,
+    surface_ref: str | None = "fake-pane-99",
+    status: SessionStatus = SessionStatus.ACTIVE,
+) -> Session:
+    """Create and save a daemon session in state."""
+    workspace = tmp_path / "workspace" / client
+    workspace.mkdir(parents=True, exist_ok=True)
+    sess = Session(
+        id=session_id,
+        name=name or f"{client}/auto-dev/GEN-42",
+        client=client,
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=status,
+        workspace_path=workspace,
+        surface_ref=surface_ref,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    return sess
+
+
+def _seed_running_task(
+    ticket_id: str = "GEN-42",
+    client: str = "test-client",
+    session_id: str = "test1234",
+) -> TicketTask:
+    """Create and save a RUNNING TicketTask in the dev queue."""
+    from cw.dev_queue import save_dev_queue
+    from cw.models import DevQueueStore, QueueItemStatus
+
+    task = TicketTask(
+        ticket_id=ticket_id,
+        client=client,
+        status=QueueItemStatus.RUNNING,
+        session_id=session_id,
+    )
+    store = DevQueueStore(tasks=[task])
+    save_dev_queue(store)
+    return task
 
 
 # ---------------------------------------------------------------------------
@@ -848,21 +896,13 @@ class TestSpawnClose:
 
     def _seed_daemon_session(self, tmp_path: Path, tmp_config_dir: Path) -> Session:
         """Save a DAEMON session to state and return it."""
-        workspace = tmp_path / "workspace" / "test-client"
-        workspace.mkdir(parents=True)
-        sess = Session(
-            id="dead1234",
+        return _seed_daemon_session(
+            tmp_path,
+            tmp_config_dir,
+            session_id="dead1234",
             name="test-client/my-task",
-            client="test-client",
-            purpose=SessionPurpose.IMPL,
-            origin=SessionOrigin.DAEMON,
-            status=SessionStatus.ACTIVE,
-            workspace_path=workspace,
             surface_ref="abc12345",
         )
-        state = CwState(sessions=[sess])
-        save_state(state)
-        return sess
 
     def test_happy_path_marks_completed(
         self, tmp_config_dir: Path, tmp_path: Path
@@ -994,6 +1034,291 @@ class TestSpawnClose:
         closed = state.find_by_name_or_id("nosurf1")
         assert closed is not None
         assert closed.status == SessionStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# TestSpawnComplete
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnComplete:
+    """Tests for _spawn_complete_impl and cw spawn complete command."""
+
+    def test_happy_path_session_completed_with_reason_user(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Happy path: session COMPLETED with reason=USER, queue task COMPLETED."""
+        from cw.cli import _spawn_complete_impl
+
+        sess = _seed_daemon_session(tmp_path, tmp_config_dir)
+        _seed_running_task(ticket_id="GEN-42", client="test-client", session_id=sess.id)
+        daemon = FakeNativeDaemonClient()
+
+        _spawn_complete_impl(
+            session_id=sess.id,
+            status="shipped",
+            ticket_id=None,
+            force=False,
+            native_daemon=daemon,
+        )
+
+        state = load_state()
+        updated = state.find_by_name_or_id(sess.id)
+        assert updated is not None
+        assert updated.status == SessionStatus.COMPLETED
+        assert updated.completed_reason == CompletionReason.USER
+        assert updated.completed_at is not None
+
+        from cw.dev_queue import load_dev_queue
+        from cw.models import QueueItemStatus
+
+        store = load_dev_queue()
+        task = next((t for t in store.tasks if t.ticket_id == "GEN-42"), None)
+        assert task is not None
+        assert task.status == QueueItemStatus.COMPLETED
+
+    def test_happy_path_event_recorded_with_correct_payload(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Happy path: SESSION_COMPLETED event recorded with correct payload."""
+        from cw.cli import _spawn_complete_impl
+        from cw.events import read_events
+        from cw.models import OrchestratorEventType
+
+        sess = _seed_daemon_session(tmp_path, tmp_config_dir)
+        _seed_running_task(ticket_id="GEN-42", client="test-client", session_id=sess.id)
+        daemon = FakeNativeDaemonClient()
+
+        _spawn_complete_impl(
+            session_id=sess.id,
+            status="shipped",
+            ticket_id=None,
+            force=False,
+            native_daemon=daemon,
+        )
+
+        events = read_events(
+            consumer="_test_consumer",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        assert len(events) == 1
+        payload = events[0].payload
+        assert payload["session_id"] == sess.id
+        assert payload["client"] == "test-client"
+        assert payload["crashed"] is False
+        assert payload["status"] == "shipped"
+        assert payload["ticket_id"] == "GEN-42"
+
+    def test_ticket_id_inferred_from_session_name_when_omitted(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """ticket_id inferred from session name when not provided."""
+        from cw.cli import _spawn_complete_impl
+        from cw.events import read_events
+        from cw.models import OrchestratorEventType
+
+        # Name encodes ticket_id via AUTO_DEV_LABEL_PREFIX pattern
+        sess = _seed_daemon_session(
+            tmp_path, tmp_config_dir, name="test-client/auto-dev/GEN-99"
+        )
+        _seed_running_task(ticket_id="GEN-99", client="test-client", session_id=sess.id)
+        daemon = FakeNativeDaemonClient()
+
+        _spawn_complete_impl(
+            session_id=sess.id,
+            status="shipped",
+            ticket_id=None,  # omitted — must be inferred
+            force=False,
+            native_daemon=daemon,
+        )
+
+        events = read_events(
+            consumer="_test_consumer2",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        assert any(e.payload.get("ticket_id") == "GEN-99" for e in events)
+
+    def test_explicit_ticket_id_overrides_inferred(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Explicit --ticket-id overrides whatever the session name encodes."""
+        from cw.cli import _spawn_complete_impl
+        from cw.dev_queue import load_dev_queue
+        from cw.models import QueueItemStatus
+
+        # Session name would infer GEN-42
+        sess = _seed_daemon_session(
+            tmp_path, tmp_config_dir, name="test-client/auto-dev/GEN-42"
+        )
+        # But we seed the queue with a different ticket_id
+        _seed_running_task(
+            ticket_id="OVERRIDE-1", client="test-client", session_id=sess.id
+        )
+        daemon = FakeNativeDaemonClient()
+
+        _spawn_complete_impl(
+            session_id=sess.id,
+            status="shipped",
+            ticket_id="OVERRIDE-1",  # explicit override
+            force=False,
+            native_daemon=daemon,
+        )
+
+        store = load_dev_queue()
+        task = next((t for t in store.tasks if t.ticket_id == "OVERRIDE-1"), None)
+        assert task is not None
+        assert task.status == QueueItemStatus.COMPLETED
+
+    def test_already_completed_session_raises_without_force(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Session already COMPLETED → CwError without --force."""
+        from cw.cli import _spawn_complete_impl
+
+        sess = _seed_daemon_session(
+            tmp_path, tmp_config_dir, status=SessionStatus.COMPLETED
+        )
+        daemon = FakeNativeDaemonClient()
+
+        with pytest.raises(CwError, match="already completed"):
+            _spawn_complete_impl(
+                session_id=sess.id,
+                status="shipped",
+                ticket_id=None,
+                force=False,
+                native_daemon=daemon,
+            )
+
+    def test_already_completed_session_force_is_noop(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Session already COMPLETED + --force → no-op, no extra events."""
+        from cw.cli import _spawn_complete_impl
+        from cw.events import read_events
+        from cw.models import OrchestratorEventType
+
+        sess = _seed_daemon_session(
+            tmp_path, tmp_config_dir, status=SessionStatus.COMPLETED
+        )
+        daemon = FakeNativeDaemonClient()
+
+        _spawn_complete_impl(
+            session_id=sess.id,
+            status="shipped",
+            ticket_id=None,
+            force=True,  # --force
+            native_daemon=daemon,
+        )
+
+        events = read_events(
+            consumer="_test_consumer3",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        assert len(events) == 0
+
+    @pytest.mark.parametrize(
+        "status_value",
+        [
+            "shipped",
+            "no_op",
+            "plan_pending_approval",
+            "review_pending_approval",
+            "merge_gate_blocked",
+            "scope_exceeded",
+            "forbidden_area",
+            "blocked",
+        ],
+    )
+    def test_status_routing_each_enum_value(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        status_value: str,
+    ) -> None:
+        """Each --status value is stored verbatim in the event payload."""
+        from cw.cli import _spawn_complete_impl
+        from cw.events import read_events
+        from cw.models import OrchestratorEventType
+
+        sess = _seed_daemon_session(
+            tmp_path,
+            tmp_config_dir,
+            session_id=f"status-{status_value[:8]}",
+            name=f"test-client/auto-dev/STATUS-{status_value[:8]}",
+        )
+        daemon = FakeNativeDaemonClient()
+
+        _spawn_complete_impl(
+            session_id=sess.id,
+            status=status_value,
+            ticket_id=None,
+            force=False,
+            native_daemon=daemon,
+        )
+
+        events = read_events(
+            consumer=f"_test_status_{status_value}",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        matching = [e for e in events if e.payload.get("session_id") == sess.id]
+        assert len(matching) == 1
+        assert matching[0].payload["status"] == status_value
+
+    def test_already_completed_queue_task_raises(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """COMPLETED queue task + ACTIVE session → CwError."""
+        from cw.cli import _spawn_complete_impl
+        from cw.dev_queue import save_dev_queue
+        from cw.models import DevQueueStore, QueueItemStatus
+
+        sess = _seed_daemon_session(tmp_path, tmp_config_dir)
+        # Seed a COMPLETED (not RUNNING) task
+        task = TicketTask(
+            ticket_id="GEN-42",
+            client="test-client",
+            status=QueueItemStatus.COMPLETED,
+            session_id=sess.id,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+        daemon = FakeNativeDaemonClient()
+
+        with pytest.raises(CwError):
+            _spawn_complete_impl(
+                session_id=sess.id,
+                status="shipped",
+                ticket_id=None,
+                force=False,
+                native_daemon=daemon,
+            )
+
+    def test_cli_spawn_complete_missing_session_exits_error(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """CLI: cw spawn complete nonexistent-id → non-zero exit, id in output."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["spawn", "complete", "nonexistent-id", "--status", "shipped"]
+        )
+        assert result.exit_code != 0
+        assert "nonexistent-id" in result.output
+
+    def test_regression_spawn_close_unaffected(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """spawn close still works unchanged after _seed_daemon_session extraction."""
+        from cw.cli import _spawn_close_impl
+
+        sess = _seed_daemon_session(tmp_path, tmp_config_dir)
+        daemon = FakeNativeDaemonClient()
+
+        _spawn_close_impl(session_id=sess.id, native_daemon=daemon)
+
+        state = load_state()
+        closed = state.find_by_name_or_id(sess.id)
+        assert closed is not None
+        assert closed.status == SessionStatus.COMPLETED
+        assert closed.completed_reason == CompletionReason.USER
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #121.

Replaces the three-command manual recovery sequence with a single atomic operation: record `session.completed` event, apply to dev queue inline, close the session — all under `dev_queue_lock`.

## Changes
- Extract `_apply_events_to_store()` from `consume_completed_sessions()` to enable the inline queue tick without re-entering the file lock
- Add `_spawn_complete_impl()` + `@spawn.command('complete')` with `--status`, `--ticket-id`, `--force` options
- Refuse if session already COMPLETED (`--force`: no-op); refuse if queue task already COMPLETED (decouple session/queue close)

## Test coverage
- `tests/test_spawn.py` +349 LOC covering atomic transition, idempotency, decoupled queue/session close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>