### PR TITLE
refactor(tests): remove 32 type: ignore suppressions via annotation fixes (#361)

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
+    import click
     import pytest
 
     from cw.cmux import FakeCmuxAdapter
@@ -2855,7 +2856,9 @@ class TestCompleteCallbacks:
         )
 
         # None ctx/param are fine - callbacks don't use them
-        items = _complete_client(None, None, "a")  # type: ignore[arg-type]
+        items = _complete_client(
+            cast("click.Context", None), cast("click.Parameter", None), "a"
+        )
         names = [item.value for item in items]
         assert "alpha" in names
         assert "apricot" in names
@@ -2874,7 +2877,9 @@ class TestCompleteCallbacks:
             "    workspace_path: /tmp/b\n"
         )
 
-        items = _complete_client(None, None, "")  # type: ignore[arg-type]
+        items = _complete_client(
+            cast("click.Context", None), cast("click.Parameter", None), ""
+        )
         names = [item.value for item in items]
         assert "alpha" in names
         assert "beta" in names
@@ -2906,7 +2911,9 @@ class TestCompleteCallbacks:
         )
         save_state(state)
 
-        items = _complete_session(None, None, "")  # type: ignore[arg-type]
+        items = _complete_session(
+            cast("click.Context", None), cast("click.Parameter", None), ""
+        )
         names = [item.value for item in items]
         assert "test-client/impl" in names
         assert "test-client/idea" not in names
@@ -2938,7 +2945,9 @@ class TestCompleteCallbacks:
         )
         save_state(state)
 
-        items = _complete_session(None, None, "alpha")  # type: ignore[arg-type]
+        items = _complete_session(
+            cast("click.Context", None), cast("click.Parameter", None), "alpha"
+        )
         names = [item.value for item in items]
         assert "alpha/impl" in names
         assert "beta/impl" not in names

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,7 +16,7 @@ from cw.doctor import CheckResult, DoctorReport, format_report, run_doctor
 if TYPE_CHECKING:
     import pytest
 
-    from cw.models import ClientConfig, Session
+    from cw.models import ClientConfig, Session, TicketTask
 
 
 def _stub_claude_version_ok(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1076,15 +1077,12 @@ class TestFormatReportFooter:
 class TestCheckClaudeVersion:
     """Direct tests for _check_claude_version via monkeypatched subprocess.run."""
 
-    def _mk_proc(self, stdout: str = "", returncode: int = 0) -> object:
-        class _Proc:
-            pass
-
-        p = _Proc()
-        p.stdout = stdout  # type: ignore[attr-defined]
-        p.stderr = ""  # type: ignore[attr-defined]
-        p.returncode = returncode  # type: ignore[attr-defined]
-        return p
+    def _mk_proc(
+        self, stdout: str = "", returncode: int = 0
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=[], returncode=returncode, stdout=stdout, stderr=""
+        )
 
     def test_version_above_floor_ok_no_warn(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1365,7 +1363,7 @@ class TestWedgePaneIdleButActive:
 
     def _make_active_session(
         self, tmp_path: Path, *, surface_ref: str | None = "s:0.1"
-    ) -> object:
+    ) -> Session:
         from datetime import UTC, datetime
 
         from cw.models import Session, SessionPurpose, SessionStatus
@@ -1396,7 +1394,7 @@ class TestWedgePaneIdleButActive:
         from cw.models import CwState, DevQueueStore
 
         session = self._make_active_session(tmp_path)
-        state = CwState(sessions=[session])  # type: ignore[list-item]
+        state = CwState(sessions=[session])
         save_state(state)
         save_dev_queue(DevQueueStore(tasks=[]))
 
@@ -1427,7 +1425,7 @@ class TestWedgePaneIdleButActive:
         from cw.models import CwState, DevQueueStore
 
         session = self._make_active_session(tmp_path)
-        state = CwState(sessions=[session])  # type: ignore[list-item]
+        state = CwState(sessions=[session])
 
         adapter = FakeCmuxAdapter()
         adapter.set_pane_info("s:0.1", {"cmd": "claude", "last_activity": None})
@@ -1451,7 +1449,7 @@ class TestWedgePaneIdleButActive:
         from cw.models import CwState, DevQueueStore
 
         session = self._make_active_session(tmp_path)
-        state = CwState(sessions=[session])  # type: ignore[list-item]
+        state = CwState(sessions=[session])
 
         adapter = FakeCmuxAdapter()
         adapter.set_pane_info("s:0.1", {"cmd": "bash", "last_activity": None})
@@ -1472,7 +1470,7 @@ class TestWedgePaneIdleButActive:
         from cw.models import CwState, DevQueueStore
 
         session = self._make_active_session(tmp_path, surface_ref=None)
-        state = CwState(sessions=[session])  # type: ignore[list-item]
+        state = CwState(sessions=[session])
 
         adapter = FakeCmuxAdapter()
         queue = DevQueueStore(tasks=[])
@@ -1490,7 +1488,7 @@ class TestWedgePaneIdleButActive:
         from cw.models import CwState, DevQueueStore
 
         session = self._make_active_session(tmp_path)
-        state = CwState(sessions=[session])  # type: ignore[list-item]
+        state = CwState(sessions=[session])
 
         adapter = FakeCmuxAdapter()
         adapter.set_pane_info("s:0.1", {"cmd": "bash", "last_activity": None})
@@ -1524,7 +1522,7 @@ class TestWedgePaneIdleButActive:
         from cw.models import CwState, DevQueueStore
 
         session = self._make_active_session(tmp_path)
-        state = CwState(sessions=[session])  # type: ignore[list-item]
+        state = CwState(sessions=[session])
 
         adapter = FakeCmuxAdapter()
         # inspect_pane returns {} (default) — fail-open, skip
@@ -1649,7 +1647,9 @@ class TestWedgeTaskRunningNoSession:
 class TestWedgeTaskRunningCompletedSession:
     """wedge/task-running-completed-session detection logic."""
 
-    def _make_completed_session(self, tmp_path: Path, sid: str = "comp-sess") -> object:
+    def _make_completed_session(
+        self, tmp_path: Path, sid: str = "comp-sess"
+    ) -> Session:
         from datetime import UTC, datetime
 
         from cw.models import CompletionReason, Session, SessionPurpose, SessionStatus
@@ -1678,7 +1678,7 @@ class TestWedgeTaskRunningCompletedSession:
             status=QueueItemStatus.RUNNING,
             session_id="comp-sess",
         )
