### PR TITLE
chore(ci): schedule native nightly, de-schedule cmux nightly

### DIFF
--- a/.github/workflows/nightly-native.yml
+++ b/.github/workflows/nightly-native.yml
@@ -1,7 +1,11 @@
 name: Nightly (native daemon integration)
 
 on:
-  # TODO: add schedule trigger once API budget allocated — see #110
+  schedule:
+    # 09:00 UTC daily (~02:00 PT / ~05:00 ET) — off peak. Starts the
+    # 2-week native-soak clock toward 1.0 (gates #242/#119/#120). The cmux
+    # nightly is de-scheduled in favour of this native path (#119 removes cmux).
+    - cron: "0 9 * * *"
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,9 @@
 name: Nightly (cmux integration)
 
 on:
-  schedule:
-    # 09:00 UTC daily (~02:00 PT / ~05:00 ET) — off peak
-    - cron: "0 9 * * *"
+  # De-scheduled: the cmux backend is slated for removal (#119), so the soak
+  # clock runs on the native nightly (nightly-native.yml) instead. Kept as a
+  # manual dispatch for on-demand cmux integration checks until #119 lands.
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
## What

- **nightly-native.yml**: add `schedule:` (daily 09:00 UTC). Was `workflow_dispatch`-only, gated on API budget (#110 TODO). This **starts the 2-week native-soak clock** — the real critical-path gate for #242/#119/#120.
- **nightly.yml** (cmux integration): **remove** `schedule:`, leave `workflow_dispatch`. The cmux backend is slated for removal (#119); running it nightly on macOS minutes is wasted spend. Manual dispatch retained until #119 lands.

## Why

Operator/budget decision to begin the soak toward 1.0. Soak runs on the native path since cmux is being deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)