### PR TITLE
fix(dev-queue): gracefully skip clients with missing workspace dirs in refresh-all

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -49,7 +49,7 @@ from cw.dev_queue import (
 from cw.dispatch import _DISPATCH_CONSUMER, _apply_events_to_store, run_dispatch_loop
 from cw.doctor import format_report, format_report_json, run_doctor
 from cw.events import advance_cursor, read_events, record_event
-from cw.exceptions import CwError, WorktreeError
+from cw.exceptions import CwError, MissingWorkspaceError, WorktreeError
 from cw.models import (
     ClientConfig,
     CompletionReason,
@@ -1635,6 +1635,9 @@ def dev_queue_refresh_all() -> None:
                 click.echo(f"{client.name}: already up to date ({before[:8]})")
             else:
                 click.echo(f"{client.name}: updated {before[:8]}..{after[:8]}")
+        except MissingWorkspaceError as exc:
+            click.echo(f"{client.name}: SKIP — {exc}", err=True)
+            # missing workspace is config-hygiene; does not contribute to had_error
         except WorktreeError as exc:
             click.echo(f"{client.name}: ERROR — {exc}", err=True)
             had_error = True

--- a/src/cw/exceptions.py
+++ b/src/cw/exceptions.py
@@ -15,6 +15,17 @@ class WorktreeError(CwError):
     __slots__ = ()
 
 
+class MissingWorkspaceError(WorktreeError):
+    """Raised when a client's workspace directory does not exist.
+
+    This is a config-hygiene condition (stale/misconfigured entry), not a git
+    operation failure. Callers should treat it as a soft skip rather than an
+    error that contributes to exit-1 semantics.
+    """
+
+    __slots__ = ()
+
+
 class HookContextConflictError(CwError):
     """A user-owned ``.claude/settings.local.json`` already exists.
 

--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -10,7 +10,7 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from cw.exceptions import WorktreeError
+from cw.exceptions import MissingWorkspaceError, WorktreeError
 
 if TYPE_CHECKING:
     from cw.models import ClientConfig
@@ -307,13 +307,17 @@ def fast_forward_main(client: ClientConfig) -> tuple[str, str]:
     """Fast-forward the client's local default branch to origin.
 
     Runs ``git pull --ff-only origin <default_branch>`` in the client's git
-    directory.  Raises :exc:`WorktreeError` if the pull fails (non-zero exit).
+    directory.  Raises :exc:`MissingWorkspaceError` if the workspace directory
+    does not exist, or :exc:`WorktreeError` if the pull fails (non-zero exit).
 
     Returns:
         ``(before_sha, after_sha)`` — the SHA before and after the pull.
         When already up to date both values are equal.
     """
     git_dir = _git_dir(client)
+    if not git_dir.exists():
+        msg = f"workspace missing for {client.name} ({git_dir})"
+        raise MissingWorkspaceError(msg)
     default_branch = client.default_branch
     before_sha = _run_git("rev-parse", default_branch, cwd=git_dir).stdout.strip()
     _run_git("pull", "--ff-only", "origin", default_branch, cwd=git_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3635,6 +3635,110 @@ class TestDevQueueRefreshAll:
         )
         assert len(events) == 0
 
+    def test_refresh_all_skips_missing_workspace_client(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """MissingWorkspaceError for one client -> SKIP line on stderr.
+
+        Other clients should still be called.
+        """
+        from cw.exceptions import MissingWorkspaceError
+
+        ws_b = tmp_path / "ws-b"
+        ws_b.mkdir()
+        self._write_clients_yaml(
+            tmp_config_dir,
+            [("client-a", str(tmp_path / "nonexistent")), ("client-b", str(ws_b))],
+        )
+
+        called_clients: list[str] = []
+
+        def _mock_ff(client: object) -> tuple[str, str]:
+            from cw.models import ClientConfig
+
+            assert isinstance(client, ClientConfig)
+            called_clients.append(client.name)
+            if client.name == "client-a":
+                msg = "workspace missing for client-a"
+                raise MissingWorkspaceError(msg)
+            return ("aaa", "bbb")
+
+        monkeypatch.setattr("cw.cli.fast_forward_main", _mock_ff)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["dev-queue", "refresh-all"])
+        assert "client-a" in called_clients
+        assert "client-b" in called_clients
+        assert "SKIP" in result.output
+
+    def test_refresh_all_missing_workspace_does_not_set_exit_1(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Missing workspace alone -> exit code 0."""
+        from cw.exceptions import MissingWorkspaceError
+
+        ws = tmp_path / "nonexistent"
+        self._write_clients_yaml(tmp_config_dir, [("client-a", str(ws))])
+
+        def _mock_ff(client: object) -> tuple[str, str]:
+            msg = "workspace missing for client-a"
+            raise MissingWorkspaceError(msg)
+
+        monkeypatch.setattr("cw.cli.fast_forward_main", _mock_ff)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["dev-queue", "refresh-all"])
+        assert result.exit_code == 0
+
+    def test_refresh_all_missing_workspace_mixed_with_real_failure(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """One missing workspace (soft skip) + one real WorktreeError.
+
+        Expects exit 1 and both SKIP and ERROR messages printed.
+        """
+        from cw.exceptions import MissingWorkspaceError, WorktreeError
+
+        ws_c = tmp_path / "ws-c"
+        ws_c.mkdir()
+        self._write_clients_yaml(
+            tmp_config_dir,
+            [
+                ("client-a", str(tmp_path / "nonexistent")),
+                ("client-b", str(tmp_path / "ws-b")),
+                ("client-c", str(ws_c)),
+            ],
+        )
+
+        def _mock_ff(client: object) -> tuple[str, str]:
+            from cw.models import ClientConfig
+
+            assert isinstance(client, ClientConfig)
+            if client.name == "client-a":
+                msg = "workspace missing for client-a"
+                raise MissingWorkspaceError(msg)
+            if client.name == "client-b":
+                msg = "ff failed"
+                raise WorktreeError(msg)
+            return ("aaa", "bbb")
+
+        monkeypatch.setattr("cw.cli.fast_forward_main", _mock_ff)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["dev-queue", "refresh-all"])
+        assert result.exit_code == 1
+        assert "SKIP" in result.output
+        assert "ERROR" in result.output
+
 
 # ---------------------------------------------------------------------------
 # TestDevQueueAddTimeout (GitHub issue #265)

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -840,9 +840,11 @@ class TestFastForwardMain:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """When already current, before_sha == after_sha."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
         client = ClientConfig(
             name="test-client",
-            workspace_path=tmp_path / "ws",
+            workspace_path=ws,
             default_branch="main",
         )
         sha = "abc123def456abc123def456abc123def456abc1"
@@ -863,9 +865,11 @@ class TestFastForwardMain:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """After a fast-forward, before_sha != after_sha."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
         client = ClientConfig(
             name="test-client",
-            workspace_path=tmp_path / "ws",
+            workspace_path=ws,
             default_branch="main",
         )
         old_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -897,9 +901,11 @@ class TestFastForwardMain:
         """WorktreeError raised on pull failure (non-FF or network error)."""
         from cw.exceptions import WorktreeError as _WorktreeError
 
+        ws = tmp_path / "ws"
+        ws.mkdir()
         client = ClientConfig(
             name="test-client",
-            workspace_path=tmp_path / "ws",
+            workspace_path=ws,
             default_branch="main",
         )
         old_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -919,6 +925,24 @@ class TestFastForwardMain:
         monkeypatch.setattr("cw.worktree._run_git", mock_run)
 
         with pytest.raises(WorktreeError, match="would clobber"):
+            fast_forward_main(client)
+
+    def test_fast_forward_main_raises_missing_workspace_error_when_dir_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """fast_forward_main raises MissingWorkspaceError when git_dir does not exist.
+
+        The guard fires before any git ops, so no _run_git mock is needed.
+        """
+        from cw.exceptions import MissingWorkspaceError
+
+        client = ClientConfig(
+            name="absent-client",
+            workspace_path=tmp_path / "nonexistent-workspace",
+            default_branch="main",
+        )
+
+        with pytest.raises(MissingWorkspaceError, match="absent-client"):
             fast_forward_main(client)
 
 


### PR DESCRIPTION
## Summary

- fix(dev-queue): gracefully skip clients with missing workspace dirs in refresh-all

Adds `MissingWorkspaceError(WorktreeError)` subclass and guard in `fast_forward_main`; `dev_queue_refresh_all` catches it as a soft skip instead of crashing.

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

Closes #356

🤖 Shipped via /prep-pr + project /ship-it