### PR TITLE
feat(#125): cw-queue-events MCP channel for queue state deltas

### DIFF
--- a/config/cw-queue-events.mcp.json.example
+++ b/config/cw-queue-events.mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "cw-queue-events": {
+      "command": "cw",
+      "args": ["queue-channel", "proxy", "--client-id", "your-session-id"],
+      "env": {
+        "CW_QUEUE_EVENTS_BASE_URL": "http://127.0.0.1:8789"
+      }
+    }
+  }
+}

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -2289,3 +2289,32 @@ def pr_channel_serve(port: int, host: str) -> None:
     from cw.cw_pr_events_server import serve as _serve  # noqa: PLC0415
 
     _serve(host=host, port=port)
+
+
+@main.group(name="queue-channel")
+def queue_channel() -> None:
+    """Queue channel server: push MCP notifications to subscribed Claude sessions."""
+
+
+@queue_channel.command(name="proxy")
+@click.option("--client-id", default=None, help="Unique client ID for cursor tracking.")
+def queue_channel_proxy(client_id: str | None) -> None:
+    """Start the MCP stdio proxy for cw-queue-events (add to .mcp.json)."""
+    from cw.cw_queue_events_channel import run_proxy  # noqa: PLC0415
+
+    run_proxy(client_id=client_id)
+
+
+@queue_channel.command(name="serve")
+@click.option("--port", default=8789, type=int, show_default=True)
+@click.option("--host", default="127.0.0.1", show_default=True)
+def queue_channel_serve(port: int, host: str) -> None:
+    """Start the cw-queue-events MCP channel server.
+
+    Defaults mirror ``cw.cw_queue_events_server.DEFAULT_HOST`` / ``DEFAULT_PORT`` —
+    kept inline here so the click decorators don't trigger an eager import of
+    ``starlette`` (lives in the ``[mcp]`` optional-deps extra).
+    """
+    from cw.cw_queue_events_server import serve as _serve  # noqa: PLC0415
+
+    _serve(host=host, port=port)

