### PR TITLE
fix(reconcile): idle watchdog auto-recovers stalled headless workers (#384)

### DIFF
--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -244,6 +244,10 @@ class OrchestratorConfig(BaseModel):
     idle_watchdog_by_tier: dict[str, int] = Field(
         default_factory=lambda: {"large": 1800}
     )
+    # Per-tier cap on idle-stall auto-retries before a headless worker is
+    # parked BLOCKED_ON_USER for the operator. Keyed by TicketTask.scope_hint;
+    # unknown tiers fall back to DEFAULT_IDLE_RETRY_CAP. See GitHub issue #384.
+    idle_retry_cap_by_tier: dict[str, int] = Field(default_factory=dict)
 
     @model_validator(mode="before")
     @classmethod

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -77,11 +77,20 @@ HEADLESS_TIMEOUT_SECONDS = 3600  # 60 minutes
 # flags the session as BLOCKED_ON_USER and fires a push notification.
 IDLE_WATCHDOG_SECONDS = 900  # 15 minutes
 
+DEFAULT_IDLE_RETRY_CAP = 2  # idle-stall auto-retries before parking (#384)
+
 # How recently a session's transcript must have been modified to be considered
 # actively making progress. If the newest .jsonl under the session's project
 # dir was written within this window, the watchdog skips the session (GitHub
 # #340). Conservative default: 2 min = well below the 15-min budget.
-TRANSCRIPT_LIVENESS_WINDOW_SECONDS = 120
+# 5 min — widened from 2 min (#384): covers short inter-turn gaps;
+# subagent gaps handled by _awaiting_subagent below.
+TRANSCRIPT_LIVENESS_WINDOW_SECONDS = 300
+
+# A worker awaiting a subagent leaves the parent transcript quiet (subagent output
+# only lands on return). Treat a pending tool_use at the transcript tail as alive
+# for up to this long before concluding the subagent itself is hung. See #384.
+SUBAGENT_LIVENESS_WINDOW_SECONDS = 900
 
 # Paused-status value written to SESSION_NEEDS_ATTENTION events for sessions
 # the watchdog flags (no sentinel ever emitted, daemon surface still live).
@@ -390,6 +399,74 @@ def _transcript_recently_active(
         if mtime <= session.started_at:
             return False
         return (now - mtime).total_seconds() < window_seconds
+    except OSError:
+        return False
+
+
+def _awaiting_subagent(session: Session, now: datetime) -> bool:
+    """Return True if the worker is mid-tool/subagent (parent tail pending).
+
+    A subagent's output only lands in the parent transcript when it returns,
+    so the parent goes quiet during execution and mtime-based liveness
+    false-positives. Detect the in-flight case: the last assistant turn is a
+    ``tool_use`` with no following ``tool_result``, and that turn is within
+    ``SUBAGENT_LIVENESS_WINDOW_SECONDS`` of *now* (a pending tool_use older than
+    that is a hung subagent — not alive). See GitHub #384.
+
+    Fail-open to False (permit the watchdog to proceed) on any read/parse error.
+    """
+    project_dir = _session_project_dir(session)
+    if project_dir is None or not project_dir.is_dir():
+        return False
+    try:
+        if session.claude_session_id is not None:
+            transcript = project_dir / f"{session.claude_session_id}.jsonl"
+        else:
+            candidates = sorted(
+                project_dir.glob("*.jsonl"),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+            if not candidates:
+                return False
+            transcript = candidates[0]
+        if not transcript.is_file():
+            return False
+
+        last_tool_use_ts: datetime | None = None
+        saw_result_after_tool_use = True
+        for raw in transcript.read_text().splitlines():
+            if not raw.strip():
+                continue
+            try:
+                entry = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            etype = entry.get("type")
+            message = entry.get("message")
+            content = message.get("content") if isinstance(message, dict) else None
+            if not isinstance(content, list):
+                continue
+            if etype == "assistant" and any(
+                isinstance(b, dict) and b.get("type") == "tool_use" for b in content
+            ):
+                ts = entry.get("timestamp")
+                if isinstance(ts, str):
+                    try:
+                        last_tool_use_ts = datetime.fromisoformat(ts)
+                    except ValueError:
+                        last_tool_use_ts = None
+                saw_result_after_tool_use = False
+            elif etype == "user" and any(
+                isinstance(b, dict) and b.get("type") == "tool_result" for b in content
+            ):
+                saw_result_after_tool_use = True
+
+        if saw_result_after_tool_use or last_tool_use_ts is None:
+            return False
+        return (
+            now - last_tool_use_ts
+        ).total_seconds() < SUBAGENT_LIVENESS_WINDOW_SECONDS
     except OSError:
         return False
 

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -642,6 +642,24 @@ def resolve_idle_watchdog_budget(
     return IDLE_WATCHDOG_SECONDS
 
 
+def resolve_idle_retry_cap(
+    task: TicketTask | None,
+    config: OrchestratorConfig,
+) -> int:
+    """Return the idle-stall auto-retry cap for a session's ticket.
+
+    Precedence: task.scope_hint per-tier override, else the global default.
+    See GitHub issue #384.
+    """
+    if task is None:
+        return DEFAULT_IDLE_RETRY_CAP
+    if task.scope_hint is not None:
+        tier_cap = config.idle_retry_cap_by_tier.get(task.scope_hint)
+        if tier_cap is not None:
+            return tier_cap
+    return DEFAULT_IDLE_RETRY_CAP
+
+
 def flag_silently_idle_daemon_sessions(
     state: CwState,
     *,

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -684,7 +684,8 @@ def flag_silently_idle_daemon_sessions(
     if task_by_ticket is None:
         task_by_ticket = {t.ticket_id: t for t in load_dev_queue().tasks}
 
-    candidates: list[tuple[Session, str | None]] = []
+    recover: list[tuple[Session, str | None]] = []
+    park: list[tuple[Session, str | None]] = []
     for session in state.sessions:
         if session.origin is not SessionOrigin.DAEMON:
             continue
@@ -709,53 +710,83 @@ def flag_silently_idle_daemon_sessions(
             session, now
         ):
             continue
-        candidates.append((session, ticket_id))
+        cap = resolve_idle_retry_cap(task, config)
+        if task is not None and task.attempts < cap:
+            recover.append((session, ticket_id))
+        else:
+            park.append((session, ticket_id))
 
-    if not candidates:
+    if not recover and not park:
         return []
 
-    for session, _ in candidates:
-        # Flag-only: do not mark session COMPLETED. The worker on the daemon
-        # is still alive; operators disposition flagged sessions via
-        # `cw spawn complete` or `cw doctor --reap`. Setting last_result with
-        # paused_status still makes _has_terminal_sentinel return True so the
-        # watchdog skips this session on subsequent ticks (GitHub #324, #348).
+    # Auto-recover: retire the session and revert its task for re-dispatch.
+    for session, _ in recover:
+        session.status = SessionStatus.TIMED_OUT
+        session.completed_at = now
+        session.completed_reason = CompletionReason.TIMED_OUT
+    # Park: flag-only (preserves #348 — no daemon stop, session stays ACTIVE).
+    for session, _ in park:
         session.last_result = {"paused_status": _SILENTLY_IDLE_REASON}
 
     # Write session to disk BEFORE queue mutation so a crash between the two
-    # leaves session.last_result set on disk — _has_terminal_sentinel returns
-    # True on the next reconcile tick and the watchdog skips the session,
-    # preventing a duplicate SESSION_NEEDS_ATTENTION. (GitHub #324)
+    # leaves state set on disk — watchdog skips on subsequent ticks. (#324, #348)
     save_state(state)
 
+    recovered_ids = {tid for _, tid in recover if tid}
+    parked_ids = {tid for _, tid in park if tid}
     blocked: list[str] = []
-    ticket_ids_to_block = [tid for _, tid in candidates if tid]
-    if ticket_ids_to_block:
-        ticket_id_set = set(ticket_ids_to_block)
+    if recovered_ids or parked_ids:
         with dev_queue_lock():
             store = load_dev_queue()
+            changed = False
             for task in store.tasks:
-                if (
-                    task.ticket_id in ticket_id_set
-                    and task.status == QueueItemStatus.RUNNING
-                ):
+                if task.status != QueueItemStatus.RUNNING:
+                    continue
+                if task.ticket_id in recovered_ids:
+                    task.status = QueueItemStatus.PENDING
+                    task.session_id = None
+                    changed = True
+                elif task.ticket_id in parked_ids:
                     task.status = QueueItemStatus.BLOCKED_ON_USER
                     blocked.append(task.ticket_id)
-            if blocked:
+                    changed = True
+            if changed:
                 save_dev_queue(store)
 
-    for session, ticket_id in candidates:
-        payload: dict[str, object] = {
-            "session_id": session.id,
-            "session_name": session.name,
-            "client": session.client,
-            "ticket_id": ticket_id,
-            "claude_session_id": session.claude_session_id,
-            "paused_status": _SILENTLY_IDLE_REASON,
-            "breadcrumbs": "",
-            "crashed": False,
-        }
-        record_event(OrchestratorEventType.SESSION_NEEDS_ATTENTION, payload)
+    # Recovery: stop the dead surface + emit a distinguishable timeout event.
+    # Payload mirrors the wall-clock timeout path; cause distinguishes the source.
+    for session, ticket_id in recover:
+        if session.surface_ref is not None:
+            get_native_daemon_client().stop(session.surface_ref)
+        record_event(
+            OrchestratorEventType.SESSION_TIMED_OUT,
+            {
+                "session_id": session.id,
+                "session_name": session.name,
+                "client": session.client,
+                "ticket_id": ticket_id,
+                "claude_session_id": session.claude_session_id,
+                "elapsed_seconds": (now - session.started_at).total_seconds(),
+                "cause": "idle_stall_recovered",
+                "last_assistant_message_excerpt": "",
+            },
+        )
+
+    # Park: needs-attention for operator disposition (unchanged from #348).
+    for session, ticket_id in park:
+        record_event(
+            OrchestratorEventType.SESSION_NEEDS_ATTENTION,
+            {
+                "session_id": session.id,
+                "session_name": session.name,
+                "client": session.client,
+                "ticket_id": ticket_id,
+                "claude_session_id": session.claude_session_id,
+                "paused_status": _SILENTLY_IDLE_REASON,
+                "breadcrumbs": "",
+                "crashed": False,
+            },
+        )
         fire_push_notification(session.name, session.client)
 
     return blocked

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -684,9 +684,12 @@ def flag_silently_idle_daemon_sessions(
         budget = resolve_idle_watchdog_budget(task, config)
         if elapsed < budget:
             continue
-        # Liveness check: if the worker's transcript was modified recently the
-        # process is still actively making progress — skip this tick (#340).
-        if _transcript_recently_active(session, now):
+        # Liveness check: skip workers that are still making progress. A recent
+        # transcript write (#340) OR an in-flight subagent (#384 — parent
+        # transcript goes quiet while a subagent runs) both count as alive.
+        if _transcript_recently_active(session, now) or _awaiting_subagent(
+            session, now
+        ):
             continue
         candidates.append((session, ticket_id))
 

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -2709,3 +2709,165 @@ def test_flag_silently_idle_parks_when_cap_exhausted(
     assert sess.last_result == {"paused_status": "silently_idle"}
     store = load_dev_queue()
     assert store.tasks[0].status == QueueItemStatus.BLOCKED_ON_USER
+
+
+# ---------------------------------------------------------------------------
+# _awaiting_subagent edge-case coverage
+# ---------------------------------------------------------------------------
+
+
+def test_awaiting_subagent_skips_blank_lines_and_bad_json(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """Blank lines and malformed JSON in transcript are skipped gracefully."""
+    from cw.reconcile import _awaiting_subagent
+
+    now = datetime(2026, 1, 1, 0, 5, 0, tzinfo=UTC)
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    transcript = project_dir / "sess-uuid.jsonl"
+    # blank line, bad JSON, then valid tool_use with no result
+    transcript.write_text(
+        "\n"
+        "not-json\n"
+        + json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-01-01T00:04:00Z",
+                "message": {
+                    "stop_reason": "tool_use",
+                    "content": [{"type": "tool_use", "name": "Agent"}],
+                },
+            }
+        )
+        + "\n"
+    )
+    sess = _make_daemon_session(claude_session_id="sess-uuid")
+    with patch("cw.reconcile._session_project_dir", return_value=project_dir):
+        assert _awaiting_subagent(sess, now) is True
+
+
+def test_awaiting_subagent_skips_non_list_content(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """Entries with non-list content field are skipped without error."""
+    from cw.reconcile import _awaiting_subagent
+
+    now = datetime(2026, 1, 1, 0, 5, 0, tzinfo=UTC)
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    transcript = project_dir / "sess-uuid.jsonl"
+    # entry with non-list content — should be skipped, not crash
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-01-01T00:04:00Z",
+                "message": {"content": "not-a-list"},
+            }
+        )
+        + "\n"
+    )
+    sess = _make_daemon_session(claude_session_id="sess-uuid")
+    with patch("cw.reconcile._session_project_dir", return_value=project_dir):
+        # Nothing to track — returns False (no pending tool_use)
+        assert _awaiting_subagent(sess, now) is False
+
+
+def test_awaiting_subagent_handles_invalid_timestamp(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """Invalid ISO timestamp on tool_use → last_tool_use_ts stays None → False."""
+    from cw.reconcile import _awaiting_subagent
+
+    now = datetime(2026, 1, 1, 0, 5, 0, tzinfo=UTC)
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    transcript = project_dir / "sess-uuid.jsonl"
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "not-a-valid-timestamp",
+                "message": {
+                    "stop_reason": "tool_use",
+                    "content": [{"type": "tool_use", "name": "Agent"}],
+                },
+            }
+        )
+        + "\n"
+    )
+    sess = _make_daemon_session(claude_session_id="sess-uuid")
+    with patch("cw.reconcile._session_project_dir", return_value=project_dir):
+        # invalid ts → last_tool_use_ts = None → returns False
+        assert _awaiting_subagent(sess, now) is False
+
+
+def test_awaiting_subagent_returns_false_on_oserror(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """OSError while reading transcript → fail-open False."""
+    from cw.reconcile import _awaiting_subagent
+
+    now = datetime(2026, 1, 1, 0, 5, 0, tzinfo=UTC)
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    # Point at a file that does not exist
+    sess = _make_daemon_session(claude_session_id="no-such-file")
+    # project_dir exists but the specific .jsonl doesn't
+    with patch("cw.reconcile._session_project_dir", return_value=project_dir):
+        assert _awaiting_subagent(sess, now) is False
+
+
+def test_flag_silently_idle_recover_skips_non_running_task(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """Queue task not RUNNING is not mutated during recover/park sweep (#384)."""
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+
+    sess = Session(
+        id="skip-nonrunning",
+        name="client-a/auto-dev/SKIP-NR",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        worktree_path=Path("/tmp/wt"),
+        surface_ref="live-ref",
+        started_at=started_at,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    # Task is PENDING (not RUNNING) — should be left alone
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="SKIP-NR",
+                    client="client-a",
+                    status=QueueItemStatus.PENDING,
+                    session_id=None,
+                    attempts=1,  # < cap → would recover if RUNNING
+                )
+            ]
+        )
+    )
+
+    mock_daemon = MagicMock()
+    with (
+        patch("cw.reconcile._transcript_recently_active", return_value=False),
+        patch("cw.reconcile._awaiting_subagent", return_value=False),
+        patch("cw.reconcile.get_native_daemon_client", return_value=mock_daemon),
+    ):
+        result = flag_silently_idle_daemon_sessions(
+            state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+        )
+        # Surface still stopped (recover path, attempts=1 < cap=2)
+        mock_daemon.stop.assert_called_once_with("live-ref")
+
+    # Task was PENDING, not RUNNING → not touched
+    store = load_dev_queue()
+    assert store.tasks[0].status == QueueItemStatus.PENDING
+    assert result == []

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -2383,3 +2383,120 @@ def test_flag_silently_idle_skips_with_known_session_id_and_recent_transcript(
 
     assert blocked == []
     assert sess.last_result is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers for _awaiting_subagent tests
+# ---------------------------------------------------------------------------
+
+
+def _make_daemon_session(
+    *, claude_session_id: str | None = None, surface_ref: str = "live-ref"
+) -> Session:
+    return Session(
+        id="sess-1",
+        name="client-a/auto-dev/T-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        worktree_path=Path("/tmp/wt"),
+        surface_ref=surface_ref,
+        claude_session_id=claude_session_id,
+        started_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _awaiting_subagent tests (Task A1)
+# ---------------------------------------------------------------------------
+
+
+def test_awaiting_subagent_true_when_tail_is_pending_tool_use(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """Last assistant turn is a tool_use with no tool_result yet → awaiting."""
+    from cw.reconcile import _awaiting_subagent
+
+    now = datetime(2026, 1, 1, 0, 5, 0, tzinfo=UTC)
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    transcript = project_dir / "sess-uuid.jsonl"
+    tu_ts = "2026-01-01T00:04:00Z"
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": tu_ts,
+                "message": {
+                    "stop_reason": "tool_use",
+                    "content": [{"type": "tool_use", "name": "Agent"}],
+                },
+            }
+        )
+        + "\n"
+    )
+    sess = _make_daemon_session(claude_session_id="sess-uuid")
+    with patch("cw.reconcile._session_project_dir", return_value=project_dir):
+        assert _awaiting_subagent(sess, now) is True
+
+
+def test_awaiting_subagent_false_when_tool_result_delivered(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """tool_use followed by tool_result → NOT awaiting (genuine hang)."""
+    from cw.reconcile import _awaiting_subagent
+
+    now = datetime(2026, 1, 1, 0, 5, 0, tzinfo=UTC)
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    transcript = project_dir / "sess-uuid.jsonl"
+    lines = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-01-01T00:04:00Z",
+            "message": {
+                "stop_reason": "tool_use",
+                "content": [{"type": "tool_use", "name": "Agent"}],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-01-01T00:04:01Z",
+            "message": {"content": [{"type": "tool_result"}]},
+        },
+    ]
+    transcript.write_text("\n".join(json.dumps(x) for x in lines) + "\n")
+    sess = _make_daemon_session(claude_session_id="sess-uuid")
+    with patch("cw.reconcile._session_project_dir", return_value=project_dir):
+        assert _awaiting_subagent(sess, now) is False
+
+
+def test_awaiting_subagent_false_when_pending_tool_use_too_old(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """Pending tool_use older than SUBAGENT_LIVENESS_WINDOW → hung subagent."""
+    from cw.reconcile import SUBAGENT_LIVENESS_WINDOW_SECONDS, _awaiting_subagent
+
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    transcript = project_dir / "sess-uuid.jsonl"
+    assert SUBAGENT_LIVENESS_WINDOW_SECONDS < 1800
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-01-01T00:30:00Z",
+                "message": {
+                    "stop_reason": "tool_use",
+                    "content": [{"type": "tool_use", "name": "Agent"}],
+                },
+            }
+        )
+        + "\n"
+    )
+    sess = _make_daemon_session(claude_session_id="sess-uuid")
+    with patch("cw.reconcile._session_project_dir", return_value=project_dir):
+        assert _awaiting_subagent(sess, now) is False

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -8,7 +8,7 @@ import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import freezegun
 