-        state = CwState(sessions=[session])  # type: ignore[list-item]
+        state = CwState(sessions=[session])
         queue = DevQueueStore(tasks=[task])
         findings = _check_wedge_task_running_completed_session(state, queue)
         assert len(findings) == 1
@@ -1750,7 +1750,7 @@ class TestWedgeTaskRunningCompletedSession:
             status=QueueItemStatus.RUNNING,
             session_id="comp-sess-field",
         )
-        state = CwState(sessions=[session])  # type: ignore[list-item]
+        state = CwState(sessions=[session])
         queue = DevQueueStore(tasks=[task])
         findings = _check_wedge_task_running_completed_session(state, queue)
         assert len(findings) == 1
@@ -1766,7 +1766,7 @@ class TestWedgeRepoAheadOfQueue:
         tmp_path: Path,
         ticket_id: str = "TST-R1",
         session_id: str | None = None,
-    ) -> object:
+    ) -> TicketTask:
         from cw.models import QueueItemStatus, TicketTask
 
         return TicketTask(
@@ -1786,7 +1786,7 @@ class TestWedgeRepoAheadOfQueue:
 
         task = self._make_running_task(tmp_path, ticket_id="TST-R1")
         state = CwState(sessions=[])
-        queue = DevQueueStore(tasks=[task])  # type: ignore[list-item]
+        queue = DevQueueStore(tasks=[task])
 
         call_count = [0]
 
@@ -1822,7 +1822,7 @@ class TestWedgeRepoAheadOfQueue:
 
         task = self._make_running_task(tmp_path, ticket_id="TST-R2")
         state = CwState(sessions=[])
-        queue = DevQueueStore(tasks=[task])  # type: ignore[list-item]
+        queue = DevQueueStore(tasks=[task])
 
         class _Proc:
             def __init__(self, rc: int, out: str) -> None:
@@ -1851,7 +1851,7 @@ class TestWedgeRepoAheadOfQueue:
 
         task = self._make_running_task(tmp_path, ticket_id="TST-R3")
         state = CwState(sessions=[])
-        queue = DevQueueStore(tasks=[task])  # type: ignore[list-item]
+        queue = DevQueueStore(tasks=[task])
 
         class _Proc:
             def __init__(self, rc: int, out: str) -> None:
@@ -1877,7 +1877,7 @@ class TestWedgeRepoAheadOfQueue:
 
         task = self._make_running_task(tmp_path, ticket_id="TST-R4")
         state = CwState(sessions=[])
-        queue = DevQueueStore(tasks=[task])  # type: ignore[list-item]
+        queue = DevQueueStore(tasks=[task])
 
         class _Proc:
             def __init__(self, rc: int, out: str) -> None:
@@ -1974,7 +1974,7 @@ class TestWedgeRepoAheadOfQueue:
 class TestWedgeReapRecipes:
     """_reap_wedge_findings applies correct mutations per wedge class."""
 
-    def _make_session(self, tmp_path: Path, sid: str = "reap-sess") -> object:
+    def _make_session(self, tmp_path: Path, sid: str = "reap-sess") -> Session:
         from datetime import UTC, datetime
 
         from cw.models import Session, SessionPurpose, SessionStatus
@@ -2009,7 +2009,7 @@ class TestWedgeReapRecipes:
         )
 
         session = self._make_session(tmp_path)