--- a/src/cw/cw_queue_events_channel.py
+++ b/src/cw/cw_queue_events_channel.py
@@ -1,0 +1,140 @@
+"""MCP stdio proxy: forwards cw-queue-events SSE notifications to Claude."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import urllib.parse
+from typing import Any, cast
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "http://127.0.0.1:8789"
+# Intentionally not imported from cw_queue_events_server to avoid triggering
+# module-level I/O (_cursors.update/_event_offset init) at import time.
+_NOTIFICATION_TYPE = "cw-queue-event"
+
+_CHANNEL_INSTRUCTIONS = """\
+Queue events from cw-queue-events server. Event types:
+- queue.ticket_enqueued: new ticket added to queue (ticket_id, client, status)
+- queue.ticket_claimed: PENDING->RUNNING (ticket_id, client, session_id)
+- queue.ticket_completed: RUNNING->COMPLETED (ticket_id, client, queue_status, \
+sentinel_status or null)
+- queue.ticket_failed: RUNNING->FAILED (ticket_id, client, error or null, attempts)
+  Note: ticket_failed fires from two code paths: cli.py validation_failed \
+(after 3 attempts)
+  and queue.py mark_item_failed(). Subscribers should not assume broader \
+failure coverage.
+- queue.session_idled: session ACTIVE->IDLE (session_id, session_name)
+RUNNING->CANCELLED: no event (system-driven cleanup)
+RUNNING->BLOCKED_ON_USER: no event (transient; session will resume)\
+"""
+
+# MCP types — deferred-import inside functions per project convention
+# (avoids hard dep at module load; mcp is an optional extra)
+
+
+def _extract_payload(session_msg: Any) -> dict[str, Any] | None:
+    """Extract event dict from upstream SSE msg.
+
+    Returns None for non-queue-event messages (type guard, not error).
+    """
+    from mcp.types import JSONRPCNotification  # noqa: PLC0415
+
+    root = session_msg.message.root
+    if not isinstance(root, JSONRPCNotification):
+        return None
+    params = root.params or {}
+    data = params.get("data")
+    if data is None:
+        return None
+    if data.get("notification_type") != _NOTIFICATION_TYPE:
+        return None
+    raw = data.get("message")
+    if raw is None:
+        return None
+    try:
+        return cast("dict[str, Any]", json.loads(raw))
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def _build_meta(data: dict[str, Any]) -> dict[str, str]:
+    """Build the meta dict for notifications/claude/channel params."""
+    meta: dict[str, str] = {
+        "event_type": str(data.get("event", "")),
+        "ticket_id": str(data.get("ticket_id", "")),
+        "client": str(data.get("client", "")),
+    }
+    return {k: v for k, v in meta.items() if v}
+
+
+def _build_outbound_notification(data: dict[str, Any]) -> Any:
+    """Build a SessionMessage to emit on the stdio MCP connection."""
+    from mcp.shared.message import SessionMessage  # noqa: PLC0415
+    from mcp.types import JSONRPCMessage, JSONRPCNotification  # noqa: PLC0415
+
+    return SessionMessage(
+        message=JSONRPCMessage(
+            JSONRPCNotification(
+                jsonrpc="2.0",
+                method="notifications/claude/channel",
+                params={"content": json.dumps(data), "meta": _build_meta(data)},
+            )
+        )
+    )
+
+
+async def _relay_upstream(
+    sse_read: Any,
+    stdio_write: Any,
+    client_id: str | None = None,
+) -> None:
+    """Read from SSE stream, write queue-event notifications to stdio."""
+    async for item in sse_read:
+        if isinstance(item, Exception):
+            logger.debug("sse read error: %s", item)
+            continue
+        payload = _extract_payload(item)
+        if payload is None:
+            continue
+        # Proxy-side client filter: skip events for other clients
+        if client_id and payload.get("client") != client_id:
+            continue
+        outbound = _build_outbound_notification(payload)
+        await stdio_write.send(outbound)
+
+
+def run_proxy(client_id: str | None = None) -> None:
+    """Start the stdio MCP proxy. Blocks until the SSE connection closes."""
+    import anyio  # noqa: PLC0415
+    from mcp.client.sse import sse_client  # noqa: PLC0415
+    from mcp.server import Server  # noqa: PLC0415
+    from mcp.server.stdio import stdio_server  # noqa: PLC0415
+
+    base_url = os.environ.get("CW_QUEUE_EVENTS_BASE_URL", _DEFAULT_BASE_URL)
+    if client_id is None:
+        client_id = os.environ.get("CW_QUEUE_EVENTS_CLIENT_ID", socket.gethostname())
+    sse_url = f"{base_url}/sse/?client_id={urllib.parse.quote(client_id)}"
+
+    mcp_server: Server = Server("cw-queue-events")
+    init_options = mcp_server.create_initialization_options(
+        experimental_capabilities={"claude/channel": {}},
+    )
+
+    async def _main() -> None:
+        async with (
+            sse_client(sse_url) as (sse_read, _sse_write),
+            stdio_server() as (stdio_read, stdio_write),
+            anyio.create_task_group() as tg,
+        ):
+            tg.start_soon(mcp_server.run, stdio_read, stdio_write, init_options)
+            tg.start_soon(_relay_upstream, sse_read, stdio_write, client_id)
+
+    anyio.run(_main)
+
+
+if __name__ == "__main__":
+    run_proxy()

--- a/src/cw/cw_queue_events_channel.py
+++ b/src/cw/cw_queue_events_channel.py
@@ -115,9 +115,11 @@ def run_proxy(client_id: str | None = None) -> None:
     from mcp.server.stdio import stdio_server  # noqa: PLC0415
 
     base_url = os.environ.get("CW_QUEUE_EVENTS_BASE_URL", _DEFAULT_BASE_URL)
-    if client_id is None:
-        client_id = os.environ.get("CW_QUEUE_EVENTS_CLIENT_ID", socket.gethostname())
-    sse_url = f"{base_url}/sse/?client_id={urllib.parse.quote(client_id)}"
+    # filter_client: the cw client name to filter events by (None = relay all)
+    filter_client = client_id or os.environ.get("CW_QUEUE_EVENTS_CLIENT_ID")
+    # cursor_id: the SSE subscription identity for replay cursor tracking
+    cursor_id = filter_client or socket.gethostname()
+    sse_url = f"{base_url}/sse/?client_id={urllib.parse.quote(cursor_id)}"
 
     mcp_server: Server = Server("cw-queue-events")
     init_options = mcp_server.create_initialization_options(
@@ -131,7 +133,7 @@ def run_proxy(client_id: str | None = None) -> None:
             anyio.create_task_group() as tg,
         ):
             tg.start_soon(mcp_server.run, stdio_read, stdio_write, init_options)
-            tg.start_soon(_relay_upstream, sse_read, stdio_write, client_id)
+            tg.start_soon(_relay_upstream, sse_read, stdio_write, filter_client)
 
     anyio.run(_main)
 

--- a/src/cw/cw_queue_events_server.py
+++ b/src/cw/cw_queue_events_server.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 
 from cw.atomic import atomic_write_text
 from cw.config import state_dir
+from cw.models import QueueItemStatus, SessionStatus
 
 if TYPE_CHECKING:
     from starlette.applications import Starlette
@@ -192,30 +193,28 @@ def _save_snapshot(snap: QueueSnapshot) -> None:
     atomic_write_text(path, snap.model_dump_json())
 
 
-def _get_sentinel_status(session_id: str | None, state: Any) -> str | None:
+def _get_last_result(session_id: str | None, state: Any) -> dict[str, Any] | None:
+    """Return last_result dict for the session matching session_id, or None."""
     if session_id is None:
         return None
     for session in state.sessions:
         if session.id == session_id:
             lr = session.last_result
-            if lr and isinstance(lr, dict):
-                return lr.get("status")
-            return None
+            return lr if isinstance(lr, dict) else None
     return None
+
+
+def _get_sentinel_status(session_id: str | None, state: Any) -> str | None:
+    lr = _get_last_result(session_id, state)
+    return lr.get("status") if lr is not None else None
 
 
 def _get_blocker_reason(session_id: str | None, state: Any) -> str | None:
-    if session_id is None:
+    lr = _get_last_result(session_id, state)
+    if lr is None:
         return None
-    for session in state.sessions:
-        if session.id == session_id:
-            lr = session.last_result
-            if lr and isinstance(lr, dict):
-                blocker = lr.get("blocker")
-                if blocker and isinstance(blocker, dict):
-                    return blocker.get("reason")
-            return None
-    return None
+    blocker = lr.get("blocker")
+    return blocker.get("reason") if isinstance(blocker, dict) else None
 
 
 def _compute_queue_deltas(
@@ -238,7 +237,7 @@ def _compute_queue_deltas(
                     "status": curr,
                 }
             )
-        elif prev == "pending" and curr == "running":
+        elif prev == QueueItemStatus.PENDING and curr == QueueItemStatus.RUNNING:
             events.append(
                 {
                     "event": "queue.ticket_claimed",
@@ -247,18 +246,18 @@ def _compute_queue_deltas(
                     "session_id": task.session_id,
                 }
             )
-        elif prev == "running" and curr == "completed":
+        elif prev == QueueItemStatus.RUNNING and curr == QueueItemStatus.COMPLETED:
             sentinel_status = _get_sentinel_status(task.session_id, state)
             events.append(
                 {
                     "event": "queue.ticket_completed",
                     "ticket_id": tid,
                     "client": task.client,
-                    "queue_status": "completed",
+                    "queue_status": QueueItemStatus.COMPLETED,
                     "sentinel_status": sentinel_status,
                 }
             )
-        elif prev == "running" and curr == "failed":
+        elif prev == QueueItemStatus.RUNNING and curr == QueueItemStatus.FAILED:
             error = _get_blocker_reason(task.session_id, state)
             events.append(
                 {
@@ -283,7 +282,7 @@ def _compute_session_deltas(
     for session in state.sessions:
         prev = old.session_statuses.get(session.id)
         curr = str(session.status)
-        if prev == "active" and curr == "idle":
+        if prev == SessionStatus.ACTIVE and curr == SessionStatus.IDLE:
             events.append(
                 {
                     "event": "queue.session_idled",
@@ -307,9 +306,12 @@ def _build_queue_notification(event: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _check_wedge() -> None:
-    """Check for wedged tasks. TODO: implement when doctor-drift ships."""
-    return
+def _check_wedge() -> dict[str, Any] | None:
+    """Check for wedged tasks. Returns wedge-event dict if detected, else None.
+
+    TODO: implement when doctor-drift ships.
+    """
+    return None
 
 
 def _poll_once(old: QueueSnapshot) -> tuple[QueueSnapshot, list[dict[str, Any]]]:
@@ -323,6 +325,11 @@ def _poll_once(old: QueueSnapshot) -> tuple[QueueSnapshot, list[dict[str, Any]]]
     events: list[dict[str, Any]] = []
     events.extend(_compute_queue_deltas(old, store, state))
     events.extend(_compute_session_deltas(old, state))
+
+    # Wire wedge-detection hook — always called, but currently a stub
+    wedge = _check_wedge()
+    if wedge is not None:
+        events.append(wedge)
 
     new_snap = QueueSnapshot(
         task_statuses={t.ticket_id: str(t.status) for t in store.tasks},
@@ -357,7 +364,14 @@ def _run_poller() -> None:
             logger.exception("poller error")
 
 
+_poller_started: list[bool] = [False]
+
+
 def _start_poller() -> None:
+    with _lock:
+        if _poller_started[0]:
+            return
+        _poller_started[0] = True
     t = threading.Thread(target=_run_poller, daemon=True, name="queue-events-poller")
     t.start()
 

--- a/src/cw/cw_queue_events_server.py
+++ b/src/cw/cw_queue_events_server.py
@@ -1,0 +1,488 @@
+"""Queue channel server: MCP notifications to subscribed Claude sessions."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import queue
+import threading
+import urllib.parse
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field
+
+from cw.atomic import atomic_write_text
+from cw.config import state_dir
+
+if TYPE_CHECKING:
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+_MCP_EXTRA_MSG = (
+    "channel server requires [mcp] extra; "
+    "run 'uv pip install cw[mcp]' or 'uv sync --extra mcp'"
+)
+
+DEFAULT_PORT = 8789
+DEFAULT_HOST = "127.0.0.1"
+_NOTIFICATION_TYPE = "cw-queue-event"
+POLL_INTERVAL_SECONDS = 2.0
+_EVENTS_FILE = "queue-channel-events.jsonl"
+_CURSORS_FILE = "queue-channel-cursors.json"
+_SNAPSHOT_FILE = "channels/queue-events.snapshot.json"
+
+
+class QueueSnapshot(BaseModel):
+    task_statuses: dict[str, str] = Field(default_factory=dict)
+    task_session_ids: dict[str, str | None] = Field(default_factory=dict)
+    session_statuses: dict[str, str] = Field(default_factory=dict)
+
+
+class AckRequest(BaseModel):
+    client_id: str
+    offset: int
+
+
+_lock = threading.Lock()
+_subscribers: list[queue.SimpleQueue[dict[str, Any]]] = []
+
+_file_lock = threading.Lock()
+_cursors: dict[str, int] = {}
+_event_offset: list[int] = [0]
+
+
+def subscribe() -> queue.SimpleQueue[dict[str, Any]]:
+    """Register a subscriber queue and return it."""
+    q: queue.SimpleQueue[dict[str, Any]] = queue.SimpleQueue()
+    with _lock:
+        _subscribers.append(q)
+    logger.info("queue-events subscriber added, total=%d", len(_subscribers))
+    return q
+
+
+def unsubscribe(q: queue.SimpleQueue[dict[str, Any]]) -> None:
+    """Remove a subscriber queue."""
+    with _lock, contextlib.suppress(ValueError):
+        _subscribers.remove(q)
+    logger.info("queue-events subscriber removed, total=%d", len(_subscribers))
+
+
+def _append_event(notification: dict[str, Any]) -> None:
+    """Persist notification to queue-channel-events.jsonl with a monotonic offset."""
+    with _file_lock:
+        path = state_dir() / _EVENTS_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = {**notification, "offset": _event_offset[0]}
+        with path.open("a") as f:
+            f.write(json.dumps(record) + "\n")
+            f.flush()
+        _event_offset[0] += 1
+
+
+def _read_events_from_offset(from_offset: int) -> list[dict[str, Any]]:
+    """Read all events with offset >= from_offset from queue-channel-events.jsonl."""
+    with _file_lock:
+        path = state_dir() / _EVENTS_FILE
+        if not path.exists():
+            return []
+        results: list[dict[str, Any]] = []
+        for raw_line in path.read_text().splitlines():
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            try:
+                record: dict[str, Any] = json.loads(stripped)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "%s: skipping malformed line: %r", _EVENTS_FILE, stripped
+                )
+                continue
+            if record.get("offset", -1) >= from_offset:
+                results.append(record)
+        return results
+
+
+def _load_cursors() -> dict[str, int]:
+    """Load per-subscriber cursors from disk."""
+    with _file_lock:
+        path = state_dir() / _CURSORS_FILE
+        if not path.exists():
+            return {}
+        try:
+            data = json.loads(path.read_text())
+            if not isinstance(data, dict):
+                logger.warning("%s: unexpected shape, ignoring", _CURSORS_FILE)
+                return {}
+            return {str(k): int(v) for k, v in data.items()}
+        except json.JSONDecodeError:
+            logger.warning("%s: corrupt, ignoring", _CURSORS_FILE)
+            return {}
+
+
+def _load_offset_from_file() -> int:
+    """Determine current offset from queue-channel-events.jsonl on disk."""
+    with _file_lock:
+        path = state_dir() / _EVENTS_FILE
+        if not path.exists():
+            return 0
+        max_offset = -1
+        for raw_line in path.read_text().splitlines():
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            try:
+                record: dict[str, Any] = json.loads(stripped)
+                offset = record.get("offset", -1)
+                if isinstance(offset, int) and offset > max_offset:
+                    max_offset = offset
+            except json.JSONDecodeError:
+                continue
+        return max_offset + 1
+
+
+def subscribe_with_cursor(client_id: str) -> queue.SimpleQueue[dict[str, Any]]:
+    """Subscribe and replay any missed events since the client's last cursor."""
+    q = subscribe()  # acquires+releases _lock (FIRST)
+    with _file_lock:  # acquires+releases _file_lock (AFTER)
+        cursor = _cursors.get(client_id, 0)
+    missed = _read_events_from_offset(cursor)
+    for record in missed:
+        q.put_nowait(record)
+    return q
+
+
+def ack_offset(client_id: str, offset: int) -> None:
+    """Advance the per-subscriber cursor and persist to disk."""
+    with _file_lock:
+        _cursors[client_id] = offset
+        path = state_dir() / _CURSORS_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(path, json.dumps(_cursors))
+
+
+def broadcast(notification: dict[str, Any]) -> None:
+    """Fan-out notification to all subscriber queues."""
+    _append_event(notification)  # FIRST: persist (file_lock only)
+    with _lock:  # THEN: get subscribers
+        subs = list(_subscribers)
+    for s in subs:
+        s.put_nowait(notification)
+    logger.debug("queue-events broadcast to %d subscribers", len(subs))
+
+
+def _load_snapshot() -> QueueSnapshot:
+    path = state_dir() / _SNAPSHOT_FILE
+    if not path.exists():
+        return QueueSnapshot()
+    try:
+        return QueueSnapshot.model_validate_json(path.read_text())
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("queue-events snapshot: corrupt or invalid, resetting")
+        return QueueSnapshot()
+
+
+def _save_snapshot(snap: QueueSnapshot) -> None:
+    path = state_dir() / _SNAPSHOT_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(path, snap.model_dump_json())
+
+
+def _get_sentinel_status(session_id: str | None, state: Any) -> str | None:
+    if session_id is None:
+        return None
+    for session in state.sessions:
+        if session.id == session_id:
+            lr = session.last_result
+            if lr and isinstance(lr, dict):
+                return lr.get("status")
+            return None
+    return None
+
+
+def _get_blocker_reason(session_id: str | None, state: Any) -> str | None:
+    if session_id is None:
+        return None
+    for session in state.sessions:
+        if session.id == session_id:
+            lr = session.last_result
+            if lr and isinstance(lr, dict):
+                blocker = lr.get("blocker")
+                if blocker and isinstance(blocker, dict):
+                    return blocker.get("reason")
+            return None
+    return None
+
+
+def _compute_queue_deltas(
+    old: QueueSnapshot,
+    store: Any,
+    state: Any,
+) -> list[dict[str, Any]]:
+    """Compute queue event dicts for changed TicketTask states."""
+    events: list[dict[str, Any]] = []
+    for task in store.tasks:
+        tid = task.ticket_id
+        prev = old.task_statuses.get(tid)
+        curr = str(task.status)
+        if prev is None:
+            events.append(
+                {
+                    "event": "queue.ticket_enqueued",
+                    "ticket_id": tid,
+                    "client": task.client,
+                    "status": curr,
+                }
+            )
+        elif prev == "pending" and curr == "running":
+            events.append(
+                {
+                    "event": "queue.ticket_claimed",
+                    "ticket_id": tid,
+                    "client": task.client,
+                    "session_id": task.session_id,
+                }
+            )
+        elif prev == "running" and curr == "completed":
+            sentinel_status = _get_sentinel_status(task.session_id, state)
+            events.append(
+                {
+                    "event": "queue.ticket_completed",
+                    "ticket_id": tid,
+                    "client": task.client,
+                    "queue_status": "completed",
+                    "sentinel_status": sentinel_status,
+                }
+            )
+        elif prev == "running" and curr == "failed":
+            error = _get_blocker_reason(task.session_id, state)
+            events.append(
+                {
+                    "event": "queue.ticket_failed",
+                    "ticket_id": tid,
+                    "client": task.client,
+                    "error": error,
+                    "attempts": task.attempts,
+                }
+            )
+        # RUNNING→CANCELLED: NO EVENT (system-driven cleanup)
+        # RUNNING→BLOCKED_ON_USER: NO EVENT (transient state)
+    return events
+
+
+def _compute_session_deltas(
+    old: QueueSnapshot,
+    state: Any,
+) -> list[dict[str, Any]]:
+    """Compute session event dicts for changed session states."""
+    events: list[dict[str, Any]] = []
+    for session in state.sessions:
+        prev = old.session_statuses.get(session.id)
+        curr = str(session.status)
+        if prev == "active" and curr == "idle":
+            events.append(
+                {
+                    "event": "queue.session_idled",
+                    "session_id": session.id,
+                    "session_name": session.name,
+                }
+            )
+    return events
+
+
+def _build_queue_notification(event: dict[str, Any]) -> dict[str, Any]:
+    event_type = event.get("event", "unknown")
+    ticket_id = event.get("ticket_id", "")
+    title = f"Queue: {event_type.replace('queue.', '').replace('_', ' ')}"
+    if ticket_id:
+        title = f"{ticket_id}: {title}"
+    return {
+        "notification_type": _NOTIFICATION_TYPE,
+        "message": json.dumps(event),
+        "title": title,
+    }
+
+
+def _check_wedge() -> None:
+    """Check for wedged tasks. TODO: implement when doctor-drift ships."""
+    return
+
+
+def _poll_once(old: QueueSnapshot) -> tuple[QueueSnapshot, list[dict[str, Any]]]:
+    """Load current state, compute deltas, return new snapshot + events."""
+    from cw.config import load_state  # noqa: PLC0415
+    from cw.dev_queue import load_dev_queue  # noqa: PLC0415
+
+    store = load_dev_queue()
+    state = load_state()
+
+    events: list[dict[str, Any]] = []
+    events.extend(_compute_queue_deltas(old, store, state))
+    events.extend(_compute_session_deltas(old, state))
+
+    new_snap = QueueSnapshot(
+        task_statuses={t.ticket_id: str(t.status) for t in store.tasks},
+        task_session_ids={t.ticket_id: t.session_id for t in store.tasks},
+        session_statuses={s.id: str(s.status) for s in state.sessions},
+    )
+    return new_snap, events
+
+
+def _run_poller() -> None:
+    """Background polling thread. Runs as daemon."""
+    import time  # noqa: PLC0415
+
+    snapshot = _load_snapshot()
+    while True:
+        time.sleep(POLL_INTERVAL_SECONDS)
+        try:
+            new_snap, events = _poll_once(snapshot)
+            for event in events:
+                broadcast(_build_queue_notification(event))
+            if events:
+                _save_snapshot(new_snap)
+                snapshot = new_snap
+            elif (
+                new_snap.task_statuses != snapshot.task_statuses
+                or new_snap.session_statuses != snapshot.session_statuses
+            ):
+                # State changed but no events — update snapshot silently
+                _save_snapshot(new_snap)
+                snapshot = new_snap
+        except Exception:
+            logger.exception("poller error")
+
+
+def _start_poller() -> None:
+    t = threading.Thread(target=_run_poller, daemon=True, name="queue-events-poller")
+    t.start()
+
+
+async def handle_post_ack(request: Request) -> Response:
+    """Handle POST /ack: advance per-subscriber cursor."""
+    from starlette.responses import JSONResponse  # noqa: PLC0415
+
+    try:
+        body = await request.json()
+        req = AckRequest.model_validate(body)
+    except (ValueError, TypeError) as exc:
+        msg = str(exc)
+        logger.warning("ack rejected: %s", msg)
+        return JSONResponse({"error": msg}, status_code=400)
+    ack_offset(req.client_id, req.offset)
+    return JSONResponse({"status": "ok"})
+
+
+_cursors.update(_load_cursors())
+_event_offset[0] = _load_offset_from_file()
+
+
+class _SSESlashMiddleware:
+    """Rewrite bare /sse → /sse/ at ASGI scope level.
+
+    Starlette's Mount("/sse") regex requires a trailing slash to produce a
+    FULL match.  Without this rewrite, a GET /sse request falls through to
+    the redirect_slashes handler and returns a 307.  We normalise the path
+    internally so neither the client nor the router needs to care which form
+    was used.
+    """
+
+    def __init__(self, app: Any) -> None:
+        self._app = app
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        if scope.get("type") == "http" and scope.get("path") == "/sse":
+            scope = dict(scope, path="/sse/")
+        await self._app(scope, receive, send)
+
+
+def make_app() -> Starlette:
+    """Build and return the Starlette ASGI app with MCP SSE + /ack route."""
+    try:
+        from starlette.applications import Starlette  # noqa: PLC0415
+        from starlette.middleware import Middleware  # noqa: PLC0415
+        from starlette.routing import Mount, Route  # noqa: PLC0415
+    except ImportError as exc:
+        raise ImportError(_MCP_EXTRA_MSG) from exc
+    import anyio  # noqa: PLC0415
+    from mcp.server import Server  # noqa: PLC0415
+    from mcp.server.sse import SseServerTransport  # noqa: PLC0415
+    from mcp.shared.message import SessionMessage  # noqa: PLC0415
+    from mcp.types import JSONRPCMessage, JSONRPCNotification  # noqa: PLC0415
+
+    mcp_server: Server[None, Any] = Server("cw-queue-events")
+    sse = SseServerTransport("/messages")
+
+    _start_poller()
+
+    async def _sse_asgi(  # pragma: no cover
+        scope: Any, receive: Any, send: Any
+    ) -> None:
+        async with sse.connect_sse(scope, receive, send) as streams:
+            read_stream, write_stream = streams
+            query = urllib.parse.parse_qs(scope.get("query_string", b"").decode())
+            client_id_list = query.get("client_id", [])
+            if client_id_list:
+                q = subscribe_with_cursor(client_id_list[0])
+            else:
+                q = subscribe()
+            try:
+                async with anyio.create_task_group() as tg:
+                    tg.start_soon(
+                        mcp_server.run,
+                        read_stream,
+                        write_stream,
+                        mcp_server.create_initialization_options(),
+                    )
+
+                    async def _drain() -> None:  # pragma: no cover
+                        while True:
+                            try:
+                                notification = q.get_nowait()
+                            except queue.Empty:
+                                await anyio.sleep(0.05)
+                                continue
+                            json_rpc_notif = JSONRPCNotification(
+                                jsonrpc="2.0",
+                                method="notifications/message",
+                                params={
+                                    "level": "info",
+                                    "logger": "cw-queue-events",
+                                    "data": notification,
+                                },
+                            )
+                            session_msg = SessionMessage(
+                                message=JSONRPCMessage(json_rpc_notif)
+                            )
+                            await write_stream.send(session_msg)
+
+                    tg.start_soon(_drain)
+            finally:
+                unsubscribe(q)
+
+    app = Starlette(
+        routes=[
+            Mount("/sse", app=_sse_asgi),
+            Mount("/messages", app=sse.handle_post_message),
+            Route("/ack", handle_post_ack, methods=["POST"]),
+        ],
+        middleware=[Middleware(_SSESlashMiddleware)],
+    )
+    app.router.redirect_slashes = False
+    return app
+
+
+def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> None:
+    """Start the server. Blocks until interrupted."""
+    import uvicorn  # noqa: PLC0415
+
+    uvicorn.run(make_app(), host=host, port=port)
+
+
+if __name__ == "__main__":
+    _port = int(os.environ.get("CW_QUEUE_EVENTS_PORT", str(DEFAULT_PORT)))
+    serve(port=_port)