@@ -1627,7 +1627,8 @@ def test_flag_silently_idle_daemon_sessions_transitions_past_budget(
     tmp_config_dir: Path,
     tmp_path: Path,
 ) -> None:
-    """DAEMON ACTIVE + no last_result + started >IDLE_WATCHDOG → BLOCKED_ON_USER."""
+    """DAEMON ACTIVE + no last_result + started >IDLE_WATCHDOG + cap exhausted →
+    BLOCKED_ON_USER park (#348, updated for #384: park only when attempts >= cap)."""
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
     now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
     assert (now - started_at).total_seconds() > IDLE_WATCHDOG_SECONDS
@@ -1653,6 +1654,7 @@ def test_flag_silently_idle_daemon_sessions_transitions_past_budget(
         client="client-a",
         status=QueueItemStatus.RUNNING,
         session_id="silent-1",
+        attempts=2,  # at DEFAULT_IDLE_RETRY_CAP → park path (#384)
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
@@ -1687,25 +1689,23 @@ def test_flag_silently_idle_daemon_sessions_transitions_past_budget(
     assert payload["crashed"] is False
 
 
-def test_flag_silently_idle_watchdog_does_not_call_native_daemon_stop(
+def test_flag_silently_idle_watchdog_does_not_stop_working_worker(
     tmp_config_dir: Path,
     tmp_path: Path,
 ) -> None:
-    """Flag-only: watchdog must not invoke native_daemon stop() (#348).
+    """#348 intent preserved (#384): a worker still doing work is never stopped.
 
-    The Track C wave-2 case study (2026-05-28) showed three workers that had
-    actually shipped work being silenced mid-stream by the watchdog. The fix
-    is flag-only: the queue task transitions to BLOCKED_ON_USER and the
-    operator dispositions the session via `cw spawn complete` or
-    `cw doctor --reap`. The session itself stays alive on the daemon.
+    Pre-#384 enforced by flag-only. Post-#384 enforced by the liveness gate:
+    a worker the liveness check considers alive (recent write OR awaiting
+    subagent) is skipped entirely, so stop() is never reached.
     """
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
     now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
     assert (now - started_at).total_seconds() > IDLE_WATCHDOG_SECONDS
 
     sess = Session(
-        id="alive-after-flag",
-        name="client-a/auto-dev/ALIVE-1",
+        id="working-1",
+        name="client-a/auto-dev/WORK-1",
         client="client-a",
         purpose=SessionPurpose.IMPL,
         origin=SessionOrigin.DAEMON,
@@ -1720,29 +1720,28 @@ def test_flag_silently_idle_watchdog_does_not_call_native_daemon_stop(
     save_state(state)
 
     task = TicketTask(
-        ticket_id="ALIVE-1",
+        ticket_id="WORK-1",
         client="client-a",
         status=QueueItemStatus.RUNNING,
-        session_id="alive-after-flag",
+        session_id="working-1",
+        attempts=0,
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
+    mock_daemon = MagicMock()
     with (
-        patch("cw.reconcile.fire_push_notification"),
-        patch("cw.reconcile.get_native_daemon_client") as mock_daemon,
+        patch("cw.reconcile._transcript_recently_active", return_value=True),
+        patch("cw.reconcile.get_native_daemon_client", return_value=mock_daemon),
     ):
-        flag_silently_idle_daemon_sessions(
+        result = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
         )
 
-    # The daemon client must not be touched — flag-only means the worker on
-    # the native daemon keeps running, even though the queue is BLOCKED_ON_USER.
-    mock_daemon.assert_not_called()
-
-    # Reload from disk and confirm session is still ACTIVE.
-    reloaded = load_state()
-    s = next(s for s in reloaded.sessions if s.id == "alive-after-flag")
-    assert s.status == SessionStatus.ACTIVE
+    mock_daemon.stop.assert_not_called()
+    assert result == []
+    assert sess.status == SessionStatus.ACTIVE
+    store = load_dev_queue()
+    assert store.tasks[0].status == QueueItemStatus.RUNNING
 
 
 def test_flag_silently_idle_watchdog_no_double_fire_on_crash_recovery(
@@ -1901,7 +1900,8 @@ def test_reconcile_includes_silently_idle_in_report(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """reconcile() calls watchdog and includes BLOCKED_ON_USER ticket in report."""
+    """reconcile() calls watchdog and includes BLOCKED_ON_USER ticket in report
+    when attempts >= cap (park path, #384)."""
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
     now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
     assert (now - started_at).total_seconds() > IDLE_WATCHDOG_SECONDS
@@ -1930,6 +1930,7 @@ def test_reconcile_includes_silently_idle_in_report(
         client="client-a",
         status=QueueItemStatus.RUNNING,
         session_id="rcl-silent",
+        attempts=2,  # at cap → park path (#384)
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
@@ -2155,6 +2156,7 @@ def test_flag_silently_idle_fires_when_project_dir_missing(
                     client="client-a",
                     status=QueueItemStatus.RUNNING,
                     session_id="no-proj-1",
+                    attempts=2,  # at cap → park path (#384)
                 )
             ]
         )
@@ -2200,6 +2202,7 @@ def test_flag_silently_idle_fires_when_session_id_file_missing(
                     client="client-a",
                     status=QueueItemStatus.RUNNING,
                     session_id="missing-file-1",
+                    attempts=2,  # at cap → park path (#384)
                 )
             ]
         )
@@ -2240,6 +2243,7 @@ def test_flag_silently_idle_fires_when_transcript_predates_session(
                     client="client-a",
                     status=QueueItemStatus.RUNNING,
                     session_id="predates-1",
+                    attempts=2,  # at cap → park path (#384)
                 )
             ]
         )