-        state = CwState(sessions=[session])  # type: ignore[list-item]
+        state = CwState(sessions=[session])
         save_state(state)
 
         task = TicketTask(
@@ -2213,7 +2213,7 @@ class TestWedgeReapRecipes:
         from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
 
         session = self._make_session(tmp_path, sid="no-reap-sess")
-        state = CwState(sessions=[session])  # type: ignore[list-item]
+        state = CwState(sessions=[session])
         save_state(state)
 
         task = TicketTask(

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -38,6 +39,8 @@ from cw.orchestrate import (
     save_dispatch_record,
 )
 
+_RunnerFn = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -65,7 +68,7 @@ def workspace(tmp_path: Path) -> Path:
 @pytest.fixture
 def captured_runner() -> tuple[
     list[list[str]],
-    subprocess.CompletedProcess[str],
+    _RunnerFn,
 ]:
     """Provide a runner that records calls and returns success."""
     calls: list[list[str]] = []
@@ -76,11 +79,11 @@ def captured_runner() -> tuple[
         return completed
 
     # Returning the closure plus the calls list so tests can inspect both.
-    return calls, _runner  # type: ignore[return-value]
+    return calls, _runner
 
 
 @pytest.fixture
-def fake_runner() -> tuple[list[list[str]], object]:
+def fake_runner() -> tuple[list[list[str]], _RunnerFn]:
     """Yield (recorded_calls, runner_callable)."""
     calls: list[list[str]] = []
 
@@ -168,18 +171,18 @@ class TestRetireMergedPRs:
     def test_no_events_returns_empty_list(
         self,
         tmp_orchestrate_dirs: Path,
-        fake_runner: tuple[list[list[str]], object],
+        fake_runner: tuple[list[list[str]], _RunnerFn],
     ) -> None:
         """When there are no pr.merged events, retirement is a no-op."""
         _calls, runner = fake_runner
-        retired = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
+        retired = retire_merged_prs(runner=runner)
         assert retired == []
 
     def test_retires_correlated_session(
         self,
         tmp_orchestrate_dirs: Path,
         workspace: Path,
-        fake_runner: tuple[list[list[str]], object],
+        fake_runner: tuple[list[list[str]], _RunnerFn],
     ) -> None:
         """A pr.merged event marks the correlated session COMPLETED."""
         # Set up state with one ACTIVE session linked via dispatch record.
@@ -189,7 +192,7 @@ class TestRetireMergedPRs:
         _seed_pr_merged("owner/repo", 42)
 
         calls, runner = fake_runner
-        retired = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
+        retired = retire_merged_prs(runner=runner)
 
         # Returned list contains the session ID.
         assert retired == ["sess0001"]
@@ -221,7 +224,7 @@ class TestRetireMergedPRs:
         self,
         tmp_orchestrate_dirs: Path,
         workspace: Path,
-        fake_runner: tuple[list[list[str]], object],
+        fake_runner: tuple[list[list[str]], _RunnerFn],
     ) -> None:
         """A second tick with no new events returns empty and does no work."""
         sess = _make_session("sess0010", workspace)
@@ -230,12 +233,12 @@ class TestRetireMergedPRs:
         _seed_pr_merged("owner/repo", 9)
 
         calls, runner = fake_runner
-        first = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
+        first = retire_merged_prs(runner=runner)
         assert first == ["sess0010"]
         assert len(calls) == 1
 
         # Second call: cursor advanced, nothing left to do.
-        second = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
+        second = retire_merged_prs(runner=runner)
         assert second == []
         assert len(calls) == 1  # no additional review-monitor invocations
 
@@ -243,7 +246,7 @@ class TestRetireMergedPRs:
         self,
         tmp_orchestrate_dirs: Path,
         workspace: Path,
-        fake_runner: tuple[list[list[str]], object],
+        fake_runner: tuple[list[list[str]], _RunnerFn],
     ) -> None:
         """The dispatch record entry is dropped after retirement."""
         sess = _make_session("sess0020", workspace)
@@ -252,7 +255,7 @@ class TestRetireMergedPRs:
         _seed_pr_merged("owner/repo", 11)
 
         _calls, runner = fake_runner
-        retire_merged_prs(runner=runner)  # type: ignore[arg-type]
+        retire_merged_prs(runner=runner)
 
         from cw.orchestrate import load_dispatch_record
 
@@ -262,14 +265,14 @@ class TestRetireMergedPRs:
     def test_no_dispatch_match_only_calls_review_monitor(
         self,
         tmp_orchestrate_dirs: Path,
-        fake_runner: tuple[list[list[str]], object],
+        fake_runner: tuple[list[list[str]], _RunnerFn],
     ) -> None:
         """A merged PR with no correlated sessions still cleans monitor state."""
         save_state(CwState(sessions=[]))
         _seed_pr_merged("owner/other", 5)
 
         calls, runner = fake_runner
-        retired = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
+        retired = retire_merged_prs(runner=runner)
 
         assert retired == []
         assert len(calls) == 1
@@ -278,7 +281,7 @@ class TestRetireMergedPRs:
         self,
         tmp_orchestrate_dirs: Path,
         workspace: Path,
-        fake_runner: tuple[list[list[str]], object],
+        fake_runner: tuple[list[list[str]], _RunnerFn],
     ) -> None:
         """An already-COMPLETED session is not re-closed but its record is removed."""
         sess = _make_session("sess0030", workspace, status=SessionStatus.COMPLETED)