--- a/tests/test_channels_queue_events.py
+++ b/tests/test_channels_queue_events.py
@@ -1,0 +1,902 @@
+"""Tests for cw_queue_events_server: delta detection, notification shape, registry."""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+from collections.abc import Generator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+starlette = pytest.importorskip(
+    "starlette", reason="requires mcp extras: pip install 'cw[mcp]'"
+)
+
+import cw.cw_queue_events_server as _server_mod  # noqa: E402
+from cw.cw_queue_events_server import (  # noqa: E402
+    _NOTIFICATION_TYPE,
+    QueueSnapshot,
+    _build_queue_notification,
+    _check_wedge,
+    _compute_queue_deltas,
+    _compute_session_deltas,
+    _load_snapshot,
+    _save_snapshot,
+    broadcast,
+    make_app,
+    serve,
+    subscribe,
+    subscribe_with_cursor,
+    unsubscribe,
+)
+from starlette.testclient import TestClient  # noqa: E402
+
+from cw.models import (  # noqa: E402
+    CwState,
+    DevQueueStore,
+    QueueItemStatus,
+    Session,
+    SessionPurpose,
+    SessionStatus,
+    TicketTask,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_subscribers() -> Generator[None]:
+    """Clear global subscriber list between tests to prevent state bleed."""
+    with _server_mod._lock:
+        _server_mod._subscribers.clear()
+    yield
+    with _server_mod._lock:
+        _server_mod._subscribers.clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_channel_state() -> Generator[None]:
+    """Reset durable-replay in-memory state between tests."""
+    with _server_mod._file_lock:
+        _server_mod._cursors.clear()
+        _server_mod._event_offset[0] = 0
+    yield
+    with _server_mod._file_lock:
+        _server_mod._cursors.clear()
+        _server_mod._event_offset[0] = 0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(
+    ticket_id: str,
+    client: str,
+    status: QueueItemStatus,
+    session_id: str | None = None,
+    attempts: int = 0,
+) -> TicketTask:
+    return TicketTask(
+        ticket_id=ticket_id,
+        client=client,
+        status=status,
+        session_id=session_id,
+        attempts=attempts,
+    )
+
+
+def _make_session(
+    session_id: str,
+    status: SessionStatus,
+    last_result: dict[str, Any] | None = None,
+    name: str = "test-client/impl",
+    client: str = "test-client",
+) -> Session:
+    from pathlib import Path
+
+    return Session(
+        id=session_id,
+        name=name,
+        client=client,
+        purpose=SessionPurpose.IMPL,
+        status=status,
+        workspace_path=Path("/tmp/test"),
+        started_at=datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC),
+        last_result=last_result,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestQueueSnapshotModel
+# ---------------------------------------------------------------------------
+
+
+class TestQueueSnapshotModel:
+    def test_empty_defaults(self) -> None:
+        snap = QueueSnapshot()
+        assert snap.task_statuses == {}
+        assert snap.task_session_ids == {}
+        assert snap.session_statuses == {}
+
+    def test_round_trip_json(self) -> None:
+        snap = QueueSnapshot(
+            task_statuses={"T-1": "pending", "T-2": "running"},
+            task_session_ids={"T-1": None, "T-2": "sess123"},
+            session_statuses={"s1": "active"},
+        )
+        serialized = snap.model_dump_json()
+        restored = QueueSnapshot.model_validate_json(serialized)
+        assert restored.task_statuses == snap.task_statuses
+        assert restored.task_session_ids == snap.task_session_ids
+        assert restored.session_statuses == snap.session_statuses
+
+    def test_partial_fields(self) -> None:
+        snap = QueueSnapshot(task_statuses={"T-3": "completed"})
+        assert snap.task_session_ids == {}
+        assert snap.session_statuses == {}
+
+
+# ---------------------------------------------------------------------------
+# TestQueueEventNotificationShape
+# ---------------------------------------------------------------------------
+
+
+class TestQueueEventNotificationShape:
+    def test_notification_type_field(self) -> None:
+        event = {
+            "event": "queue.ticket_enqueued",
+            "ticket_id": "T-1",
+            "client": "acme",
+            "status": "pending",
+        }
+        notif = _build_queue_notification(event)
+        assert notif["notification_type"] == _NOTIFICATION_TYPE
+
+    def test_message_field_is_valid_json(self) -> None:
+        event = {
+            "event": "queue.ticket_enqueued",
+            "ticket_id": "T-1",
+            "client": "acme",
+            "status": "pending",
+        }
+        notif = _build_queue_notification(event)
+        data = json.loads(notif["message"])
+        assert "event" in data
+        assert data["ticket_id"] == "T-1"
+
+    def test_title_field_present(self) -> None:
+        event = {
+            "event": "queue.ticket_enqueued",
+            "ticket_id": "T-1",
+            "client": "acme",
+            "status": "pending",
+        }
+        notif = _build_queue_notification(event)
+        assert isinstance(notif["title"], str)
+        assert notif["title"]
+
+    @pytest.mark.parametrize(
+        "event_type",
+        [
+            "queue.ticket_enqueued",
+            "queue.ticket_claimed",
+            "queue.ticket_completed",
+            "queue.ticket_failed",
+            "queue.session_idled",
+            "queue.wedge_detected",
+        ],
+    )
+    def test_all_event_types_produce_title(self, event_type: str) -> None:
+        event = {"event": event_type, "ticket_id": "T-42", "client": "x"}
+        notif = _build_queue_notification(event)
+        assert notif["title"]
+
+    def test_title_includes_ticket_id(self) -> None:
+        event = {"event": "queue.ticket_claimed", "ticket_id": "T-99", "client": "acme"}
+        notif = _build_queue_notification(event)
+        assert "T-99" in notif["title"]
+
+    def test_title_without_ticket_id(self) -> None:
+        event = {"event": "queue.session_idled", "session_id": "s1"}
+        notif = _build_queue_notification(event)
+        assert isinstance(notif["title"], str)
+        assert notif["title"]
+
+
+# ---------------------------------------------------------------------------
+# TestSubscriberRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestSubscriberRegistry:
+    def test_subscribe_adds_to_registry(self) -> None:
+        q = subscribe()
+        try:
+            assert isinstance(q, queue.SimpleQueue)
+        finally:
+            unsubscribe(q)
+
+    def test_unsubscribe_removes_from_registry(self) -> None:
+        q = subscribe()
+        unsubscribe(q)
+        broadcast({"test": True})
+        assert q.empty()
+
+    def test_broadcast_sends_to_all_queues(self) -> None:
+        q1 = subscribe()
+        q2 = subscribe()
+        try:
+            broadcast({"x": 1})
+            assert q1.get_nowait() == {"x": 1}
+            assert q2.get_nowait() == {"x": 1}
+        finally:
+            unsubscribe(q1)
+            unsubscribe(q2)
+
+
+# ---------------------------------------------------------------------------
+# TestAppendEventQueueChannel
+# ---------------------------------------------------------------------------
+
+
+class TestAppendEventQueueChannel:
+    def test_appends_to_queue_channel_events_jsonl(self) -> None:
+        from cw.cw_queue_events_server import _append_event
+
+        from cw.config import state_dir
+
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "m", "title": "t"}
+        )
+        path = state_dir() / "queue-channel-events.jsonl"
+        assert path.exists()
+        lines = path.read_text().splitlines()
+        assert len(lines) == 1
+
+    def test_does_not_write_to_channel_events_jsonl(self) -> None:
+        """Must use queue-channel-events.jsonl, NOT channel-events.jsonl."""
+        from cw.cw_queue_events_server import _append_event
+
+        from cw.config import state_dir
+
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "m", "title": "t"}
+        )
+        wrong_path = state_dir() / "channel-events.jsonl"
+        assert not wrong_path.exists()
+
+    def test_offset_increments_monotonically(self) -> None:
+        from cw.cw_queue_events_server import _append_event
+
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "m", "title": "t"}
+        )
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "m2", "title": "t2"}
+        )
+        assert _server_mod._event_offset[0] == 2
+
+    def test_record_contains_offset_field(self) -> None:
+        from cw.cw_queue_events_server import _append_event
+
+        from cw.config import state_dir
+
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "m", "title": "t"}
+        )
+        path = state_dir() / "queue-channel-events.jsonl"
+        record = json.loads(path.read_text().splitlines()[0])
+        assert record["offset"] == 0
+
+    def test_thread_safe_under_concurrent_appends(self) -> None:
+        from cw.cw_queue_events_server import _append_event
+
+        from cw.config import state_dir
+
+        def worker() -> None:
+            _append_event(
+                {"notification_type": _NOTIFICATION_TYPE, "message": "x", "title": "x"}
+            )
+
+        threads = [threading.Thread(target=worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        path = state_dir() / "queue-channel-events.jsonl"
+        lines = path.read_text().splitlines()
+        assert len(lines) == 10
+        records = [json.loads(line) for line in lines]
+        offsets = {r["offset"] for r in records}
+        assert len(offsets) == 10  # all unique
+
+
+# ---------------------------------------------------------------------------
+# TestReadEventsFromOffsetQueueChannel
+# ---------------------------------------------------------------------------
+
+
+class TestReadEventsFromOffsetQueueChannel:
+    def test_returns_empty_for_missing_file(self) -> None:
+        from cw.cw_queue_events_server import _read_events_from_offset
+
+        result = _read_events_from_offset(0)
+        assert result == []
+
+    def test_returns_all_events_from_zero(self) -> None:
+        from cw.cw_queue_events_server import (
+            _append_event,
+            _read_events_from_offset,
+        )
+
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "a", "title": "a"}
+        )
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "b", "title": "b"}
+        )
+        result = _read_events_from_offset(0)
+        assert len(result) == 2
+
+    def test_respects_offset_filter(self) -> None:
+        from cw.cw_queue_events_server import (
+            _append_event,
+            _read_events_from_offset,
+        )
+
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "a", "title": "a"}
+        )
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "b", "title": "b"}
+        )
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "c", "title": "c"}
+        )
+        result = _read_events_from_offset(1)
+        assert len(result) == 2
+        assert result[0]["offset"] == 1
+        assert result[1]["offset"] == 2
+
+    def test_skips_malformed_lines(self) -> None:
+        from cw.cw_queue_events_server import (
+            _append_event,
+            _read_events_from_offset,
+        )
+
+        from cw.config import state_dir
+
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "a", "title": "a"}
+        )
+        path = state_dir() / "queue-channel-events.jsonl"
+        with path.open("a") as f:
+            f.write("not-json\n")
+        result = _read_events_from_offset(0)
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestSubscribeWithCursorQueueChannel
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribeWithCursorQueueChannel:
+    def test_returns_queue(self) -> None:
+        q = subscribe_with_cursor("sub1")
+        assert isinstance(q, queue.SimpleQueue)
+        unsubscribe(q)
+
+    def test_replays_missed_events(self) -> None:
+        from cw.cw_queue_events_server import _append_event
+
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "a", "title": "a"}
+        )
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "b", "title": "b"}
+        )
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "c", "title": "c"}
+        )
+
+        _server_mod._cursors["sub2"] = 1
+        q = subscribe_with_cursor("sub2")
+        try:
+            items = []
+            while not q.empty():
+                items.append(q.get_nowait())
+            assert len(items) == 2
+            assert items[0]["offset"] == 1
+            assert items[1]["offset"] == 2
+        finally:
+            unsubscribe(q)
+
+    def test_no_replay_when_caught_up(self) -> None:
+        from cw.cw_queue_events_server import _append_event
+
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "a", "title": "a"}
+        )
+        _append_event(
+            {"notification_type": _NOTIFICATION_TYPE, "message": "b", "title": "b"}
+        )
+
+        _server_mod._cursors["sub3"] = 2
+        q = subscribe_with_cursor("sub3")
+        try:
+            assert q.empty()
+        finally:
+            unsubscribe(q)
+
+    def test_registers_for_future_events(self) -> None:
+        q = subscribe_with_cursor("sub4")
+        try:
+            broadcast(
+                {
+                    "notification_type": _NOTIFICATION_TYPE,
+                    "message": "future",
+                    "title": "f",
+                }
+            )
+            item = q.get_nowait()
+            assert item["notification_type"] == _NOTIFICATION_TYPE
+        finally:
+            unsubscribe(q)
+
+
+# ---------------------------------------------------------------------------
+# TestAckOffsetQueueChannel
+# ---------------------------------------------------------------------------
+
+
+class TestAckOffsetQueueChannel:
+    def test_persists_to_queue_channel_cursors_json(self) -> None:
+        from cw.cw_queue_events_server import ack_offset
+
+        from cw.config import state_dir
+
+        ack_offset("sub-a", 3)
+        path = state_dir() / "queue-channel-cursors.json"
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data == {"sub-a": 3}
+
+    def test_does_not_write_channel_cursors_json(self) -> None:
+        """Must use queue-channel-cursors.json, NOT channel-cursors.json."""
+        from cw.cw_queue_events_server import ack_offset
+
+        from cw.config import state_dir
+
+        ack_offset("sub-b", 5)
+        wrong_path = state_dir() / "channel-cursors.json"
+        assert not wrong_path.exists()
+
+    def test_updates_in_memory_cursors(self) -> None:
+        from cw.cw_queue_events_server import ack_offset
+
+        ack_offset("sub-c", 7)
+        assert _server_mod._cursors["sub-c"] == 7
+
+    def test_overwrites_previous_cursor(self) -> None:
+        from cw.cw_queue_events_server import ack_offset
+
+        ack_offset("sub-d", 1)
+        ack_offset("sub-d", 5)
+        assert _server_mod._cursors["sub-d"] == 5
+
+
+# ---------------------------------------------------------------------------
+# TestHandlePostAckQueueChannel
+# ---------------------------------------------------------------------------
+
+
+class TestHandlePostAckQueueChannel:
+    def _make_client(self) -> TestClient:
+        return TestClient(make_app())
+
+    def test_valid_request_returns_ok(self) -> None:
+        client = self._make_client()
+        resp = client.post("/ack", json={"client_id": "c1", "offset": 0})
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_invalid_body_returns_400(self) -> None:
+        client = self._make_client()
+        resp = client.post("/ack", json={"client_id": "c1"})  # missing offset
+        assert resp.status_code == 400
+
+    def test_updates_cursor(self) -> None:
+        client = self._make_client()
+        client.post("/ack", json={"client_id": "c2", "offset": 42})
+        assert _server_mod._cursors["c2"] == 42
+
+    def test_route_registered(self) -> None:
+        app = make_app()
+        route_paths = [r.path for r in app.routes]
+        assert "/ack" in route_paths
+
+
+# ---------------------------------------------------------------------------
+# TestMakeAppQueueEvents
+# ---------------------------------------------------------------------------
+
+
+class TestMakeAppQueueEvents:
+    def test_app_is_starlette(self) -> None:
+        from starlette.applications import Starlette
+
+        app = make_app()
+        assert isinstance(app, Starlette)
+
+    def test_redirect_slashes_false(self) -> None:
+        app = make_app()
+        assert not app.router.redirect_slashes
+
+    def test_sse_slash_middleware_present(self) -> None:
+        app = make_app()
+        # Check _SSESlashMiddleware is in user_middleware by class name
+        mw_classes = [
+            m.cls.__name__ if hasattr(m, "cls") else type(m).__name__
+            for m in app.user_middleware
+        ]
+        assert any("_SSESlashMiddleware" in cls for cls in mw_classes)
+
+    def test_no_pr_event_route(self) -> None:
+        """Queue events server must NOT have a /pr-event route."""
+        app = make_app()
+        route_paths = [r.path for r in app.routes]
+        assert "/pr-event" not in route_paths
+
+
+# ---------------------------------------------------------------------------
+# TestServeQueueEvents
+# ---------------------------------------------------------------------------
+
+
+class TestServeQueueEvents:
+    def test_serve_calls_uvicorn_run(self) -> None:
+        mock_run = MagicMock()
+        with patch("uvicorn.run", mock_run):
+            serve(host="127.0.0.1", port=9999)
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs.get("host") == "127.0.0.1"
+        assert call_kwargs.get("port") == 9999
+
+    def test_default_port_is_8789(self) -> None:
+        from cw.cw_queue_events_server import DEFAULT_PORT
+
+        assert DEFAULT_PORT == 8789
+
+
+# ---------------------------------------------------------------------------
+# TestCLIQueueChannel
+# ---------------------------------------------------------------------------
+
+
+class TestCLIQueueChannel:
+    def test_queue_channel_serve_command_invokes_serve(self) -> None:
+        from cw.cli import main
+
+        mock_serve = MagicMock()
+        runner = CliRunner()
+        with patch("cw.cw_queue_events_server.serve", mock_serve):
+            result = runner.invoke(main, ["queue-channel", "serve", "--port", "9124"])
+        assert result.exit_code == 0
+        mock_serve.assert_called_once_with(host="127.0.0.1", port=9124)
+
+    def test_queue_channel_proxy_help(self) -> None:
+        from cw.cli import main
+
+        result = CliRunner().invoke(main, ["queue-channel", "proxy", "--help"])
+        assert result.exit_code == 0
+        assert "--client-id" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TestCheckWedgeStub
+# ---------------------------------------------------------------------------
+
+
+class TestCheckWedgeStub:
+    def test_returns_none(self) -> None:
+        result = _check_wedge()
+        assert result is None
+
+    def test_does_not_raise(self) -> None:
+        _check_wedge()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# TestPollerDeltaDetection
+# ---------------------------------------------------------------------------
+
+
+class TestPollerDeltaDetection:
+    def test_new_task_produces_ticket_enqueued(self) -> None:
+        old = QueueSnapshot()
+        store = DevQueueStore(
+            tasks=[_make_task("T-1", "acme", QueueItemStatus.PENDING)]
+        )
+        state = CwState()
+        events = _compute_queue_deltas(old, store, state)
+        assert len(events) == 1
+        assert events[0]["event"] == "queue.ticket_enqueued"
+        assert events[0]["ticket_id"] == "T-1"
+        assert events[0]["client"] == "acme"
+        assert events[0]["status"] == "pending"
+
+    def test_pending_to_running_produces_ticket_claimed(self) -> None:
+        old = QueueSnapshot(task_statuses={"T-2": "pending"})
+        store = DevQueueStore(
+            tasks=[
+                _make_task(
+                    "T-2", "acme", QueueItemStatus.RUNNING, session_id="sess-abc"
+                )
+            ]
+        )
+        state = CwState()
+        events = _compute_queue_deltas(old, store, state)
+        assert len(events) == 1
+        assert events[0]["event"] == "queue.ticket_claimed"
+        assert events[0]["ticket_id"] == "T-2"
+        assert events[0]["session_id"] == "sess-abc"
+
+    def test_running_to_completed_produces_ticket_completed(self) -> None:
+        old = QueueSnapshot(
+            task_statuses={"T-3": "running"},
+            task_session_ids={"T-3": "sess-xyz"},
+        )
+        session = _make_session(
+            "sess-xyz",
+            SessionStatus.COMPLETED,
+            last_result={"status": "success"},
+        )
+        store = DevQueueStore(
+            tasks=[
+                _make_task(
+                    "T-3", "acme", QueueItemStatus.COMPLETED, session_id="sess-xyz"
+                )
+            ]
+        )
+        state = CwState(sessions=[session])
+        events = _compute_queue_deltas(old, store, state)
+        assert len(events) == 1
+        ev = events[0]
+        assert ev["event"] == "queue.ticket_completed"
+        assert ev["ticket_id"] == "T-3"
+        assert ev["queue_status"] == "completed"
+        assert ev["sentinel_status"] == "success"
+
+    def test_running_to_completed_sentinel_status_null_when_no_session(self) -> None:
+        old = QueueSnapshot(task_statuses={"T-4": "running"})
+        store = DevQueueStore(
+            tasks=[_make_task("T-4", "acme", QueueItemStatus.COMPLETED)]
+        )
+        state = CwState()
+        events = _compute_queue_deltas(old, store, state)
+        assert events[0]["sentinel_status"] is None
+
+    def test_running_to_failed_produces_ticket_failed(self) -> None:
+        old = QueueSnapshot(
+            task_statuses={"T-5": "running"},
+            task_session_ids={"T-5": "sess-err"},
+        )
+        session = _make_session(
+            "sess-err",
+            SessionStatus.COMPLETED,
+            last_result={"status": "failed", "blocker": {"reason": "build broke"}},
+        )
+        store = DevQueueStore(
+            tasks=[
+                _make_task(
+                    "T-5",
+                    "acme",
+                    QueueItemStatus.FAILED,
+                    session_id="sess-err",
+                    attempts=3,
+                )
+            ]
+        )
+        state = CwState(sessions=[session])
+        events = _compute_queue_deltas(old, store, state)
+        assert len(events) == 1
+        ev = events[0]
+        assert ev["event"] == "queue.ticket_failed"
+        assert ev["ticket_id"] == "T-5"
+        assert ev["error"] == "build broke"
+        assert ev["attempts"] == 3
+
+    def test_running_to_failed_error_null_when_no_blocker(self) -> None:
+        old = QueueSnapshot(task_statuses={"T-6": "running"})
+        store = DevQueueStore(
+            tasks=[_make_task("T-6", "acme", QueueItemStatus.FAILED, attempts=1)]
+        )
+        state = CwState()
+        events = _compute_queue_deltas(old, store, state)
+        assert events[0]["error"] is None
+
+    def test_running_to_cancelled_produces_no_event(self) -> None:
+        old = QueueSnapshot(task_statuses={"T-7": "running"})
+        store = DevQueueStore(
+            tasks=[_make_task("T-7", "acme", QueueItemStatus.CANCELLED)]
+        )
+        state = CwState()
+        events = _compute_queue_deltas(old, store, state)
+        assert events == []
+
+    def test_running_to_blocked_on_user_produces_no_event(self) -> None:
+        old = QueueSnapshot(task_statuses={"T-8": "running"})
+        store = DevQueueStore(
+            tasks=[_make_task("T-8", "acme", QueueItemStatus.BLOCKED_ON_USER)]
+        )
+        state = CwState()
+        events = _compute_queue_deltas(old, store, state)
+        assert events == []
+
+    def test_known_task_with_no_state_change_produces_no_event(self) -> None:
+        old = QueueSnapshot(task_statuses={"T-9": "pending"})
+        store = DevQueueStore(
+            tasks=[_make_task("T-9", "acme", QueueItemStatus.PENDING)]
+        )
+        state = CwState()
+        events = _compute_queue_deltas(old, store, state)
+        assert events == []
+
+
+# ---------------------------------------------------------------------------
+# TestPollerSessionDeltaDetection
+# ---------------------------------------------------------------------------
+
+
+class TestPollerSessionDeltaDetection:
+    def test_active_to_idle_produces_session_idled(self) -> None:
+        sess = _make_session("s1", SessionStatus.IDLE, name="acme/impl")
+        old = QueueSnapshot(session_statuses={"s1": "active"})
+        state = CwState(sessions=[sess])
+        events = _compute_session_deltas(old, state)
+        assert len(events) == 1
+        ev = events[0]
+        assert ev["event"] == "queue.session_idled"
+        assert ev["session_id"] == "s1"
+        assert ev["session_name"] == "acme/impl"
+
+    def test_idle_to_completed_produces_no_event(self) -> None:
+        sess = _make_session("s2", SessionStatus.COMPLETED)
+        old = QueueSnapshot(session_statuses={"s2": "idle"})
+        state = CwState(sessions=[sess])
+        events = _compute_session_deltas(old, state)
+        assert events == []
+
+    def test_new_active_session_produces_no_event(self) -> None:
+        sess = _make_session("s3", SessionStatus.ACTIVE)
+        old = QueueSnapshot()
+        state = CwState(sessions=[sess])
+        events = _compute_session_deltas(old, state)
+        assert events == []
+
+    def test_active_to_active_no_event(self) -> None:
+        sess = _make_session("s4", SessionStatus.ACTIVE)
+        old = QueueSnapshot(session_statuses={"s4": "active"})
+        state = CwState(sessions=[sess])
+        events = _compute_session_deltas(old, state)
+        assert events == []
+
+
+# ---------------------------------------------------------------------------
+# TestQueueSnapshotPersistence
+# ---------------------------------------------------------------------------
+
+
+class TestQueueSnapshotPersistence:
+    def test_load_snapshot_returns_empty_when_missing(self) -> None:
+        snap = _load_snapshot()
+        assert snap.task_statuses == {}
+        assert snap.session_statuses == {}
+
+    def test_save_and_load_round_trip(self) -> None:
+        snap = QueueSnapshot(
+            task_statuses={"T-1": "running"},
+            task_session_ids={"T-1": "sess1"},
+            session_statuses={"s1": "active"},
+        )
+        _save_snapshot(snap)
+        loaded = _load_snapshot()
+        assert loaded.task_statuses == snap.task_statuses
+        assert loaded.task_session_ids == snap.task_session_ids
+        assert loaded.session_statuses == snap.session_statuses
+
+    def test_snapshot_path_is_under_channels_subdir(self) -> None:
+        from cw.config import state_dir
+
+        snap = QueueSnapshot(task_statuses={"T-1": "pending"})
+        _save_snapshot(snap)
+        expected_path = state_dir() / "channels" / "queue-events.snapshot.json"
+        assert expected_path.exists()
+
+    def test_load_snapshot_returns_empty_on_corrupt_file(self) -> None:
+        from cw.config import state_dir
+
+        path = state_dir() / "channels" / "queue-events.snapshot.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not-json")
+        snap = _load_snapshot()
+        assert snap.task_statuses == {}
+
+
+# ---------------------------------------------------------------------------
+# TestLazyStarlette
+# ---------------------------------------------------------------------------
+
+
+class TestLazyStarlette:
+    def test_module_import_does_not_require_starlette(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import importlib
+        import sys
+
+        for key in (
+            "starlette",
+            "starlette.applications",
+            "starlette.responses",
+            "starlette.routing",
+            "starlette.requests",
+        ):
+            monkeypatch.setitem(sys.modules, key, None)
+
+        mod_name = "cw.cw_queue_events_server"
+        original_mod = sys.modules.pop(mod_name, None)
+        try:
+            mod = importlib.import_module(mod_name)
+            assert mod is not None
+        finally:
+            sys.modules.pop(mod_name, None)
+            if original_mod is not None:
+                sys.modules[mod_name] = original_mod
+
+    def test_make_app_raises_clear_importerror_without_starlette(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+
+        monkeypatch.setitem(sys.modules, "starlette.applications", None)
+
+        with pytest.raises(ImportError, match=r"channel server requires \[mcp\] extra"):
+            _server_mod.make_app()
+
+
+# ---------------------------------------------------------------------------
+# TestDurableReplayQueueChannel
+# ---------------------------------------------------------------------------
+
+
+class TestDurableReplayQueueChannel:
+    def test_five_events_survive_subscriber_restart(self) -> None:
+        """Primary acceptance: 5 events survive subscribe/unsubscribe cycle."""
+        for i in range(5):
+            broadcast(
+                {
+                    "notification_type": _NOTIFICATION_TYPE,
+                    "message": f"msg{i}",
+                    "title": f"t{i}",
+                }
+            )
+
+        q = subscribe_with_cursor("dispatcher")
+        try:
+            items = []
+            while not q.empty():
+                items.append(q.get_nowait())
+
+            assert len(items) == 5
+            assert {item["offset"] for item in items} == {0, 1, 2, 3, 4}
+        finally:
+            unsubscribe(q)

--- a/tests/test_channels_queue_events.py
+++ b/tests/test_channels_queue_events.py
@@ -27,6 +27,7 @@ from cw.cw_queue_events_server import (  # noqa: E402
     _check_wedge,
     _compute_queue_deltas,
     _compute_session_deltas,
+    _load_offset_from_file,
     _load_snapshot,
     _save_snapshot,
     broadcast,
@@ -895,3 +896,55 @@ class TestDurableReplayQueueChannel:
             assert {item["offset"] for item in items} == {0, 1, 2, 3, 4}
         finally:
             unsubscribe(q)
+
+
+# ---------------------------------------------------------------------------
+# TestLoadOffsetFromFile
+# ---------------------------------------------------------------------------
+
+
+class TestLoadOffsetFromFile:
+    """Deterministic coverage for _load_offset_from_file parse loop.
+
+    Without an explicit populated-file test, lines 134-146 are only covered
+    incidentally when a prior test leaves a file behind — which fails on a
+    clean ubuntu run where the early return (no file) fires first.
+    """
+
+    def test_returns_zero_when_file_missing(self) -> None:
+        from cw.config import state_dir
+
+        assert not (state_dir() / "queue-channel-events.jsonl").exists()
+        assert _load_offset_from_file() == 0
+
+    def test_returns_max_offset_plus_one_skipping_blank_and_malformed(self) -> None:
+        from cw.config import state_dir
+
+        path = state_dir() / "queue-channel-events.jsonl"
+        lines = [
+            json.dumps({"offset": 2, "message": "a"}),
+            "",  # blank line -> continue (137-138)
+            json.dumps({"offset": 5, "message": "b"}),
+            "not-json",  # malformed -> JSONDecodeError continue (144-145)
+            json.dumps({"offset": 3, "message": "c"}),
+        ]
+        path.write_text("\n".join(lines) + "\n")
+        assert _load_offset_from_file() == 6
+
+    def test_returns_zero_when_only_blank_and_malformed_lines(self) -> None:
+        from cw.config import state_dir
+
+        path = state_dir() / "queue-channel-events.jsonl"
+        path.write_text("\n   \nnot-json\n")
+        assert _load_offset_from_file() == 0
+
+    def test_ignores_non_int_offset(self) -> None:
+        from cw.config import state_dir
+
+        path = state_dir() / "queue-channel-events.jsonl"
+        lines = [
+            json.dumps({"offset": "bad", "message": "a"}),
+            json.dumps({"offset": 4, "message": "b"}),
+        ]
+        path.write_text("\n".join(lines) + "\n")
+        assert _load_offset_from_file() == 5

--- a/tests/test_channels_queue_events.py
+++ b/tests/test_channels_queue_events.py
@@ -17,6 +17,8 @@ starlette = pytest.importorskip(
     "starlette", reason="requires mcp extras: pip install 'cw[mcp]'"
 )
 
+from starlette.testclient import TestClient  # noqa: E402
+
 import cw.cw_queue_events_server as _server_mod  # noqa: E402
 from cw.cw_queue_events_server import (  # noqa: E402
     _NOTIFICATION_TYPE,
@@ -34,8 +36,6 @@ from cw.cw_queue_events_server import (  # noqa: E402
     subscribe_with_cursor,
     unsubscribe,
 )
-from starlette.testclient import TestClient  # noqa: E402
-
 from cw.models import (  # noqa: E402
     CwState,
     DevQueueStore,
@@ -63,10 +63,12 @@ def _reset_channel_state() -> Generator[None]:
     with _server_mod._file_lock:
         _server_mod._cursors.clear()
         _server_mod._event_offset[0] = 0
+    _server_mod._poller_started[0] = False
     yield
     with _server_mod._file_lock:
         _server_mod._cursors.clear()
         _server_mod._event_offset[0] = 0
+    _server_mod._poller_started[0] = False
 
 
 # ---------------------------------------------------------------------------
@@ -246,9 +248,8 @@ class TestSubscriberRegistry:
 
 class TestAppendEventQueueChannel:
     def test_appends_to_queue_channel_events_jsonl(self) -> None:
-        from cw.cw_queue_events_server import _append_event
-
         from cw.config import state_dir
+        from cw.cw_queue_events_server import _append_event
 
         _append_event(
             {"notification_type": _NOTIFICATION_TYPE, "message": "m", "title": "t"}
@@ -260,9 +261,8 @@ class TestAppendEventQueueChannel:
 
     def test_does_not_write_to_channel_events_jsonl(self) -> None:
         """Must use queue-channel-events.jsonl, NOT channel-events.jsonl."""
-        from cw.cw_queue_events_server import _append_event
-
         from cw.config import state_dir
+        from cw.cw_queue_events_server import _append_event
 
         _append_event(
             {"notification_type": _NOTIFICATION_TYPE, "message": "m", "title": "t"}
@@ -282,9 +282,8 @@ class TestAppendEventQueueChannel:
         assert _server_mod._event_offset[0] == 2
 
     def test_record_contains_offset_field(self) -> None:
-        from cw.cw_queue_events_server import _append_event
-
         from cw.config import state_dir
+        from cw.cw_queue_events_server import _append_event
 
         _append_event(
             {"notification_type": _NOTIFICATION_TYPE, "message": "m", "title": "t"}
@@ -294,9 +293,8 @@ class TestAppendEventQueueChannel:
         assert record["offset"] == 0
 
     def test_thread_safe_under_concurrent_appends(self) -> None:
-        from cw.cw_queue_events_server import _append_event
-
         from cw.config import state_dir
+        from cw.cw_queue_events_server import _append_event
 
         def worker() -> None:
             _append_event(
@@ -365,12 +363,11 @@ class TestReadEventsFromOffsetQueueChannel:
         assert result[1]["offset"] == 2
 
     def test_skips_malformed_lines(self) -> None:
+        from cw.config import state_dir
         from cw.cw_queue_events_server import (
             _append_event,
             _read_events_from_offset,
         )
-
-        from cw.config import state_dir
 
         _append_event(
             {"notification_type": _NOTIFICATION_TYPE, "message": "a", "title": "a"}
@@ -458,9 +455,8 @@ class TestSubscribeWithCursorQueueChannel:
 
 class TestAckOffsetQueueChannel:
     def test_persists_to_queue_channel_cursors_json(self) -> None:
-        from cw.cw_queue_events_server import ack_offset
-
         from cw.config import state_dir
+        from cw.cw_queue_events_server import ack_offset
 
         ack_offset("sub-a", 3)
         path = state_dir() / "queue-channel-cursors.json"
@@ -470,9 +466,8 @@ class TestAckOffsetQueueChannel:
 
     def test_does_not_write_channel_cursors_json(self) -> None:
         """Must use queue-channel-cursors.json, NOT channel-cursors.json."""
-        from cw.cw_queue_events_server import ack_offset
-
         from cw.config import state_dir
+        from cw.cw_queue_events_server import ack_offset
 
         ack_offset("sub-b", 5)
         wrong_path = state_dir() / "channel-cursors.json"

--- a/tests/test_cw_queue_events_channel.py
+++ b/tests/test_cw_queue_events_channel.py
@@ -14,6 +14,9 @@ starlette = pytest.importorskip(
     "starlette", reason="requires mcp extras: pip install 'cw[mcp]'"
 )
 
+from mcp.shared.message import SessionMessage  # noqa: E402
+from mcp.types import JSONRPCMessage, JSONRPCNotification, JSONRPCResponse  # noqa: E402
+
 from cw.cw_queue_events_channel import (  # noqa: E402
     _DEFAULT_BASE_URL,
     _NOTIFICATION_TYPE,
@@ -22,8 +25,6 @@ from cw.cw_queue_events_channel import (  # noqa: E402
     _extract_payload,
     _relay_upstream,
 )
-from mcp.shared.message import SessionMessage  # noqa: E402
-from mcp.types import JSONRPCMessage, JSONRPCNotification, JSONRPCResponse  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -309,6 +310,7 @@ class TestRunProxyEnvVars:
         from contextlib import asynccontextmanager
 
         import mcp.client.sse as _sse_mod
+
         from cw.cw_queue_events_channel import run_proxy
 
         captured: list[str] = []

--- a/tests/test_cw_queue_events_channel.py
+++ b/tests/test_cw_queue_events_channel.py
@@ -1,0 +1,477 @@
+"""Tests for cw_queue_events_channel: payload extraction, notification building."""
+
+from __future__ import annotations
+
+import json
+import socket
+import urllib.parse
+from typing import Any, cast
+
+import pytest
+from click.testing import CliRunner
+
+starlette = pytest.importorskip(
+    "starlette", reason="requires mcp extras: pip install 'cw[mcp]'"
+)
+
+from cw.cw_queue_events_channel import (  # noqa: E402
+    _DEFAULT_BASE_URL,
+    _NOTIFICATION_TYPE,
+    _build_meta,
+    _build_outbound_notification,
+    _extract_payload,
+    _relay_upstream,
+)
+from mcp.shared.message import SessionMessage  # noqa: E402
+from mcp.types import JSONRPCMessage, JSONRPCNotification, JSONRPCResponse  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_queue_session_message(
+    ticket_id: str,
+    client: str,
+    event_type: str,
+    payload: dict[str, Any] | None = None,
+) -> SessionMessage:
+    """Build a server-shaped SessionMessage for testing the proxy."""
+    extra: dict[str, Any] = payload or {}
+    data = {
+        "notification_type": "cw-queue-event",
+        "message": json.dumps(
+            {"event": event_type, "ticket_id": ticket_id, "client": client, **extra}
+        ),
+        "title": f"{ticket_id}: queue {event_type}",
+    }
+    return SessionMessage(
+        message=JSONRPCMessage(
+            JSONRPCNotification(
+                jsonrpc="2.0",
+                method="notifications/message",
+                params={"level": "info", "logger": "cw-queue-events", "data": data},
+            )
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestExtractPayload
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPayload:
+    def test_valid_cw_queue_event(self) -> None:
+        msg = _make_queue_session_message("T-1", "acme", "queue.ticket_enqueued")
+        result = _extract_payload(msg)
+        assert result is not None
+        assert result["event"] == "queue.ticket_enqueued"
+        assert result["ticket_id"] == "T-1"
+        assert result["client"] == "acme"
+
+    def test_non_notification_root(self) -> None:
+        response = JSONRPCResponse(jsonrpc="2.0", id=1, result={})
+        msg = SessionMessage(message=JSONRPCMessage(response))
+        assert _extract_payload(msg) is None
+
+    def test_notification_type_mismatch(self) -> None:
+        notif = JSONRPCNotification(
+            jsonrpc="2.0",
+            method="notifications/message",
+            params={
+                "level": "info",
+                "logger": "cw-queue-events",
+                "data": {
+                    "notification_type": "not-a-queue-event",
+                    "message": json.dumps({"event": "queue.ticket_enqueued"}),
+                },
+            },
+        )
+        msg = SessionMessage(message=JSONRPCMessage(notif))
+        assert _extract_payload(msg) is None
+
+    def test_missing_data_key(self) -> None:
+        notif = JSONRPCNotification(
+            jsonrpc="2.0",
+            method="notifications/message",
+            params={"level": "info"},
+        )
+        msg = SessionMessage(message=JSONRPCMessage(notif))
+        assert _extract_payload(msg) is None
+
+    def test_malformed_json_in_message(self) -> None:
+        notif = JSONRPCNotification(
+            jsonrpc="2.0",
+            method="notifications/message",
+            params={
+                "level": "info",
+                "logger": "cw-queue-events",
+                "data": {
+                    "notification_type": _NOTIFICATION_TYPE,
+                    "message": "not-json",
+                },
+            },
+        )
+        msg = SessionMessage(message=JSONRPCMessage(notif))
+        assert _extract_payload(msg) is None
+
+    def test_missing_message_key(self) -> None:
+        notif = JSONRPCNotification(
+            jsonrpc="2.0",
+            method="notifications/message",
+            params={
+                "level": "info",
+                "data": {
+                    "notification_type": _NOTIFICATION_TYPE,
+                },
+            },
+        )
+        msg = SessionMessage(message=JSONRPCMessage(notif))
+        assert _extract_payload(msg) is None
+
+
+# ---------------------------------------------------------------------------
+# TestBuildMeta
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMeta:
+    def test_basic_fields(self) -> None:
+        data = {"event": "queue.ticket_enqueued", "ticket_id": "T-1", "client": "acme"}
+        meta = _build_meta(data)
+        assert meta["event_type"] == "queue.ticket_enqueued"
+        assert meta["ticket_id"] == "T-1"
+        assert meta["client"] == "acme"
+
+    def test_empty_values_omitted(self) -> None:
+        data = {"event": "queue.session_idled", "ticket_id": "", "client": ""}
+        meta = _build_meta(data)
+        assert "ticket_id" not in meta
+        assert "client" not in meta
+        assert meta["event_type"] == "queue.session_idled"
+
+    def test_uses_event_key_not_event_type_key(self) -> None:
+        """event_type in meta comes from data["event"], not data["event_type"]."""
+        data = {
+            "event": "queue.ticket_claimed",
+            "event_type": "should-be-ignored",
+            "ticket_id": "T-2",
+            "client": "acme",
+        }
+        meta = _build_meta(data)
+        assert meta["event_type"] == "queue.ticket_claimed"
+
+    def test_missing_optional_keys_omitted(self) -> None:
+        data = {"event": "queue.session_idled"}
+        meta = _build_meta(data)
+        assert meta["event_type"] == "queue.session_idled"
+        assert "ticket_id" not in meta
+        assert "client" not in meta
+
+
+# ---------------------------------------------------------------------------
+# TestBuildOutboundNotification
+# ---------------------------------------------------------------------------
+
+
+class TestBuildOutboundNotification:
+    def _data(self) -> dict[str, Any]:
+        return {
+            "event": "queue.ticket_claimed",
+            "ticket_id": "T-5",
+            "client": "acme",
+            "session_id": "sess-abc",
+        }
+
+    def test_returns_session_message(self) -> None:
+        result = _build_outbound_notification(self._data())
+        assert isinstance(result, SessionMessage)
+
+    def test_root_is_json_rpc_notification(self) -> None:
+        result = _build_outbound_notification(self._data())
+        assert isinstance(result.message.root, JSONRPCNotification)
+
+    def test_method_is_notifications_claude_channel(self) -> None:
+        result = _build_outbound_notification(self._data())
+        assert result.message.root.method == "notifications/claude/channel"
+
+    def test_data_preserved(self) -> None:
+        data = self._data()
+        result = _build_outbound_notification(data)
+        params = result.message.root.params or {}
+        assert json.loads(params["content"]) == data
+
+
+# ---------------------------------------------------------------------------
+# TestRelayUpstream
+# ---------------------------------------------------------------------------
+
+
+class TestRelayUpstream:
+    def test_valid_message_forwarded(self) -> None:
+        import anyio
+
+        msg = _make_queue_session_message("T-10", "acme", "queue.ticket_enqueued")
+
+        async def _run() -> SessionMessage | None:
+            send_in, recv_in = anyio.create_memory_object_stream[Any](max_buffer_size=5)
+            send_out, recv_out = anyio.create_memory_object_stream[Any](
+                max_buffer_size=5
+            )
+            await send_in.send(msg)
+            await send_in.aclose()
+
+            await _relay_upstream(recv_in, send_out)
+            await send_out.aclose()
+
+            try:
+                return cast("SessionMessage", await recv_out.receive())
+            except anyio.EndOfStream:
+                return None
+
+        result = anyio.run(_run)
+        assert result is not None
+        assert isinstance(result, SessionMessage)
+        root = result.message.root
+        assert isinstance(root, JSONRPCNotification)
+        assert root.method == "notifications/claude/channel"
+        params = root.params or {}
+        assert json.loads(params["content"])["ticket_id"] == "T-10"
+
+    def test_exception_skipped(self) -> None:
+        import anyio
+
+        exc = Exception("sse error")
+
+        async def _run() -> int:
+            send_in, recv_in = anyio.create_memory_object_stream[Any](max_buffer_size=5)
+            send_out, recv_out = anyio.create_memory_object_stream[Any](
+                max_buffer_size=5
+            )
+            await send_in.send(exc)
+            await send_in.aclose()
+
+            await _relay_upstream(recv_in, send_out)
+            await send_out.aclose()
+
+            count = 0
+            async for _ in recv_out:
+                count += 1
+            return count
+
+        count = anyio.run(_run)
+        assert count == 0
+
+    def test_non_queue_event_skipped(self) -> None:
+        import anyio
+
+        notif = JSONRPCNotification(
+            jsonrpc="2.0",
+            method="notifications/message",
+            params={"data": {"notification_type": "other"}},
+        )
+        msg = SessionMessage(message=JSONRPCMessage(notif))
+
+        async def _run() -> int:
+            send_in, recv_in = anyio.create_memory_object_stream[Any](max_buffer_size=5)
+            send_out, recv_out = anyio.create_memory_object_stream[Any](
+                max_buffer_size=5
+            )
+            await send_in.send(msg)
+            await send_in.aclose()
+
+            await _relay_upstream(recv_in, send_out)
+            await send_out.aclose()
+
+            count = 0
+            async for _ in recv_out:
+                count += 1
+            return count
+
+        count = anyio.run(_run)
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# TestRunProxyEnvVars
+# ---------------------------------------------------------------------------
+
+
+class TestRunProxyEnvVars:
+    def _invoke_proxy_capture_url(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        client_id: str | None = None,
+    ) -> str:
+        """Invoke run_proxy, capturing the SSE URL via sse_client patch."""
+        import contextlib
+        from contextlib import asynccontextmanager
+
+        import mcp.client.sse as _sse_mod
+        from cw.cw_queue_events_channel import run_proxy
+
+        captured: list[str] = []
+
+        class _StopEarly(Exception):  # noqa: N818
+            pass
+
+        @asynccontextmanager
+        async def _fake_sse_client(url: str, **_kw: Any) -> Any:
+            captured.append(url)
+            raise _StopEarly
+            yield
+
+        monkeypatch.setattr(_sse_mod, "sse_client", _fake_sse_client)
+
+        with contextlib.suppress(_StopEarly, RuntimeError):
+            run_proxy(client_id=client_id)
+
+        return captured[0] if captured else ""
+
+    def test_default_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CW_QUEUE_EVENTS_BASE_URL", raising=False)
+        monkeypatch.delenv("CW_QUEUE_EVENTS_CLIENT_ID", raising=False)
+        url = self._invoke_proxy_capture_url(monkeypatch)
+        parsed = urllib.parse.urlparse(url)
+        assert parsed.scheme + "://" + parsed.netloc == _DEFAULT_BASE_URL
+        assert parsed.path == "/sse/"
+
+    def test_custom_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CW_QUEUE_EVENTS_BASE_URL", "http://example.com:9999")
+        monkeypatch.delenv("CW_QUEUE_EVENTS_CLIENT_ID", raising=False)
+        url = self._invoke_proxy_capture_url(monkeypatch)
+        parsed = urllib.parse.urlparse(url)
+        assert parsed.netloc == "example.com:9999"
+        assert parsed.path == "/sse/"
+
+    def test_custom_client_id_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CW_QUEUE_EVENTS_BASE_URL", raising=False)
+        monkeypatch.setenv("CW_QUEUE_EVENTS_CLIENT_ID", "my-custom-id")
+        url = self._invoke_proxy_capture_url(monkeypatch)
+        parsed = urllib.parse.urlparse(url)
+        params = urllib.parse.parse_qs(parsed.query)
+        assert params.get("client_id") == ["my-custom-id"]
+
+    def test_client_id_param_overrides_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CW_QUEUE_EVENTS_BASE_URL", raising=False)
+        monkeypatch.setenv("CW_QUEUE_EVENTS_CLIENT_ID", "env-id")
+        url = self._invoke_proxy_capture_url(monkeypatch, client_id="explicit-id")
+        parsed = urllib.parse.urlparse(url)
+        params = urllib.parse.parse_qs(parsed.query)
+        assert params.get("client_id") == ["explicit-id"]
+
+    def test_default_client_id_is_hostname(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CW_QUEUE_EVENTS_BASE_URL", raising=False)
+        monkeypatch.delenv("CW_QUEUE_EVENTS_CLIENT_ID", raising=False)
+        url = self._invoke_proxy_capture_url(monkeypatch)
+        parsed = urllib.parse.urlparse(url)
+        params = urllib.parse.parse_qs(parsed.query)
+        assert params.get("client_id") == [socket.gethostname()]
+
+    def test_sse_url_uses_trailing_slash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SSE URL must use /sse/ to connect directly, not /sse which redirects."""
+        monkeypatch.delenv("CW_QUEUE_EVENTS_BASE_URL", raising=False)
+        monkeypatch.delenv("CW_QUEUE_EVENTS_CLIENT_ID", raising=False)
+        url = self._invoke_proxy_capture_url(monkeypatch)
+        parsed = urllib.parse.urlparse(url)
+        assert parsed.path == "/sse/", f"Expected /sse/ path, got {parsed.path!r}"
+
+
+# ---------------------------------------------------------------------------
+# TestCLI
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_queue_channel_proxy_help(self) -> None:
+        from cw.cli import main
+
+        result = CliRunner().invoke(main, ["queue-channel", "proxy", "--help"])
+        assert result.exit_code == 0
+        assert "--client-id" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TestClientIdFilter
+# ---------------------------------------------------------------------------
+
+
+class TestClientIdFilter:
+    def test_matching_client_id_relayed(self) -> None:
+        import anyio
+
+        msg = _make_queue_session_message("T-20", "acme", "queue.ticket_enqueued")
+
+        async def _run() -> int:
+            send_in, recv_in = anyio.create_memory_object_stream[Any](max_buffer_size=5)
+            send_out, recv_out = anyio.create_memory_object_stream[Any](
+                max_buffer_size=5
+            )
+            await send_in.send(msg)
+            await send_in.aclose()
+
+            await _relay_upstream(recv_in, send_out, client_id="acme")
+            await send_out.aclose()
+
+            count = 0
+            async for _ in recv_out:
+                count += 1
+            return count
+
+        count = anyio.run(_run)
+        assert count == 1
+
+    def test_non_matching_client_id_suppressed(self) -> None:
+        import anyio
+
+        msg = _make_queue_session_message("T-21", "acme", "queue.ticket_enqueued")
+
+        async def _run() -> int:
+            send_in, recv_in = anyio.create_memory_object_stream[Any](max_buffer_size=5)
+            send_out, recv_out = anyio.create_memory_object_stream[Any](
+                max_buffer_size=5
+            )
+            await send_in.send(msg)
+            await send_in.aclose()
+
+            await _relay_upstream(recv_in, send_out, client_id="other-client")
+            await send_out.aclose()
+
+            count = 0
+            async for _ in recv_out:
+                count += 1
+            return count
+
+        count = anyio.run(_run)
+        assert count == 0
+
+    def test_no_client_id_relays_all(self) -> None:
+        import anyio
+
+        msg1 = _make_queue_session_message("T-22", "acme", "queue.ticket_enqueued")
+        msg2 = _make_queue_session_message("T-23", "other", "queue.ticket_claimed")
+
+        async def _run() -> int:
+            send_in, recv_in = anyio.create_memory_object_stream[Any](max_buffer_size=5)
+            send_out, recv_out = anyio.create_memory_object_stream[Any](
+                max_buffer_size=5
+            )
+            await send_in.send(msg1)
+            await send_in.send(msg2)
+            await send_in.aclose()
+
+            await _relay_upstream(recv_in, send_out, client_id=None)
+            await send_out.aclose()
+
+            count = 0
+            async for _ in recv_out:
+                count += 1
+            return count
+
+        count = anyio.run(_run)
+        assert count == 2


### PR DESCRIPTION
## Summary

Adds the `cw-queue-events` MCP channel publishing queue state deltas (subscriber/broadcast/cursor infra + server + CLI wiring) — closes #125.

- feat: implement cw-queue-events channel files
- fix: address review findings in cw-queue-events channel

Produced by `/auto-dev` (session ce223ec8), Track C wave-3 re-dispatch on a 90min budget (the prior 60min attempt timed out mid-review). Reached `review_pending_approval` at stage3_review; 5 initial must-fixes resolved across 1 fix cycle. Health recommendation: **PROCEED** (agent confidence **HIGH**, no incomplete-risk, no shortcuts).

## Design note (accepted, not deferred)

The subscriber/broadcast/cursor infrastructure intentionally mirrors `cw_pr_events_server` via a flat-file copy pattern — an explicit plan decision. At 2 occurrences it sits below the PYTHON-PATTERNS.md 3-occurrence DRY-extraction threshold. If a third channel is added, consolidate to a shared base then.

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or channel infra

🤖 Shipped via /cw-followup (ship-as-is)