@@ -2285,6 +2289,7 @@ def test_flag_silently_idle_fires_on_stale_transcript(
                     client="client-a",
                     status=QueueItemStatus.RUNNING,
                     session_id="stale-tx-1",
+                    attempts=2,  # at cap → park path (#384)
                 )
             ]
         )
@@ -2336,6 +2341,7 @@ def test_flag_silently_idle_fires_when_no_transcript_in_project_dir(
                     client="client-a",
                     status=QueueItemStatus.RUNNING,
                     session_id="no-tx-1",
+                    attempts=2,  # at cap → park path (#384)
                 )
             ]
         )
@@ -2582,3 +2588,124 @@ def test_resolve_idle_retry_cap_unknown_tier_falls_back() -> None:
     cfg = OrchestratorConfig(idle_retry_cap_by_tier={"large": 4})
     task = TicketTask(ticket_id="T", client="c", scope_hint="small")
     assert resolve_idle_retry_cap(task, cfg) == DEFAULT_IDLE_RETRY_CAP
+
+
+# ---------------------------------------------------------------------------
+# Task B2: auto-recover under cap, park on exhaustion
+# ---------------------------------------------------------------------------
+
+
+def test_flag_silently_idle_auto_recovers_under_cap(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """Confirmed-idle worker, attempts < cap → surface stopped, task PENDING (#384)."""
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    sess = Session(
+        id="hang-1",
+        name="client-a/auto-dev/HANG-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        worktree_path=Path("/tmp/wt"),
+        surface_ref="live-ref",
+        started_at=started_at,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="HANG-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="hang-1",
+                    attempts=1,  # < DEFAULT_IDLE_RETRY_CAP (2)
+                )
+            ]
+        )
+    )
+
+    mock_daemon = MagicMock()
+    with (
+        patch("cw.reconcile._transcript_recently_active", return_value=False),
+        patch("cw.reconcile._awaiting_subagent", return_value=False),
+        patch("cw.reconcile.get_native_daemon_client", return_value=mock_daemon),
+        patch("cw.reconcile.fire_push_notification") as mock_notify,
+    ):
+        flag_silently_idle_daemon_sessions(
+            state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+        )
+        mock_daemon.stop.assert_called_once_with("live-ref")
+        mock_notify.assert_not_called()
+
+    store = load_dev_queue()
+    t = store.tasks[0]
+    assert t.status == QueueItemStatus.PENDING
+    assert t.session_id is None
+    assert sess.status == SessionStatus.TIMED_OUT
+    assert sess.completed_reason == CompletionReason.TIMED_OUT
+    events = read_events(
+        consumer="test-hang-recover",
+        event_types=[OrchestratorEventType.SESSION_TIMED_OUT],
+    )
+    assert len(events) == 1
+    assert events[0].payload["cause"] == "idle_stall_recovered"
+
+
+def test_flag_silently_idle_parks_when_cap_exhausted(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """Confirmed-idle worker, attempts >= cap → BLOCKED_ON_USER park (#384)."""
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    sess = Session(
+        id="hang-2",
+        name="client-a/auto-dev/HANG-2",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        worktree_path=Path("/tmp/wt"),
+        surface_ref="live-ref",
+        started_at=started_at,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="HANG-2",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="hang-2",
+                    attempts=2,  # == DEFAULT_IDLE_RETRY_CAP
+                )
+            ]
+        )
+    )
+
+    mock_daemon = MagicMock()
+    with (
+        patch("cw.reconcile._transcript_recently_active", return_value=False),
+        patch("cw.reconcile._awaiting_subagent", return_value=False),
+        patch("cw.reconcile.get_native_daemon_client", return_value=mock_daemon),
+        patch("cw.reconcile.fire_push_notification") as mock_notify,
+    ):
+        blocked = flag_silently_idle_daemon_sessions(
+            state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+        )
+        mock_daemon.stop.assert_not_called()
+        mock_notify.assert_called_once_with(sess.name, sess.client)
+
+    assert "HANG-2" in blocked
+    assert sess.status == SessionStatus.ACTIVE
+    assert sess.last_result == {"paused_status": "silently_idle"}
+    store = load_dev_queue()
+    assert store.tasks[0].status == QueueItemStatus.BLOCKED_ON_USER

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -2555,3 +2555,30 @@ def test_flag_silently_idle_skips_worker_awaiting_subagent(
     assert sess.status == SessionStatus.ACTIVE
     store = load_dev_queue()
     assert store.tasks[0].status == QueueItemStatus.RUNNING
+
+
+# ---------------------------------------------------------------------------
+# Task B1: resolve_idle_retry_cap + idle_retry_cap_by_tier config field
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_idle_retry_cap_default_with_no_task() -> None:
+    from cw.reconcile import DEFAULT_IDLE_RETRY_CAP, resolve_idle_retry_cap
+
+    assert resolve_idle_retry_cap(None, OrchestratorConfig()) == DEFAULT_IDLE_RETRY_CAP
+
+
+def test_resolve_idle_retry_cap_respects_per_tier() -> None:
+    from cw.reconcile import resolve_idle_retry_cap
+
+    cfg = OrchestratorConfig(idle_retry_cap_by_tier={"large": 4})
+    task = TicketTask(ticket_id="T", client="c", scope_hint="large")
+    assert resolve_idle_retry_cap(task, cfg) == 4
+
+
+def test_resolve_idle_retry_cap_unknown_tier_falls_back() -> None:
+    from cw.reconcile import DEFAULT_IDLE_RETRY_CAP, resolve_idle_retry_cap
+
+    cfg = OrchestratorConfig(idle_retry_cap_by_tier={"large": 4})
+    task = TicketTask(ticket_id="T", client="c", scope_hint="small")
+    assert resolve_idle_retry_cap(task, cfg) == DEFAULT_IDLE_RETRY_CAP

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -2500,3 +2500,58 @@ def test_awaiting_subagent_false_when_pending_tool_use_too_old(
     sess = _make_daemon_session(claude_session_id="sess-uuid")
     with patch("cw.reconcile._session_project_dir", return_value=project_dir):
         assert _awaiting_subagent(sess, now) is False
+
+
+# ---------------------------------------------------------------------------
+# Task A2: watchdog skips workers awaiting a subagent
+# ---------------------------------------------------------------------------
+
+
+def test_flag_silently_idle_skips_worker_awaiting_subagent(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """A worker past the idle budget but awaiting a subagent is NOT flagged (#384)."""
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+
+    sess = Session(
+        id="busy-1",
+        name="client-a/auto-dev/BUSY-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        worktree_path=Path("/tmp/wt"),
+        surface_ref="live-ref",
+        started_at=started_at,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="BUSY-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="busy-1",
+                )
+            ]
+        )
+    )
+
+    with (
+        patch("cw.reconcile._transcript_recently_active", return_value=False),
+        patch("cw.reconcile._awaiting_subagent", return_value=True),
+        patch("cw.reconcile.fire_push_notification") as mock_notify,
+    ):
+        blocked = flag_silently_idle_daemon_sessions(
+            state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+        )
+        mock_notify.assert_not_called()
+
+    assert blocked == []
+    assert sess.status == SessionStatus.ACTIVE
+    store = load_dev_queue()
+    assert store.tasks[0].status == QueueItemStatus.RUNNING


