### PR TITLE
fix(reconcile): salvage terminal sentinel before timeout/crash disposition (#372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sentinel salvage on timeout/crash** (#372): the `TIMED_OUT` and
+  crashed-phantom sweeps in `reconcile` now recover a terminal-success
+  `AUTO_DEV_RESULT` (`shipped`/`no_op`) from the session's transcript before
+  finalizing disposition. A headless worker that emitted a valid sentinel and
+  then stalled (e.g. waiting on CI) or whose surface died is now recorded
+  COMPLETED with its real result — and its ticket is **not** reverted to
+  PENDING — instead of being mislabeled `timed_out`/`crash` and re-dispatched
+  (dup-PR risk). Guards the reused-worktree stale-transcript case (#358) by
+  only trusting a transcript modified after the session started.
+
 ## [0.12.0] — 2026-05-29
 
 Minor release covering the cw 1.0-march observability and orchestration

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -31,8 +31,10 @@ import json
 import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+from cw.auto_dev_result import AutoDevResult, parse_stdout
 from cw.config import load_orchestrator_config, load_state, save_state
 from cw.dev_queue import dev_queue_lock, load_dev_queue, save_dev_queue
 from cw.events import record_event
@@ -255,6 +257,111 @@ def _is_headless(session: Session) -> bool:
         return False
 
 
+# AUTO_DEV_RESULT statuses for which a stalled/crashed session must NOT be
+# re-dispatched: the work either shipped (a PR exists) or no work was needed.
+# Salvaging these recovers the real disposition instead of mislabeling the
+# session timed_out/crashed and re-running already-finished work. Non-success
+# statuses (blocked, *_pending_*) keep the existing retry-on-timeout behavior.
+# See GitHub issue #372.
+_SALVAGE_TERMINAL_STATUSES: frozenset[str] = frozenset({"shipped", "no_op"})
+
+
+def _assistant_text_from_transcript(path: Path) -> str:
+    """Concatenate the text of every assistant message in a jsonl transcript.
+
+    The AUTO_DEV_RESULT sentinel block is emitted inside an assistant text
+    message, so joining assistant text reconstructs the input ``parse_stdout``
+    would have seen on the worker's stdout. Returns "" on any read error.
+    """
+    parts: list[str] = []
+    try:
+        with path.open() as handle:
+            for line in handle:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if record.get("type") != "assistant":
+                    continue
+                message = record.get("message")
+                if not isinstance(message, dict):
+                    continue
+                content = message.get("content")
+                if not isinstance(content, list):
+                    continue
+                parts.extend(
+                    block["text"]
+                    for block in content
+                    if isinstance(block, dict)
+                    and block.get("type") == "text"
+                    and isinstance(block.get("text"), str)
+                )
+    except OSError:
+        return ""
+    return "\n".join(parts)
+
+
+def _salvage_terminal_result(
+    session: Session, *, after: datetime
+) -> tuple[AutoDevResult, str] | None:
+    """Recover a terminal-success AUTO_DEV_RESULT from the session's transcript.
+
+    A headless session that emitted a valid sentinel and then stalled (e.g.
+    sitting in ``wait_for_ci``) or crashed never reaches the wrapper's
+    post-exit parse, so its disposition is lost. This recovers it directly
+    from the transcript.
+
+    Returns ``(result, claude_session_id)`` only when the newest transcript
+    in the session's worktree — modified strictly after ``after`` (the session
+    start, guarding the reused-worktree stale-transcript case, #358) — parses
+    to an :class:`AutoDevResult` whose status is in
+    :data:`_SALVAGE_TERMINAL_STATUSES`. Returns ``None`` otherwise.
+    """
+    worktree = session.worktree_path
+    if worktree is None:
+        return None
+    encoded = str(worktree).replace("/", "-")
+    project_dir = Path.home() / ".claude" / "projects" / encoded
+    if not project_dir.is_dir():
+        return None
+    candidates = sorted(
+        project_dir.glob("*.jsonl"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not candidates:
+        return None
+    newest = candidates[0]
+    # Stale-transcript guard (#358): a reused worktree may retain a prior
+    # run's transcript. Only trust output written since this session began.
+    if datetime.fromtimestamp(newest.stat().st_mtime, tz=UTC) <= after:
+        return None
+    result = parse_stdout(_assistant_text_from_transcript(newest))
+    if (
+        isinstance(result, AutoDevResult)
+        and result.status in _SALVAGE_TERMINAL_STATUSES
+    ):
+        return result, newest.stem
+    return None
+
+
+def _apply_salvaged_completion(
+    session: Session,
+    result: AutoDevResult,
+    claude_session_id: str,
+    *,
+    now: datetime,
+) -> None:
+    """Mark ``session`` COMPLETED from a salvaged sentinel (like signal_completed)."""
+    session.status = SessionStatus.COMPLETED
+    session.completed_at = now
+    session.completed_reason = CompletionReason.NORMAL
+    session.last_result = result.model_dump(mode="json")
+    if result.cost_usd is not None:
+        session.cost_usd = result.cost_usd
+    session.claude_session_id = claude_session_id
+
+
 def revert_stalled_headless_sessions(
     state: CwState,
     *,
@@ -292,6 +399,7 @@ def revert_stalled_headless_sessions(
         task_by_ticket = {t.ticket_id: t for t in load_dev_queue().tasks}
 
     pending: list[tuple[Session, str | None]] = []
+    salvaged: list[tuple[Session, str | None, AutoDevResult]] = []
     for session in state.sessions:
         if session.status not in _LIVE_STATUSES:
             continue
@@ -305,31 +413,48 @@ def revert_stalled_headless_sessions(
         elapsed = (now - session.started_at).total_seconds()
         if elapsed < budget:
             continue
+        # Before declaring a timeout, try to recover a terminal-success
+        # sentinel the worker emitted before stalling (e.g. waiting on CI).
+        # If found, the session is dispositioned by that sentinel and its
+        # ticket is NOT reverted for re-dispatch. See GitHub issue #372.
+        salvage = _salvage_terminal_result(session, after=session.started_at)
+        if salvage is not None:
+            result, claude_session_id = salvage
+            _apply_salvaged_completion(session, result, claude_session_id, now=now)
+            salvaged.append((session, ticket_id, result))
+            continue
         session.status = SessionStatus.TIMED_OUT
         session.completed_at = now
         session.completed_reason = CompletionReason.TIMED_OUT
         pending.append((session, ticket_id))
 
-    if not pending:
+    if not pending and not salvaged:
         return []
 
     save_state(state)
 
-    ticket_ids_to_revert = [tid for _, tid in pending if tid]
+    timed_out_ticket_ids = {tid for _, tid in pending if tid}
+    salvaged_ticket_ids = {tid for _, tid, _ in salvaged if tid}
     reverted: list[str] = []
-    if ticket_ids_to_revert:
-        ticket_id_set = set(ticket_ids_to_revert)
+    if timed_out_ticket_ids or salvaged_ticket_ids:
         with dev_queue_lock():
             store = load_dev_queue()
+            changed = False
             for task in store.tasks:
-                if (
-                    task.ticket_id in ticket_id_set
-                    and task.status == QueueItemStatus.RUNNING
-                ):
+                if task.status != QueueItemStatus.RUNNING:
+                    continue
+                if task.ticket_id in timed_out_ticket_ids:
                     task.status = QueueItemStatus.PENDING
                     task.session_id = None
                     reverted.append(task.ticket_id)
-            if reverted:
+                    changed = True
+                elif task.ticket_id in salvaged_ticket_ids:
+                    # Terminal-success salvage: retire the task so the
+                    # COMPLETED-silent backstop does not revert it to PENDING
+                    # and re-dispatch already-finished work (#372).
+                    task.status = QueueItemStatus.COMPLETED
+                    changed = True
+            if changed:
                 save_dev_queue(store)
 
     for session, ticket_id in pending:
@@ -343,6 +468,21 @@ def revert_stalled_headless_sessions(
             "last_assistant_message_excerpt": "",
         }
         record_event(OrchestratorEventType.SESSION_TIMED_OUT, payload)
+        if session.surface_ref is not None:
+            get_native_daemon_client().stop(session.surface_ref)
+
+    for session, ticket_id, result in salvaged:
+        completed_payload: dict[str, object] = {
+            "session_id": session.id,
+            "session_name": session.name,
+            "client": session.client,
+            "ticket_id": ticket_id,
+            "claude_session_id": session.claude_session_id,
+            "crashed": False,
+            "salvaged": True,
+            "status": result.status,
+        }
+        record_event(OrchestratorEventType.SESSION_COMPLETED, completed_payload)
         if session.surface_ref is not None:
             get_native_daemon_client().stop(session.surface_ref)
 
@@ -552,16 +692,42 @@ def reconcile() -> ReconcileReport:
 
     phantom_set = set(drift.phantom_session_ids)
     ticket_ids_to_revert: list[str] = []
+    salvaged_ticket_ids: list[str] = []
     pending_events: list[dict[str, object]] = []
     phantom_names: list[str] = []
     for session in state.sessions:
         if session.id not in phantom_set:
             continue
+        ticket_id = ticket_id_for_session(session.name)
+        # Recover a terminal-success sentinel before declaring the phantom
+        # crashed, so already-shipped work is not re-dispatched (#372).
+        salvage = (
+            _salvage_terminal_result(session, after=session.started_at)
+            if session.origin is SessionOrigin.DAEMON
+            else None
+        )
+        if salvage is not None:
+            result, claude_session_id = salvage
+            _apply_salvaged_completion(session, result, claude_session_id, now=now)
+            phantom_names.append(session.name)
+            if ticket_id:
+                salvaged_ticket_ids.append(ticket_id)
+            salvaged_payload: dict[str, object] = {
+                "session_id": session.id,
+                "session_name": session.name,
+                "client": session.client,
+                "crashed": False,
+                "salvaged": True,
+                "status": result.status,
+            }
+            if ticket_id:
+                salvaged_payload["ticket_id"] = ticket_id
+            pending_events.append(salvaged_payload)
+            continue
         session.status = SessionStatus.COMPLETED
         session.completed_reason = CompletionReason.CRASHED
         session.completed_at = now
         phantom_names.append(session.name)
-        ticket_id = ticket_id_for_session(session.name)
         if ticket_id and session.origin is SessionOrigin.DAEMON:
             ticket_ids_to_revert.append(ticket_id)
         payload: dict[str, object] = {
@@ -579,14 +745,16 @@ def reconcile() -> ReconcileReport:
         record_event(OrchestratorEventType.SESSION_COMPLETED, payload)
 
     reverted: list[str] = []
-    if ticket_ids_to_revert:
+    if ticket_ids_to_revert or salvaged_ticket_ids:
+        revert_set = set(ticket_ids_to_revert)
+        salvaged_set = set(salvaged_ticket_ids)
         with dev_queue_lock():
             store = load_dev_queue()
+            changed = False
             for task in store.tasks:
-                if (
-                    task.ticket_id in ticket_ids_to_revert
-                    and task.status == QueueItemStatus.RUNNING
-                ):
+                if task.status != QueueItemStatus.RUNNING:
+                    continue
+                if task.ticket_id in revert_set:
                     task.status = QueueItemStatus.PENDING
                     # Drop the stamp from the prior (now-crashed) session so
                     # the next dispatch_tick can re-stamp with the freshly
@@ -594,7 +762,13 @@ def reconcile() -> ReconcileReport:
                     # carries a stale id. See GitHub issue #97.
                     task.session_id = None
                     reverted.append(task.ticket_id)
-            if reverted:
+                    changed = True
+                elif task.ticket_id in salvaged_set:
+                    # Terminal-success salvage: retire the task instead of
+                    # reverting, so shipped/no_op work is not re-dispatched (#372).
+                    task.status = QueueItemStatus.COMPLETED
+                    changed = True
+            if changed:
                 save_dev_queue(store)
 
     # Sweep for TIMED_OUT and DAEMON-COMPLETED sessions whose owning TicketTask

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import freezegun
@@ -1036,6 +1037,368 @@ def test_revert_stalled_headless_sessions_stops_daemon_surface(
     revert_stalled_headless_sessions(state, now=now, config=OrchestratorConfig())
 
     assert short_id in daemon.stop_calls
+
+
+# ---------------------------------------------------------------------------
+# Sentinel-salvage tests (GitHub issue #372): a stalled/crashed session that
+# emitted a terminal-success sentinel must be dispositioned by that sentinel,
+# not mislabeled timed_out/crash, and its ticket must NOT be re-dispatched.
+# ---------------------------------------------------------------------------
+
+
+def _shipped_salvage_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 4,
+        "ticket_id": "salv-1",
+        "status": "shipped",
+        "stage_reached": "stage5_post_create",
+        "scope": {
+            "tier": "small",
+            "files": 1,
+            "lines_estimate": 10,
+            "lines_actual": 12,
+            "forbidden_touched": False,
+        },
+        "plan_source": "github_issue_existing",
+        "branch": "auto-dev/salv-1",
+        "worktree_path": "/tmp/wt/salv-1",
+        "fork_point_sha": "abc1234",
+        "commits": ["sha1"],
+        "pr": {
+            "number": 99,
+            "url": "https://github.com/foo/bar/pull/99",
+            "auto_merge": True,
+            "base": "main",
+        },
+        "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+        "health": {
+            "lowest_agent_confidence": "HIGH",
+            "any_incomplete_risk": False,
+            "shortcuts": [],
+            "recommendation": "PROCEED",
+            "downgrade_applied": False,
+            "fix_loop_escalated": False,
+        },
+        "friction_highlights": [],
+        "blocker": None,
+        "cost_usd": 1.5,
+        "next_actions": ["wait_for_ci"],
+    }
+
+
+def _no_op_salvage_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 4,
+        "ticket_id": "salv-noop",
+        "status": "no_op",
+        "stage_reached": "stage1_pre_flight",
+        "scope": {
+            "tier": "small",
+            "files": 0,
+            "lines_estimate": 0,
+            "lines_actual": None,
+            "forbidden_touched": False,
+        },
+        "plan_source": "none",
+        "branch": None,
+        "worktree_path": None,
+        "fork_point_sha": None,
+        "commits": [],
+        "pr": None,
+        "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+        "health": {
+            "lowest_agent_confidence": "HIGH",
+            "any_incomplete_risk": False,
+            "shortcuts": [],
+            "recommendation": "PROCEED",
+            "downgrade_applied": False,
+            "fix_loop_escalated": False,
+        },
+        "friction_highlights": [],
+        "blocker": None,
+        "next_actions": ["close_issue_as_completed"],
+    }
+
+
+def _write_salvage_transcript(
+    home: Path, worktree: Path, claude_session_id: str, payload: dict[str, Any]
+) -> Path:
+    """Write a transcript jsonl under ``home`` carrying a wrapped sentinel.
+
+    Mirrors Claude's on-disk layout: ``<home>/.claude/projects/<encoded>/
+    <uuid>.jsonl`` with the encoded path replacing ``/`` with ``-``.
+    """
+    encoded = str(worktree).replace("/", "-")
+    project_dir = home / ".claude" / "projects" / encoded
+    project_dir.mkdir(parents=True, exist_ok=True)
+    body = json.dumps(payload)
+    sentinel = f"narrative\n<<<AUTO_DEV_RESULT\n{body}\nAUTO_DEV_RESULT>>>\n"
+    record = {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": sentinel}],
+        },
+    }
+    path = project_dir / f"{claude_session_id}.jsonl"
+    path.write_text(json.dumps(record) + "\n")
+    return path
+
+
+def test_revert_stalled_salvages_shipped_sentinel(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Over-budget session that shipped → COMPLETED, task NOT reverted."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    worktree = tmp_path / "wt-salv"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("salv-1", worktree, started_at)
+    _write_salvage_transcript(
+        home, worktree, "claude-uuid-1", _shipped_salvage_payload()
+    )
+    save_state(CwState(sessions=[sess]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="salv-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="salv-1",
+                )
+            ]
+        )
+    )
+
+    reverted = revert_stalled_headless_sessions(
+        state=load_state(), now=now, config=OrchestratorConfig()
+    )
+
+    # Not reverted for re-dispatch.
+    assert reverted == []
+    reloaded = next(s for s in load_state().sessions if s.id == "salv-1")
+    assert reloaded.status == SessionStatus.COMPLETED
+    assert reloaded.completed_reason == CompletionReason.NORMAL
+    assert reloaded.last_result is not None
+    assert reloaded.last_result["status"] == "shipped"
+    assert reloaded.claude_session_id == "claude-uuid-1"
+    assert reloaded.cost_usd == 1.5
+
+    task = next(t for t in load_dev_queue().tasks if t.ticket_id == "salv-1")
+    assert task.status == QueueItemStatus.COMPLETED
+
+    events = read_events(
+        consumer="test-salv-1",
+        event_types=[OrchestratorEventType.SESSION_COMPLETED],
+    )
+    payload = next(e.payload for e in events if e.payload.get("ticket_id") == "salv-1")
+    assert payload["crashed"] is False
+    assert payload["salvaged"] is True
+
+
+def test_revert_stalled_salvages_no_op_sentinel(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Over-budget session that no-op'd → COMPLETED, task NOT reverted."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    worktree = tmp_path / "wt-noop"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("salv-noop", worktree, started_at)
+    _write_salvage_transcript(home, worktree, "claude-uuid-2", _no_op_salvage_payload())
+    save_state(CwState(sessions=[sess]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="salv-noop",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="salv-noop",
+                )
+            ]
+        )
+    )
+
+    reverted = revert_stalled_headless_sessions(
+        state=load_state(), now=now, config=OrchestratorConfig()
+    )
+
+    assert reverted == []
+    reloaded = next(s for s in load_state().sessions if s.id == "salv-noop")
+    assert reloaded.status == SessionStatus.COMPLETED
+    assert reloaded.last_result is not None
+    assert reloaded.last_result["status"] == "no_op"
+    task = next(t for t in load_dev_queue().tasks if t.ticket_id == "salv-noop")
+    assert task.status == QueueItemStatus.COMPLETED
+
+
+def test_revert_stalled_no_salvage_without_sentinel_times_out(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fresh transcript but no terminal sentinel → TIMED_OUT + revert (unchanged)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    worktree = tmp_path / "wt-nosent"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("salv-none", worktree, started_at)
+    # Transcript exists but carries no AUTO_DEV_RESULT block.
+    encoded = str(worktree).replace("/", "-")
+    proj = home / ".claude" / "projects" / encoded
+    proj.mkdir(parents=True, exist_ok=True)
+    (proj / "claude-uuid-3.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "still working on it"}],
+                },
+            }
+        )
+        + "\n"
+    )
+    save_state(CwState(sessions=[sess]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="salv-none",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="salv-none",
+                )
+            ]
+        )
+    )
+
+    reverted = revert_stalled_headless_sessions(
+        state=load_state(), now=now, config=OrchestratorConfig()
+    )
+
+    assert "salv-none" in reverted
+    reloaded = next(s for s in load_state().sessions if s.id == "salv-none")
+    assert reloaded.status == SessionStatus.TIMED_OUT
+    task = next(t for t in load_dev_queue().tasks if t.ticket_id == "salv-none")
+    assert task.status == QueueItemStatus.PENDING
+
+
+def test_revert_stalled_ignores_stale_transcript(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Transcript older than started_at (reused worktree, #358) → TIMED_OUT."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    worktree = tmp_path / "wt-stale"
+    # started_at in the future relative to the (real-now) transcript mtime, so
+    # the freshly-written transcript is "stale" by the started_at guard.
+    started_at = datetime(2099, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2099, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("salv-stale", worktree, started_at)
+    _write_salvage_transcript(
+        home, worktree, "claude-uuid-4", _shipped_salvage_payload()
+    )
+    save_state(CwState(sessions=[sess]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="salv-stale",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="salv-stale",
+                )
+            ]
+        )
+    )
+
+    reverted = revert_stalled_headless_sessions(
+        state=load_state(), now=now, config=OrchestratorConfig()
+    )
+
+    # Stale transcript ignored → genuine timeout.
+    assert "salv-stale" in reverted
+    reloaded = next(s for s in load_state().sessions if s.id == "salv-stale")
+    assert reloaded.status == SessionStatus.TIMED_OUT
+
+
+def test_reconcile_crashed_phantom_salvages_shipped_sentinel(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phantom (surface gone) session that shipped → COMPLETED, not re-dispatched."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    worktree = tmp_path / "wt-crash"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    # Past the spawn grace window but well under the headless budget, so the
+    # timeout sweep ignores it and the crashed-phantom sweep handles it.
+    now = started_at + timedelta(seconds=SPAWN_GRACE_SECONDS + 60)
+
+    sess = _mk_headless_daemon_session(
+        "salv-crash", worktree, started_at, surface_ref="gone-ref"
+    )
+    payload = _shipped_salvage_payload()
+    payload["ticket_id"] = "salv-crash"
+    _write_salvage_transcript(home, worktree, "claude-uuid-5", payload)
+    # A second, genuinely-live session keeps the daemon roster non-empty so the
+    # transient-outage guard does not trip (it would otherwise abort reconcile
+    # when native_live is empty). Its ref IS in the live set, so it is not a
+    # phantom; only "gone-ref" is.
+    alive = _mk_session("alive", surface_ref="live-ref")
+    save_state(CwState(sessions=[sess, alive]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="salv-crash",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="salv-crash",
+                )
+            ]
+        )
+    )
+
+    # Only "live-ref" is live → "gone-ref" is a phantom; non-empty roster
+    # keeps the outage guard from tripping.
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "live-ref"}],
+    )
+    with freezegun.freeze_time(now):
+        report = reconcile()
+
+    assert "salv-crash" not in report.reverted_ticket_ids
+    reloaded = next(s for s in load_state().sessions if s.id == "salv-crash")
+    assert reloaded.status == SessionStatus.COMPLETED
+    assert reloaded.completed_reason == CompletionReason.NORMAL
+    assert reloaded.last_result is not None
+    assert reloaded.last_result["status"] == "shipped"
+    task = next(t for t in load_dev_queue().tasks if t.ticket_id == "salv-crash")
+    assert task.status == QueueItemStatus.COMPLETED
 
 
 def test_reconcile_includes_stalled_reverts_in_report(


### PR DESCRIPTION
Fixes #372.

## Problem
A headless worker captures `claude_session_id` and parses its `AUTO_DEV_RESULT` sentinel only on a **clean wrapper exit** (`wrapper.py:261`). When a session is killed at the 60-min ceiling (e.g. sitting in `wait_for_ci`) or its surface dies, that path is bypassed — the emitted sentinel is discarded, the session is mislabeled `timed_out`/`crash`, and `TIMED_OUT`/`CRASHED` **reverts the ticket to PENDING → re-dispatches already-shipped work** (dup-PR risk). Observed on #367 (PR#370 merged, yet recorded `timed_out`) and #361.

## Fix
Add a sentinel-salvage step to `revert_stalled_headless_sessions` and the crashed-phantom sweep. Before finalizing disposition: locate the session's newest transcript — **only if modified after `session.started_at`** (guards the reused-worktree stale-transcript case, #358) — parse it, and if it yields a terminal-success result (`shipped`/`no_op`), record COMPLETED + `last_result` + `claude_session_id` and mark the ticket COMPLETED instead of reverting. Non-success statuses and missing sentinels keep today's timeout/crash + revert behavior.

## Tests
salvage-shipped (no revert), salvage-no_op, no-sentinel-timeout, stale-transcript-ignored, crashed-phantom-salvage. Full suite green (1509 passed), ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)