### PR TITLE
fix(doctor): wedge-detection robustness — BACKGROUNDED exclusion + subprocess timeouts (#354)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -295,14 +295,41 @@ def doctor(reap: bool, as_json: bool) -> None:
 
     Reports the resolved backend, backend binary/daemon availability,
     config file locations and validity, and state file parseability.
-    With ``--reap`` also reconciles cw's session state with the live
-    multiplexer, marking phantom sessions COMPLETED and reverting their
-    tickets to PENDING. Exits non-zero if any check fails.
+    Exits non-zero if any check fails.
+
+    With ``--reap``, also detects and repairs the following wedge conditions:
+
+    \b
+    Class 1 — wedge/pane-idle-but-active
+      Session pane shows an idle shell with no recent worktree activity.
+      Action: mark session COMPLETED, close pane, revert queue task to PENDING.
+      Recipe: cw doctor --reap
+
+    \b
+    Class 2 — wedge/task-running-no-session
+      Queue task is RUNNING but has no associated live session.
+      Action: revert queue task to PENDING.
+      Recipe: cw doctor --reap
+
+    \b
+    Class 3 — wedge/task-running-completed-session
+      Queue task is RUNNING but its session is already COMPLETED.
+      Action: revert queue task to PENDING.
+      Recipe: cw doctor --reap
+
+    \b
+    Class 4 — wedge/repo-ahead-of-queue (advisory only)
+      Branch is pushed to remote but queue task is still RUNNING.
+      No automatic mutation — inspect and resolve manually.
+      Recipe: cw spawn-complete <ticket_id> [--status shipped]
+
+    ``--reap`` also reconciles session state with the live multiplexer,
+    marking phantom sessions COMPLETED and reverting their tickets to PENDING.
     """
     report = run_doctor(reap=reap)
     if as_json:
         click.echo(format_report_json(report))
-        sys.exit(0 if report.ok else 1)
+        raise click.exceptions.Exit(0 if report.ok else 1)
     click.echo(format_report(report))
     if not report.ok:
         raise click.exceptions.Exit(1)

--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -432,12 +432,14 @@ def _check_wedge_task_running_no_session(
             )
         elif task.session_id not in live_session_ids:
             # session_id set but points to a non-live session (missing from
-            # state, TIMED_OUT, BACKGROUNDED, etc.).
-            # _check_wedge_task_running_completed_session handles COMPLETED
-            # specifically; everything else falls here.
+            # state, TIMED_OUT, etc.).
+            # _check_wedge_task_running_completed_session handles COMPLETED.
+            # BACKGROUNDED is excluded: the session is intentionally paused
+            # and will resume — flagging it as a wedge is a false positive.
             session_by_id_local = {s.id: s for s in state.sessions}
             sess = session_by_id_local.get(task.session_id)
-            if sess is None or sess.status != SessionStatus.COMPLETED:
+            _non_wedge = {SessionStatus.COMPLETED, SessionStatus.BACKGROUNDED}
+            if sess is None or sess.status not in _non_wedge:
                 findings.append(
                     WedgeFinding(
                         wedge_class="wedge/task-running-no-session",
@@ -526,10 +528,11 @@ def _check_wedge_repo_ahead(
                 capture_output=True,
                 text=True,
                 check=False,
+                timeout=10,
             )
             if ls_result.returncode != 0 or not ls_result.stdout.strip():
                 continue
-        except OSError:
+        except (OSError, _sp.TimeoutExpired):
             continue
         # Check PR status via gh CLI
         recipe: str
@@ -549,9 +552,10 @@ def _check_wedge_repo_ahead(
                 capture_output=True,
                 text=True,
                 check=False,
+                timeout=10,
             )
             prs = json.loads(pr_result.stdout) if pr_result.returncode == 0 else []
-        except (OSError, ValueError):
+        except (OSError, ValueError, _sp.TimeoutExpired):
             prs = []
         if not prs:
             recipe = (
@@ -592,20 +596,14 @@ def _reap_wedge_findings(
     session_by_id = {s.id: s for s in state.sessions}
     now = datetime.now(UTC)
 
-    # --- Class-1: in-memory mutations only (not yet persisted) ---
+    # Collect IDs for class-1 sessions and ticket IDs for queue revert (classes 1-3).
     class1_session_ids: set[str] = set()
     for f in findings:
         if f.wedge_class != "wedge/pane-idle-but-active" or f.session_id is None:
             continue
-        session = session_by_id.get(f.session_id)
-        if session is None:
-            continue
-        session.status = SessionStatus.COMPLETED
-        session.completed_reason = CompletionReason.NORMAL
-        session.completed_at = now
-        class1_session_ids.add(f.session_id)
+        if f.session_id in session_by_id:
+            class1_session_ids.add(f.session_id)
 
-    # Collect ticket IDs for queue revert (classes 1-3, not class-4).
     revert_ticket_ids: set[str] = set()
     for f in findings:
         if f.wedge_class == "wedge/repo-ahead-of-queue":
@@ -613,13 +611,17 @@ def _reap_wedge_findings(
         if f.ticket_id:
             revert_ticket_ids.add(f.ticket_id)
 
-    # FIX 5: Hold queue lock across BOTH state writes to prevent torn state
-    # window where dispatch observes sessions.json=COMPLETED but
-    # dev_queue.json=RUNNING and triggers a spurious re-spawn.
+    # Hold queue lock across BOTH state writes — mutations happen inside the
+    # lock so no reader sees sessions.json=COMPLETED while dev_queue.json=RUNNING.
     if class1_session_ids or revert_ticket_ids:
         with dev_queue_lock():
             if class1_session_ids:
-                save_state(state)  # session mutations persisted inside lock
+                for sid in class1_session_ids:
+                    session = session_by_id[sid]
+                    session.status = SessionStatus.COMPLETED
+                    session.completed_reason = CompletionReason.NORMAL
+                    session.completed_at = now
+                save_state(state)
             if revert_ticket_ids:
                 queue = load_dev_queue()
                 changed = False

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1643,6 +1643,43 @@ class TestWedgeTaskRunningNoSession:
         assert f.ticket_id == "TST-99"
         assert "PENDING" in f.recipe or "revert" in f.recipe.lower()
 
+    def test_backgrounded_session_skips(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from cw.doctor import _check_wedge_task_running_no_session
+        from cw.models import (
+            CwState,
+            DevQueueStore,
+            QueueItemStatus,
+            Session,
+            SessionPurpose,
+            SessionStatus,
+            TicketTask,
+        )
+
+        session = Session(
+            id="bg-sess",
+            name="client-a/auto-dev/TST-BG",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.BACKGROUNDED,
+            workspace_path=Path("/tmp"),
+        )
+        old_time = datetime.now(UTC) - timedelta(seconds=120)
+        task = TicketTask(
+            ticket_id="TST-BG",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="bg-sess",
+            created_at=old_time,
+        )
+        state = CwState(sessions=[session])
+        queue = DevQueueStore(tasks=[task])
+        findings = _check_wedge_task_running_no_session(state, queue)
+        assert findings == []
+
 
 class TestWedgeTaskRunningCompletedSession:
     """wedge/task-running-completed-session detection logic."""
@@ -1969,6 +2006,69 @@ class TestWedgeRepoAheadOfQueue:
         _check_wedge_repo_ahead(state, queue)
         # The ls-remote call must reference my-branch, not auto-dev/TST-R6
         assert any("my-branch" in str(a) for a in ls_remote_args_seen)
+
+    def test_ls_remote_timeout_no_finding(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        import subprocess
+
+        from cw.doctor import _check_wedge_repo_ahead
+        from cw.models import CwState, DevQueueStore
+
+        task = self._make_running_task(tmp_path, ticket_id="TST-RT1")
+        state = CwState(sessions=[])
+        queue = DevQueueStore(tasks=[task])
+
+        class _Proc:
+            def __init__(self, rc: int, out: str) -> None:
+                self.returncode = rc
+                self.stdout = out
+
+        def fake_run(args: list[str], **_kw: object) -> _Proc:
+            if "remote" in args and "get-url" in args:
+                return _Proc(0, "https://github.com/org/repo.git\n")
+            if "ls-remote" in args:
+                raise subprocess.TimeoutExpired(cmd=args, timeout=10)
+            return _Proc(0, "")
+
+        monkeypatch.setattr("cw.doctor._sp.run", fake_run)
+        findings = _check_wedge_repo_ahead(state, queue)
+        assert findings == []
+
+    def test_gh_pr_timeout_emits_finding_with_empty_prs(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
+    ) -> None:
+        import subprocess
+
+        from cw.doctor import _check_wedge_repo_ahead
+        from cw.models import CwState, DevQueueStore
+
+        task = self._make_running_task(tmp_path, ticket_id="TST-RT2")
+        state = CwState(sessions=[])
+        queue = DevQueueStore(tasks=[task])
+
+        class _Proc:
+            def __init__(self, rc: int, out: str) -> None:
+                self.returncode = rc
+                self.stdout = out
+
+        def fake_run(args: list[str], **_kw: object) -> _Proc:
+            if "remote" in args and "get-url" in args:
+                return _Proc(0, "https://github.com/org/repo.git\n")
+            if "ls-remote" in args:
+                return _Proc(0, "abc123\trefs/heads/auto-dev/TST-RT2\n")
+            if "pr" in args and "list" in args:
+                raise subprocess.TimeoutExpired(cmd=args, timeout=10)
+            return _Proc(0, "")
+
+        monkeypatch.setattr("cw.doctor._sp.run", fake_run)
+        # TimeoutExpired on gh pr list → treated as no PRs → recipe mentions no open PR
+        findings = _check_wedge_repo_ahead(state, queue)
+        assert len(findings) == 1
+        assert (
+            "no open PR" in findings[0].recipe
+            or "cw spawn-complete" in findings[0].recipe
+        )
 
 
 class TestWedgeReapRecipes:


### PR DESCRIPTION
## Summary

Resolves **#354** (#123 follow-up): two deferred robustness items in `cw doctor` wedge detection, plus two small related cleanups the worker bundled.

**Ticket items:**
1. **Exclude BACKGROUNDED from wedge detection** — `_check_wedge_task_running_no_session` no longer flags a BACKGROUNDED session (intentionally paused, will resume) as `wedge/task-running-no-session`. Adds `BACKGROUNDED` to the non-wedge set alongside `COMPLETED`.
2. **Subprocess timeouts in `_check_wedge_repo_ahead`** — `git ls-remote` and `gh pr list` calls get `timeout=10` and catch `TimeoutExpired`, so a hung remote can't wedge the doctor itself.

**Bundled extras (scope note — beyond the 2 ticket items):**
3. `_reap_wedge_findings`: session mutations moved *inside* `dev_queue_lock()` (previously mutated outside, only the save was inside) — narrows the torn-state window further.
4. `cli.py`: `--json` branch uses `raise click.exceptions.Exit(...)` instead of `sys.exit(...)` (consistency with the non-json branch, more testable) + expanded doctor docstring documenting the 4 wedge classes.

## Quality gates (local, on branch)

- `ruff check` — clean
- `mypy src/` — clean (33 files)
- `pytest tests/test_doctor.py` — 102 passed

## Provenance

Auto-dev worker shipped this branch but was false-flagged `silently_idle` (#340 watchdog bug) at ~17 min before opening the PR. Branch reviewed + gates re-run by hand; PR opened on the worker's behalf.

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)