### PR TITLE
fix(dispatch): align docstring + is-None guard on _accumulate_task_cost (#352)

### DIFF
--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -282,13 +282,13 @@ def _accumulate_task_cost(task: TicketTask, session_id: str | None) -> None:
     Reads cost via two-source fallback:
       1. session.cost_usd (populated by signal_completed — normal headless path)
       2. session.last_result.get('cost_usd') (populated by persist_last_result —
-         event-replay path where signal_completed did not run first)
+         event-replay path where signal_completed did not run)
 
     When both sources are absent, total_cost_usd is left unchanged.
     Called inside dev_queue_lock so the mutation is covered by the same
     save_dev_queue call that persists the COMPLETED status.
     """
-    if not session_id:
+    if session_id is None:
         return
     state = load_state()
     session = next((s for s in state.sessions if s.id == session_id), None)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -13,6 +13,7 @@ import pytest
 from cw.config import load_state, save_state
 from cw.dev_queue import add_ticket, load_dev_queue, save_dev_queue, save_plan
 from cw.dispatch import (
+    _accumulate_task_cost,
     consume_completed_sessions,
     dispatch_tick,
     persist_last_result,
@@ -1627,7 +1628,7 @@ class TestSpawnCloseRaceRegression:
            now-CANCELLED task.
         """
         from cw.cli import _spawn_close_impl
-        from cw.config import CwState, save_state
+        from cw.config import save_state
         from cw.models import SessionPurpose
 
         _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
@@ -1703,7 +1704,7 @@ class TestAccumulateTaskCost:
         session_id: str,
         *,
         cost_usd: float | None = None,
-        last_result: dict | None = None,
+        last_result: dict[str, object] | None = None,
     ) -> None:
         sess = Session(
             id=session_id,
@@ -1769,3 +1770,20 @@ class TestAccumulateTaskCost:
         consume_completed_sessions()
         store = load_dev_queue()
         assert store.tasks[0].total_cost_usd == pytest.approx(5.0)
+
+    def test_empty_string_session_id_is_not_treated_as_missing(
+        self, tmp_dispatch_dirs: Path
+    ) -> None:
+        """Empty-string session_id must not short-circuit like None."""
+        task = TicketTask(
+            ticket_id="GEN-1",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+            session_id="",
+            total_cost_usd=3.0,
+        )
+        # No session in state — _accumulate_task_cost should attempt the lookup
+        # (not return early on empty string) and leave total_cost_usd unchanged.
+        save_state(CwState(sessions=[]))
+        _accumulate_task_cost(task, "")
+        assert task.total_cost_usd == pytest.approx(3.0)


### PR DESCRIPTION
## Summary

- Fixes misleading docstring: `did not run first` → `did not run` — the fallback exists for DAEMON sessions where `signal_completed` **never** runs, not an ordering issue
- Fixes type-precision guard: `if not session_id:` → `if session_id is None:` — empty-string session IDs should not be treated as missing
- Adds regression test `test_empty_string_session_id_is_not_treated_as_missing` to `TestAccumulateTaskCost`
- Fixes two pre-existing mypy errors in `tests/test_dispatch.py`: `CwState` re-imported from wrong module (`cw.config` → already in top-level `cw.models` import), bare `dict` missing type args

Closes #352

## Test plan

- [ ] `uv run pytest tests/test_dispatch.py::TestAccumulateTaskCost -v` — 4 tests pass
- [ ] `uv run pytest tests/test_dispatch.py -v` — 48 tests pass
- [ ] `uv run mypy src/cw/dispatch.py tests/test_dispatch.py` — no errors
- [ ] `uv run ruff check src/ tests/` — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)