### PR DESCRIPTION
## Summary

Closes #384. A headless DAEMON worker that stalled early (intermittent `claude --bg` continuation drop) was parked in `BLOCKED_ON_USER` permanently: the 15-min idle watchdog always fired before the 60-min wall-clock retry sweep, moving the task off `RUNNING` so the retry sweep (RUNNING-only) never reclaimed it. This converts a recoverable transient stall into mandatory manual intervention — fatal for unattended dispatch.

Implements the ticket's preferred direction (1): the idle watchdog now **recovers, not just flags**. When a worker is provably idle past the budget and its transcript is inactive, the surface is stopped and the task reverts to `PENDING` with a bounded, per-tier idle-retry cap. Genuine human-input-needed cases still park after retries are exhausted.

## Commits

- test(reconcile): rework #348 guarantee for #384 liveness-gated stop
- feat(reconcile): capped idle-stall auto-recovery, park on exhaustion (#384)
- feat(config): idle_retry_cap_by_tier + resolve_idle_retry_cap (#384)
- fix(reconcile): idle watchdog skips workers awaiting a subagent (#384)
- feat(reconcile): _awaiting_subagent liveness helper + widen window (#384)

## Test plan

- [x] ruff check — zero violations
- [x] mypy — zero type errors
- [x] pytest — 1543 passed, 3 deselected
- [x] Regression test for idle-sweep-vs-wall-clock ordering (reworked #348 guarantee for liveness-gated stop)
- [x] No regressions in reconcile (81 reconcile tests pass)

## Notes

- Acceptance criterion #4 (one-time cleanup of the 11 currently-parked `blocked_on_user` tasks) is operational cleanup tracked separately from this code fix.

🤖 Shipped via project /ship-it