### PR TITLE
fix(contract): coerce no_op+stray-pr to clean no_op at parse boundary (#367)

### DIFF
--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -693,6 +693,34 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
             ),
         )
 
+    # Pre-validation normalization for no_op + stray pr/branch/commits (issue
+    # #367). The producer sometimes emits status=no_op alongside a non-null pr
+    # or branch when the pipeline ran far enough to create a branch/PR before
+    # determining no work was needed. AutoDevResult._check_invariants (§3.3)
+    # correctly rejects this shape; leniency here applies only at the stdout-
+    # parse boundary where producer drift is expected. Does NOT apply to
+    # shipped or blocked — those contradictions are genuinely ambiguous and
+    # should still fail loudly.
+    if raw_status == "no_op":
+        stray: list[str] = []
+        if payload.get("pr") is not None:
+            stray.append("pr")
+            payload["pr"] = None
+        if payload.get("branch") is not None:
+            stray.append("branch")
+            payload["branch"] = None
+        if payload.get("commits"):
+            stray.append("commits")
+            payload["commits"] = []
+        if stray:
+            _log.warning(
+                "auto-dev: no_op sentinel carried non-null %s; coercing to clean "
+                "no_op (ticket=%s, schema_version=%s)",
+                stray,
+                payload.get("ticket_id", "unknown"),
+                payload.get("schema_version"),
+            )
+
     try:
         return AutoDevResult.model_validate(payload)
     except ValidationError as exc:

--- a/tests/test_auto_dev_result.py
+++ b/tests/test_auto_dev_result.py
@@ -904,6 +904,49 @@ class TestPreFlightNoOp:
         assert result.plan_source == "none"
         assert result.schema_version == 2
 
+    def test_no_op_with_stray_pr_coerced_to_clean_no_op(self) -> None:
+        """parse_stdout coerces no_op+non-null pr to a clean no_op (issue #367).
+
+        A producer bug emitted status=no_op alongside a non-null pr field,
+        causing the §3.3 invariant to reject it as validation_failed/blocked.
+        The strict AutoDevResult.model_validate still rejects the shape
+        (see test_no_op_rejects_pr); leniency applies only at the parse boundary.
+        """
+        p = _no_op_payload()
+        p["pr"] = {
+            "number": 42,
+            "url": "https://github.com/x/y/pull/42",
+            "auto_merge": True,
+            "base": "main",
+        }
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "no_op"
+        assert result.pr is None
+        assert result.next_actions == ["close_issue_as_completed"]
+
+    def test_no_op_with_stray_branch_and_commits_coerced(self) -> None:
+        """parse_stdout strips stray branch/commits from no_op sentinels."""
+        p = _no_op_payload()
+        p["branch"] = "dev/gen-327-no-op"
+        p["commits"] = ["abc1234", "def5678"]
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "no_op"
+        assert result.branch is None
+        assert result.commits == []
+
+    def test_shipped_with_null_pr_still_fails_loudly(self) -> None:
+        """Coerce logic does NOT apply to shipped; shipped+null pr still rejects."""
+        p = _no_op_payload()
+        p["status"] = "shipped"
+        p["pr"] = None
+        p["stage_reached"] = "stage5_post_create"
+        p["scope"]["lines_actual"] = 10
+        p["next_actions"] = ["wait_for_ci"]
+        with pytest.raises(ValidationError, match="pr must be non-null"):
+            AutoDevResult.model_validate(p)
+
     def test_stage1_pre_flight_rejects_incompatible_status(self) -> None:
         """Pre-flight exit only allows {no_op, blocked} — shipped et al are rejected.
 


### PR DESCRIPTION
## Summary

- fix(contract): coerce no_op+stray-pr to clean no_op at parse boundary (#367)
- test(contract): add regression tests for no_op+stray-pr coerce path (#367)

Adds pre-validation normalization in `parse_stdout` to coerce a `no_op` sentinel with stray non-null `pr`/`branch`/`commits` fields to a clean `no_op` (with a warning log) rather than failing to `validation_failed`/`blocked`. The strict `AutoDevResult._check_invariants` (§3.3) is unchanged — leniency applies only at the stdout-parse boundary where producer drift is expected. `shipped` and `blocked` contradictions still fail loudly.

Closes #367.

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] `test_no_op_with_stray_pr_coerced_to_clean_no_op` — primary regression test
- [ ] `test_no_op_with_stray_branch_and_commits_coerced` — branch/commits coerce path
- [ ] `test_shipped_with_null_pr_still_fails_loudly` — boundary guard
- [ ] Existing `test_no_op_rejects_pr` still passes (strict construction path unchanged)

🤖 Shipped via /prep-pr + project /ship-it