### PR TITLE
Audit cw skills against current workflows + add /cw-fanout

### DIFF
--- a/.claude/skills/cw-fanout/SKILL.md
+++ b/.claude/skills/cw-fanout/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: cw-fanout
+description: Multi-ticket parallel dispatch with a monitoring handoff — takes a list of tickets, runs pre-flight per ticket, enqueues the batch, starts the cw dispatch loop, then watches the wave via the queue-peek ladder and the session.needs_attention / session.timed_out event bus until every ticket is terminal. Use when the user wants to enqueue several tickets and then monitor the queue in one motion. Triggers on "fan out these tickets", "dispatch a wave", "enqueue these and watch them", "run /auto-dev on N tickets and monitor", "dispatch and babysit the queue".
+---
+
+# cw-fanout
+
+Carries a batch of tickets from **"enqueue these"** to **"now monitoring the
+queue"** in one orchestrated motion. It is the N-way companion to
+`/cw-smoke-test` (which does the same enqueue → dispatch → monitor arc for a
+single ticket, one tick) and the active driver that sits in front of
+`/cw-queue-peek` (the in-flight health ladder).
+
+Pure orchestration — it composes existing pieces and adds no new parsing or
+validation logic:
+
+- **pre-flight** reuses `cw-smoke-test/scripts/preflight.py` (per ticket).
+- **dispatch** uses `cw dev-queue add` + `cw dev-queue run`.
+- **wave lifecycle** uses the bundled `scripts/wave_status.py` (is the batch done?).
+- **in-flight health** uses `.claude/scripts/cw_queue_peek.py` (WAIT/PEEK/STOP).
+- **attention** uses the `session.needs_attention` / `session.timed_out` event bus.
+
+## When to use
+
+- The operator has several ready tickets and wants them dispatched in parallel,
+  then watched as a single wave.
+- A meta-test spray across N tech-debt tickets where each should run `/auto-dev`
+  headless and surface only when it needs a human.
+- Re-dispatching at N>1 after `/cw-followup` has prepared the ground (decisions
+  appended, branches rebased).
+
+Do **not** use this skill for:
+
+- A single ticket end-to-end validation — use `/cw-smoke-test`.
+- Acting on one finished session's sentinel — use `/cw-followup`.
+- A forensic read of one session — use `/cw-validate-result`.
+- Interactive (USER-origin) sessions started via `cw start` — those don't go
+  through dev-queue.
+
+## Inputs
+
+One or more ticket ids (e.g. `201 202 203` or `#201 #202`).
+
+Optional flags:
+- `--client <NAME>` — cw client for the queue (default `claude-workspace`).
+- `--max-parallel <N>` — override the per-client concurrency cap for this wave.
+- `--skip-preflight` — run pre-flight in advisory mode (report, do not drop).
+- `--dry-run` — pre-flight only; do not enqueue or dispatch.
+- `--no-monitor` — enqueue + start dispatch, then hand back to the operator
+  without entering the monitoring phase.
+
+## How it works
+
+### Step 1 — batch pre-flight
+
+Run the bundled checker once per ticket (it is the single source of truth for
+readiness; never re-implement it):
+
+```bash
+uv run --project "$(git rev-parse --show-toplevel)" python \
+  .claude/skills/cw-smoke-test/scripts/preflight.py \
+  --ticket-id <NUMBER> --client <CLIENT>
+```
+
+Each call emits one JSON object with `ok` (bool) and `checks`. Aggregate into a
+table: one row per ticket, `ok` plus any failing hard checks. Then:
+
+- **Default:** drop tickets whose `ok` is false from the wave. Print the dropped
+  rows with their failing checks. Continue with the survivors.
+- **`--skip-preflight`:** keep every ticket; print a warning banner listing the
+  failed checks so the operator sees the wave launched in degraded mode.
+- **No survivors:** stop. Nothing to dispatch.
+
+On `--dry-run`, print the table and stop here.
+
+### Step 2 — enqueue the survivors
+
+`cw dev-queue add` accepts the whole batch in one call:
+
+```bash
+cw dev-queue add <T1> <T2> <T3> -c <CLIENT>
+```
+
+Record the exact ticket set you enqueued — that is the **wave set** every later
+step keys off. Tickets dropped in Step 1 are not part of it.
+
+### Step 3 — start the dispatch loop
+
+```bash
+cw dev-queue run --max-parallel <N>   # omit --max-parallel to use the configured cap
+```
+
+`cw dev-queue run` (without `--once`) **loops forever** — it does not exit when
+the queue drains. Each tick it `reconcile()`s (which drives the idle/timeout
+watchdog and emits the attention events), spawns workers up to the concurrency
+cap, and consumes completion events. So:
+
+- **Launch it in the background** and capture the moment you started it as the
+  event-bus cursor for Step 4.
+- Wave completion is detected from queue state (Step 4), **not** from this
+  process exiting.
+- If the loop is already running (an operator wave is in flight), do not start a
+  second one — reuse it.
+
+On `--no-monitor`, stop here: report the started loop + the wave set and hand
+back to the operator.
+
+### Step 4 — monitor the wave
+
+This is the handoff `/cw-queue-peek` was built to receive. Drive it from
+**checkpoints**, not a busy `sleep` poll — react to events and re-check state.
+
+**a. Wave lifecycle — am I done?**
+
+```bash
+python3 .claude/skills/cw-fanout/scripts/wave_status.py <T1> <T2> <T3> \
+  --client <CLIENT> --json
+```
+
+Exit 0 / `"terminal": true` when every wave ticket is terminal
+(`completed` / `failed` / `cancelled` / `blocked_on_user`, or removed from the
+queue). `"in_flight"` lists the tickets still `pending`/`running`;
+`"needs_attention"` lists `blocked_on_user` tickets (a session paused for the
+operator). Loop the rest of Step 4 until this reports terminal.
+
+**b. Attention signals — does anything need me now?**
+
+Tail the event bus with a durable consumer cursor (resumes where it left off):
+
+```bash
+cw event tail --since fanout-mon \
+  --type session.needs_attention \
+  --type session.timed_out \
+  --type session.completed --json
+```
+
+On `session.needs_attention` (paused-for-input, user-directed blocked, or
+exited-without-sentinel) or `session.timed_out`: surface the ticket + session
+immediately and pause for the operator. Do not silently re-dispatch.
+
+**c. In-flight health — is a running session stuck?**
+
+For the `in_flight` tickets, run the peek-stop ladder:
+
+```bash
+python3 .claude/scripts/cw_queue_peek.py --client <CLIENT>
+```
+
+Follow `/cw-queue-peek`: act on STOP / STOP-OR-PEEK rows (stuck post-PR-merge,
+retry loop, approaching the 60-min ceiling) per its ladder. Always
+`cw spawn close <session_id>` **before** `cw dev-queue remove`.
+
+Surface progress sparingly — one line when the wave shrinks or a ticket flips
+to needs-attention; otherwise stay quiet. The operator can `cw watch` for the
+live board.
+
+### Step 5 — report + disposition
+
+When `wave_status.py` reports terminal, stop the background dispatch loop (if no
+other wave is queued behind it), then print a per-ticket disposition table.
+Suggest the right follow-up per ticket:
+
+- `completed` → `/cw-validate-result --ticket-id <N>` to confirm what shipped.
+- `blocked_on_user` → `/cw-followup --ticket-id <N>` to disposition it.
+- `failed` / dropped → surface the reason; let the operator decide.
+
+## Output shape
+
+End with one summary line per wave, caveman-tight:
+
+```
+fanout: client=claude-workspace wave=[201,202,203] → 2 shipped, 1 blocked_on_user (#202)
+  #202 needs attention → /cw-followup --ticket-id 202
+fanout: wave=[210,211] → all shipped; 0 need attention
+```
+
+## Failure modes
+
+- **Pre-flight drops the whole wave** — print the failing rows; do not enqueue.
+  Offer `--skip-preflight` if the operator wants to override.
+- **Dispatch loop not running** — the watchdog only ticks while `cw dev-queue
+  run` is alive; if the operator killed it, the wave stalls silently. Re-launch
+  it (Step 3) and note the gap.
+- **A ticket sits `pending` forever** — concurrency cap is saturated by other
+  clients, or the freshness gate keeps rejecting it (stale `main`). Surface
+  `cw dev-queue status` + `cw doctor`; suggest `cw dev-queue refresh-all`.
+- **`needs_attention` storm** — many tickets pause at once (often the same
+  ambiguity across a batch). Disposition one via `/cw-followup`, then re-dispatch
+  the rest with the same decision rather than answering each separately.
+
+## Out of scope
+
+- Generating or rebasing the per-ticket branches — `/cw-followup` owns that.
+- Mutating the sentinel schema or the dispatch internals.
+- Continuous standing-queue operation — this skill drives one wave to terminal;
+  for an always-on queue, leave `cw dev-queue run` up and watch `cw watch`.
+
+## Related
+
+- `/cw-smoke-test` — single-ticket end-to-end dogfood (the N=1 form of this).
+- `/cw-queue-peek` — in-flight WAIT/PEEK/STOP ladder (Step 4c).
+- `/cw-validate-result` — forensic read on a finished ticket (Step 5).
+- `/cw-followup` — act on a finished/blocked ticket's sentinel (Step 5).
+- `cw event tail --type session.needs_attention --type session.timed_out` —
+  the durable attention bus this skill watches in Step 4b.

