### PR TITLE
refactor(cw-queue-peek): extract helpers to reduce find_transcript_for_ticket size

### DIFF
--- a/.claude/scripts/cw_queue_peek.py
+++ b/.claude/scripts/cw_queue_peek.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 DEV_QUEUE = Path.home() / ".local/share/cw/dev_queue.json"
+CW_STATE = Path.home() / ".local/share/cw/sessions.json"
 CLAUDE_PROJECTS = Path.home() / ".claude/projects"
 NOW = dt.datetime.now(dt.UTC)
 
@@ -63,17 +64,53 @@ def load_running_tasks(client: str | None) -> list[dict[str, Any]]:
     return out
 
 
-def find_transcript_for_ticket(ticket_id: str) -> Path | None:
+def load_claude_session_id(session_id: str | None) -> str | None:
+    """Map TicketTask.session_id (8-char) to claude_session_id (full UUID)."""
+    if not session_id or not CW_STATE.exists():
+        return None
+    try:
+        data = json.loads(CW_STATE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    for sess in data.get("sessions", []):
+        if sess.get("id") == session_id:
+            raw = sess.get("claude_session_id")
+            return str(raw) if raw is not None else None
+    return None
+
+
+def find_transcript_for_ticket(
+    ticket_id: str, session_id: str | None = None
+) -> Path | None:
     """Locate the main /auto-dev transcript jsonl for a ticket.
 
-    A worker's project directory can contain multiple jsonls — the main
-    /auto-dev session plus one jsonl per fork-session subagent. The main
-    session has the earliest first user message (it spawned the others)
-    and its first user message references "/auto-dev <ticket>".
+    A worker's project directory can contain multiple jsonls across multiple
+    dispatch attempts. Candidate selection works in two steps:
+
+    1. If session_id is provided, resolve it to a claude_session_id via
+       sessions.json and return the matching jsonl directly (exact match).
+    2. Fallback heuristic: prefer jsonls whose first user message references
+       "/auto-dev <ticket>" (score 0), then within that group pick the most
+       recent run by first_user_ts (latest first). This prevents a reused
+       worktree from returning stale transcripts from an earlier dispatch.
     """
     if not CLAUDE_PROJECTS.exists():
         return None
-    candidates: list[tuple[Path, str]] = []  # (path, first_user_ts)
+
+    # Primary path: exact session match via sessions.json
+    claude_id = load_claude_session_id(session_id)
+    if claude_id:
+        for proj in CLAUDE_PROJECTS.iterdir():
+            if not proj.is_dir():
+                continue
+            if f"auto-dev-{ticket_id}" not in proj.name:
+                continue
+            candidate = proj / f"{claude_id}.jsonl"
+            if candidate.exists():
+                return candidate
+
+    # Fallback heuristic
+    candidates: list[tuple[Path, int, str]] = []  # (path, score, first_user_ts)
     for proj in CLAUDE_PROJECTS.iterdir():
         if not proj.is_dir():
             continue
@@ -100,13 +137,17 @@ def find_transcript_for_ticket(ticket_id: str) -> Path | None:
                             if isinstance(c, dict) and c.get("type") == "text":
                                 first_user_text += c.get("text", "")
                     break
-            # Prefer jsonls whose first user message references /auto-dev
             score = 0 if f"/auto-dev {ticket_id}" in first_user_text else 1
-            candidates.append((jsonl, f"{score}-{first_user_ts}"))
+            candidates.append((jsonl, score, first_user_ts))
+
     if not candidates:
         return None
-    # Sort: prefer /auto-dev-prefixed (score 0), then earliest first_user_ts
-    candidates.sort(key=lambda c: c[1])
+
+    # Two-pass stable sort: latest timestamp first, then score ascending.
+    # Result: score=0 (main session) beats score=1 (subagents); among score=0
+    # candidates across multiple runs, the most recent run's transcript wins.
+    candidates.sort(key=lambda c: c[2], reverse=True)  # latest timestamp first
+    candidates.sort(key=lambda c: c[1])  # score 0 before 1 (stable)
     return candidates[0][0]
 
 
@@ -190,7 +231,7 @@ def gh_pr_state(pr_number: int) -> str:
         if result.returncode != 0:
             return "UNKNOWN"
         data = json.loads(result.stdout)
-        return data.get("state", "UNKNOWN")
+        return str(data.get("state", "UNKNOWN"))
     except (subprocess.SubprocessError, json.JSONDecodeError, OSError):
         return "UNKNOWN"
 
@@ -334,7 +375,7 @@ def main() -> int:
     rows = []
     for t in tasks:
         ticket = t.get("ticket_id")
-        transcript = find_transcript_for_ticket(str(ticket))
+        transcript = find_transcript_for_ticket(str(ticket), t.get("session_id"))
         info = parse_transcript(transcript) if transcript else {}
         rows.append(format_row(t, info))
 

--- a/.claude/scripts/cw_queue_peek.py
+++ b/.claude/scripts/cw_queue_peek.py
@@ -79,43 +79,21 @@ def load_claude_session_id(session_id: str | None) -> str | None:
     return None
 
 
-def find_transcript_for_ticket(
-    ticket_id: str, session_id: str | None = None
-) -> Path | None:
-    """Locate the main /auto-dev transcript jsonl for a ticket.
-
-    A worker's project directory can contain multiple jsonls across multiple
-    dispatch attempts. Candidate selection works in two steps:
-
-    1. If session_id is provided, resolve it to a claude_session_id via
-       sessions.json and return the matching jsonl directly (exact match).
-    2. Fallback heuristic: prefer jsonls whose first user message references
-       "/auto-dev <ticket>" (score 0), then within that group pick the most
-       recent run by first_user_ts (latest first). This prevents a reused
-       worktree from returning stale transcripts from an earlier dispatch.
-    """
+def _matching_project_dirs(ticket_id: str) -> list[Path]:
+    """Return project dirs whose name contains 'auto-dev-{ticket_id}'."""
     if not CLAUDE_PROJECTS.exists():
-        return None
+        return []
+    return [
+        p
+        for p in CLAUDE_PROJECTS.iterdir()
+        if p.is_dir() and f"auto-dev-{ticket_id}" in p.name
+    ]
 
-    # Primary path: exact session match via sessions.json
-    claude_id = load_claude_session_id(session_id)
-    if claude_id:
-        for proj in CLAUDE_PROJECTS.iterdir():
-            if not proj.is_dir():
-                continue
-            if f"auto-dev-{ticket_id}" not in proj.name:
-                continue
-            candidate = proj / f"{claude_id}.jsonl"
-            if candidate.exists():
-                return candidate
 
-    # Fallback heuristic
+def _find_transcript_heuristic(ticket_id: str) -> Path | None:
+    """Heuristic fallback: score by /auto-dev prefix, pick the most recent run."""
     candidates: list[tuple[Path, int, str]] = []  # (path, score, first_user_ts)
-    for proj in CLAUDE_PROJECTS.iterdir():
-        if not proj.is_dir():
-            continue
-        if f"auto-dev-{ticket_id}" not in proj.name:
-            continue
+    for proj in _matching_project_dirs(ticket_id):
         for jsonl in proj.glob("*.jsonl"):
             first_user_ts = ""
             first_user_text = ""
@@ -139,16 +117,33 @@ def find_transcript_for_ticket(
                     break
             score = 0 if f"/auto-dev {ticket_id}" in first_user_text else 1
             candidates.append((jsonl, score, first_user_ts))
-
     if not candidates:
         return None
-
     # Two-pass stable sort: latest timestamp first, then score ascending.
     # Result: score=0 (main session) beats score=1 (subagents); among score=0
     # candidates across multiple runs, the most recent run's transcript wins.
     candidates.sort(key=lambda c: c[2], reverse=True)  # latest timestamp first
     candidates.sort(key=lambda c: c[1])  # score 0 before 1 (stable)
     return candidates[0][0]
+
+
+def find_transcript_for_ticket(
+    ticket_id: str, session_id: str | None = None
+) -> Path | None:
+    """Locate the main /auto-dev transcript jsonl for a ticket.
+
+    If session_id is provided, resolves it to a claude_session_id via
+    sessions.json and returns the matching jsonl directly (exact match).
+    Falls back to a heuristic that prefers the most recent main-session
+    transcript when no exact match is found.
+    """
+    claude_id = load_claude_session_id(session_id)
+    if claude_id:
+        for proj in _matching_project_dirs(ticket_id):
+            candidate = proj / f"{claude_id}.jsonl"
+            if candidate.exists():
+                return candidate
+    return _find_transcript_heuristic(ticket_id)
 
 
 def parse_transcript(path: Path) -> dict[str, Any]:

--- a/tests/test_cw_queue_peek.py
+++ b/tests/test_cw_queue_peek.py
@@ -1,0 +1,260 @@
+"""Tests for cw_queue_peek.py — transcript selection logic."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_peek_module() -> Any:
+    script = Path(__file__).parent.parent / ".claude" / "scripts" / "cw_queue_peek.py"
+    spec = importlib.util.spec_from_file_location("cw_queue_peek", script)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def peek(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
+    """Load the peek module with CLAUDE_PROJECTS and CW_STATE redirected to tmp_path."""
+    mod = _load_peek_module()
+    projects_dir = tmp_path / "projects"
+    projects_dir.mkdir()
+    state_file = tmp_path / "sessions.json"
+    monkeypatch.setattr(mod, "CLAUDE_PROJECTS", projects_dir)
+    monkeypatch.setattr(mod, "CW_STATE", state_file)
+    return mod
+
+
+def _make_jsonl(
+    proj_dir: Path, session_uuid: str, first_ts: str, first_text: str
+) -> Path:
+    """Create a minimal transcript jsonl at proj_dir/{session_uuid}.jsonl."""
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    jsonl = proj_dir / f"{session_uuid}.jsonl"
+    with jsonl.open("w") as f:
+        f.write(json.dumps({"type": "init", "sessionId": session_uuid}) + "\n")
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "sessionId": session_uuid,
+                    "timestamp": first_ts,
+                    "message": {"content": first_text},
+                }
+            )
+            + "\n"
+        )
+    return jsonl
+
+
+def _write_sessions(state_file: Path, sessions: list[dict]) -> None:  # type: ignore[type-arg]
+    state_file.write_text(json.dumps({"sessions": sessions}))
+
+
+# ---------------------------------------------------------------------------
+# find_transcript_for_ticket
+# ---------------------------------------------------------------------------
+
+
+class TestFindTranscriptForTicket:
+    def test_no_project_dir_returns_none(self, peek: Any, tmp_path: Path) -> None:
+        peek.CLAUDE_PROJECTS = tmp_path / "nonexistent"
+        assert peek.find_transcript_for_ticket("143") is None
+
+    def test_no_matching_project_dir_returns_none(
+        self, peek: Any, tmp_path: Path
+    ) -> None:
+        unrelated = peek.CLAUDE_PROJECTS / "-home-cw-auto-dev-999"
+        unrelated.mkdir()
+        assert peek.find_transcript_for_ticket("143") is None
+
+    def test_single_transcript_returned(self, peek: Any, tmp_path: Path) -> None:
+        proj = peek.CLAUDE_PROJECTS / "-home-cw-auto-dev-143"
+        expected = _make_jsonl(
+            proj,
+            "aaaa1111-0000-0000-0000-000000000000",
+            "2026-05-27T01:00:00Z",
+            "/auto-dev 143 --headless",
+        )
+        result = peek.find_transcript_for_ticket("143")
+        assert result == expected
+
+    def test_two_runs_picks_latest(self, peek: Any, tmp_path: Path) -> None:
+        """Regression test for GH #358: two dispatch runs → picks the fresh one."""
+        proj = peek.CLAUDE_PROJECTS / "-home-cw-wt-auto-dev-143"
+        _make_jsonl(
+            proj,
+            "old00000-0000-0000-0000-000000000000",
+            "2026-05-27T02:00:00Z",
+            "/auto-dev 143 --headless",
+        )
+        fresh = _make_jsonl(
+            proj,
+            "fresh000-0000-0000-0000-000000000000",
+            "2026-05-29T02:35:00Z",
+            "/auto-dev 143 --headless",
+        )
+        result = peek.find_transcript_for_ticket("143")
+        assert result == fresh
+
+    def test_session_id_match_selects_exact_jsonl(
+        self, peek: Any, tmp_path: Path
+    ) -> None:
+        """When session_id resolves to a claude_session_id, that exact jsonl is used."""
+        proj = peek.CLAUDE_PROJECTS / "-home-cw-wt-auto-dev-143"
+        fresh_uuid = "23d81c88-0000-0000-0000-000000000000"
+        _make_jsonl(
+            proj,
+            "old00000-0000-0000-0000-000000000000",
+            "2026-05-27T02:00:00Z",
+            "/auto-dev 143 --headless",
+        )
+        fresh = _make_jsonl(
+            proj,
+            fresh_uuid,
+            "2026-05-29T02:35:00Z",
+            "/auto-dev 143 --headless",
+        )
+        _write_sessions(
+            peek.CW_STATE,
+            [{"id": "23d81c88", "claude_session_id": fresh_uuid, "status": "active"}],
+        )
+        result = peek.find_transcript_for_ticket("143", session_id="23d81c88")
+        assert result == fresh
+
+    def test_session_id_not_in_sessions_json_falls_back_to_latest(
+        self, peek: Any, tmp_path: Path
+    ) -> None:
+        """If session_id has no match in sessions.json, falls back to latest."""
+        proj = peek.CLAUDE_PROJECTS / "-home-cw-wt-auto-dev-143"
+        _make_jsonl(
+            proj,
+            "old00000-0000-0000-0000-000000000000",
+            "2026-05-27T02:00:00Z",
+            "/auto-dev 143 --headless",
+        )
+        fresh = _make_jsonl(
+            proj,
+            "fresh000-0000-0000-0000-000000000000",
+            "2026-05-29T02:35:00Z",
+            "/auto-dev 143 --headless",
+        )
+        _write_sessions(peek.CW_STATE, [])
+        result = peek.find_transcript_for_ticket("143", session_id="unknown1")
+        assert result == fresh
+
+    def test_session_id_resolves_but_jsonl_missing_falls_back_to_latest(
+        self, peek: Any, tmp_path: Path
+    ) -> None:
+        """If session resolves but jsonl doesn't exist on disk, falls back to latest."""
+        proj = peek.CLAUDE_PROJECTS / "-home-cw-wt-auto-dev-143"
+        _make_jsonl(
+            proj,
+            "old00000-0000-0000-0000-000000000000",
+            "2026-05-27T02:00:00Z",
+            "/auto-dev 143 --headless",
+        )
+        fresh = _make_jsonl(
+            proj,
+            "fresh000-0000-0000-0000-000000000000",
+            "2026-05-29T02:35:00Z",
+            "/auto-dev 143 --headless",
+        )
+        # session maps to a UUID that has no corresponding jsonl file
+        _write_sessions(
+            peek.CW_STATE,
+            [
+                {
+                    "id": "23d81c88",
+                    "claude_session_id": "23d81c88-0000-0000-0000-000000000000",
+                    "status": "active",
+                }
+            ],
+        )
+        result = peek.find_transcript_for_ticket("143", session_id="23d81c88")
+        assert result == fresh
+
+    def test_main_vs_subagent_within_single_run(
+        self, peek: Any, tmp_path: Path
+    ) -> None:
+        """Within one run, main session (score=0) wins over subagent (score=1)."""
+        proj = peek.CLAUDE_PROJECTS / "-home-cw-wt-auto-dev-143"
+        main = _make_jsonl(
+            proj,
+            "main0000-0000-0000-0000-000000000000",
+            "2026-05-29T02:35:00Z",
+            "/auto-dev 143 --headless",
+        )
+        # Subagent: different first user text → score=1 but later timestamp
+        _make_jsonl(
+            proj,
+            "sub00000-0000-0000-0000-000000000000",
+            "2026-05-29T02:36:00Z",
+            "Implement the fix in file.py per the plan",
+        )
+        result = peek.find_transcript_for_ticket("143")
+        assert result == main
+
+    def test_no_session_id_arg_uses_heuristic(self, peek: Any, tmp_path: Path) -> None:
+        """Calling without session_id still works (backward compat)."""
+        proj = peek.CLAUDE_PROJECTS / "-home-cw-wt-auto-dev-200"
+        expected = _make_jsonl(
+            proj,
+            "bbbb2222-0000-0000-0000-000000000000",
+            "2026-05-29T03:00:00Z",
+            "/auto-dev 200 --headless",
+        )
+        result = peek.find_transcript_for_ticket("200")
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# load_claude_session_id
+# ---------------------------------------------------------------------------
+
+
+class TestLoadClaudeSessionId:
+    def test_returns_none_when_no_state_file(self, peek: Any, tmp_path: Path) -> None:
+        assert peek.load_claude_session_id("abc12345") is None
+
+    def test_returns_none_when_session_id_is_none(
+        self, peek: Any, tmp_path: Path
+    ) -> None:
+        assert peek.load_claude_session_id(None) is None
+
+    def test_returns_claude_session_id_when_found(
+        self, peek: Any, tmp_path: Path
+    ) -> None:
+        uuid = "23d81c88-1234-5678-abcd-000000000000"
+        _write_sessions(
+            peek.CW_STATE,
+            [{"id": "23d81c88", "claude_session_id": uuid, "status": "active"}],
+        )
+        assert peek.load_claude_session_id("23d81c88") == uuid
+
+    def test_returns_none_when_id_not_in_sessions(
+        self, peek: Any, tmp_path: Path
+    ) -> None:
+        _write_sessions(
+            peek.CW_STATE,
+            [
+                {
+                    "id": "other123",
+                    "claude_session_id": "other123-0000-0000-0000-000000000000",
+                }
+            ],
+        )
+        assert peek.load_claude_session_id("notfound") is None
+
+    def test_handles_corrupt_sessions_json_gracefully(
+        self, peek: Any, tmp_path: Path
+    ) -> None:
+        peek.CW_STATE.write_text("{not valid json}")
+        assert peek.load_claude_session_id("abc12345") is None


### PR DESCRIPTION
## Summary

- refactor(cw-queue-peek): extract helpers to reduce find_transcript_for_ticket size
- fix(cw-queue-peek): pick latest transcript for reused worktrees

Fixes #358.

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors on touched files
- [ ] pytest — 1306 passed
- [ ] Regression test: two dispatch transcripts → fresh one selected (`test_two_runs_picks_latest`)
- [ ] Session-id exact match: `test_session_id_match_selects_exact_jsonl`
- [ ] No regression: main-vs-subagent within single run (`test_main_vs_subagent_within_single_run`)

🤖 Shipped via /prep-pr + project /ship-it