### PR TITLE
feat(#123): cw doctor wedge-detection drift checks + --reap recipes + --json

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -48,7 +48,7 @@ from cw.dev_queue import (
     save_dev_queue,
 )
 from cw.dispatch import _DISPATCH_CONSUMER, _apply_events_to_store, run_dispatch_loop
-from cw.doctor import format_report, run_doctor
+from cw.doctor import format_report, format_report_json, run_doctor
 from cw.events import advance_cursor, read_events, record_event
 from cw.exceptions import CwError, WorktreeError
 from cw.models import (
@@ -280,8 +280,15 @@ def config() -> None:
     is_flag=True,
     help="Also reconcile state with the live multiplexer and reap phantoms.",
 )
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output report as JSON.",
+)
 @handle_errors
-def doctor(reap: bool) -> None:
+def doctor(reap: bool, as_json: bool) -> None:
     """Run environment preflight checks and print a health report.
 
     Reports the resolved backend, backend binary/daemon availability,
@@ -291,6 +298,9 @@ def doctor(reap: bool) -> None:
     tickets to PENDING. Exits non-zero if any check fails.
     """
     report = run_doctor(reap=reap)
+    if as_json:
+        click.echo(format_report_json(report))
+        sys.exit(0 if report.ok else 1)
     click.echo(format_report(report))
     if not report.ok:
         raise click.exceptions.Exit(1)

--- a/src/cw/cmux.py
+++ b/src/cw/cmux.py
@@ -104,6 +104,10 @@ class MultiplexerAdapter(Protocol):
         """
         ...
 
+    def inspect_pane(self, surface_ref: str) -> dict[str, Any]:
+        """Return pane info best-effort; {} if unavailable."""
+        ...
+
     def capture_surface(self, surface_ref: str, lines: int, scrollback: int) -> str:
         """Return last *lines* lines of worker output for *surface_ref*.
 
@@ -241,6 +245,10 @@ class RealCmuxAdapter:
         """
         return dict.fromkeys(self.list_surfaces(), "cmux-surface")
 
+    def inspect_pane(self, _surface_ref: str) -> dict[str, Any]:
+        """Return empty dict — cmux does not expose pane activity info."""
+        return {}
+
     def capture_surface(self, _surface_ref: str, _lines: int, _scrollback: int) -> str:
         """Raise CwError — cmux does not support output capture.
 
@@ -259,18 +267,20 @@ class FakeCmuxAdapter:
 
     def __init__(self) -> None:
         self._counter = 0