@@ -287,7 +290,7 @@ class TestRetireMergedPRs:
         _seed_pr_merged("owner/repo", 14)
 
         _calls, runner = fake_runner
-        retired = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
+        retired = retire_merged_prs(runner=runner)
 
         assert retired == []
 
@@ -298,7 +301,7 @@ class TestRetireMergedPRs:
     def test_invalid_pr_number_advances_cursor(
         self,
         tmp_orchestrate_dirs: Path,
-        fake_runner: tuple[list[list[str]], object],
+        fake_runner: tuple[list[list[str]], _RunnerFn],
     ) -> None:
         """A pr.merged event without a usable pr_number is skipped, cursor advances."""
         record_event(
@@ -307,14 +310,14 @@ class TestRetireMergedPRs:
         )
 
         calls, runner = fake_runner
-        retired = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
+        retired = retire_merged_prs(runner=runner)
 
         assert retired == []
         # review_monitor.py was NOT invoked because pr_number was invalid.
         assert calls == []
 
         # Second call is a no-op (cursor advanced).
-        retired_second = retire_merged_prs(runner=runner)  # type: ignore[arg-type]
+        retired_second = retire_merged_prs(runner=runner)
         assert retired_second == []
 
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -698,7 +698,7 @@ class TestWatchFlat:
         # we can control termination without relying on timing.
         call_count = 0
 
-        class _FakeSimpleQueue(_queue.SimpleQueue[str]):  # type: ignore[type-arg]
+        class _FakeSimpleQueue(_queue.SimpleQueue[str]):
             def __init__(self) -> None:
                 nonlocal call_count
                 call_count += 1
@@ -710,9 +710,6 @@ class TestWatchFlat:
 
         buf = StringIO()
         con = Console(file=buf, width=120, force_terminal=False)
-        import cw.tui as _tui
-
-        monkeypatch.setattr(_tui.queue, "SimpleQueue", _FakeSimpleQueue)
 
         # Not passing key_queue → hits the key_queue is None branch
         watch_flat(ticks=None, status_fn=lambda: sample_status, console=con)


### PR DESCRIPTION
## Summary

- refactor(tests): fix helper return types in test_doctor.py to remove 17 type: ignore suppressions
- refactor(tests): fix captured_runner + fake_runner return types in test_orchestrate.py
- refactor(tests): fix completion callback arg-type suppressions in test_cli.py
- refactor(tests): remove type-arg suppression + redundant setattr in test_tui.py

Closes #361

Approach: fix return type annotations on existing test helpers (they already return real typed objects — just had wrong `-> object` annotations). No new builder/protocol infrastructure needed.

## Test plan

- [x] ruff check — zero violations
- [x] mypy src/ — zero type errors
- [x] mypy (touched test files) — zero type errors
- [x] pytest — 1323 passed, 4 skipped, 0 failures
- [x] 0 `type: ignore[list-item|arg-type|attr-defined|type-arg|return-value]` remain in the 4 test files

🤖 Shipped via /prep-pr + project /ship-it