--- a/.claude/skills/cw-fanout/scripts/wave_status.py
+++ b/.claude/skills/cw-fanout/scripts/wave_status.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Wave lifecycle rollup for /cw-fanout.
+
+Reports the per-ticket dev-queue lifecycle state for a single dispatch wave
+(the ticket set passed on the command line) plus a ``terminal`` rollup that
+tells the monitor loop when every ticket has reached a terminal state and the
+wave is done.
+
+Distinct from ``cw_queue_peek.py``: that script inspects the *health* of
+RUNNING worker sessions (age, idle gap, stuck-post-merge) to recommend
+WAIT/PEEK/STOP. This one answers the orthogonal question — *what lifecycle
+state is each ticket in, and is the whole batch finished?* — across all states
+(pending, running, completed, blocked_on_user, ...), not just RUNNING. The two
+compose: wave_status decides when to stop monitoring; cw_queue_peek decides
+what to do with the sessions still in flight.
+
+Lightweight by design: reads ``~/.local/share/cw/dev_queue.json`` directly (no
+``uv`` / cw import) so it is cheap to call repeatedly during monitoring.
+
+Output: a table on stdout, or a JSON object with ``--json``. Exit code is 0
+when the wave is terminal (every ticket done), 1 when at least one ticket is
+still in flight (pending or running).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+DEV_QUEUE = Path.home() / ".local/share/cw/dev_queue.json"
+
+# Terminal dev-queue states: the dispatcher will not advance these on its own.
+# blocked_on_user means a session paused for operator input (needs attention);
+# failed/cancelled are dead ends; completed shipped or no_op'd.
+TERMINAL_STATES = frozenset({"completed", "failed", "cancelled", "blocked_on_user"})
+# In-flight states the dispatcher is still driving.
+IN_FLIGHT_STATES = frozenset({"pending", "running"})
+# Synthetic state for a wave ticket no longer present in the queue at all —
+# typically completed and then retired/removed. Treated as terminal.
+_ABSENT = "absent"
+_SESSION_SHORT_LEN = 12
+
+
+def _load_tasks() -> list[dict[str, Any]]:
+    if not DEV_QUEUE.exists():
+        return []
+    try:
+        data = json.loads(DEV_QUEUE.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    tasks = data.get("tasks", []) if isinstance(data, dict) else []
+    return [t for t in tasks if isinstance(t, dict)]
+
+
+def _row_for_ticket(
+    ticket: str, client: str | None, tasks: list[dict[str, Any]]
+) -> dict[str, Any]:
+    for task in tasks:
+        if str(task.get("ticket_id")) != ticket:
+            continue
+        if client and task.get("client") != client:
+            continue
+        session_id = task.get("session_id") or ""
+        short = session_id[:_SESSION_SHORT_LEN] if isinstance(session_id, str) else ""
+        return {
+            "ticket_id": ticket,
+            "state": task.get("status", "unknown"),
+            "attempts": task.get("attempts", 0),
+            "session_id": short,
+            "client": task.get("client", client),
+        }
+    return {
+        "ticket_id": ticket,
+        "state": _ABSENT,
+        "attempts": 0,
+        "session_id": "",
+        "client": client,
+    }
+
+
+def _is_terminal(state: str) -> bool:
+    return state == _ABSENT or state in TERMINAL_STATES
+
+
+def build_report(tickets: list[str], client: str | None) -> dict[str, Any]:
+    tasks = _load_tasks()
+    rows = [_row_for_ticket(t.lstrip("#"), client, tasks) for t in tickets]
+    counts: dict[str, int] = {}
+    for row in rows:
+        counts[row["state"]] = counts.get(row["state"], 0) + 1
+    in_flight = [row["ticket_id"] for row in rows if not _is_terminal(row["state"])]
+    needs_attention = [
+        row["ticket_id"] for row in rows if row["state"] == "blocked_on_user"
+    ]
+    return {
+        "client": client,
+        "terminal": not in_flight,
+        "counts": counts,
+        "in_flight": in_flight,
+        "needs_attention": needs_attention,
+        "tickets": rows,
+    }
+
+
+def _print_table(report: dict[str, Any]) -> None:
+    print(f"{'TICKET':<10} {'STATE':<16} {'ATT':>3}  SESSION")
+    print("-" * 44)
+    for row in report["tickets"]:
+        print(
+            f"{row['ticket_id']:<10} {row['state']:<16} "
+            f"{row['attempts']:>3}  {row['session_id']}"
+        )
+    counts = ", ".join(f"{k}={v}" for k, v in sorted(report["counts"].items()))
+    print(f"\ncounts: {counts}")
+    if report["needs_attention"]:
+        flagged = ", ".join(report["needs_attention"])
+        print(f"needs attention (blocked_on_user): {flagged}")
+    print(f"wave terminal: {report['terminal']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Wave lifecycle rollup for /cw-fanout."
+    )
+    parser.add_argument(
+        "tickets", nargs="+", help="Ticket ids in the wave (e.g. 201 202 203)."
+    )
+    parser.add_argument(
+        "--client", "-c", default=None, help="Filter to this cw client."
+    )
+    parser.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="Emit JSON instead of a table.",
+    )
+    args = parser.parse_args()
+
+    report = build_report(args.tickets, args.client)
+    if args.as_json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_table(report)
+    return 0 if report["terminal"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/cw-followup/SKILL.md
+++ b/.claude/skills/cw-followup/SKILL.md
@@ -41,7 +41,7 @@ Optional flags from the user:
 Run the bundled parser to resolve the session and pull the parsed sentinel plus the raw payload:
 
 ```bash
-uv run --project /home/matthew/workspace/personal/claude-workspace python \
+uv run --project "$(git rev-parse --show-toplevel)" python \
   .claude/skills/cw-followup/scripts/parse_sentinel.py \
   --ticket-id <NUMBER>
 # or --session-id <SHORT> or --transcript-path <PATH>
@@ -53,7 +53,7 @@ If `sentinel_found` is false, stop and surface the transcript path + the session
 
 ### Step 2 — branch on the effective status
 
-The parser's `Status` enum is closed, so producer-emitted statuses like `premises_pending_verification` and `ambiguities_pending_resolution` route through a `BlockedResult` with `reason=status_unknown`. The skill reads the **raw payload** to recover the producer-emitted status, while preferring the validated `result.status` when the kind is `AutoDevResult`.
+As of schema v4 (issue #191), `premises_pending_verification` and `ambiguities_pending_resolution` are canonical `Status` members — they now parse as a normal `AutoDevResult`, not a `BlockedResult`. Only a status the parser has *never* heard of still routes through `BlockedResult` with `reason=status_unknown`. The skill prefers the **raw payload**'s `status` (it survives even that unknown-status case) and falls back to the validated `result.status`.
 
 ```text
 effective_status =
@@ -121,7 +121,7 @@ gh pr create --base main --head "$BRANCH"  # body derived from the review summar
 Render a Decisions section and append it to the ticket body. Pipe the parser output through `render_decisions.py`:
 
 ```bash
-echo "$RESULT" | uv run --project /home/matthew/workspace/personal/claude-workspace \
+echo "$RESULT" | uv run --project "$(git rev-parse --show-toplevel)" \
   python .claude/skills/cw-followup/scripts/render_decisions.py \
   --auto-accept-defaults  # only when the user opted in
 ```
@@ -150,7 +150,7 @@ jq '.result.blocker' <<<"$RESULT"
 
 When `blocker.reason == "tool_denied"` (issue #182): re-dispatch is the typical recovery, but the classifier non-determinism flagged in #183 means a delay before retry is sensible. Recommend `cw spawn --headless ...` with a 2-3 minute pause for the auto-mode classifier to settle.
 
-When `blocker.reason` is anything else: surface to user, do not auto-route. Ticket #174's Blocker expansion (Phase E) will eventually add `retry_eligible` and `recovery_hint`; until that lands, treat anything non-`tool_denied` as human-escalation.
+When `blocker.reason` is anything else: read the Phase E retry fields the Blocker now carries (issue #174) — `retry_eligible`, `retry_delay_seconds`, and `recovery_hint`. When `retry_eligible` is true, recommend re-dispatch after `retry_delay_seconds` (surfacing `recovery_hint`); when it is false or absent, treat as human-escalation and surface verbatim.
 
 #### `plan_pending_approval`
 

--- a/.claude/skills/cw-followup/scripts/parse_sentinel.py
+++ b/.claude/skills/cw-followup/scripts/parse_sentinel.py
@@ -13,7 +13,7 @@ not be resolved or the transcript file was missing.
 
 Run via ``uv run`` from the cw repo so ``cw.auto_dev_result`` imports cleanly:
 
-    uv run --project /home/matthew/workspace/personal/claude-workspace \\
+    uv run --project "$(git rev-parse --show-toplevel)" \\
         python .claude/skills/cw-followup/scripts/parse_sentinel.py \\
         --session-id <short-id>
 """

--- a/.claude/skills/cw-queue-peek/SKILL.md
+++ b/.claude/skills/cw-queue-peek/SKILL.md
@@ -10,10 +10,12 @@ Reports-only inspection of in-flight dev-queue sessions. Surfaces stalls and
 stuck sessions before they hit the 60-min hard timeout, so the operator can
 stop wasteful work early and re-dispatch productively.
 
-This skill is the **in-flight** counterpart to `cw-session-watch` (which
-determines exit status after a session ends) and `cw-validate-result` (which
-inspects what a finished session produced). Use `cw-queue-peek` *during* a
-wave to decide what to do with long-running sessions.
+This skill is the **in-flight** counterpart to the orchestrator event bus
+(`cw event tail --type session.needs_attention --type session.timed_out`,
+which surfaces a session's exit/attention state after it ends) and
+`cw-validate-result` (which inspects what a finished session produced). Use
+`cw-queue-peek` *during* a wave to decide what to do with long-running
+sessions.
 
 ## When to use
 
@@ -25,7 +27,10 @@ wave to decide what to do with long-running sessions.
 
 Do **not** use this skill for:
 
-- Post-mortem on a session that already ended — use `cw-session-watch` or `cw-validate-result`
+- Post-mortem on a session that already ended — tail the event bus
+  (`cw event tail --type session.needs_attention --type session.timed_out`)
+  for its exit/attention state, or use `cw-validate-result` for the sentinel
+  content
 - Deciding what to do with the sentinel result — use `cw-followup`
 - Interactive (USER-origin) sessions started via `cw start` — they don't go through dev-queue
 
@@ -145,7 +150,10 @@ between the remove and the close).
 
 ## Related skills
 
-- `cw-session-watch` — exit-status lookup for finished sessions
+- `cw event tail --type session.needs_attention --type session.timed_out` —
+  durable exit/attention state for finished or stalled sessions. The bus is
+  emitted automatically by the wrapper (on exit) and reconcile (idle/timeout
+  watchdog), so it supersedes a dedicated session-watch skill.
 - `cw-validate-result` — post-mortem sentinel + PR inspection
 - `cw-followup` — react to a finished session's sentinel result
 - `cw-smoke-test` — end-to-end dogfood validation

--- a/.claude/skills/cw-smoke-test/SKILL.md
+++ b/.claude/skills/cw-smoke-test/SKILL.md
@@ -130,7 +130,7 @@ smoke-test: #999 → no_sentinel — worker session 4f44d145 exited without emit
 ## Out of scope
 
 - Continuous-loop dispatching (use `cw dev-queue run` without `--once`).
-- Multi-ticket batch dispatch (use `cw spawn --headless` per ticket; or build `/cw-fanout` (#187) for parallel N-way).
+- Multi-ticket batch dispatch — use `/cw-fanout` for parallel N-way (pre-flight + enqueue + dispatch loop + monitoring handoff).
 - Phase A stage-transition events. This skill works without them; with them, monitoring becomes more informative.
 - Re-dispatching after a failure. The user owns the dispatch trigger; the smoke test is one-shot.
 

--- a/.claude/skills/cw-smoke-test/SKILL.md
+++ b/.claude/skills/cw-smoke-test/SKILL.md
@@ -31,7 +31,7 @@ Optional flags:
 Run the bundled checker:
 
 ```bash
-uv run --project /home/matthew/workspace/personal/claude-workspace python \
+uv run --project "$(git rev-parse --show-toplevel)" python \
   .claude/skills/cw-smoke-test/scripts/preflight.py \
   --ticket-id <NUMBER>
 ```
@@ -95,7 +95,7 @@ That skill resolves the transcript, parses the sentinel via `cw-followup/scripts
 | Outcome | Smoke-test verdict |
 |---|---|
 | `valid` | PASS — the pipeline produced a usable result. Print the `effective_status` and the PR / branch / worktree as applicable. |
-| `producer_status_unknown` | PASS-WITH-WARNING — the run finished and emitted a structured payload, but the producer used a status not yet in the parser's enum. File against `#190` / `#191` patterns if this is new. |
+| `producer_status_unknown` | PASS-WITH-WARNING — the run finished and emitted a structured payload, but the producer used a status the parser has never heard of. (Note: `premises_pending_verification` / `ambiguities_pending_resolution` became canonical in v4 (#191) and now report `valid` — this outcome is reserved for genuinely new statuses.) File a parser ticket if it is new. |
 | `invalid_sentinel` | FAIL — schema validation failed. This is producer/consumer drift; surface the validation error verbatim and recommend filing a parser bug. |
 | `no_sentinel` | FAIL — the run exited without emitting a sentinel at all. Walk the user through `references/no-sentinel-patterns.md` (in the validator skill's references). |
 
@@ -108,7 +108,7 @@ smoke-test: #<TICKET> → <effective_status>; ready to <suggested action>
   /cw-followup --session-id <WORKER_SHORT_ID>
 ```
 
-On FAIL, do NOT suggest `/cw-followup` — surface the failure and let the user decide whether to file a producer or parser ticket. If the failure looks like a known drift case (e.g. status not yet in enum, plan_source not yet in enum), point at the relevant open ticket (`#190`, `#191`) so the user can subscribe rather than re-file.
+On FAIL, do NOT suggest `/cw-followup` — surface the failure and let the user decide whether to file a producer or parser ticket. The historical drift cases (`#190` plan_source, `#191` v4 statuses) are resolved in the current parser; if a *new* unknown status or plan_source surfaces, file a fresh parser ticket rather than re-opening those.
 
 ## Output shape
 
@@ -116,7 +116,7 @@ Print exactly one summary line at the end, caveman-tight:
 
 ```
 smoke-test: #171 → valid (status=shipped, PR #234) — ready for review
-smoke-test: #185 → producer_status_unknown (status=premises_pending_verification) — disposition via /cw-followup
+smoke-test: #185 → valid (status=premises_pending_verification) — disposition via /cw-followup
 smoke-test: #999 → no_sentinel — worker session 4f44d145 exited without emitting; transcript at <path>
 ```
 
@@ -139,6 +139,6 @@ smoke-test: #999 → no_sentinel — worker session 4f44d145 exited without emit
 - `#172` / PR #192 — `/cw-validate-result` (the diagnostic step this skill delegates to).
 - `#188` / PR #189 — `/cw-followup` (the action step suggested on PASS).
 - `#187` — `/cw-fanout` (multi-ticket parallel dispatch; companion of this skill).
-- `#190` — `plan_source` enum drift surfaced via dogfood.
-- `#191` — Status enum drift (`premises_pending_verification` / `ambiguities_pending_resolution`) surfaced via dogfood.
+- `#190` — `plan_source` enum drift surfaced via dogfood (resolved: `github_issue_existing` now accepted).
+- `#191` — Status enum drift (`premises_pending_verification` / `ambiguities_pending_resolution`) surfaced via dogfood (resolved: promoted to canonical v4 statuses).
 - `#185` — Layer 1 backstop edge case (no Stop hook ⇒ no timeout fire). This skill's 30-minute timeout matches the Layer 1 cap.

--- a/.claude/skills/cw-validate-result/SKILL.md
+++ b/.claude/skills/cw-validate-result/SKILL.md
@@ -28,7 +28,7 @@ One of:
 Runs the bundled validator script:
 
 ```bash
-uv run --project /home/matthew/workspace/personal/claude-workspace python \
+uv run --project "$(git rev-parse --show-toplevel)" python \
   .claude/skills/cw-validate-result/scripts/validate_sentinel.py \
   --ticket-id <N>
 ```
@@ -42,7 +42,7 @@ The script reports one of four `outcome` values. Treat each differently:
 | `outcome` | Meaning | Exit |
 |---|---|---|
 | `valid` | Sentinel parsed cleanly as a canonical `AutoDevResult` | 0 |
-| `producer_status_unknown` | Sentinel present, but the producer emitted a status not yet in the parser's enum (e.g. `premises_pending_verification`). Treat as a real outcome the human should act on. | 0 |
+| `producer_status_unknown` | Sentinel present, but the producer emitted a status the parser has never heard of. (`premises_pending_verification` / `ambiguities_pending_resolution` are *no longer* this case — they became canonical in v4, issue #191, and now report `valid`.) Treat as a real outcome the human should act on. | 0 |
 | `invalid_sentinel` | Sentinel present but schema validation failed. Producer/consumer drift — report it. | 1 |
 | `no_sentinel` | No sentinel block in the transcript — the run exited before emitting. Diagnose via `references/no-sentinel-patterns.md`. | 1 |
 
@@ -53,7 +53,7 @@ Each output row is one of:
 | Check | What it verifies |
 |---|---|
 | `sentinel_emitted` | At least one assistant text block contained the sentinel pair. |
-| `status_is_canonical` | `effective_status` is one of the 8 canonical `Status` Literal values. Failing this with `outcome=producer_status_unknown` is expected today; failing it with other outcomes is a bug. |
+| `status_is_canonical` | `effective_status` is one of the canonical `Status` Literal values (the script derives the set from `cw.auto_dev_result.Status` — 10 members as of v4). Failing this with `outcome=producer_status_unknown` is expected; failing it with other outcomes is a bug. |
 | `health_present` | `health` carries `lowest_agent_confidence`, `any_incomplete_risk`, `recommendation`. |
 | `blocker_iff_blocked` | Cross-field invariant from §3.3: `blocker` non-null iff `status=blocked`. |
 | `pr_iff_shipped` | Cross-field invariant: `pr` non-null iff `status=shipped`. |
@@ -71,8 +71,8 @@ After running the validator, print:
 Keep it tight — caveman style:
 
 ```
-session 76f060e7 (#185): outcome=producer_status_unknown, status=premises_pending_verification
-  - status_is_canonical: FAIL (premises_pending_verification not in Status enum)
+session 76f060e7 (#185): outcome=valid, status=premises_pending_verification
+  all checks PASS
   next_actions: ['resolve_premises', 're_dispatch_after_disposition']
 ```
 
@@ -93,4 +93,4 @@ If outcome is `invalid_sentinel`, surface the validation error verbatim — the 
 - #188 / PR #189 — `/cw-followup` (companion skill; owns `parse_sentinel.py`)
 - #171 — `/cw-smoke-test` (end-to-end dogfood; uses this validator as its check step)
 - #117 / #140 — sentinel parsing / schema migration (this skill rides on top of whatever schema is current)
-- #190 / #191 — producer/consumer drift surfaced through dogfood; will reduce the `producer_status_unknown` / `invalid_sentinel` outcomes when fixed
+- #190 / #191 — producer/consumer drift surfaced through dogfood, now resolved: `github_issue_existing` (plan_source) and the two v4 statuses are accepted by the current parser, so they report `valid` instead of `producer_status_unknown` / `invalid_sentinel`

--- a/.claude/skills/cw-validate-result/scripts/validate_sentinel.py
+++ b/.claude/skills/cw-validate-result/scripts/validate_sentinel.py
@@ -24,7 +24,13 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args
+
+# Single source of truth for the canonical status set — never hardcode it.
+# `Status` grew two v4 members in issue #191 (ambiguities_pending_resolution,
+# premises_pending_verification); deriving the set keeps this validator in
+# lockstep with the parser instead of drifting behind it.
+from cw.auto_dev_result import Status
 
 _SKILL_DIR = Path(__file__).resolve().parents[1]
 # cw-followup's parse_sentinel lives in a sibling skill — it owns transcript
@@ -99,16 +105,7 @@ def _build_checks(parser_output: dict[str, Any], outcome: str) -> list[dict[str,
         ),
     )
 
-    canonical_statuses = {
-        "shipped",
-        "plan_pending_approval",
-        "review_pending_approval",
-        "merge_gate_blocked",
-        "scope_exceeded",
-        "forbidden_area",
-        "blocked",
-        "no_op",
-    }
+    canonical_statuses = set(get_args(Status))
     effective_status = raw.get("status") or result.get("status")
     checks.append(
         _check(


### PR DESCRIPTION
Audits the bundled skills against the live `cw` codebase, fixes the drift, and adds the previously-unbuilt `/cw-fanout` skill. All changes are confined to `.claude/`; no `src/` or `tests/` touched.

## 1. Skill audit (`7b3c0fd`)
Brought the four existing skills back in line with the current code:

- **`validate_sentinel.py` — functional bug fix.** Its canonical status set was hardcoded to 8 values, but `cw.auto_dev_result.Status` grew two members in schema v4 (`ambiguities_pending_resolution`, `premises_pending_verification`, #191). A now-valid premises run reported `outcome: valid` *and* a spurious `status_is_canonical: FAIL`. Now derives the set from `get_args(Status)` so it can't drift again.
- **Portable invocation.** Replaced the hardcoded `/home/matthew/workspace/personal/claude-workspace` path in 4 skill docs + 1 docstring with `uv run --project "$(git rev-parse --show-toplevel)"`.
- **Stale-status prose.** Updated `cw-followup`, `cw-validate-result`, and `cw-smoke-test`: v4 statuses are canonical `AutoDevResult` statuses (not `BlockedResult` / `status_unknown`), and the `Blocker` now carries Phase E retry fields (`retry_eligible` / `retry_delay_seconds` / `recovery_hint`, #174). Marked the #190/#191 drift cases resolved.

## 2. Repoint dangling `cw-session-watch` references (`643ae96`)
`cw-session-watch` was never built. Its intended role — exit/attention state for finished or stalled sessions — is already covered by the orchestrator event bus, which emits `session.needs_attention` (wrapper on exit; reconcile idle watchdog) and `session.timed_out` (reconcile wall-clock watchdog). Repointed the three references in `cw-queue-peek` to `cw event tail --type session.needs_attention --type session.timed_out`.

## 3. New `/cw-fanout` skill (`801feb0`)
Builds the previously-unbuilt `/cw-fanout` (#187) — the N-way companion to `/cw-smoke-test` that carries a batch of tickets from "enqueue these" to "now monitoring the queue":

- batch pre-flight (reuses `cw-smoke-test/scripts/preflight.py` per ticket)
- enqueue survivors (`cw dev-queue add`)
- start the dispatch loop (`cw dev-queue run`, backgrounded — it loops forever and drives reconcile/attention each tick)
- monitor via the new `scripts/wave_status.py` lifecycle rollup ("is the batch terminal?"), the `cw_queue_peek` ladder (in-flight health), and the `session.needs_attention` / `session.timed_out` event bus
- per-ticket disposition → suggest `/cw-followup` or `/cw-validate-result`

`wave_status.py` reads `dev_queue.json` directly (no `uv`/`cw` import) so it's cheap to poll; it's distinct from `cw_queue_peek` (session *health*) in that it reports lifecycle *state* across all queue states plus a `terminal` rollup.

## Verification
- `ruff` + `mypy` clean on all skill scripts (including the new `wave_status.py`).
- `wave_status.py` logic unit-checked (terminal detection, client isolation, needs-attention, session truncation) and smoke-tested in table + JSON modes.
- Reproduced the `validate_sentinel.py` bug before the fix and confirmed it resolved after.
- **Note:** the full `pytest` suite has pre-existing environmental failures (throwaway `/tmp` test repos fail `git commit` with exit 128 — no global git identity in the container). These reproduce on the clean baseline with these changes stashed and live entirely in `src` modules untouched here.

https://claude.ai/code/session_01DFQRN4nQb3j6o5jzTF3yTD

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFQRN4nQb3j6o5jzTF3yTD)_