### PR TITLE
fix(contract): coerce blocked+stray-next_actions at parse boundary (#371)

### DIFF
--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -721,6 +721,35 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
                 payload.get("schema_version"),
             )
 
+    # Pre-validation normalization for blocked + stray next_actions (issue
+    # #371 — follow-up to #367/#370). A producer bug emitted status=blocked
+    # alongside next_actions=['redispatch_ticket'] (or similar non-user-directed
+    # verbs). The §4.3 terminal-reject invariant rejects the whole sentinel as
+    # validation_failed, masking the real blocker. Coerce: drop stray
+    # next_actions, preserve the original blocker intact. Leniency applies only
+    # at the parse boundary (same scoping as the no_op coerce above).
+    # Two legitimate shapes carry next_actions on blocked and MUST NOT be coerced:
+    #   - pre-flight blocked (stage_reached='stage1_pre_flight'), and
+    #   - user-directed blocked (all next_actions start with user_* prefixes).
+    if raw_status == "blocked":
+        raw_next_actions = payload.get("next_actions")
+        if isinstance(raw_next_actions, list) and raw_next_actions:
+            is_pre_flight = payload.get("stage_reached") == "stage1_pre_flight"
+            is_user_directed = all(
+                isinstance(a, str) and a.startswith(USER_DIRECTED_PREFIXES)
+                for a in raw_next_actions
+            )
+            if not is_pre_flight and not is_user_directed:
+                _log.warning(
+                    "auto-dev: blocked sentinel carried stray next_actions=%r; "
+                    "dropping next_actions, preserving blocker "
+                    "(ticket=%s, schema_version=%s)",
+                    raw_next_actions,
+                    payload.get("ticket_id", "unknown"),
+                    payload.get("schema_version"),
+                )
+                payload["next_actions"] = []
+
     try:
         return AutoDevResult.model_validate(payload)
     except ValidationError as exc:

--- a/tests/test_auto_dev_result.py
+++ b/tests/test_auto_dev_result.py
@@ -983,6 +983,79 @@ class TestPreFlightNoOp:
 
 
 # ---------------------------------------------------------------------------
+# blocked + stray next_actions coerce (issue #371 — follow-up to #367/#370)
+# A producer bug emits status=blocked alongside next_actions=['redispatch_ticket']
+# (or other non-user-directed verbs). The §4.3 terminal-reject invariant then
+# rejects the whole sentinel as validation_failed, masking the real blocker.
+# parse_stdout coerces by dropping next_actions and preserving the blocker.
+# Two exempt shapes are NOT coerced: pre-flight blocked and user-directed blocked.
+# ---------------------------------------------------------------------------
+
+
+class TestBlockedWithStrayNextActionsCoerce:
+    def test_blocked_with_stray_next_actions_coerced(self) -> None:
+        """parse_stdout coerces blocked+stray next_actions to clean blocked.
+
+        Regression for issue #371: the exact failure mode from #367's first
+        attempt — worker emitted blocked+next_actions=['redispatch_ticket'],
+        causing validation_failed and masking the underlying impl_failed blocker.
+        """
+        p = _blocked_payload()
+        p["next_actions"] = ["redispatch_ticket"]
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "blocked"
+        assert result.next_actions == []
+
+    def test_blocked_coerce_preserves_blocker(self) -> None:
+        """Coercing stray next_actions must preserve the original blocker intact."""
+        p = _blocked_payload()
+        p["next_actions"] = ["redispatch_ticket"]
+        p["blocker"]["retry_eligible"] = True
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.blocker is not None
+        assert result.blocker.reason == "impl_failed"
+        assert result.blocker.retry_eligible is True
+
+    def test_blocked_strict_construction_still_rejects_stray_next_actions(
+        self,
+    ) -> None:
+        """Strict AutoDevResult.model_validate still rejects blocked+next_actions."""
+        p = _blocked_payload()
+        p["next_actions"] = ["redispatch_ticket"]
+        with pytest.raises(ValidationError, match="next_actions must be empty"):
+            AutoDevResult.model_validate(p)
+
+    def test_blocked_pre_flight_not_coerced(self) -> None:
+        """Pre-flight blocked with sync_local_main is NOT coerced (legitimate shape)."""
+        p = _blocked_payload()
+        p["status"] = "blocked"
+        p["stage_reached"] = "stage1_pre_flight"
+        p["next_actions"] = ["sync_local_main"]
+        p["scope"]["lines_actual"] = None
+        p["branch"] = None
+        p["worktree_path"] = None
+        p["fork_point_sha"] = None
+        p["commits"] = []
+        p["blocker"]["stage"] = "stage1_pre_flight"
+        p["blocker"]["reason"] = "local_main_diverged_from_origin"
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "blocked"
+        assert result.next_actions == ["sync_local_main"]
+
+    def test_blocked_user_directed_not_coerced(self) -> None:
+        """User-directed blocked (user_resolve_ prefix) is NOT coerced."""
+        p = _blocked_payload()
+        p["next_actions"] = ["user_resolve_ambiguity"]
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "blocked"
+        assert result.next_actions == ["user_resolve_ambiguity"]
+
+
+# ---------------------------------------------------------------------------
 # stage1_pre_flight + blocked (added per #226 — Origin Sync block emits this
 # combo legitimately; the consumer previously rejected it as a §4.3 violation,
 # so every Origin-Sync-blocked sentinel became validation_failed). When status


### PR DESCRIPTION
## Summary

- fix(contract): coerce blocked+stray-next_actions at parse boundary (#371)

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] `test_blocked_with_stray_next_actions_coerced` — primary regression test
- [ ] `test_blocked_coerce_preserves_blocker` — blocker preserved through coerce
- [ ] `test_blocked_strict_construction_still_rejects_stray_next_actions` — strict path unchanged
- [ ] `test_blocked_pre_flight_not_coerced` — pre-flight exempt from coerce
- [ ] `test_blocked_user_directed_not_coerced` — user-directed exempt from coerce
- [ ] Existing blocked tests still pass

🤖 Shipped via /prep-pr + project /ship-it