### PR TITLE
fix(reconcile): transcript-mtime liveness check prevents false-positive watchdog fires (#340)

### DIFF
--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -320,12 +320,8 @@ def _salvage_terminal_result(
     to an :class:`AutoDevResult` whose status is in
     :data:`_SALVAGE_TERMINAL_STATUSES`. Returns ``None`` otherwise.
     """
-    worktree = session.worktree_path
-    if worktree is None:
-        return None
-    encoded = str(worktree).replace("/", "-")
-    project_dir = Path.home() / ".claude" / "projects" / encoded
-    if not project_dir.is_dir():
+    project_dir = _session_project_dir(session)
+    if project_dir is None or not project_dir.is_dir():
         return None
     candidates = sorted(
         project_dir.glob("*.jsonl"),
@@ -348,6 +344,14 @@ def _salvage_terminal_result(
     return None
 
 
+def _session_project_dir(session: Session) -> Path | None:
+    """Return the Claude project dir for *session*, or None if worktree path unset."""
+    worktree = session.worktree_path
+    if worktree is None:
+        return None
+    return Path.home() / ".claude" / "projects" / str(worktree).replace("/", "-")
+
+
 def _transcript_recently_active(
     session: Session,
     now: datetime,
@@ -361,12 +365,8 @@ def _transcript_recently_active(
     is found (either the session is pre-first-write or path unavailable).
     See GitHub #340.
     """
-    worktree = session.worktree_path
-    if worktree is None:
-        return False
-    encoded = str(worktree).replace("/", "-")
-    project_dir = Path.home() / ".claude" / "projects" / encoded
-    if not project_dir.is_dir():
+    project_dir = _session_project_dir(session)
+    if project_dir is None or not project_dir.is_dir():
         return False
 
     try:
@@ -386,9 +386,9 @@ def _transcript_recently_active(
         if not candidates:
             return False
         newest = candidates[0]
-        if datetime.fromtimestamp(newest.stat().st_mtime, tz=UTC) <= session.started_at:
-            return False
         mtime = datetime.fromtimestamp(newest.stat().st_mtime, tz=UTC)
+        if mtime <= session.started_at:
+            return False
         return (now - mtime).total_seconds() < window_seconds
     except OSError:
         return False

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -71,14 +71,17 @@ AUTO_DEV_LABEL_PREFIX = "auto-dev/"
 HEADLESS_TIMEOUT_SECONDS = 3600  # 60 minutes
 
 # Watchdog budget for DAEMON RUNNING sessions that have not yet emitted any
-# AUTO_DEV_RESULT sentinel. Fires on time elapsed alone — no liveness signal
-# is read from the worker's transcript (GitHub #340 tracks the deeper fix).
-# Set generous enough to cover legitimate small-tier work (parser change +
-# tests + skill doc routinely takes 10-20 min wall time). Per-tier overrides
-# in OrchestratorConfig.idle_watchdog_by_tier take precedence; per-ticket
+# AUTO_DEV_RESULT sentinel. Per-tier overrides in
+# OrchestratorConfig.idle_watchdog_by_tier take precedence; per-ticket
 # TicketTask.idle_watchdog_override beats both. After this window, reconcile
 # flags the session as BLOCKED_ON_USER and fires a push notification.
 IDLE_WATCHDOG_SECONDS = 900  # 15 minutes
+
+# How recently a session's transcript must have been modified to be considered
+# actively making progress. If the newest .jsonl under the session's project
+# dir was written within this window, the watchdog skips the session (GitHub
+# #340). Conservative default: 2 min = well below the 15-min budget.
+TRANSCRIPT_LIVENESS_WINDOW_SECONDS = 120
 
 # Paused-status value written to SESSION_NEEDS_ATTENTION events for sessions
 # the watchdog flags (no sentinel ever emitted, daemon surface still live).
@@ -345,6 +348,52 @@ def _salvage_terminal_result(
     return None
 
 
+def _transcript_recently_active(
+    session: Session,
+    now: datetime,
+    *,
+    window_seconds: int = TRANSCRIPT_LIVENESS_WINDOW_SECONDS,
+) -> bool:
+    """Return True if the session's transcript was written within *window_seconds* ago.
+
+    Reuses the project-dir layout from :func:`_salvage_terminal_result`.
+    Returns False — permitting the watchdog to proceed — when no transcript
+    is found (either the session is pre-first-write or path unavailable).
+    See GitHub #340.
+    """
+    worktree = session.worktree_path
+    if worktree is None:
+        return False
+    encoded = str(worktree).replace("/", "-")
+    project_dir = Path.home() / ".claude" / "projects" / encoded
+    if not project_dir.is_dir():
+        return False
+
+    try:
+        if session.claude_session_id is not None:
+            transcript = project_dir / f"{session.claude_session_id}.jsonl"
+            if not transcript.is_file():
+                return False
+            mtime = datetime.fromtimestamp(transcript.stat().st_mtime, tz=UTC)
+            return (now - mtime).total_seconds() < window_seconds
+
+        # claude_session_id not yet recorded — scan for the newest post-spawn .jsonl
+        candidates = sorted(
+            project_dir.glob("*.jsonl"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if not candidates:
+            return False
+        newest = candidates[0]
+        if datetime.fromtimestamp(newest.stat().st_mtime, tz=UTC) <= session.started_at:
+            return False
+        mtime = datetime.fromtimestamp(newest.stat().st_mtime, tz=UTC)
+        return (now - mtime).total_seconds() < window_seconds
+    except OSError:
+        return False
+
+
 def _apply_salvaged_completion(
     session: Session,
     result: AutoDevResult,
@@ -557,6 +606,10 @@ def flag_silently_idle_daemon_sessions(
         task = task_by_ticket.get(ticket_id) if ticket_id else None
         budget = resolve_idle_watchdog_budget(task, config)
         if elapsed < budget:
+            continue
+        # Liveness check: if the worker's transcript was modified recently the
+        # process is still actively making progress — skip this tick (#340).
+        if _transcript_recently_active(session, now):
             continue
         candidates.append((session, ticket_id))
 

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -2129,6 +2129,137 @@ def test_flag_silently_idle_skips_worker_with_recent_transcript(
     assert sess.last_result is None  # watchdog did not fire
 
 
+def test_flag_silently_idle_fires_when_project_dir_missing(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """worktree_path set but project dir absent → proceeds to fire watchdog."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    assert (now - started_at).total_seconds() > IDLE_WATCHDOG_SECONDS
+
+    worktree = tmp_path / "wt-no-proj"
+    sess = _mk_headless_daemon_session("no-proj-1", worktree, started_at)
+    sess.surface_ref = "live-ref"
+    # Do NOT create the .claude/projects/<encoded>/ directory.
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="no-proj-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="no-proj-1",
+                )
+            ]
+        )
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    with patch("cw.reconcile.fire_push_notification"):
+        blocked = flag_silently_idle_daemon_sessions(
+            state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+        )
+
+    assert "no-proj-1" in blocked
+
+
+def test_flag_silently_idle_fires_when_session_id_file_missing(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Known claude_session_id but the specific .jsonl doesn't exist → fires."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    assert (now - started_at).total_seconds() > IDLE_WATCHDOG_SECONDS
+
+    worktree = tmp_path / "wt-missing-file"
+    sess = _mk_headless_daemon_session("missing-file-1", worktree, started_at)
+    sess.surface_ref = "live-ref"
+    sess.claude_session_id = "missing-uuid"
+    # Create project dir but NOT the expected .jsonl.
+    encoded = str(worktree).replace("/", "-")
+    (home / ".claude" / "projects" / encoded).mkdir(parents=True, exist_ok=True)
+
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="missing-file-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="missing-file-1",
+                )
+            ]
+        )
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    with patch("cw.reconcile.fire_push_notification"):
+        blocked = flag_silently_idle_daemon_sessions(
+            state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+        )
+
+    assert "missing-file-1" in blocked
+
+
+def test_flag_silently_idle_fires_when_transcript_predates_session(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Transcript mtime <= started_at → stale-transcript guard fires watchdog."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    assert (now - started_at).total_seconds() > IDLE_WATCHDOG_SECONDS
+
+    worktree = tmp_path / "wt-predates"
+    sess = _mk_headless_daemon_session("predates-1", worktree, started_at)
+    sess.surface_ref = "live-ref"
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="predates-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="predates-1",
+                )
+            ]
+        )
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    transcript = _write_idle_transcript(home, worktree)
+    # Stamp before started_at — stale-transcript guard should reject this file.
+    before_start = (started_at - timedelta(seconds=60)).timestamp()
+    os.utime(str(transcript), (before_start, before_start))
+
+    with patch("cw.reconcile.fire_push_notification"):
+        blocked = flag_silently_idle_daemon_sessions(
+            state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+        )
+
+    assert "predates-1" in blocked
+
+
 def test_flag_silently_idle_fires_on_stale_transcript(
     tmp_config_dir: Path,
     tmp_path: Path,

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -36,6 +37,7 @@ from cw.reconcile import (
     HEADLESS_TIMEOUT_SECONDS,
     IDLE_WATCHDOG_SECONDS,
     SPAWN_GRACE_SECONDS,
+    TRANSCRIPT_LIVENESS_WINDOW_SECONDS,
     _claude_agents_json,
     compute_drift,
     flag_silently_idle_daemon_sessions,
@@ -2073,3 +2075,180 @@ def test_flag_silently_idle_daemon_sessions_respects_per_ticket_override(
 
     assert blocked == []
     assert sess.status == SessionStatus.ACTIVE
+
+
+# ---------------------------------------------------------------------------
+# flag_silently_idle — transcript liveness check (GitHub #340)
+# ---------------------------------------------------------------------------
+
+
+def _write_idle_transcript(
+    home: Path, worktree: Path, filename: str = "sess.jsonl"
+) -> Path:
+    """Write a minimal transcript .jsonl under the project dir for *worktree*."""
+    encoded = str(worktree).replace("/", "-")
+    project_dir = home / ".claude" / "projects" / encoded
+    project_dir.mkdir(parents=True, exist_ok=True)
+    path = project_dir / filename
+    record = '{"type": "assistant", "message": {"role": "assistant", "content": []}}\n'
+    path.write_text(record)
+    return path
+
+
+def test_flag_silently_idle_skips_worker_with_recent_transcript(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Elapsed > budget but transcript recently written → no fire (GitHub #340)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)  # 1200s > IDLE_WATCHDOG_SECONDS
+    assert (now - started_at).total_seconds() > IDLE_WATCHDOG_SECONDS
+
+    worktree = tmp_path / "wt-live"
+    sess = _mk_headless_daemon_session("live-1", worktree, started_at)
+    sess.surface_ref = "live-ref"
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    transcript = _write_idle_transcript(home, worktree)
+    # Stamp at half the liveness window — well within TRANSCRIPT_LIVENESS_WINDOW_SECONDS
+    half_window = TRANSCRIPT_LIVENESS_WINDOW_SECONDS // 2
+    recent_ts = (now - timedelta(seconds=half_window)).timestamp()
+    os.utime(str(transcript), (recent_ts, recent_ts))
+
+    blocked = flag_silently_idle_daemon_sessions(
+        state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+    )
+
+    assert blocked == []
+    assert sess.last_result is None  # watchdog did not fire
+
+
+def test_flag_silently_idle_fires_on_stale_transcript(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Elapsed > budget and transcript older than liveness window → fires."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)  # 1200s > budget
+    assert (now - started_at).total_seconds() > IDLE_WATCHDOG_SECONDS
+
+    worktree = tmp_path / "wt-stale-tx"
+    sess = _mk_headless_daemon_session("stale-tx-1", worktree, started_at)
+    sess.surface_ref = "live-ref"
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="stale-tx-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="stale-tx-1",
+                )
+            ]
+        )
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    transcript = _write_idle_transcript(home, worktree)
+    # Stamp beyond the liveness window — stale, watchdog should fire
+    past_window = TRANSCRIPT_LIVENESS_WINDOW_SECONDS + 80
+    stale_ts = (now - timedelta(seconds=past_window)).timestamp()
+    os.utime(str(transcript), (stale_ts, stale_ts))
+
+    with patch("cw.reconcile.fire_push_notification"):
+        blocked = flag_silently_idle_daemon_sessions(
+            state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+        )
+
+    assert "stale-tx-1" in blocked
+    assert sess.last_result == {"paused_status": _SILENTLY_IDLE_REASON}
+
+
+def test_flag_silently_idle_fires_when_no_transcript_in_project_dir(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Elapsed > budget, project dir exists but no .jsonl → fires (grace case)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    assert (now - started_at).total_seconds() > IDLE_WATCHDOG_SECONDS
+
+    worktree = tmp_path / "wt-no-tx"
+    sess = _mk_headless_daemon_session("no-tx-1", worktree, started_at)
+    sess.surface_ref = "live-ref"
+    # Create project dir but write no .jsonl files
+    encoded = str(worktree).replace("/", "-")
+    (home / ".claude" / "projects" / encoded).mkdir(parents=True, exist_ok=True)
+
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="no-tx-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="no-tx-1",
+                )
+            ]
+        )
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    with patch("cw.reconcile.fire_push_notification"):
+        blocked = flag_silently_idle_daemon_sessions(
+            state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+        )
+
+    assert "no-tx-1" in blocked
+    assert sess.last_result == {"paused_status": _SILENTLY_IDLE_REASON}
+
+
+def test_flag_silently_idle_skips_with_known_session_id_and_recent_transcript(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Known claude_session_id → specific file checked; recent write skips watchdog."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    assert (now - started_at).total_seconds() > IDLE_WATCHDOG_SECONDS
+
+    worktree = tmp_path / "wt-known-id"
+    sess = _mk_headless_daemon_session("known-id-1", worktree, started_at)
+    sess.surface_ref = "live-ref"
+    sess.claude_session_id = "known-uuid"
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    transcript = _write_idle_transcript(home, worktree, filename="known-uuid.jsonl")
+    recent_ts = (now - timedelta(seconds=30)).timestamp()
+    os.utime(str(transcript), (recent_ts, recent_ts))
+
+    blocked = flag_silently_idle_daemon_sessions(
+        state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+    )
+
+    assert blocked == []
+    assert sess.last_result is None


### PR DESCRIPTION
## Summary

- fix(reconcile): transcript-mtime liveness check prevents false-positive watchdog fires
- test(reconcile): cover _transcript_recently_active edge-case branches
- refactor(reconcile): extract _session_project_dir, fix double stat()

Adds transcript modification-time check to `flag_silently_idle_daemon_sessions` so active workers are not incorrectly flagged as idle when their transcript file has been recently written. Prevents false-positive watchdog fires on busy sessions.

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors (pre-existing unrelated error in test_atomic.py on main)
- [ ] pytest — 1344 passed, 4 skipped
- [ ] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it