### PR TITLE
fix(dev-queue): route schema_version_unsupported to FAILED, unknowns to COMPLETED (#263)

### DIFF
--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -85,6 +85,12 @@ _V4_STATUSES: frozenset[str] = frozenset(
 # session is paused waiting for human input (issue #129).
 PAUSED_FOR_USER_INPUT_STATUSES: frozenset[str] = _V4_STATUSES
 
+# BlockedResult reason codes produced by parse_stdout.  Exported so consumers
+# (e.g. cli.py) can reference them without duplicating the literal strings.
+BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED = "schema_version_unsupported"
+BLOCKER_REASON_NO_RESULT_EMITTED = "no_result_emitted"
+BLOCKER_REASON_VALIDATION_FAILED = "validation_failed"
+
 # NOTE: stage1_pre_flight (StageReached) and "none" (PlanSource) are NOT
 # gated by schema_version. Spec §8 says enum additions require a version
 # bump (v3), and v3 IS the official home for these values, BUT the producer

--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -87,8 +87,10 @@ PAUSED_FOR_USER_INPUT_STATUSES: frozenset[str] = _V4_STATUSES
 
 # BlockedResult reason codes produced by parse_stdout.  Exported so consumers
 # (e.g. cli.py) can reference them without duplicating the literal strings.
-BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED = "schema_version_unsupported"
+BLOCKER_REASON_MULTIPLE_RESULT_BLOCKS = "multiple_result_blocks"
 BLOCKER_REASON_NO_RESULT_EMITTED = "no_result_emitted"
+BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED = "schema_version_unsupported"
+BLOCKER_REASON_STATUS_UNKNOWN = "status_unknown"
 BLOCKER_REASON_VALIDATION_FAILED = "validation_failed"
 
 # NOTE: stage1_pre_flight (StageReached) and "none" (PlanSource) are NOT
@@ -592,7 +594,7 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
         return BlockedResult(
             blocker=Blocker(
                 stage="unknown",
-                reason="multiple_result_blocks",
+                reason=BLOCKER_REASON_MULTIPLE_RESULT_BLOCKS,
                 details=f"count={len(matches)}; last_block={last_payload}",
             ),
         )
@@ -603,7 +605,7 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
             return BlockedResult(
                 blocker=Blocker(
                     stage="unknown",
-                    reason="no_result_emitted",
+                    reason=BLOCKER_REASON_NO_RESULT_EMITTED,
                     details=(
                         f"opening sentinel present, close missing; tail:\n{_tail(text)}"
                     ),
@@ -618,7 +620,7 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
             return BlockedResult(
                 blocker=Blocker(
                     stage="unknown",
-                    reason="no_result_emitted",
+                    reason=BLOCKER_REASON_NO_RESULT_EMITTED,
                     details=f"no sentinel block in stdout; tail:\n{_tail(text)}",
                 ),
             )
@@ -638,7 +640,7 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
         return BlockedResult(
             blocker=Blocker(
                 stage="unknown",
-                reason="no_result_emitted",
+                reason=BLOCKER_REASON_NO_RESULT_EMITTED,
                 details=f"sentinel block JSON parse failed ({exc}); raw:\n{raw_block}",
             ),
         )
@@ -648,7 +650,7 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
         return BlockedResult(
             blocker=Blocker(
                 stage="unknown",
-                reason="no_result_emitted",
+                reason=BLOCKER_REASON_NO_RESULT_EMITTED,
                 details=f"sentinel block was not a JSON object (got {type_name})",
             ),
         )
@@ -666,7 +668,7 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
         return BlockedResult(
             blocker=Blocker(
                 stage="unknown",
-                reason="schema_version_unsupported",
+                reason=BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED,
                 details=(
                     f"got schema_version={raw_version!r}, "
                     f"parser supports {sorted(SUPPORTED_SCHEMA_VERSIONS)}"
@@ -692,7 +694,7 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
         return BlockedResult(
             blocker=Blocker(
                 stage="unknown",
-                reason="status_unknown",
+                reason=BLOCKER_REASON_STATUS_UNKNOWN,
                 details=(
                     f"got status={raw_status!r}; surface verbatim, do not auto-route"
                 ),
@@ -763,7 +765,7 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
         return BlockedResult(
             blocker=Blocker(
                 stage="unknown",
-                reason="validation_failed",
+                reason=BLOCKER_REASON_VALIDATION_FAILED,
                 details=f"{exc}",
             ),
         )

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -886,6 +886,17 @@ def run_claude(extra_args: tuple[str, ...]) -> None:
 # FAILED rather than reverting to PENDING. See issue #251 Bug B.
 _VALIDATION_FAILED_MAX_ATTEMPTS = 3
 
+# BlockedResult reason codes that are deterministic — the running parser binary
+# will produce the same result on every retry, so there is no point retrying.
+# Route these to FAILED on first occurrence.  See GitHub issue #263.
+_DETERMINISTIC_PARSE_FAILURES: frozenset[str] = frozenset(
+    {"schema_version_unsupported"}
+)
+
+# BlockedResult reason codes that are transient — the failure condition could
+# resolve on a fresh dispatch (e.g. worker crashed before emitting a sentinel).
+_TRANSIENT_PARSE_FAILURES: frozenset[str] = frozenset({"no_result_emitted"})
+
 # AutoDevResult statuses that represent terminal outcomes the dev-queue should
 # never auto-retry. Marking these COMPLETED prevents the race described in
 # issue #251 Bug A where revert_completed_silent_tasks reverts a task to
@@ -960,16 +971,22 @@ def _apply_sentinel_to_task(
                 target.status = QueueItemStatus.COMPLETED
         else:
             # BlockedResult: sentinel failed to parse or was malformed.
-            if sentinel.blocker.reason == "validation_failed":
+            if sentinel.blocker.reason in _DETERMINISTIC_PARSE_FAILURES:
+                # Deterministic failure — retrying the same binary won't help.
+                target.status = QueueItemStatus.FAILED
+            elif sentinel.blocker.reason == "validation_failed":
                 if target.attempts >= _VALIDATION_FAILED_MAX_ATTEMPTS:
                     target.status = QueueItemStatus.FAILED
                 else:
                     target.status = QueueItemStatus.PENDING
                     target.session_id = None
-            else:
-                # Other parse failures (no_result_emitted, etc.) → retry.
+            elif sentinel.blocker.reason in _TRANSIENT_PARSE_FAILURES:
                 target.status = QueueItemStatus.PENDING
                 target.session_id = None
+            else:
+                # Unknown reason — conservative: COMPLETED to avoid re-burning
+                # dispatch cycles on an unrecognised failure type.
+                target.status = QueueItemStatus.COMPLETED
 
         save_dev_queue(store)
 

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -16,6 +16,9 @@ from click.shell_completion import CompletionItem
 
 from cw import __version__
 from cw.auto_dev_result import (
+    BLOCKER_REASON_NO_RESULT_EMITTED,
+    BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED,
+    BLOCKER_REASON_VALIDATION_FAILED,
     PAUSED_FOR_USER_INPUT_STATUSES,
     AutoDevResult,
     BlockedResult,
@@ -890,12 +893,14 @@ _VALIDATION_FAILED_MAX_ATTEMPTS = 3
 # will produce the same result on every retry, so there is no point retrying.
 # Route these to FAILED on first occurrence.  See GitHub issue #263.
 _DETERMINISTIC_PARSE_FAILURES: frozenset[str] = frozenset(
-    {"schema_version_unsupported"}
+    {BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED}
 )
 
 # BlockedResult reason codes that are transient — the failure condition could
 # resolve on a fresh dispatch (e.g. worker crashed before emitting a sentinel).
-_TRANSIENT_PARSE_FAILURES: frozenset[str] = frozenset({"no_result_emitted"})
+_TRANSIENT_PARSE_FAILURES: frozenset[str] = frozenset(
+    {BLOCKER_REASON_NO_RESULT_EMITTED}
+)
 
 # AutoDevResult statuses that represent terminal outcomes the dev-queue should
 # never auto-retry. Marking these COMPLETED prevents the race described in
@@ -974,7 +979,7 @@ def _apply_sentinel_to_task(
             if sentinel.blocker.reason in _DETERMINISTIC_PARSE_FAILURES:
                 # Deterministic failure — retrying the same binary won't help.
                 target.status = QueueItemStatus.FAILED
-            elif sentinel.blocker.reason == "validation_failed":
+            elif sentinel.blocker.reason == BLOCKER_REASON_VALIDATION_FAILED:
                 if target.attempts >= _VALIDATION_FAILED_MAX_ATTEMPTS:
                     target.status = QueueItemStatus.FAILED
                 else:
@@ -984,8 +989,10 @@ def _apply_sentinel_to_task(
                 target.status = QueueItemStatus.PENDING
                 target.session_id = None
             else:
-                # Unknown reason — conservative: COMPLETED to avoid re-burning
-                # dispatch cycles on an unrecognised failure type.
+                # Known unhandled codes that intentionally fall here:
+                # multiple_result_blocks, status_unknown.  Both are terminal
+                # (retry won't fix them) and conservative COMPLETED avoids
+                # re-burning dispatch cycles.
                 target.status = QueueItemStatus.COMPLETED
 
         save_dev_queue(store)

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -989,10 +989,12 @@ def _apply_sentinel_to_task(
                 target.status = QueueItemStatus.PENDING
                 target.session_id = None
             else:
-                # Known unhandled codes that intentionally fall here:
-                # multiple_result_blocks, status_unknown.  Both are terminal
-                # (retry won't fix them) and conservative COMPLETED avoids
-                # re-burning dispatch cycles.
+                # Known codes that intentionally fall here:
+                # BLOCKER_REASON_MULTIPLE_RESULT_BLOCKS,
+                # BLOCKER_REASON_STATUS_UNKNOWN.
+                # Both are terminal (retry won't fix them); COMPLETED avoids
+                # re-burning dispatch cycles.  The else also catches any future
+                # unknown reason code conservatively.
                 target.status = QueueItemStatus.COMPLETED
 
         save_dev_queue(store)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2165,6 +2165,121 @@ class TestSignalStop:
             "regression: stale stop hook left task PENDING after blocked→retry→shipped"
         )
 
+    def test_signal_stop_schema_version_unsupported_marks_failed(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """schema_version_unsupported sentinel → task FAILED on first occurrence.
+
+        Regression for GitHub issue #263 Bug A: a BlockedResult with
+        reason='schema_version_unsupported' is a deterministic failure —
+        retrying will not produce a different schema_version in the running
+        parser binary.  Must be routed to FAILED (not PENDING).
+        """
+        import datetime as dt
+
+        from cw.dev_queue import load_dev_queue, save_dev_queue
+        from cw.models import DevQueueStore, QueueItemStatus, TicketTask
+        from cw.native_daemon import FakeNativeDaemonClient
+
+        worktree, session = self._setup_headless_session(
+            tmp_path, "sess-263-schema-unsupported", "worktree-263-schema-unsupported"
+        )
+        dev_store = DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id=self.SEED_TICKET_ID,
+                    client="test-client",
+                    status=QueueItemStatus.RUNNING,
+                    session_id=session.id,
+                    attempts=1,
+                )
+            ]
+        )
+        save_dev_queue(dev_store)
+        self._write_headless_context(worktree, session_id=session.id)
+
+        claude_session_id = "uuid-263-schema-unsupported"
+        fake_home = tmp_path / "fake-home-263-schema-unsupported"
+        self._write_transcript(
+            worktree,
+            claude_session_id,
+            _SENTINEL_263_SCHEMA_VERSION_UNSUPPORTED,
+            fake_home,
+        )
+        monkeypatch.setattr("cw.cli.Path.home", lambda: fake_home)
+
+        daemon = FakeNativeDaemonClient()
+        monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: daemon)
+
+        hook_stdin = json.dumps(
+            {
+                "session_id": claude_session_id,
+                "cwd": str(worktree),
+                "hook_event_name": "Stop",
+            }
+        )
+        hook_time = dt.datetime(2026, 1, 1, 0, 5, 0, tzinfo=UTC)
+        runner = CliRunner()
+        with freeze_time(hook_time):
+            result = runner.invoke(main, ["signal-stop"], input=hook_stdin)
+        assert result.exit_code == 0, result.output
+
+        updated = next(s for s in load_state().sessions if s.id == session.id)
+        assert updated.status == SessionStatus.COMPLETED
+
+        store = load_dev_queue()
+        task = next(t for t in store.tasks if t.ticket_id == self.SEED_TICKET_ID)
+        assert task.status == QueueItemStatus.FAILED
+
+    def test_signal_stop_unknown_blocker_reason_marks_completed(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Unknown blocker reason → task COMPLETED (conservative, don't re-burn cycles).
+
+        Regression for GitHub issue #263 Bug A: unrecognised BlockedResult
+        reasons must not perpetually re-dispatch via PENDING.  COMPLETED is
+        the conservative terminal state for anything that doesn't match a
+        known deterministic or transient failure reason.
+        """
+        from cw.auto_dev_result import BlockedResult, Blocker
+        from cw.cli import _apply_sentinel_to_task
+        from cw.dev_queue import load_dev_queue, save_dev_queue
+        from cw.models import DevQueueStore, QueueItemStatus, TicketTask
+
+        _worktree, session = self._setup_headless_session(
+            tmp_path, "sess-263-unknown-reason", "worktree-263-unknown-reason"
+        )
+        dev_store = DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id=self.SEED_TICKET_ID,
+                    client="test-client",
+                    status=QueueItemStatus.RUNNING,
+                    session_id=session.id,
+                    attempts=1,
+                )
+            ]
+        )
+        save_dev_queue(dev_store)
+
+        sentinel = BlockedResult(
+            blocker=Blocker(
+                stage="unknown",
+                reason="unknown_reason_xyz",
+                details="test: unrecognised reason code",
+            )
+        )
+        _apply_sentinel_to_task(self.SEED_TICKET_ID, session.id, sentinel)
+
+        store = load_dev_queue()
+        task = next(t for t in store.tasks if t.ticket_id == self.SEED_TICKET_ID)
+        assert task.status == QueueItemStatus.COMPLETED
+
 
 class TestSentinelPresentInTranscript:
     """Direct tests for the real _sentinel_present_in_transcript helper.
@@ -2621,6 +2736,15 @@ _SENTINEL_316_AMBIGUITIES_PENDING_V2 = (
     '  "premises": [],\n'
     '  "next_actions": ["user_resolve_ambiguities"]\n'
     "}\n"
+    "AUTO_DEV_RESULT>>>"
+)
+
+# Sentinel for GitHub issue #263 regression tests.
+# schema_version=99 is not in SUPPORTED_SCHEMA_VERSIONS, so parse_stdout
+# returns BlockedResult(reason="schema_version_unsupported").
+_SENTINEL_263_SCHEMA_VERSION_UNSUPPORTED = (
+    "<<<AUTO_DEV_RESULT\n"
+    '{"schema_version": 99, "status": "shipped"}\n'
     "AUTO_DEV_RESULT>>>"
 )
 


### PR DESCRIPTION
## Summary

- refactor(auto-dev-result): use BLOCKER_REASON_* constants at production site (#263)
- refactor(dev-queue): extract blocker reason constants, document else-branch (#263)
- fix(dev-queue): route schema_version_unsupported to FAILED, unknowns to COMPLETED (#263)

Fixes #263 — `schema_version_unsupported` was being mis-routed to PENDING instead of FAILED. Extracts blocker reason constants for maintainability and documents the else-branch behavior for unknown reasons.

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it