-        self.calls: dict[str, list[tuple[object, ...]]] = {
+        self.calls: dict[str, list[tuple[object, ...] | str]] = {
             "spawn": [],
             "close": [],
             "identify": [],
             "list_surfaces": [],
             "list_live_surface_commands": [],
+            "inspect_pane": [],
         }
         self.capture_calls: list[dict[str, object]] = []
         self._live: set[str] = set()
         self._live_commands: dict[str, str] = {}
         self._commands_fail: bool = False
         self._surface_content: dict[str, str] = {}
+        self._pane_info: dict[str, dict[str, Any]] = {}
 
     def spawn(self, workspace: str, command: str, surface: str = "right") -> str:
         """Record call and return a deterministic fake surface ref."""
@@ -340,6 +350,15 @@ class FakeCmuxAdapter:
     def set_surface_content(self, surface_ref: str, content: str) -> None:
         """Set the stored output content for a surface (test helper)."""
         self._surface_content[surface_ref] = content
+
+    def inspect_pane(self, surface_ref: str) -> dict[str, Any]:
+        """Return stored pane info for *surface_ref*, or {} if unknown."""
+        self.calls["inspect_pane"].append(surface_ref)
+        return dict(self._pane_info.get(surface_ref, {}))
+
+    def set_pane_info(self, surface_ref: str, data: dict[str, Any]) -> None:
+        """Configure the value returned by inspect_pane (test helper)."""
+        self._pane_info[surface_ref] = data
 
 
 def _resolve_backend_name() -> BackendName:

--- a/src/cw/cmux.py
+++ b/src/cw/cmux.py
@@ -267,7 +267,7 @@ class FakeCmuxAdapter:
 
     def __init__(self) -> None:
         self._counter = 0
-        self.calls: dict[str, list[tuple[object, ...] | str]] = {
+        self.calls: dict[str, list[tuple[object, ...]]] = {
             "spawn": [],
             "close": [],
             "identify": [],
@@ -353,7 +353,7 @@ class FakeCmuxAdapter:
 
     def inspect_pane(self, surface_ref: str) -> dict[str, Any]:
         """Return stored pane info for *surface_ref*, or {} if unknown."""
-        self.calls["inspect_pane"].append(surface_ref)
+        self.calls["inspect_pane"].append((surface_ref,))  # tuple, like all other calls
         return dict(self._pane_info.get(surface_ref, {}))
 
     def set_pane_info(self, surface_ref: str, data: dict[str, Any]) -> None:

--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -11,8 +11,11 @@ assert on specific checks.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import subprocess as _sp
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -20,21 +23,31 @@ import yaml
 from pydantic import ValidationError
 
 from cw import __version__
+from cw.cmux import get_backend_adapter
 from cw.config import (
     clients_file,
     load_clients,
     load_state,
     orchestrator_config_file,
+    save_state,
     state_file,
 )
-from cw.dev_queue import load_dev_queue
+from cw.dev_queue import dev_queue_lock, load_dev_queue, save_dev_queue
+from cw.events import record_event
 from cw.exceptions import CwError
+from cw.models import (
+    CompletionReason,
+    OrchestratorEventType,
+    QueueItemStatus,
+    SessionStatus,
+)
 from cw.native_daemon import _ROSTER_PATH
-from cw.reconcile import reconcile
+from cw.reconcile import SPAWN_GRACE_SECONDS, reconcile, ticket_id_for_session
 from cw.worktree import _git_dir
 
 if TYPE_CHECKING:
-    from cw.models import CwState, Session
+    from cw.cmux import MultiplexerAdapter
+    from cw.models import CwState, DevQueueStore, Session
 
 
 @dataclass(frozen=True)
@@ -47,12 +60,24 @@ class CheckResult:
     warn: bool = False
 
 
+@dataclass(frozen=True)
+class WedgeFinding:
+    """A detected wedge condition with an actionable recipe."""
+
+    wedge_class: str
+    session_id: str | None
+    ticket_id: str | None
+    recipe: str
+    state_file: str
+
+
 @dataclass
 class DoctorReport:
     """Aggregated output from :func:`run_doctor`."""
 
     version: str
     checks: list[CheckResult] = field(default_factory=list)
+    wedge_findings: list[WedgeFinding] = field(default_factory=list)
 
     @property
     def ok(self) -> bool:
@@ -72,6 +97,13 @@ _MIN_CLAUDE_VERSION = (2, 1, 139)
 
 # Number of components (major.minor.patch) required in a version string.
 _VERSION_PARTS = 3
+
+# Seconds of worktree inactivity (no non-.git file modified) before a pane
+# showing an idle shell is considered wedged.
+WEDGE_IDLE_MTIME_SECONDS = 300
+
+# Shell command names that indicate a pane is idle (back at prompt).
+_SHELL_COMMANDS: frozenset[str] = frozenset({"bash", "zsh", "fish", "sh", "dash"})
 
 
 def _check_config_file() -> CheckResult:
@@ -265,12 +297,311 @@ def _check_workspace_paths() -> list[CheckResult]:
     return results
 
 
+# ---------------------------------------------------------------------------
+# Wedge detection helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_wedge_pane_idle(
+    state: CwState,
+    _queue: DevQueueStore,
+    adapter: MultiplexerAdapter,
+) -> list[WedgeFinding]:
+    """Detect panes showing idle shell with no recent worktree file activity.
+
+    Fail-open: if inspect_pane returns {}, skip — missing info must not
+    trigger false-positive findings.
+    """
+    findings: list[WedgeFinding] = []
+    live_statuses = {SessionStatus.ACTIVE, SessionStatus.IDLE}
+    for session in state.sessions:
+        if session.status not in live_statuses:
+            continue
+        if session.surface_ref is None:
+            continue
+        pane_info = adapter.inspect_pane(session.surface_ref)
+        if not pane_info:
+            continue
+        if pane_info.get("cmd") not in _SHELL_COMMANDS:
+            continue
+        worktree = session.worktree_path
+        if worktree is None or not worktree.is_dir():
+            continue
+        cutoff = datetime.now(UTC).timestamp() - WEDGE_IDLE_MTIME_SECONDS
+        recent = False
+        for dirpath, dirnames, filenames in os.walk(worktree):
+            # Exclude .git from mtime scan — git operations update files there
+            # even when no real work is happening.
+            dirnames[:] = [d for d in dirnames if d != ".git"]
+            for fname in filenames:
+                fpath = Path(dirpath) / fname
+                try:
+                    if fpath.stat().st_mtime > cutoff:
+                        recent = True
+                        break
+                except OSError:
+                    continue
+            if recent:
+                break
+        if recent:
+            continue
+        findings.append(
+            WedgeFinding(
+                wedge_class="wedge/pane-idle-but-active",
+                session_id=session.id,
+                ticket_id=ticket_id_for_session(session.name),
+                recipe=(
+                    "Session pane shows idle shell prompt with no recent worktree"
+                    " activity. Run: cw doctor --reap to synthesize completed event"
+                    " and revert queue task."
+                ),
+                state_file=str(state_file()),
+            )
+        )
+    return findings
+
+
+def _check_wedge_task_running_no_session(
+    state: CwState,
+    queue: DevQueueStore,
+) -> list[WedgeFinding]:
+    """Detect RUNNING queue tasks with no associated live session.
+
+    Skips tasks within SPAWN_GRACE_SECONDS of creation — newly spawned
+    tasks have not yet registered their session_id.
+    """
+    findings: list[WedgeFinding] = []
+    _live = {SessionStatus.ACTIVE, SessionStatus.IDLE}
+    live_session_ids = {s.id for s in state.sessions if s.status in _live}
+    now = datetime.now(UTC)
+    for task in queue.tasks:
+        if task.status != QueueItemStatus.RUNNING:
+            continue
+        if task.session_id is None:
+            created = task.created_at
+            if created.tzinfo is None:
+                created = created.replace(tzinfo=UTC)
+            if (now - created).total_seconds() < SPAWN_GRACE_SECONDS:
+                continue
+            findings.append(
+                WedgeFinding(
+                    wedge_class="wedge/task-running-no-session",
+                    session_id=None,
+                    ticket_id=task.ticket_id,
+                    recipe=(
+                        "Queue task RUNNING with no matching session. "
+                        "Run: cw doctor --reap to revert task to PENDING."
+                    ),
+                    state_file=str(state_file()),
+                )
+            )
+        elif task.session_id not in live_session_ids:
+            # session_id set but no live session — handled by
+            # _check_wedge_task_running_completed_session if COMPLETED
+            pass
+    return findings
+
+
+def _check_wedge_task_running_completed_session(
+    state: CwState,
+    queue: DevQueueStore,
+) -> list[WedgeFinding]:
+    """Detect RUNNING queue tasks whose session is already COMPLETED."""
+    findings: list[WedgeFinding] = []
+    session_by_id = {s.id: s for s in state.sessions}
+    for task in queue.tasks:
+        if task.status != QueueItemStatus.RUNNING or task.session_id is None:
+            continue
+        session = session_by_id.get(task.session_id)
+        if session is None or session.status != SessionStatus.COMPLETED:
+            continue
+        findings.append(
+            WedgeFinding(
+                wedge_class="wedge/task-running-completed-session",
+                session_id=task.session_id,
+                ticket_id=task.ticket_id,
+                recipe=(
+                    "Queue task RUNNING but its session is already COMPLETED. "
+                    "Run: cw doctor --reap to revert task to PENDING."
+                ),
+                state_file=str(state_file()),
+            )
+        )
+    return findings
+
+
+def _check_wedge_repo_ahead(
+    state: CwState,
+    queue: DevQueueStore,
+) -> list[WedgeFinding]:
+    """Detect RUNNING tasks whose branch is pushed to remote but queue not updated.
+
+    Uses ``git ls-remote`` to check if the branch exists on the remote and
+    ``gh pr list`` to determine whether a PR is open. Advisory only — no
+    automatic reap.
+    """
+    findings: list[WedgeFinding] = []
+    session_by_id = {s.id: s for s in state.sessions}
+    for task in queue.tasks:
+        if task.status != QueueItemStatus.RUNNING:
+            continue
+        if task.worktree_path is None:
+            continue
+        # Branch resolution: prefer session branch, fallback to auto-dev/<ticket>
+        branch: str | None = None
+        if task.session_id is not None:
+            session = session_by_id.get(task.session_id)
+            if session is not None:
+                branch = session.branch
+        if not branch:
+            branch = f"auto-dev/{task.ticket_id}"
+        # Get remote URL from worktree
+        try:
+            remote_result = _sp.run(
+                ["git", "-C", str(task.worktree_path), "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if remote_result.returncode != 0:
+                continue
+            remote_url = remote_result.stdout.strip()
+        except OSError:
+            continue
+        # Check if branch exists on remote
+        try:
+            ls_result = _sp.run(
+                ["git", "ls-remote", remote_url, f"refs/heads/{branch}"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if ls_result.returncode != 0 or not ls_result.stdout.strip():
+                continue
+        except OSError:
+            continue
+        # Check PR status via gh CLI
+        recipe: str
+        try:
+            pr_result = _sp.run(
+                [
+                    "gh",
+                    "pr",
+                    "list",
+                    "--head",
+                    branch,
+                    "--json",
+                    "state",
+                    "--limit",
+                    "1",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            prs = json.loads(pr_result.stdout) if pr_result.returncode == 0 else []
+        except (OSError, ValueError):
+            prs = []
+        if not prs:
+            recipe = (
+                f"Branch {branch} is ahead of main with no open PR. "
+                f"Suggested: cw spawn-complete {task.ticket_id} or open PR manually."
+            )
+        else:
+            pr_state = prs[0].get("state", "OPEN")
+            recipe = (
+                f"Branch {branch} has {pr_state} PR but queue still RUNNING. "
+                f"Suggested: cw spawn-complete {task.ticket_id} --status shipped."
+            )
+        findings.append(
+            WedgeFinding(
+                wedge_class="wedge/repo-ahead-of-queue",
+                session_id=task.session_id,
+                ticket_id=task.ticket_id,
+                recipe=recipe,
+                state_file=str(state_file()),
+            )
+        )
+    return findings
+
+
+def _reap_wedge_findings(
+    findings: list[WedgeFinding],
+    state: CwState,
+    adapter: MultiplexerAdapter,
+) -> None:
+    """Apply mutations for actionable wedge classes.
+
+    Class-1 (pane-idle-but-active): mark session COMPLETED, close pane,
+    revert queue task to PENDING.
+    Class-2 (task-running-no-session): revert queue task to PENDING.
+    Class-3 (task-running-completed-session): revert queue task to PENDING.
+    Class-4 (repo-ahead-of-queue): advisory only — no mutations.
+    """
+    session_by_id = {s.id: s for s in state.sessions}
+    now = datetime.now(UTC)
+
+    # --- Class-1: pane-idle-but-active ---
+    class1_session_ids: set[str] = set()
+    for f in findings:
+        if f.wedge_class != "wedge/pane-idle-but-active" or f.session_id is None:
+            continue
+        session = session_by_id.get(f.session_id)
+        if session is None:
+            continue
+        session.status = SessionStatus.COMPLETED
+        session.completed_reason = CompletionReason.CRASHED
+        session.completed_at = now
+        class1_session_ids.add(f.session_id)
+
+    if class1_session_ids:
+        save_state(state)
+        for sid in class1_session_ids:
+            session = session_by_id[sid]
+            record_event(
+                OrchestratorEventType.SESSION_COMPLETED,
+                {
+                    "session_id": session.id,
+                    "session_name": session.name,
+                    "client": session.client,
+                    "crashed": True,
+                    "ticket_id": ticket_id_for_session(session.name),
+                },
+            )
+            if session.surface_ref is not None:
+                adapter.close(session.surface_ref)
+
+    # --- Revert queue tasks for all actionable classes ---
+    # class-4 (repo-ahead-of-queue) is advisory — skip it.
+    revert_ticket_ids: set[str] = set()
+    for f in findings:
+        if f.wedge_class == "wedge/repo-ahead-of-queue":
+            continue
+        if f.ticket_id:
+            revert_ticket_ids.add(f.ticket_id)
+
+    if revert_ticket_ids:
+        with dev_queue_lock():
+            queue = load_dev_queue()
+            changed = False
+            for task in queue.tasks:
+                if (
+                    task.ticket_id in revert_ticket_ids
+                    and task.status == QueueItemStatus.RUNNING
+                ):
+                    task.status = QueueItemStatus.PENDING
+                    task.session_id = None
+                    changed = True
+            if changed:
+                save_dev_queue(queue)
+
+
 def run_doctor(*, reap: bool = False) -> DoctorReport:
     """Run every preflight check and return a populated report.
 
     When *reap* is True, also run state reconciliation and append a
     ``reconciliation`` check summarising the number of reaped sessions and
-    reverted tickets.
+    reverted tickets. Also runs wedge checks and applies reap recipes.
 
     Linkage drift checks (parent/worker reference integrity) are always run,
     independent of the *reap* flag.
@@ -293,6 +624,21 @@ def run_doctor(*, reap: bool = False) -> DoctorReport:
     report.checks.append(_check_claude_version())
     report.checks.append(_check_daemon_reachable())
     report.checks.extend(_check_workspace_paths())
+
+    if link_state is not None:
+        # Wedge checks: load queue once, run all four checks.
+        queue = load_dev_queue()
+        adapter = get_backend_adapter()
+        report.wedge_findings.extend(_check_wedge_pane_idle(link_state, queue, adapter))
+        report.wedge_findings.extend(
+            _check_wedge_task_running_no_session(link_state, queue)
+        )
+        report.wedge_findings.extend(
+            _check_wedge_task_running_completed_session(link_state, queue)
+        )
+        report.wedge_findings.extend(_check_wedge_repo_ahead(link_state, queue))
+        if reap and report.wedge_findings:
+            _reap_wedge_findings(report.wedge_findings, link_state, adapter)
 
     if reap:
         report.checks.append(_check_reconcile())
@@ -446,6 +792,12 @@ def format_report(report: DoctorReport) -> str:
         if check.detail:
             line += f" — {check.detail}"
         lines.append(line)
+    if report.wedge_findings:
+        lines.append("")
+        lines.append("wedge findings:")
+        for wf in report.wedge_findings:
+            lines.append(f"  [{wf.wedge_class}] ticket={wf.ticket_id}")
+            lines.append(f"    {wf.recipe}")
     lines.append("")
     if not report.ok:
         footer = "status: problems detected"
@@ -455,3 +807,29 @@ def format_report(report: DoctorReport) -> str:
         footer = "status: healthy — advisory warnings"
     lines.append(footer)
     return "\n".join(lines)
+
+
+def format_report_json(report: DoctorReport) -> str:
+    """Render a :class:`DoctorReport` as JSON."""
+    return json.dumps(
+        {
+            "version": 1,
+            "ok": report.ok,
+            "clean": report.clean,
+            "checks": [
+                {"name": c.name, "ok": c.ok, "warn": c.warn, "detail": c.detail}
+                for c in report.checks
+            ],
+            "wedge_findings": [
+                {
+                    "wedge_class": f.wedge_class,
+                    "session_id": f.session_id,
+                    "ticket_id": f.ticket_id,
+                    "recipe": f.recipe,
+                    "state_file": f.state_file,
+                }
+                for f in report.wedge_findings
+            ],
+        },
+        indent=2,
+    )

--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -396,9 +396,25 @@ def _check_wedge_task_running_no_session(
                 )
             )
         elif task.session_id not in live_session_ids:
-            # session_id set but no live session — handled by
-            # _check_wedge_task_running_completed_session if COMPLETED
-            pass
+            # session_id set but points to a non-live session (missing from
+            # state, TIMED_OUT, BACKGROUNDED, etc.).
+            # _check_wedge_task_running_completed_session handles COMPLETED
+            # specifically; everything else falls here.
+            session_by_id_local = {s.id: s for s in state.sessions}
+            sess = session_by_id_local.get(task.session_id)
+            if sess is None or sess.status != SessionStatus.COMPLETED:
+                findings.append(
+                    WedgeFinding(
+                        wedge_class="wedge/task-running-no-session",
+                        session_id=task.session_id,
+                        ticket_id=task.ticket_id,
+                        recipe=(
+                            "Queue task RUNNING with no matching session. "
+                            "Run: cw doctor --reap to revert task to PENDING."
+                        ),
+                        state_file=str(state_file()),
+                    )
+                )
     return findings
 
 
@@ -541,7 +557,7 @@ def _reap_wedge_findings(
     session_by_id = {s.id: s for s in state.sessions}
     now = datetime.now(UTC)
 
-    # --- Class-1: pane-idle-but-active ---
+    # --- Class-1: in-memory mutations only (not yet persisted) ---
     class1_session_ids: set[str] = set()
     for f in findings:
         if f.wedge_class != "wedge/pane-idle-but-active" or f.session_id is None:
@@ -550,29 +566,11 @@ def _reap_wedge_findings(
         if session is None:
             continue
         session.status = SessionStatus.COMPLETED
-        session.completed_reason = CompletionReason.CRASHED
+        session.completed_reason = CompletionReason.NORMAL
         session.completed_at = now
         class1_session_ids.add(f.session_id)
 
-    if class1_session_ids:
-        save_state(state)
-        for sid in class1_session_ids:
-            session = session_by_id[sid]
-            record_event(
-                OrchestratorEventType.SESSION_COMPLETED,
-                {
-                    "session_id": session.id,
-                    "session_name": session.name,
-                    "client": session.client,
-                    "crashed": True,
-                    "ticket_id": ticket_id_for_session(session.name),
-                },
-            )
-            if session.surface_ref is not None:
-                adapter.close(session.surface_ref)
-
-    # --- Revert queue tasks for all actionable classes ---
-    # class-4 (repo-ahead-of-queue) is advisory — skip it.
+    # Collect ticket IDs for queue revert (classes 1-3, not class-4).
     revert_ticket_ids: set[str] = set()
     for f in findings:
         if f.wedge_class == "wedge/repo-ahead-of-queue":
@@ -580,20 +578,42 @@ def _reap_wedge_findings(
         if f.ticket_id:
             revert_ticket_ids.add(f.ticket_id)
 
-    if revert_ticket_ids:
+    # FIX 5: Hold queue lock across BOTH state writes to prevent torn state
+    # window where dispatch observes sessions.json=COMPLETED but
+    # dev_queue.json=RUNNING and triggers a spurious re-spawn.
+    if class1_session_ids or revert_ticket_ids:
         with dev_queue_lock():
-            queue = load_dev_queue()
-            changed = False
-            for task in queue.tasks:
-                if (
-                    task.ticket_id in revert_ticket_ids
-                    and task.status == QueueItemStatus.RUNNING
-                ):
-                    task.status = QueueItemStatus.PENDING
-                    task.session_id = None
-                    changed = True
-            if changed:
-                save_dev_queue(queue)
+            if class1_session_ids:
+                save_state(state)  # session mutations persisted inside lock
+            if revert_ticket_ids:
+                queue = load_dev_queue()
+                changed = False
+                for task in queue.tasks:
+                    if (
+                        task.ticket_id in revert_ticket_ids
+                        and task.status == QueueItemStatus.RUNNING
+                    ):
+                        task.status = QueueItemStatus.PENDING
+                        task.session_id = None
+                        changed = True
+                if changed:
+                    save_dev_queue(queue)
+
+    # Side effects AFTER both writes succeed.
+    for sid in class1_session_ids:
+        session = session_by_id[sid]
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {
+                "session_id": session.id,
+                "session_name": session.name,
+                "client": session.client,
+                "crashed": False,  # FIX 4: not a crash
+                "ticket_id": ticket_id_for_session(session.name),
+            },
+        )
+        if session.surface_ref is not None:
+            adapter.close(session.surface_ref)
 
 
 def run_doctor(*, reap: bool = False) -> DoctorReport:

--- a/src/cw/tmux.py
+++ b/src/cw/tmux.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+from datetime import UTC, datetime
 from typing import Any
 
 from cw._util import _tail_lines
@@ -18,6 +19,13 @@ from cw.exceptions import CwError
 
 # Pane reference format returned by ``tmux split-window -P -F ...``.
 _PANE_FORMAT = "#{session_name}:#{window_index}.#{pane_index}"
+
+# Pane reference format used by inspect_pane to capture pane ref, current
+# command, and pane activity time (Unix epoch from #{pane_activity}).
+_PANE_FORMAT_WITH_ACTIVITY = (
+    "#{session_name}:#{window_index}.#{pane_index}"
+    " #{pane_current_command} #{pane_activity}"
+)
 
 # Pane reference format that also captures the foreground command name.
 # Used by :meth:`TmuxAdapter.list_live_surface_commands` to detect zombie
@@ -173,3 +181,38 @@ class TmuxAdapter:
             if len(parts) == 2:
                 commands[parts[0]] = parts[1].strip()
         return commands
+
+    def inspect_pane(self, surface_ref: str) -> dict[str, Any]:
+        """Return pane info for *surface_ref*; empty dict if unavailable.
+
+        Calls ``tmux list-panes`` with a format string capturing the pane
+        ref, current command, and pane activity epoch. Fails open —
+        returns ``{}`` on any error so callers can treat missing info as
+        "skip this check" rather than false-positive detection.
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "tmux",
+                    "list-panes",
+                    "-t",
+                    surface_ref,
+                    "-F",
+                    _PANE_FORMAT_WITH_ACTIVITY,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode != 0 or not result.stdout.strip():
+                return {}
+            parts = result.stdout.strip().split()
+            if len(parts) < 3:  # need ref, cmd, and epoch
+                return {}
+            cmd = parts[1]
+            dt = datetime.fromtimestamp(int(parts[2]), tz=UTC)
+        except (ValueError, OSError):
+            return {}
+        else:
+            return {"cmd": cmd, "last_activity": dt}
+        return {}

--- a/src/cw/tmux.py
+++ b/src/cw/tmux.py
@@ -215,4 +215,3 @@ class TmuxAdapter:
             return {}
         else:
             return {"cmd": cmd, "last_activity": dt}
-        return {}

--- a/tests/test_cmux.py
+++ b/tests/test_cmux.py
@@ -853,3 +853,93 @@ class TestFakeCmuxAdapterCaptureSurface:
         adapter.set_surface_content(ref2, "session2-output")
         assert "session1" in adapter.capture_surface(ref1, lines=50, scrollback=200)
         assert "session2" in adapter.capture_surface(ref2, lines=50, scrollback=200)
+
+
+# ---------------------------------------------------------------------------
+# inspect_pane tests
+# ---------------------------------------------------------------------------
+
+
+class TestFakeCmuxAdapterInspectPane:
+    """Tests for FakeCmuxAdapter.inspect_pane and set_pane_info."""
+
+    def test_default_returns_empty_dict(self) -> None:
+        adapter = FakeCmuxAdapter()
+        assert adapter.inspect_pane("s:w.p") == {}
+
+    def test_set_pane_info_configures_return(self) -> None:
+        from datetime import UTC, datetime
+
+        adapter = FakeCmuxAdapter()
+        dt = datetime(2025, 5, 28, 12, 0, 0, tzinfo=UTC)
+        data: dict[str, Any] = {"cmd": "bash", "last_activity": dt}
+        adapter.set_pane_info("s:w.p", data)
+        assert adapter.inspect_pane("s:w.p") == data
+
+    def test_inspect_pane_call_recorded(self) -> None:
+        adapter = FakeCmuxAdapter()
+        adapter.inspect_pane("s:w.p")
+        assert adapter.calls["inspect_pane"] == ["s:w.p"]
+
+    def test_unknown_ref_returns_empty(self) -> None:
+        adapter = FakeCmuxAdapter()
+        assert adapter.inspect_pane("unknown") == {}
+
+
+class TestTmuxAdapterInspectPane:
+    """Tests for TmuxAdapter.inspect_pane."""
+
+    def _make_adapter(self, monkeypatch: pytest.MonkeyPatch) -> TmuxAdapter:
+        monkeypatch.setattr("cw.tmux.shutil.which", lambda _: "/usr/bin/tmux")
+        return TmuxAdapter()
+
+    def test_parses_valid_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from datetime import UTC, datetime
+
+        adapter = self._make_adapter(monkeypatch)
+
+        class _Proc:
+            returncode = 0
+            stdout = "s:0.1 bash 1748390400\n"
+
+        monkeypatch.setattr(
+            "cw.tmux.subprocess.run",
+            lambda *_a, **_kw: _Proc(),
+        )
+        result = adapter.inspect_pane("s:0.1")
+        assert result["cmd"] == "bash"
+        assert result["last_activity"] == datetime.fromtimestamp(1748390400, tz=UTC)
+
+    def test_nonzero_returncode_returns_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = self._make_adapter(monkeypatch)
+
+        class _Proc:
+            returncode = 1
+            stdout = ""
+
+        monkeypatch.setattr("cw.tmux.subprocess.run", lambda *_a, **_kw: _Proc())
+        assert adapter.inspect_pane("s:0.1") == {}
+
+    def test_empty_output_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        adapter = self._make_adapter(monkeypatch)
+
+        class _Proc:
+            returncode = 0
+            stdout = ""
+
+        monkeypatch.setattr("cw.tmux.subprocess.run", lambda *_a, **_kw: _Proc())
+        assert adapter.inspect_pane("s:0.1") == {}
+
+    def test_malformed_epoch_returns_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = self._make_adapter(monkeypatch)
+
+        class _Proc:
+            returncode = 0
+            stdout = "s:0.1 bash notanumber\n"
+
+        monkeypatch.setattr("cw.tmux.subprocess.run", lambda *_a, **_kw: _Proc())
+        assert adapter.inspect_pane("s:0.1") == {}

--- a/tests/test_cmux.py
+++ b/tests/test_cmux.py
@@ -879,7 +879,7 @@ class TestFakeCmuxAdapterInspectPane:
     def test_inspect_pane_call_recorded(self) -> None:
         adapter = FakeCmuxAdapter()
         adapter.inspect_pane("s:w.p")
-        assert adapter.calls["inspect_pane"] == ["s:w.p"]
+        assert adapter.calls["inspect_pane"] == [("s:w.p",)]
 
     def test_unknown_ref_returns_empty(self) -> None:
         adapter = FakeCmuxAdapter()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from click.testing import CliRunner
 
 from cw.cli import main
+from cw.cmux import FakeCmuxAdapter
 from cw.doctor import CheckResult, DoctorReport, format_report, run_doctor
 
 if TYPE_CHECKING:
@@ -790,7 +791,12 @@ def test_doctor_reap_reverts_completed_silent_dev_queue_task(
     result = runner.invoke(main, ["doctor", "--reap"])
     assert result.exit_code == 0, result.output
     assert "reconciliation" in result.output
-    assert "reverted 1 ticket(s)" in result.output
+    # Task may be reverted by the wedge reap (wedge/task-running-completed-session)
+    # before reconcile runs, or by reconcile's revert_completed_silent_tasks sweep.
+    # Either way the task must end up PENDING.
+    reverted_by_wedge = "task-running-completed-session" in result.output
+    reverted_by_reconcile = "reverted 1 ticket(s)" in result.output
+    assert reverted_by_wedge or reverted_by_reconcile, result.output
 
     store = load_dev_queue()
     t = next(t for t in store.tasks if t.ticket_id == "TKT-DR1")
@@ -1304,3 +1310,1113 @@ class TestCheckWorkspacePaths:
         workspace_checks = [c for c in report.checks if c.name.startswith("workspace/")]
         assert len(workspace_checks) == 1
         assert workspace_checks[0].ok is False
+
+
+# ---------------------------------------------------------------------------
+# Wedge detection tests
+# ---------------------------------------------------------------------------
+
+
+class TestWedgeFindingDataclass:
+    """WedgeFinding dataclass structure and DoctorReport integration."""
+
+    def test_fields_exist(self) -> None:
+        from cw.doctor import WedgeFinding
+
+        wf = WedgeFinding(
+            wedge_class="wedge/pane-idle-but-active",
+            session_id="abc",
+            ticket_id="123",
+            recipe="run cw doctor --reap",
+            state_file="/tmp/x.json",
+        )
+        assert wf.wedge_class == "wedge/pane-idle-but-active"
+        assert wf.session_id == "abc"
+        assert wf.ticket_id == "123"
+        assert wf.recipe == "run cw doctor --reap"
+        assert wf.state_file == "/tmp/x.json"
+
+    def test_doctor_report_has_wedge_findings(self) -> None:
+        from cw.doctor import DoctorReport
+
+        report = DoctorReport(version="0.0.0", checks=[])
+        assert report.wedge_findings == []
+
+    def test_wedge_findings_do_not_affect_ok(self) -> None:
+        from cw.doctor import DoctorReport, WedgeFinding
+
+        wf = WedgeFinding(
+            wedge_class="wedge/pane-idle-but-active",
+            session_id="abc",
+            ticket_id="123",
+            recipe="fix it",
+            state_file="/tmp/x.json",
+        )
+        report = DoctorReport(
+            version="0.0.0",
+            checks=[CheckResult("check-a", ok=True, detail="")],
+            wedge_findings=[wf],
+        )
+        assert report.ok is True
+
+
+class TestWedgePaneIdleButActive:
+    """wedge/pane-idle-but-active detection logic."""
+
+    def _make_active_session(
+        self, tmp_path: Path, *, surface_ref: str | None = "s:0.1"
+    ) -> object:
+        from datetime import UTC, datetime
+
+        from cw.models import Session, SessionPurpose, SessionStatus
+
+        wt = tmp_path / "worktree"
+        wt.mkdir(parents=True, exist_ok=True)
+        return Session(
+            id="sess-active",
+            name="client-a/auto-dev/TST-1",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=tmp_path,
+            worktree_path=wt if surface_ref is not None else None,
+            surface_ref=surface_ref,
+            started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+    def test_detected_when_shell_and_old_mtime(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        import time
+
+        from cw.cmux import FakeCmuxAdapter
+        from cw.config import save_state
+        from cw.dev_queue import save_dev_queue
+        from cw.doctor import _check_wedge_pane_idle
+        from cw.models import CwState, DevQueueStore
+
+        session = self._make_active_session(tmp_path)
+        state = CwState(sessions=[session])  # type: ignore[list-item]
+        save_state(state)
+        save_dev_queue(DevQueueStore(tasks=[]))
+
+        adapter = FakeCmuxAdapter()
+        old_time = time.time() - 700
+        adapter.set_pane_info("s:0.1", {"cmd": "bash", "last_activity": None})
+
+        # Create a file with old mtime
+        test_file = tmp_path / "worktree" / "test.py"
+        test_file.write_text("code")
+        import os
+
+        os.utime(str(test_file), (old_time, old_time))
+
+        queue = DevQueueStore(tasks=[])
+        findings = _check_wedge_pane_idle(state, queue, adapter)
+        assert len(findings) == 1
+        assert findings[0].wedge_class == "wedge/pane-idle-but-active"
+        assert findings[0].session_id == "sess-active"
+
+    def test_not_detected_nonshell_cmd(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        import time
+
+        from cw.cmux import FakeCmuxAdapter
+        from cw.doctor import _check_wedge_pane_idle
+        from cw.models import CwState, DevQueueStore
+
+        session = self._make_active_session(tmp_path)
+        state = CwState(sessions=[session])  # type: ignore[list-item]
+
+        adapter = FakeCmuxAdapter()
+        adapter.set_pane_info("s:0.1", {"cmd": "claude", "last_activity": None})
+
+        old_time = time.time() - 700
+        test_file = tmp_path / "worktree" / "test.py"
+        test_file.write_text("code")
+        import os
+
+        os.utime(str(test_file), (old_time, old_time))
+
+        queue = DevQueueStore(tasks=[])
+        findings = _check_wedge_pane_idle(state, queue, adapter)
+        assert findings == []
+
+    def test_not_detected_recent_mtime(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        from cw.cmux import FakeCmuxAdapter
+        from cw.doctor import _check_wedge_pane_idle
+        from cw.models import CwState, DevQueueStore
+
+        session = self._make_active_session(tmp_path)
+        state = CwState(sessions=[session])  # type: ignore[list-item]
+
+        adapter = FakeCmuxAdapter()
+        adapter.set_pane_info("s:0.1", {"cmd": "bash", "last_activity": None})
+
+        # File with recent mtime (now)
+        test_file = tmp_path / "worktree" / "test.py"
+        test_file.write_text("fresh code")
+
+        queue = DevQueueStore(tasks=[])
+        findings = _check_wedge_pane_idle(state, queue, adapter)
+        assert findings == []
+
+    def test_not_detected_no_surface_ref(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        from cw.cmux import FakeCmuxAdapter
+        from cw.doctor import _check_wedge_pane_idle
+        from cw.models import CwState, DevQueueStore
+
+        session = self._make_active_session(tmp_path, surface_ref=None)
+        state = CwState(sessions=[session])  # type: ignore[list-item]
+
+        adapter = FakeCmuxAdapter()
+        queue = DevQueueStore(tasks=[])
+        findings = _check_wedge_pane_idle(state, queue, adapter)
+        assert findings == []
+
+    def test_git_dir_excluded_from_mtime(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        import os
+        import time
+
+        from cw.cmux import FakeCmuxAdapter
+        from cw.doctor import _check_wedge_pane_idle
+        from cw.models import CwState, DevQueueStore
+
+        session = self._make_active_session(tmp_path)
+        state = CwState(sessions=[session])  # type: ignore[list-item]
+
+        adapter = FakeCmuxAdapter()
+        adapter.set_pane_info("s:0.1", {"cmd": "bash", "last_activity": None})
+
+        wt = tmp_path / "worktree"
+        old_time = time.time() - 700
+
+        # Create old non-.git file
+        old_file = wt / "old.py"
+        old_file.write_text("old code")
+        os.utime(str(old_file), (old_time, old_time))
+
+        # Create recent .git/FETCH_HEAD — must be excluded
+        git_dir = wt / ".git"
+        git_dir.mkdir()
+        fetch_head = git_dir / "FETCH_HEAD"
+        fetch_head.write_text("ref")
+        # leave fetch_head with current mtime (recent)
+
+        queue = DevQueueStore(tasks=[])
+        findings = _check_wedge_pane_idle(state, queue, adapter)
+        # .git/ excluded → old.py is only non-.git file → finding IS emitted
+        assert len(findings) == 1
+        assert findings[0].wedge_class == "wedge/pane-idle-but-active"
+
+    def test_inspect_pane_empty_skips(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        from cw.cmux import FakeCmuxAdapter
+        from cw.doctor import _check_wedge_pane_idle
+        from cw.models import CwState, DevQueueStore
+
+        session = self._make_active_session(tmp_path)
+        state = CwState(sessions=[session])  # type: ignore[list-item]
+
+        adapter = FakeCmuxAdapter()
+        # inspect_pane returns {} (default) — fail-open, skip
+
+        queue = DevQueueStore(tasks=[])
+        findings = _check_wedge_pane_idle(state, queue, adapter)
+        assert findings == []
+
+
+class TestWedgeTaskRunningNoSession:
+    """wedge/task-running-no-session detection logic."""
+
+    def test_orphan_detected_null_session_id(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from cw.config import save_state
+        from cw.doctor import _check_wedge_task_running_no_session
+        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
+
+        # Task created long ago with session_id=None
+        old_time = datetime.now(UTC) - timedelta(seconds=120)
+        task = TicketTask(
+            ticket_id="TST-1",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id=None,
+            created_at=old_time,
+        )
+        state = CwState(sessions=[])
+        save_state(state)
+        queue = DevQueueStore(tasks=[task])
+        findings = _check_wedge_task_running_no_session(state, queue)
+        assert len(findings) == 1
+        assert findings[0].wedge_class == "wedge/task-running-no-session"
+
+    def test_grace_window_skips(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from cw.doctor import _check_wedge_task_running_no_session
+        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
+
+        # Task created 5 seconds ago
+        recent_time = datetime.now(UTC) - timedelta(seconds=5)
+        task = TicketTask(
+            ticket_id="TST-2",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id=None,
+            created_at=recent_time,
+        )
+        state = CwState(sessions=[])
+        queue = DevQueueStore(tasks=[task])
+        findings = _check_wedge_task_running_no_session(state, queue)
+        assert findings == []
+
+    def test_active_session_skips(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from cw.doctor import _check_wedge_task_running_no_session
+        from cw.models import (
+            CwState,
+            DevQueueStore,
+            QueueItemStatus,
+            Session,
+            SessionPurpose,
+            SessionStatus,
+            TicketTask,
+        )
+
+        session = Session(
+            id="live-sess",
+            name="client-a/auto-dev/TST-3",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/tmp"),
+        )
+        old_time = datetime.now(UTC) - timedelta(seconds=120)
+        task = TicketTask(
+            ticket_id="TST-3",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="live-sess",
+            created_at=old_time,
+        )
+        state = CwState(sessions=[session])
+        queue = DevQueueStore(tasks=[task])
+        findings = _check_wedge_task_running_no_session(state, queue)
+        assert findings == []
+
+    def test_correct_fields(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from cw.doctor import _check_wedge_task_running_no_session
+        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
+
+        old_time = datetime.now(UTC) - timedelta(seconds=120)
+        task = TicketTask(
+            ticket_id="TST-99",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id=None,
+            created_at=old_time,
+        )
+        state = CwState(sessions=[])
+        queue = DevQueueStore(tasks=[task])
+        findings = _check_wedge_task_running_no_session(state, queue)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.ticket_id == "TST-99"
+        assert "PENDING" in f.recipe or "revert" in f.recipe.lower()
+
+
+class TestWedgeTaskRunningCompletedSession:
+    """wedge/task-running-completed-session detection logic."""
+
+    def _make_completed_session(self, tmp_path: Path, sid: str = "comp-sess") -> object:
+        from datetime import UTC, datetime
+
+        from cw.models import CompletionReason, Session, SessionPurpose, SessionStatus
+
+        return Session(
+            id=sid,
+            name="client-a/auto-dev/TST-C1",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.COMPLETED,
+            workspace_path=tmp_path,
+            completed_reason=CompletionReason.NORMAL,
+            started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+    def test_detected_completed_session(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        from cw.doctor import _check_wedge_task_running_completed_session
+        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
+
+        session = self._make_completed_session(tmp_path)
+        task = TicketTask(
+            ticket_id="TST-C1",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="comp-sess",
+        )
+        state = CwState(sessions=[session])  # type: ignore[list-item]
+        queue = DevQueueStore(tasks=[task])
+        findings = _check_wedge_task_running_completed_session(state, queue)
+        assert len(findings) == 1
+        assert findings[0].wedge_class == "wedge/task-running-completed-session"
+
+    def test_not_detected_active_session(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        from datetime import UTC, datetime
+
+        from cw.doctor import _check_wedge_task_running_completed_session
+        from cw.models import (
+            CwState,
+            DevQueueStore,
+            QueueItemStatus,
+            Session,
+            SessionPurpose,
+            SessionStatus,
+            TicketTask,
+        )
+
+        session = Session(
+            id="active-sess",
+            name="client-a/auto-dev/TST-C2",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=tmp_path,
+            started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        task = TicketTask(
+            ticket_id="TST-C2",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="active-sess",
+        )
+        state = CwState(sessions=[session])
+        queue = DevQueueStore(tasks=[task])
+        findings = _check_wedge_task_running_completed_session(state, queue)
+        assert findings == []
+
+    def test_not_detected_null_session_id(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        from cw.doctor import _check_wedge_task_running_completed_session
+        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
+
+        task = TicketTask(
+            ticket_id="TST-C3",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id=None,
+        )
+        state = CwState(sessions=[])
+        queue = DevQueueStore(tasks=[task])
+        findings = _check_wedge_task_running_completed_session(state, queue)
+        assert findings == []
+
+    def test_correct_fields(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        from cw.doctor import _check_wedge_task_running_completed_session
+        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
+
+        session = self._make_completed_session(tmp_path, sid="comp-sess-field")
+        task = TicketTask(
+            ticket_id="TST-CF",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="comp-sess-field",
+        )
+        state = CwState(sessions=[session])  # type: ignore[list-item]
+        queue = DevQueueStore(tasks=[task])
+        findings = _check_wedge_task_running_completed_session(state, queue)
+        assert len(findings) == 1
+        f = findings[0]
+        assert "PENDING" in f.recipe
+
+
+class TestWedgeRepoAheadOfQueue:
+    """wedge/repo-ahead-of-queue detection logic."""
+
+    def _make_running_task(
+        self,
+        tmp_path: Path,
+        ticket_id: str = "TST-R1",
+        session_id: str | None = None,
+    ) -> object:
+        from cw.models import QueueItemStatus, TicketTask
+
+        return TicketTask(
+            ticket_id=ticket_id,
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id=session_id,
+            worktree_path=tmp_path,
+        )
+
+    def test_ahead_no_pr_emits_warn_recipe(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+
+        from cw.doctor import _check_wedge_repo_ahead
+        from cw.models import CwState, DevQueueStore
+
+        task = self._make_running_task(tmp_path, ticket_id="TST-R1")
+        state = CwState(sessions=[])
+        queue = DevQueueStore(tasks=[task])  # type: ignore[list-item]
+
+        call_count = [0]
+
+        class _Proc:
+            def __init__(self, rc: int, out: str) -> None:
+                self.returncode = rc
+                self.stdout = out
+
+        def fake_run(args: list[str], **_kw: object) -> _Proc:
+            call_count[0] += 1
+            if "remote" in args and "get-url" in args:
+                return _Proc(0, "https://github.com/org/repo.git\n")
+            if "ls-remote" in args:
+                return _Proc(0, "abc123\trefs/heads/auto-dev/TST-R1\n")
+            if "pr" in args and "list" in args:
+                return _Proc(0, "[]\n")
+            return _Proc(0, "")
+
+        monkeypatch.setattr("cw.doctor._sp.run", fake_run)
+        findings = _check_wedge_repo_ahead(state, queue)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.wedge_class == "wedge/repo-ahead-of-queue"
+        assert "no open PR" in f.recipe or "cw spawn-complete" in f.recipe
+
+    def test_ahead_open_pr_emits_shipped_recipe(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        import json
+
+        from cw.doctor import _check_wedge_repo_ahead
+        from cw.models import CwState, DevQueueStore
+
+        task = self._make_running_task(tmp_path, ticket_id="TST-R2")
+        state = CwState(sessions=[])
+        queue = DevQueueStore(tasks=[task])  # type: ignore[list-item]
+
+        class _Proc:
+            def __init__(self, rc: int, out: str) -> None:
+                self.returncode = rc
+                self.stdout = out
+
+        def fake_run(args: list[str], **_kw: object) -> _Proc:
+            if "remote" in args and "get-url" in args:
+                return _Proc(0, "https://github.com/org/repo.git\n")
+            if "ls-remote" in args:
+                return _Proc(0, "abc123\trefs/heads/auto-dev/TST-R2\n")
+            if "pr" in args and "list" in args:
+                return _Proc(0, json.dumps([{"state": "OPEN"}]))
+            return _Proc(0, "")
+
+        monkeypatch.setattr("cw.doctor._sp.run", fake_run)
+        findings = _check_wedge_repo_ahead(state, queue)
+        assert len(findings) == 1
+        assert "cw spawn-complete" in findings[0].recipe
+
+    def test_not_ahead_no_finding(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        from cw.doctor import _check_wedge_repo_ahead
+        from cw.models import CwState, DevQueueStore
+
+        task = self._make_running_task(tmp_path, ticket_id="TST-R3")
+        state = CwState(sessions=[])
+        queue = DevQueueStore(tasks=[task])  # type: ignore[list-item]
+
+        class _Proc:
+            def __init__(self, rc: int, out: str) -> None:
+                self.returncode = rc
+                self.stdout = out
+
+        def fake_run(args: list[str], **_kw: object) -> _Proc:
+            if "remote" in args and "get-url" in args:
+                return _Proc(0, "https://github.com/org/repo.git\n")
+            if "ls-remote" in args:
+                return _Proc(0, "")  # empty — not ahead
+            return _Proc(0, "")
+
+        monkeypatch.setattr("cw.doctor._sp.run", fake_run)
+        findings = _check_wedge_repo_ahead(state, queue)
+        assert findings == []
+
+    def test_ls_remote_fail_no_finding(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        from cw.doctor import _check_wedge_repo_ahead
+        from cw.models import CwState, DevQueueStore
+
+        task = self._make_running_task(tmp_path, ticket_id="TST-R4")
+        state = CwState(sessions=[])
+        queue = DevQueueStore(tasks=[task])  # type: ignore[list-item]
+
+        class _Proc:
+            def __init__(self, rc: int, out: str) -> None:
+                self.returncode = rc
+                self.stdout = out
+
+        def fake_run(args: list[str], **_kw: object) -> _Proc:
+            if "remote" in args and "get-url" in args:
+                return _Proc(0, "https://github.com/org/repo.git\n")
+            if "ls-remote" in args:
+                return _Proc(1, "")  # failure
+            return _Proc(0, "")
+
+        monkeypatch.setattr("cw.doctor._sp.run", fake_run)
+        findings = _check_wedge_repo_ahead(state, queue)
+        assert findings == []
+
+    def test_worktree_path_none_skips(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        from cw.doctor import _check_wedge_repo_ahead
+        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
+
+        task = TicketTask(
+            ticket_id="TST-R5",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            worktree_path=None,
+        )
+        state = CwState(sessions=[])
+        queue = DevQueueStore(tasks=[task])
+        findings = _check_wedge_repo_ahead(state, queue)
+        assert findings == []
+
+    def test_branch_resolution_uses_session_branch(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        from datetime import UTC, datetime
+
+        from cw.doctor import _check_wedge_repo_ahead
+        from cw.models import (
+            CwState,
+            DevQueueStore,
+            QueueItemStatus,
+            Session,
+            SessionPurpose,
+            SessionStatus,
+            TicketTask,
+        )
+
+        session = Session(
+            id="sess-branch",
+            name="client-a/auto-dev/TST-R6",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=tmp_path,
+            branch="my-branch",
+            started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        task = TicketTask(
+            ticket_id="TST-R6",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="sess-branch",
+            worktree_path=tmp_path,
+        )
+        state = CwState(sessions=[session])
+        queue = DevQueueStore(tasks=[task])
+
+        ls_remote_args_seen: list[list[str]] = []
+
+        class _Proc:
+            def __init__(self, rc: int, out: str) -> None:
+                self.returncode = rc
+                self.stdout = out
+
+        def fake_run(args: list[str], **_kw: object) -> _Proc:
+            if "remote" in args and "get-url" in args:
+                return _Proc(0, "https://github.com/org/repo.git\n")
+            if "ls-remote" in args:
+                ls_remote_args_seen.append(list(args))
+                return _Proc(0, "abc123\trefs/heads/my-branch\n")
+            if "pr" in args and "list" in args:
+                return _Proc(0, "[]\n")
+            return _Proc(0, "")
+
+        monkeypatch.setattr("cw.doctor._sp.run", fake_run)
+        _check_wedge_repo_ahead(state, queue)
+        # The ls-remote call must reference my-branch, not auto-dev/TST-R6
+        assert any("my-branch" in str(a) for a in ls_remote_args_seen)
+
+
+class TestWedgeReapRecipes:
+    """_reap_wedge_findings applies correct mutations per wedge class."""
+
+    def _make_session(self, tmp_path: Path, sid: str = "reap-sess") -> object:
+        from datetime import UTC, datetime
+
+        from cw.models import Session, SessionPurpose, SessionStatus
+
+        return Session(
+            id=sid,
+            name="client-a/auto-dev/TST-REAP",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=tmp_path,
+            surface_ref="s:0.1",
+            started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+    def test_class1_reap_mutates_session_and_queue(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        tmp_config_dir: Path,
+        mock_cmux_adapter: FakeCmuxAdapter,
+    ) -> None:
+        from cw.config import load_state, save_state
+        from cw.dev_queue import load_dev_queue, save_dev_queue
+        from cw.doctor import WedgeFinding, _reap_wedge_findings
+        from cw.models import (
+            CwState,
+            DevQueueStore,
+            QueueItemStatus,
+            SessionStatus,
+            TicketTask,
+        )
+
+        session = self._make_session(tmp_path)
+        state = CwState(sessions=[session])  # type: ignore[list-item]
+        save_state(state)
+
+        task = TicketTask(
+            ticket_id="TST-REAP",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="reap-sess",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        from cw.config import state_file as _sf
+
+        finding = WedgeFinding(
+            wedge_class="wedge/pane-idle-but-active",
+            session_id="reap-sess",
+            ticket_id="TST-REAP",
+            recipe="fix",
+            state_file=str(_sf()),
+        )
+
+        _reap_wedge_findings([finding], state, mock_cmux_adapter)
+
+        # session should be COMPLETED
+        reloaded = load_state()
+        sess = next(s for s in reloaded.sessions if s.id == "reap-sess")
+        assert sess.status == SessionStatus.COMPLETED
+
+        # queue task should be PENDING
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "TST-REAP")
+        assert t.status == QueueItemStatus.PENDING
+
+        # adapter.close should have been called
+        assert len(mock_cmux_adapter.calls["close"]) == 1
+
+    def test_class2_reap_reverts_queue_only(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        tmp_config_dir: Path,
+        mock_cmux_adapter: FakeCmuxAdapter,
+    ) -> None:
+        from cw.config import save_state
+        from cw.dev_queue import load_dev_queue, save_dev_queue
+        from cw.doctor import WedgeFinding, _reap_wedge_findings
+        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
+
+        state = CwState(sessions=[])
+        save_state(state)
+
+        task = TicketTask(
+            ticket_id="TST-C2",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id=None,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        from cw.config import state_file as _sf
+
+        finding = WedgeFinding(
+            wedge_class="wedge/task-running-no-session",
+            session_id=None,
+            ticket_id="TST-C2",
+            recipe="fix",
+            state_file=str(_sf()),
+        )
+
+        _reap_wedge_findings([finding], state, mock_cmux_adapter)
+
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "TST-C2")
+        assert t.status == QueueItemStatus.PENDING
+
+    def test_class3_reap_reverts_queue_only(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        tmp_config_dir: Path,
+        mock_cmux_adapter: FakeCmuxAdapter,
+    ) -> None:
+        from cw.config import save_state
+        from cw.dev_queue import load_dev_queue, save_dev_queue
+        from cw.doctor import WedgeFinding, _reap_wedge_findings
+        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
+
+        state = CwState(sessions=[])
+        save_state(state)
+
+        task = TicketTask(
+            ticket_id="TST-C3",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="some-completed-sess",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        from cw.config import state_file as _sf
+
+        finding = WedgeFinding(
+            wedge_class="wedge/task-running-completed-session",
+            session_id="some-completed-sess",
+            ticket_id="TST-C3",
+            recipe="fix",
+            state_file=str(_sf()),
+        )
+
+        _reap_wedge_findings([finding], state, mock_cmux_adapter)
+
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "TST-C3")
+        assert t.status == QueueItemStatus.PENDING
+
+    def test_class4_no_reap_action(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        tmp_config_dir: Path,
+        mock_cmux_adapter: FakeCmuxAdapter,
+    ) -> None:
+        from cw.config import save_state
+        from cw.dev_queue import load_dev_queue, save_dev_queue
+        from cw.doctor import WedgeFinding, _reap_wedge_findings
+        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
+
+        state = CwState(sessions=[])
+        save_state(state)
+
+        task = TicketTask(
+            ticket_id="TST-C4",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        from cw.config import state_file as _sf
+
+        finding = WedgeFinding(
+            wedge_class="wedge/repo-ahead-of-queue",
+            session_id=None,
+            ticket_id="TST-C4",
+            recipe="advisory",
+            state_file=str(_sf()),
+        )
+
+        _reap_wedge_findings([finding], state, mock_cmux_adapter)
+
+        # advisory only — queue should remain RUNNING
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "TST-C4")
+        assert t.status == QueueItemStatus.RUNNING
+
+    def test_adapter_close_only_for_class1(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        tmp_config_dir: Path,
+        mock_cmux_adapter: FakeCmuxAdapter,
+    ) -> None:
+        from cw.config import save_state
+        from cw.dev_queue import save_dev_queue
+        from cw.doctor import WedgeFinding, _reap_wedge_findings
+        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
+
+        state = CwState(sessions=[])
+        save_state(state)
+
+        task = TicketTask(
+            ticket_id="TST-NCLOSE",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id=None,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        from cw.config import state_file as _sf
+
+        finding = WedgeFinding(
+            wedge_class="wedge/task-running-no-session",
+            session_id=None,
+            ticket_id="TST-NCLOSE",
+            recipe="fix",
+            state_file=str(_sf()),
+        )
+
+        _reap_wedge_findings([finding], state, mock_cmux_adapter)
+
+        # adapter.close must NOT have been called for class-2
+        assert len(mock_cmux_adapter.calls["close"]) == 0
+
+    def test_reap_false_no_mutations(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        tmp_config_dir: Path,
+        mock_cmux_adapter: FakeCmuxAdapter,
+    ) -> None:
+        """run_doctor(reap=False) must not trigger _reap_wedge_findings."""
+        from cw.config import save_state
+        from cw.dev_queue import load_dev_queue, save_dev_queue
+        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
+
+        session = self._make_session(tmp_path, sid="no-reap-sess")
+        state = CwState(sessions=[session])  # type: ignore[list-item]
+        save_state(state)
+
+        task = TicketTask(
+            ticket_id="TST-NOREAP",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="no-reap-sess",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        # Monkeypatch to prevent wedge check from modifying the report
+        monkeypatch.setattr(
+            "cw.doctor._check_wedge_pane_idle",
+            lambda *_a, **_kw: [],
+        )
+        monkeypatch.setattr(
+            "cw.doctor._check_wedge_task_running_no_session",
+            lambda *_a, **_kw: [],
+        )
+        monkeypatch.setattr(
+            "cw.doctor._check_wedge_task_running_completed_session",
+            lambda *_a, **_kw: [],
+        )
+        monkeypatch.setattr(
+            "cw.doctor._check_wedge_repo_ahead",
+            lambda *_a, **_kw: [],
+        )
+
+        # run_doctor without --reap, queue should remain RUNNING
+        from cw.doctor import run_doctor
+
+        _stub_claude_version_ok(monkeypatch)
+        run_doctor(reap=False)
+
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "TST-NOREAP")
+        assert t.status == QueueItemStatus.RUNNING
+
+
+class TestDoctorJsonMode:
+    """cw doctor --json produces parseable JSON with required structure."""
+
+    def test_output_is_valid_json(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        import json
+
+        from click.testing import CliRunner
+
+        from cw.cli import main
+
+        _stub_claude_version_ok(monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor", "--json"])
+        assert result.exit_code == 0, result.output
+        json.loads(result.output)  # must not raise
+
+    def test_json_has_required_keys(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        import json
+
+        from click.testing import CliRunner
+
+        from cw.cli import main
+
+        _stub_claude_version_ok(monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor", "--json"])
+        data = json.loads(result.output)
+        assert "version" in data
+        assert "ok" in data
+        assert "checks" in data
+        assert "wedge_findings" in data
+
+    def test_json_wedge_findings_structure(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        import json
+
+        from click.testing import CliRunner
+
+        from cw.cli import main
+        from cw.doctor import WedgeFinding
+
+        _stub_claude_version_ok(monkeypatch)
+
+        wf = WedgeFinding(
+            wedge_class="wedge/pane-idle-but-active",
+            session_id="abc",
+            ticket_id="123",
+            recipe="fix it",
+            state_file="/tmp/x.json",
+        )
+        monkeypatch.setattr(
+            "cw.cli.run_doctor",
+            lambda **_kw: __import__(
+                "cw.doctor", fromlist=["DoctorReport"]
+            ).DoctorReport(
+                version="0.0.0",
+                checks=[CheckResult("check-a", ok=True, detail="")],
+                wedge_findings=[wf],
+            ),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor", "--json"])
+        data = json.loads(result.output)
+        assert len(data["wedge_findings"]) == 1
+        wfd = data["wedge_findings"][0]
+        assert "wedge_class" in wfd
+        assert "session_id" in wfd
+        assert "ticket_id" in wfd
+        assert "recipe" in wfd
+        assert "state_file" in wfd
+
+    def test_json_composes_with_reap(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        import json
+
+        from click.testing import CliRunner
+
+        from cw.cli import main
+
+        _stub_claude_version_ok(monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor", "--json", "--reap"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert "ok" in data
+
+    def test_exit_0_when_healthy(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        from click.testing import CliRunner
+
+        from cw.cli import main
+
+        _stub_claude_version_ok(monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor", "--json"])
+        assert result.exit_code == 0
+
+    def test_exit_1_when_checks_fail(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        from click.testing import CliRunner
+
+        from cw.cli import main
+
+        monkeypatch.setattr(
+            "cw.cli.run_doctor",
+            lambda **_kw: __import__(
+                "cw.doctor", fromlist=["DoctorReport"]
+            ).DoctorReport(
+                version="0.0.0",
+                checks=[CheckResult("check-fail", ok=False, detail="broken")],
+            ),
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor", "--json"])
+        assert result.exit_code == 1
+
+
+class TestWedgeRegression:
+    """Regression tests: existing checks unaffected, excluded classes absent."""
+
+    def test_existing_linkage_checks_unaffected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        from cw.config import save_state
+        from cw.doctor import run_doctor
+        from cw.models import CwState, Session, SessionPurpose, SessionStatus
+
+        _stub_claude_version_ok(monkeypatch)
+        # Session with dangling worker — linkage/dangling-worker should fail
+        session = Session(
+            id="orch-reg",
+            name="client/impl",
+            client="client",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=tmp_path,
+            worker_session_ids=["missing-worker-reg"],
+        )
+        save_state(CwState(sessions=[session]))
+        report = run_doctor()
+        dw = next(c for c in report.checks if c.name == "linkage/dangling-worker")
+        assert not dw.ok
+        # wedge_findings should be empty (no queue tasks RUNNING)
+        assert report.wedge_findings == []
+
+    def test_classes_5_6_not_present(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        from cw.doctor import run_doctor
+
+        _stub_claude_version_ok(monkeypatch)
+        report = run_doctor()
+        excluded = {
+            "wedge/supervisor-says-done-cw-says-running",
+            "wedge/cw-says-done-supervisor-says-alive",
+        }
+        for wf in report.wedge_findings:
+            assert wf.wedge_class not in excluded


### PR DESCRIPTION
## Summary

Adds `cw doctor` drift checks (supervisor↔cw, repo↔queue wedge detection) with `--reap` recipes and `--json` output — closes #123.

- feat(doctor): wedge detection checks + --reap recipes + --json mode (#123)
- fix(doctor): address review findings — wedge detection gaps and reap state correctness

Produced by `/auto-dev` (session 54ea97ca), Track C wave-3. Reached `review_pending_approval` at stage3_review; 6 initial must-fixes resolved across 1 fix cycle. Health recommendation: **PROCEED** (agent confidence MEDIUM, no incomplete-risk, no shortcuts).

## Deferred friction (follow-up filed)

- BACKGROUNDED session status not excluded from wedge / task-running-no-session detection (false-positive risk; lower stakes since #348 made reaping flag-only)
- `_check_wedge_repo_ahead` has no subprocess timeout on `git ls-remote` / `gh pr list`
- Minor: `sys.exit` vs `raise click.exceptions.Exit` in `--json` branch; reap docstring incomplete; in-memory mutations before lock in `_reap_wedge_findings`

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or doctor

🤖 Shipped via /cw-followup (ship-as-is + follow-up)