### PR TITLE
fix(reconcile): downgrade silently-idle watchdog to flag-only (#348)

### DIFF
--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -424,9 +424,11 @@ def flag_silently_idle_daemon_sessions(
         return []
 
     for session, _ in candidates:
-        session.status = SessionStatus.COMPLETED
-        session.completed_at = now
-        session.completed_reason = CompletionReason.NORMAL
+        # Flag-only: do not mark session COMPLETED. The worker on the daemon
+        # is still alive; operators disposition flagged sessions via
+        # `cw spawn complete` or `cw doctor --reap`. Setting last_result with
+        # paused_status still makes _has_terminal_sentinel return True so the
+        # watchdog skips this session on subsequent ticks (GitHub #324, #348).
         session.last_result = {"paused_status": _SILENTLY_IDLE_REASON}
 
     # Write session to disk BEFORE queue mutation so a crash between the two

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1298,9 +1298,13 @@ def test_flag_silently_idle_daemon_sessions_transitions_past_budget(
         mock_notify.assert_called_once_with(sess.name, sess.client)
 
     assert "SILENT-1" in blocked
-    assert sess.status == SessionStatus.COMPLETED
-    assert sess.completed_reason == CompletionReason.NORMAL
-    assert sess.completed_at == now
+    # #348: flag-only — session stays ACTIVE so daemon worker can keep running.
+    # Operators disposition flagged sessions via `cw spawn complete` /
+    # `cw doctor --reap`. last_result.paused_status still set to prevent
+    # double-firing via _has_terminal_sentinel on subsequent ticks (#324).
+    assert sess.status == SessionStatus.ACTIVE
+    assert sess.completed_at is None
+    assert sess.completed_reason is None
     assert sess.last_result == {"paused_status": _SILENTLY_IDLE_REASON}
 
     store = load_dev_queue()
@@ -1316,6 +1320,64 @@ def test_flag_silently_idle_daemon_sessions_transitions_past_budget(
     assert payload["session_id"] == "silent-1"
     assert payload["paused_status"] == _SILENTLY_IDLE_REASON
     assert payload["crashed"] is False
+
+
+def test_flag_silently_idle_watchdog_does_not_call_native_daemon_stop(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """Flag-only: watchdog must not invoke native_daemon stop() (#348).
+
+    The Track C wave-2 case study (2026-05-28) showed three workers that had
+    actually shipped work being silenced mid-stream by the watchdog. The fix
+    is flag-only: the queue task transitions to BLOCKED_ON_USER and the
+    operator dispositions the session via `cw spawn complete` or
+    `cw doctor --reap`. The session itself stays alive on the daemon.
+    """
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    assert (now - started_at).total_seconds() > IDLE_WATCHDOG_SECONDS
+
+    sess = Session(
+        id="alive-after-flag",
+        name="client-a/auto-dev/ALIVE-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=ClientConfig(
+            name="client-a", workspace_path=Path("/tmp/ws")
+        ).workspace_path,
+        surface_ref="live-ref",
+        started_at=started_at,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    task = TicketTask(
+        ticket_id="ALIVE-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="alive-after-flag",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    with (
+        patch("cw.reconcile.fire_push_notification"),
+        patch("cw.reconcile.get_native_daemon_client") as mock_daemon,
+    ):
+        flag_silently_idle_daemon_sessions(
+            state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+        )
+
+    # The daemon client must not be touched — flag-only means the worker on
+    # the native daemon keeps running, even though the queue is BLOCKED_ON_USER.
+    mock_daemon.assert_not_called()
+
+    # Reload from disk and confirm session is still ACTIVE.
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "alive-after-flag")
+    assert s.status == SessionStatus.ACTIVE
 
 
 def test_flag_silently_idle_watchdog_no_double_fire_on_crash_recovery(


### PR DESCRIPTION
## Summary

- Removes `session.status = COMPLETED` + completed_at/completed_reason from `flag_silently_idle_daemon_sessions`. Session stays ACTIVE; queue task still flips to BLOCKED_ON_USER and a `SESSION_NEEDS_ATTENTION` event + push notification still fire.
- The worker keeps running on the daemon — operators disposition flagged sessions via `cw spawn complete` (#121) or `cw doctor --reap`.
- `last_result.paused_status` is still set so `_has_terminal_sentinel` skips the session on the next tick (preserves the #324 no-double-fire invariant).

## Why

Track C wave-2 (2026-05-28) put three workers in the post-PR / PR-creation wait window past the 15min budget. They had shipped substantial work to `origin/auto-dev/*` (#121 → PR #344, #122 → 9 commits, #126 → 4 commits) and were marked silently_idle anyway. False-positive rate: 3/6.

Age is not a proxy for idleness, and kill is too aggressive for an uncertain signal. Until #340 lands a transcript-mtime liveness check, treat the watchdog as advisory.

## Test plan

- [x] `uv run pytest tests/test_reconcile.py` — 55 passed
- [x] `uv run pytest tests/` — 1282 passed
- [x] `uv run ruff check src/cw/reconcile.py tests/test_reconcile.py`
- [x] `uv run mypy src/cw/reconcile.py`
- [x] New test `test_flag_silently_idle_watchdog_does_not_call_native_daemon_stop` asserts the daemon client is never touched and the session stays ACTIVE on reload.
- [x] Existing test `test_flag_silently_idle_daemon_sessions_transitions_past_budget` updated: now asserts session stays ACTIVE / `completed_at is None` / `completed_reason is None`.

Closes #348.