### PR TITLE
chore(release): cut 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-05-29
+
+Minor release hardening the dispatch-reliability path: terminal-sentinel
+salvage before timeout/crash disposition, cleaner no_op contract parsing, and a
+`cw doctor` worktree-path check — plus the dev-queue missing-dir guard and a
+type-suppression cleanup batch.
+
+### Added
+
+- **`cw doctor` worktree path existence check** (#143 → PR #365): `cw doctor`
+  now flags sessions whose recorded worktree path no longer exists on disk,
+  catching the drift where a worktree is removed out from under a tracked
+  session.
+
 ### Fixed
 
-- **Sentinel salvage on timeout/crash** (#372): the `TIMED_OUT` and
+- **Sentinel salvage on timeout/crash** (#372 → PR #374): the `TIMED_OUT` and
   crashed-phantom sweeps in `reconcile` now recover a terminal-success
   `AUTO_DEV_RESULT` (`shipped`/`no_op`) from the session's transcript before
   finalizing disposition. A headless worker that emitted a valid sentinel and
@@ -17,6 +31,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   PENDING — instead of being mislabeled `timed_out`/`crash` and re-dispatched
   (dup-PR risk). Guards the reused-worktree stale-transcript case (#358) by
   only trusting a transcript modified after the session started.
+- **`no_op` + stray-PR coerced at parse boundary** (#367 → PR #370): a sentinel
+  reporting `no_op` while also carrying a stray `pr_url` is now coerced to a
+  clean `no_op` at the parse boundary, so the disposition isn't ambiguous
+  downstream.
+- **dev-queue `refresh-all` skips missing client dirs** (#356 → PR #369):
+  `refresh-all` now gracefully skips clients whose workspace directory is
+  missing (e.g. a dead `sigma` entry) instead of crashing the whole refresh.
+
+### Removed / chore
+
+- **`get_item` queue helper** (#360 → PR #368): adds a `get_item` accessor,
+  dropping 7 `type: ignore[union-attr]` suppressions.
+- **Test annotation fixes** (#361 → PR #373): removes 32 `type: ignore`
+  suppressions across the test suite via proper annotations.
 
 ## [0.12.0] — 2026-05-29
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-workspace"
-version = "0.12.0"
+version = "0.13.0"
 description = "Multi-session workspace orchestrator for Claude Code"
 readme = "README.md"
 authors = [

--- a/src/cw/__init__.py
+++ b/src/cw/__init__.py
@@ -1,3 +1,3 @@
 """claude-workspace: Multi-session workspace orchestrator for Claude Code."""
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "claude-workspace"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Cut **0.13.0** — minor release hardening the dispatch-reliability path plus a `cw doctor` worktree-path check and a type-suppression cleanup batch.

Six commits since `v0.12.0`:

- `feat(doctor)`: worktree path existence check (#143 → #365)
- `fix(reconcile)`: salvage terminal sentinel before timeout/crash (#372 → #374)
- `fix(contract)`: coerce no_op+stray-pr to clean no_op (#367 → #370)
- `fix(dev-queue)`: skip missing client dirs in refresh-all (#356 → #369)
- `refactor(queue)`: get_item helper, drop 7 `type: ignore` (#360 → #368)
- `refactor(tests)`: remove 32 `type: ignore` via annotations (#361 → #373)

One `feat:` present → minor bump per repo convention.

## Changes

- `CHANGELOG.md`: `[Unreleased]` → `## [0.13.0] — 2026-05-29`
- `pyproject.toml` + `src/cw/__init__.py`: `0.12.0` → `0.13.0` (release.sh verifies they match)
- `uv.lock`: self-version bump

## Quality gates

- `ruff check` — clean
- `mypy src/` — clean (33 files)
- `pytest` — 1509 passed, 3 deselected

After merge: ff `main`, then `./scripts/release.sh 0.13.0` tags + triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)