### PR TITLE
feat(#124): persist cost_usd on Session + TicketTask (schema v4)

### DIFF
--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -316,6 +316,18 @@ class AutoDevResult(BaseModel):
     # all keys optional, tolerate producer-side key-name drift.
     ambiguities: list[dict[str, Any]] = Field(default_factory=list)
     premises: list[dict[str, Any]] = Field(default_factory=list)
+    # Total USD cost for this auto-dev run. Optional — producers that don't
+    # track cost omit this field; consumers treat None as "cost unknown".
+    # Must be non-negative when present. See GitHub issue #124.
+    cost_usd: float | None = None
+
+    @field_validator("cost_usd")
+    @classmethod
+    def _validate_cost_usd(cls, v: float | None) -> float | None:
+        if v is not None and v < 0:
+            msg = "cost_usd must be non-negative"
+            raise ValueError(msg)
+        return v
 
     @field_validator("stage_reached", mode="before")
     @classmethod

--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -209,6 +209,7 @@ def migrate_cw_state(raw: dict[str, Any]) -> dict[str, Any]:
             _coerce_session_origin(session_raw)
             _fill_linkage_field_defaults(session_raw)
             _fill_last_result_default(session_raw)
+            _fill_cost_fields_default(session_raw)
     # Bump persisted schema_version to current after all migration steps.
     raw["schema_version"] = CW_STATE_SCHEMA_VERSION
     return raw
@@ -270,6 +271,17 @@ def _fill_last_result_default(session_raw: dict[str, Any]) -> None:
     """
     if "last_result" not in session_raw:
         session_raw["last_result"] = None
+
+
+def _fill_cost_fields_default(session_raw: dict[str, Any]) -> None:
+    """Fill cost_usd and cost_breakdown introduced in schema v4.
+
+    Idempotent: existing values are preserved.
+    """
+    if "cost_usd" not in session_raw:
+        session_raw["cost_usd"] = None
+    if "cost_breakdown" not in session_raw:
+        session_raw["cost_breakdown"] = None
 
 
 def save_state(state: CwState) -> None:

--- a/src/cw/dev_queue.py
+++ b/src/cw/dev_queue.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextlib
 import fcntl
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from cw.atomic import atomic_write_text
 from cw.config import (
@@ -18,6 +18,7 @@ from cw.config import (
 )
 from cw.exceptions import CwError
 from cw.models import (
+    DEV_QUEUE_SCHEMA_VERSION,
     DevQueueStore,
     DispatchPlan,
     OrchestratorConfig,
@@ -95,13 +96,30 @@ def load_plan() -> DispatchPlan | None:
         return None
 
 
+def _fill_task_cost_default(task_raw: dict[str, Any]) -> None:
+    """Fill total_cost_usd introduced in dev-queue schema v2."""
+    if "total_cost_usd" not in task_raw:
+        task_raw["total_cost_usd"] = None
+
+
+def migrate_dev_queue(raw: dict[str, Any]) -> dict[str, Any]:
+    """Normalise a raw dev_queue.json payload into a currently-valid shape."""
+    tasks = raw.get("tasks")
+    if isinstance(tasks, list):
+        for task_raw in tasks:
+            if isinstance(task_raw, dict):
+                _fill_task_cost_default(task_raw)
+    raw["schema_version"] = DEV_QUEUE_SCHEMA_VERSION
+    return raw
+
+
 def load_dev_queue() -> DevQueueStore:
     """Load the dev queue from disk, returning an empty store if missing."""
     path = dev_queue_file()
     if not path.exists():
         return DevQueueStore()
     raw = json.loads(path.read_text())
-    return DevQueueStore.model_validate(raw)
+    return DevQueueStore.model_validate(migrate_dev_queue(raw))
 
 
 def save_dev_queue(store: DevQueueStore) -> None:

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -276,6 +276,33 @@ def dispatch_tick(
     return spawned
 
 
+def _accumulate_task_cost(task: TicketTask, session_id: str | None) -> None:
+    """Add the session's cost_usd to task.total_cost_usd, if available.
+
+    Reads cost via two-source fallback:
+      1. session.cost_usd (populated by signal_completed — normal headless path)
+      2. session.last_result.get('cost_usd') (populated by persist_last_result —
+         event-replay path where signal_completed did not run first)
+
+    When both sources are absent, total_cost_usd is left unchanged.
+    Called inside dev_queue_lock so the mutation is covered by the same
+    save_dev_queue call that persists the COMPLETED status.
+    """
+    if not session_id:
+        return
+    state = load_state()
+    session = next((s for s in state.sessions if s.id == session_id), None)
+    if session is None:
+        return
+    cost: float | None = session.cost_usd
+    if cost is None and isinstance(session.last_result, dict):
+        raw_cost = session.last_result.get("cost_usd")
+        if isinstance(raw_cost, (int, float)):
+            cost = float(raw_cost)
+    if cost is not None:
+        task.total_cost_usd = (task.total_cost_usd or 0.0) + cost
+
+
 def _apply_events_to_store(
     store: DevQueueStore,
     events: list[OrchestratorEvent],
@@ -330,6 +357,8 @@ def _apply_events_to_store(
             ):
                 continue
             task.status = QueueItemStatus.COMPLETED
+            sid = event_session_id if isinstance(event_session_id, str) else None
+            _accumulate_task_cost(task, sid)
             completed += 1
             break
     if completed:

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -54,8 +54,8 @@ class QueueItemStatus(StrEnum):
 # Schema versions for persisted state. Bump when making a breaking change
 # to the on-disk layout; add a migration in `cw.config.migrate_cw_state`
 # or `cw.dev_queue.migrate_dev_queue` to handle older versions.
-CW_STATE_SCHEMA_VERSION = 3
-DEV_QUEUE_SCHEMA_VERSION = 1
+CW_STATE_SCHEMA_VERSION = 4
+DEV_QUEUE_SCHEMA_VERSION = 2
 
 
 class TaskSpec(BaseModel):
@@ -172,6 +172,10 @@ class TicketTask(BaseModel):
     # the global IDLE_WATCHDOG_SECONDS fallback. None means "use tier or global
     # default". See GitHub issue #326.
     idle_watchdog_override: int | None = None
+    # Cumulative USD cost across all auto-dev attempts for this ticket.
+    # Populated by _accumulate_task_cost in consume_completed_sessions.
+    # None when no cost data has been recorded yet. See GitHub issue #124.
+    total_cost_usd: float | None = None
 
 
 class DispatchPlan(BaseModel):
@@ -309,6 +313,13 @@ class Session(BaseModel):
     # readable when the result schema bumps independently of cw's CW_STATE
     # schema. See ``cw.auto_dev_result`` for the parser.
     last_result: dict[str, Any] | None = None
+    # Total USD cost for this session's auto-dev run. Populated by
+    # signal_completed from AutoDevResult.cost_usd. None when cost data
+    # was not emitted by the producer. See GitHub issue #124.
+    cost_usd: float | None = None
+    # Per-model cost breakdown for this session. Populated via the SDK
+    # orchestrator path (post-#116). None when not available.
+    cost_breakdown: dict[str, float] | None = None
 
 
 DEFAULT_AUTO_PURPOSES: list[SessionPurpose] = [

--- a/src/cw/orchestrate.py
+++ b/src/cw/orchestrate.py
@@ -329,6 +329,7 @@ class OrchestratorStatus(BaseModel):
     running_sessions: list[SessionSummary] = Field(default_factory=list)
     monitored_prs: list[MonitoredPR] = Field(default_factory=list)
     recent_events: list[EventSummary] = Field(default_factory=list)
+    total_cost_by_client: dict[str, float] = Field(default_factory=dict)
 
 
 def _summarise_ticket(task: TicketTask) -> TicketSummary:
@@ -459,12 +460,19 @@ def orchestrator_status() -> OrchestratorStatus:
     tail = all_events[-_RECENT_EVENTS_LIMIT:]
     recent = [_summarise_event(e) for e in tail]
 
+    total_cost: dict[str, float] = {}
+    for task in queue.tasks:
+        if task.status == QueueItemStatus.COMPLETED and task.total_cost_usd is not None:
+            prior = total_cost.get(task.client, 0.0)
+            total_cost[task.client] = prior + task.total_cost_usd
+
     return OrchestratorStatus(
         generated_at=datetime.now(UTC),
         pending_tickets=pending,
         running_sessions=running,
         monitored_prs=monitored,
         recent_events=recent,
+        total_cost_by_client=total_cost,
     )
 
 

--- a/src/cw/wrapper.py
+++ b/src/cw/wrapper.py
@@ -397,6 +397,8 @@ def signal_completed(
     session.completed_at = now
     session.completed_reason = CompletionReason.NORMAL
     session.last_result = result.model_dump(mode="json")
+    if result.cost_usd is not None:
+        session.cost_usd = result.cost_usd
     if claude_session_id:
         session.claude_session_id = claude_session_id
     save_state(state)

--- a/tests/test_auto_dev_result.py
+++ b/tests/test_auto_dev_result.py
@@ -1625,3 +1625,68 @@ class TestAllPhasesBECDCombined:
         # Phase C
         assert result.health.agent_health_summary[0].confidence == "LOW"
         assert result.health.agent_health_summary[0].scope is None
+
+
+class TestCostUsdField:
+    def _make_shipped_payload(self, **extra: object) -> dict[str, object]:
+        """Minimal valid shipped payload for building test AutoDevResults."""
+        base: dict[str, object] = {
+            "schema_version": 2,
+            "ticket_id": "T-1",
+            "status": "shipped",
+            "stage_reached": "stage5_post_create",
+            "scope": {
+                "tier": "small",
+                "files": 1,
+                "lines_estimate": 5,
+                "lines_actual": 5,
+                "forbidden_touched": False,
+            },
+            "plan_source": "linear_existing",
+            "branch": "dev/t-1",
+            "worktree_path": "/tmp/wt",
+            "fork_point_sha": "abc",
+            "commits": ["c1"],
+            "pr": {
+                "number": 1,
+                "url": "https://example.com",
+                "auto_merge": True,
+                "base": "main",
+            },
+            "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+            "health": {
+                "lowest_agent_confidence": "HIGH",
+                "any_incomplete_risk": False,
+                "shortcuts": [],
+                "recommendation": "PROCEED",
+                "downgrade_applied": False,
+                "fix_loop_escalated": False,
+            },
+            "friction_highlights": [],
+            "blocker": None,
+            "next_actions": ["wait_for_ci"],
+        }
+        base.update(extra)
+        return base
+
+    def test_cost_usd_defaults_to_none(self) -> None:
+        payload = self._make_shipped_payload()
+        result = AutoDevResult.model_validate(payload)
+        assert result.cost_usd is None
+
+    def test_cost_usd_accepts_float(self) -> None:
+        payload = self._make_shipped_payload(cost_usd=1.23)
+        result = AutoDevResult.model_validate(payload)
+        assert result.cost_usd == 1.23
+
+    def test_cost_usd_must_be_non_negative(self) -> None:
+        payload = self._make_shipped_payload(cost_usd=-0.01)
+        with pytest.raises(ValidationError):
+            AutoDevResult.model_validate(payload)
+
+    def test_cost_usd_round_trip(self) -> None:
+        payload = self._make_shipped_payload(cost_usd=2.5)
+        result = AutoDevResult.model_validate(payload)
+        dumped = result.model_dump(mode="json")
+        restored = AutoDevResult.model_validate(dumped)
+        assert restored.cost_usd == 2.5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -753,3 +753,42 @@ class TestMigrateCwState:
         raw = {"schema_version": 1, "sessions": "oops"}
         migrated = migrate_cw_state(raw)
         assert migrated["schema_version"] == 1
+
+    def test_v3_to_v4_fills_cost_fields(self) -> None:
+        """migrate_cw_state fills cost_usd and cost_breakdown on sessions."""
+        raw = {
+            "schema_version": 3,
+            "sessions": [
+                {
+                    "id": "s1",
+                    "parent_session_id": None,
+                    "worker_session_ids": [],
+                    "last_result": None,
+                }
+            ],
+        }
+        migrated = migrate_cw_state(raw)
+        session = migrated["sessions"][0]
+        assert session["cost_usd"] is None
+        assert session["cost_breakdown"] is None
+        assert migrated["schema_version"] == CW_STATE_SCHEMA_VERSION
+
+    def test_v4_cost_fields_preserved_idempotently(self) -> None:
+        """Existing cost values survive a second migration pass."""
+        raw = {
+            "schema_version": 4,
+            "sessions": [
+                {
+                    "id": "s1",
+                    "parent_session_id": None,
+                    "worker_session_ids": [],
+                    "last_result": None,
+                    "cost_usd": 1.5,
+                    "cost_breakdown": {"claude-sonnet-4-6": 1.5},
+                }
+            ],
+        }
+        migrated = migrate_cw_state(raw)
+        session = migrated["sessions"][0]
+        assert session["cost_usd"] == 1.5
+        assert session["cost_breakdown"] == {"claude-sonnet-4-6": 1.5}

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -19,6 +19,7 @@ from cw.dev_queue import (
     list_tickets,
     load_dev_queue,
     load_plan,
+    migrate_dev_queue,
     plan_path,
     remove_ticket,
     resolve_client,
@@ -27,6 +28,7 @@ from cw.dev_queue import (
 )
 from cw.exceptions import CwError
 from cw.models import (
+    DEV_QUEUE_SCHEMA_VERSION,
     DevQueueStore,
     DispatchPlan,
     OrchestratorConfig,
@@ -1067,3 +1069,68 @@ class TestCLIDevQueueCancel:
         )
         assert result.exit_code != 0
         assert "No dev-queue task found" in result.output
+
+
+class TestMigrateDevQueue:
+    def test_v1_to_v2_fills_total_cost_usd(self) -> None:
+        """migrate_dev_queue fills total_cost_usd on tasks missing it."""
+        raw = {
+            "schema_version": 1,
+            "tasks": [
+                {
+                    "ticket_id": "GEN-1",
+                    "client": "test-client",
+                    "priority": 0,
+                    "status": "pending",
+                }
+            ],
+        }
+        migrated = migrate_dev_queue(raw)
+        assert migrated["tasks"][0]["total_cost_usd"] is None
+        assert migrated["schema_version"] == DEV_QUEUE_SCHEMA_VERSION
+
+    def test_v2_total_cost_preserved_idempotently(self) -> None:
+        """Existing total_cost_usd values survive a second migration pass."""
+        raw = {
+            "schema_version": 2,
+            "tasks": [
+                {
+                    "ticket_id": "GEN-2",
+                    "client": "test-client",
+                    "priority": 0,
+                    "status": "pending",
+                    "total_cost_usd": 2.5,
+                }
+            ],
+        }
+        migrated = migrate_dev_queue(raw)
+        assert migrated["tasks"][0]["total_cost_usd"] == 2.5
+
+    def test_load_dev_queue_migrates_v1_file(self, tmp_config_dir: Path) -> None:
+        """load_dev_queue applies migration when loading a v1 file from disk."""
+        import json
+
+        from cw.config import dev_queue_file
+
+        v1_data = {
+            "schema_version": 1,
+            "tasks": [
+                {
+                    "ticket_id": "GEN-3",
+                    "client": "test-client",
+                    "priority": 0,
+                    "status": "pending",
+                }
+            ],
+        }
+        dev_queue_file().parent.mkdir(parents=True, exist_ok=True)
+        dev_queue_file().write_text(json.dumps(v1_data))
+        store = load_dev_queue()
+        assert store.tasks[0].total_cost_usd is None
+        assert store.schema_version == DEV_QUEUE_SCHEMA_VERSION
+
+    def test_migrate_dev_queue_no_tasks(self) -> None:
+        """migrate_dev_queue handles missing tasks key without crashing."""
+        raw: dict[str, object] = {"schema_version": 1}
+        migrated = migrate_dev_queue(raw)
+        assert migrated["schema_version"] == DEV_QUEUE_SCHEMA_VERSION

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1681,3 +1681,91 @@ class TestSpawnCloseRaceRegression:
         store2 = load_dev_queue()
         t2 = next(t for t in store2.tasks if t.ticket_id == "RACE-1")
         assert t2.status == QueueItemStatus.CANCELLED
+
+
+class TestAccumulateTaskCost:
+    """Tests for _accumulate_task_cost helper inside consume_completed_sessions."""
+
+    def _make_running_task(
+        self, session_id: str, ticket_id: str = "GEN-1"
+    ) -> TicketTask:
+        task = TicketTask(
+            ticket_id=ticket_id,
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+            session_id=session_id,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+        return task
+
+    def _make_session(
+        self,
+        session_id: str,
+        *,
+        cost_usd: float | None = None,
+        last_result: dict | None = None,
+    ) -> None:
+        sess = Session(
+            id=session_id,
+            name="test-client/auto-dev/GEN-1",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/dev/null"),
+            cost_usd=cost_usd,
+            last_result=last_result,
+        )
+        save_state(CwState(sessions=[sess]))
+
+    def test_accumulates_cost_from_cost_usd_field(
+        self, tmp_dispatch_dirs: Path
+    ) -> None:
+        """When session.cost_usd is set, accumulates from that field."""
+        self._make_running_task("s_cost1")
+        self._make_session("s_cost1", cost_usd=1.5)
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {"ticket_id": "GEN-1", "session_id": "s_cost1"},
+        )
+        consume_completed_sessions()
+        store = load_dev_queue()
+        assert store.tasks[0].total_cost_usd == pytest.approx(1.5)
+
+    def test_accumulates_cost_from_last_result_when_cost_usd_field_absent(
+        self, tmp_dispatch_dirs: Path
+    ) -> None:
+        """Falls back to session.last_result['cost_usd'] when cost_usd field is None."""
+        self._make_running_task("s_lr1")
+        self._make_session(
+            "s_lr1",
+            cost_usd=None,
+            last_result={"cost_usd": 2.0, "status": "shipped"},
+        )
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {"ticket_id": "GEN-1", "session_id": "s_lr1"},
+        )
+        consume_completed_sessions()
+        store = load_dev_queue()
+        assert store.tasks[0].total_cost_usd == pytest.approx(2.0)
+
+    def test_accumulates_cost_zero_when_both_sources_absent(
+        self, tmp_dispatch_dirs: Path
+    ) -> None:
+        """When both cost sources are None, total_cost_usd is unchanged (no crash)."""
+        task = TicketTask(
+            ticket_id="GEN-1",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+            session_id="s_none1",
+            total_cost_usd=5.0,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+        self._make_session("s_none1", cost_usd=None, last_result=None)
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {"ticket_id": "GEN-1", "session_id": "s_none1"},
+        )
+        consume_completed_sessions()
+        store = load_dev_queue()
+        assert store.tasks[0].total_cost_usd == pytest.approx(5.0)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -588,3 +588,39 @@ class TestOrchestratorEventTypeSessionNeedsAttention:
             OrchestratorEventType.SESSION_NEEDS_ATTENTION.value
             == "session.needs_attention"
         )
+
+
+class TestCostFields:
+    def test_cost_fields_default_none(self) -> None:
+        sess = Session(
+            name="c/impl",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            workspace_path=Path("/dev/null"),
+        )
+        assert sess.cost_usd is None
+        assert sess.cost_breakdown is None
+
+    def test_cost_fields_round_trip(self) -> None:
+        sess = Session(
+            name="c/impl",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            workspace_path=Path("/dev/null"),
+            cost_usd=1.5,
+            cost_breakdown={"model-a": 1.5},
+        )
+        dumped = sess.model_dump(mode="json")
+        restored = Session.model_validate(dumped)
+        assert restored.cost_usd == 1.5
+        assert restored.cost_breakdown == {"model-a": 1.5}
+
+    def test_ticket_task_total_cost_usd_defaults_none(self) -> None:
+        task = TicketTask(ticket_id="T-1", client="c")
+        assert task.total_cost_usd is None
+
+    def test_ticket_task_total_cost_round_trip(self) -> None:
+        task = TicketTask(ticket_id="T-1", client="c", total_cost_usd=3.14)
+        dumped = task.model_dump(mode="json")
+        restored = TicketTask.model_validate(dumped)
+        assert restored.total_cost_usd == pytest.approx(3.14)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -44,6 +44,7 @@ def _make_result(
     status: str = "shipped",
     ticket_id: str = "T-1",
     next_actions: list[str] | None = None,
+    cost_usd: float | None = None,
 ) -> AutoDevResult:
     """Build a minimal AutoDevResult that satisfies §3-§5 invariants."""
     _base_health: dict[str, Any] = {
@@ -84,6 +85,7 @@ def _make_result(
         "review": _base_review,
         "health": _base_health,
         "next_actions": next_actions if next_actions is not None else [],
+        "cost_usd": cost_usd,
     }
 
     if pre_branch:
@@ -557,6 +559,154 @@ class TestSignalCompleted:
         sess_b = next(s for s in updated.sessions if s.id == "bbb")
         assert sess_a.status == SessionStatus.ACTIVE
         assert sess_b.status == SessionStatus.COMPLETED
+
+    def test_writes_cost_usd_to_session_when_present(
+        self, tmp_config_dir: Path, tmp_state_dir: Path
+    ) -> None:
+        """signal_completed writes cost_usd to session when result has cost_usd."""
+        self._seed_active_session("w_cost1")
+        result = _make_result(status="shipped", ticket_id="T-cost", cost_usd=2.5)
+
+        signal_completed("c", "impl", result=result, session_id="w_cost1")
+
+        updated = load_state()
+        sess = next(s for s in updated.sessions if s.id == "w_cost1")
+        assert sess.cost_usd == 2.5
+
+    def test_cost_usd_none_when_result_has_no_cost(
+        self, tmp_config_dir: Path, tmp_state_dir: Path
+    ) -> None:
+        """signal_completed leaves cost_usd None when result has no cost_usd."""
+        self._seed_active_session("w_cost2")
+        result = _make_result(status="shipped", ticket_id="T-cost2")  # no cost_usd
+
+        signal_completed("c", "impl", result=result, session_id="w_cost2")
+
+        updated = load_state()
+        sess = next(s for s in updated.sessions if s.id == "w_cost2")
+        assert sess.cost_usd is None
+
+    def test_accumulates_total_cost_usd_on_ticket_task(
+        self, tmp_config_dir: Path, tmp_state_dir: Path
+    ) -> None:
+        """Total cost accumulates across multiple completions for the same ticket."""
+        from cw.dispatch import consume_completed_sessions
+        from cw.events import record_event
+
+        # Seed task with existing total
+        task = TicketTask(
+            ticket_id="T-acc",
+            client="c",
+            status=QueueItemStatus.RUNNING,
+            session_id="w_acc1",
+            total_cost_usd=1.0,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        # Session with cost_usd=0.75
+        sess = Session(
+            id="w_acc1",
+            name="c/auto-dev/T-acc",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/dev/null"),
+        )
+        save_state(CwState(sessions=[sess]))
+
+        result = _make_result(status="shipped", ticket_id="T-acc", cost_usd=0.75)
+        signal_completed("c", "impl", result=result, session_id="w_acc1")
+
+        # Now consume to trigger accumulation
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {"ticket_id": "T-acc", "session_id": "w_acc1", "client": "c"},
+        )
+        consume_completed_sessions()
+
+        updated_queue = load_dev_queue()
+        updated_task = next(t for t in updated_queue.tasks if t.ticket_id == "T-acc")
+        assert updated_task.total_cost_usd == pytest.approx(1.75)
+
+    def test_total_cost_usd_starts_at_zero_for_first_attempt(
+        self, tmp_config_dir: Path, tmp_state_dir: Path
+    ) -> None:
+        """When total_cost_usd is None, first completion sets it to cost_usd."""
+        from cw.dispatch import consume_completed_sessions
+        from cw.events import record_event
+
+        task = TicketTask(
+            ticket_id="T-first",
+            client="c",
+            status=QueueItemStatus.RUNNING,
+            session_id="w_first",
+            total_cost_usd=None,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        sess = Session(
+            id="w_first",
+            name="c/auto-dev/T-first",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/dev/null"),
+        )
+        save_state(CwState(sessions=[sess]))
+
+        result = _make_result(status="shipped", ticket_id="T-first", cost_usd=2.0)
+        signal_completed("c", "impl", result=result, session_id="w_first")
+
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {"ticket_id": "T-first", "session_id": "w_first", "client": "c"},
+        )
+        consume_completed_sessions()
+
+        updated_queue = load_dev_queue()
+        updated_task = next(t for t in updated_queue.tasks if t.ticket_id == "T-first")
+        assert updated_task.total_cost_usd == pytest.approx(2.0)
+
+    def test_total_cost_usd_unchanged_when_no_cost_in_result(
+        self, tmp_config_dir: Path, tmp_state_dir: Path
+    ) -> None:
+        """When result has no cost_usd, total_cost_usd is not modified."""
+        from cw.dispatch import consume_completed_sessions
+        from cw.events import record_event
+
+        task = TicketTask(
+            ticket_id="T-nochange",
+            client="c",
+            status=QueueItemStatus.RUNNING,
+            session_id="w_nochange",
+            total_cost_usd=3.0,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        sess = Session(
+            id="w_nochange",
+            name="c/auto-dev/T-nochange",
+            client="c",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/dev/null"),
+        )
+        save_state(CwState(sessions=[sess]))
+
+        result = _make_result(status="shipped", ticket_id="T-nochange")  # no cost_usd
+        signal_completed("c", "impl", result=result, session_id="w_nochange")
+
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {"ticket_id": "T-nochange", "session_id": "w_nochange", "client": "c"},
+        )
+        consume_completed_sessions()
+
+        updated_queue = load_dev_queue()
+        updated_task = next(
+            t for t in updated_queue.tasks if t.ticket_id == "T-nochange"
+        )
+        assert updated_task.total_cost_usd == pytest.approx(3.0)
 
 
 class TestHeadlessWrapper:


### PR DESCRIPTION
## Summary

Persists `total_cost_usd` on Session and TicketTask (schema v4) and rolls it up in orchestrate status — closes #124.

- feat(#124): persist cost_usd on Session + TicketTask (schema v4)

Produced by `/auto-dev` (session d462d3d2), Track C wave-3. Reached `review_pending_approval` at stage3_review; both initial must-fixes cleared by cross-reviewer consensus (one dismissed per spec — cost_breakdown placeholder field confirmed by PM reviewer; one reclassified to should-fix — plan-soundness/data-safety/sysadmin all clear). Health recommendation: PROCEED.

## Deferred should-fixes (follow-up filed)

- `accumulate_task_cost` docstring has a misleading fallback description
- `if not session_id` should be `is None` for type precision

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /cw-followup (ship-as-is + follow-up)