### PR TITLE
fix(parser): coerce stray scope.lines_actual on no_op pre-impl exits (#399)

### DIFF
--- a/docs/headless-contract.md
+++ b/docs/headless-contract.md
@@ -391,6 +391,18 @@ The parser tolerates this format. When no sentinel markers are found and the ope
 
 Parser must NEVER act on a partial parse — if any of the above fire, treat the run as blocked and require human attention.
 
+### Parse-boundary coercions
+
+The parser applies several pre-validation coercions before handing the payload to Pydantic. Each coercion targets a known producer-drift pattern: a field combination that the model correctly rejects, but that arises from a well-understood producer bug rather than a genuinely ambiguous payload. These coercions are scoped tightly — they fire only for the specific `status` + `stage_reached` shapes where the producer bug has been observed. They do NOT apply to `shipped` or `blocked` (where the same field contradictions are genuinely ambiguous and should fail loudly).
+
+| Coercion | Trigger | Action | Issue |
+|---|---|---|---|
+| `no_op` + stray `pr` / `branch` / `commits` | `status=no_op` and `pr`, `branch`, or `commits` is non-null/non-empty | Set `pr=null`, `branch=null`, `commits=[]` | #367 |
+| `blocked` + stray `next_actions` | `status=blocked` and `next_actions` is non-empty with non-user-directed verbs (not `user_resolve_*` / `user_decide_*` / `user_verify_*` prefixes; not `stage_reached=stage1_pre_flight`) | Drop `next_actions` (set to `[]`), preserve `blocker` | #371 |
+| `no_op` + stray `scope.lines_actual` | `status=no_op` and `stage_reached ∈ {stage1_pre_flight, stage1_plan}` and `scope.lines_actual` is non-null | Set `scope.lines_actual=null` | #399 |
+
+All coercions log a `WARNING` with the affected field names and ticket ID. The model-level invariants remain strict — coercion happens only at the parse boundary so existing test coverage for the invariants is unaffected.
+
 ---
 
 ## 7. Resume Protocol (Reserved — Not Yet Specified)

--- a/src/cw/auto_dev_result.py
+++ b/src/cw/auto_dev_result.py
@@ -720,6 +720,22 @@ def parse_stdout(text: str) -> AutoDevResult | BlockedResult:
         if payload.get("commits"):
             stray.append("commits")
             payload["commits"] = []
+        # Coerce stray scope.lines_actual on pre-impl exits (issue #399).
+        # A no_op at stage1_pre_flight or stage1_plan exited before any
+        # implementation work; lines_actual must be null. The producer
+        # sometimes emits a non-null value, tripping the §3.3 cross-field
+        # invariant and causing the sentinel to fail as validation_failed.
+        scope_dict = payload.get("scope")
+        if isinstance(scope_dict, dict) and scope_dict.get("lines_actual") is not None:
+            raw_stage = payload.get("stage_reached", "")
+            effective_stage = (
+                _STAGE_REACHED_ALIASES.get(raw_stage, raw_stage)
+                if isinstance(raw_stage, str)
+                else raw_stage
+            )
+            if effective_stage in ("stage1_pre_flight", "stage1_plan"):
+                stray.append("scope.lines_actual")
+                scope_dict["lines_actual"] = None
         if stray:
             _log.warning(
                 "auto-dev: no_op sentinel carried non-null %s; coercing to clean "

--- a/tests/test_auto_dev_result.py
+++ b/tests/test_auto_dev_result.py
@@ -983,6 +983,122 @@ class TestPreFlightNoOp:
 
 
 # ---------------------------------------------------------------------------
+# no_op + stray scope.lines_actual coerce (issue #399)
+# A producer bug emitted status=no_op with stage_reached=stage1_pre_flight
+# carrying a non-null scope.lines_actual.  The §3.3 cross-field invariant
+# rejects this, routing a legitimate no_op to validation_failed → retry cap
+# → failed (session 8043fe9f re-running already-satisfied ticket #143).
+# parse_stdout coerces scope.lines_actual to null for no_op sentinels where
+# stage_reached is stage1_pre_flight or stage1_plan.
+# ---------------------------------------------------------------------------
+
+
+class TestNoOpStrayLinesActualCoerce:
+    def test_no_op_stray_lines_actual_coerced_at_stage1_pre_flight(self) -> None:
+        """parse_stdout coerces no_op + stray scope.lines_actual to clean no_op.
+
+        Regression for issue #399: the exact failure mode from session 8043fe9f
+        re-running already-satisfied ticket #143 — a no_op sentinel carrying a
+        non-null scope.lines_actual triggered the §3.3 pre-impl invariant,
+        routing to validation_failed instead of cleanly closing the issue.
+        """
+        p = _no_op_payload()
+        p["scope"]["lines_actual"] = 42  # stray non-null value from producer
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "no_op"
+        assert result.scope.lines_actual is None
+
+    def test_no_op_stray_lines_actual_coerced_at_stage1_plan(self) -> None:
+        """Coercion also fires when stage_reached is stage1_plan (pre-impl)."""
+        p = _no_op_payload()
+        p["stage_reached"] = "stage1_plan"
+        p["scope"]["lines_actual"] = 10
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "no_op"
+        assert result.scope.lines_actual is None
+
+    def test_no_op_stray_lines_actual_coerced_via_alias(self) -> None:
+        """Coercion fires when stage_reached uses a short-form alias (pre_flight)."""
+        p = _no_op_payload()
+        p["stage_reached"] = "pre_flight"  # alias for stage1_pre_flight
+        p["scope"]["lines_actual"] = 7
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "no_op"
+        assert result.scope.lines_actual is None
+
+    def test_no_op_null_lines_actual_unchanged(self) -> None:
+        """null scope.lines_actual is the correct shape — coerce must not touch it."""
+        p = _no_op_payload()
+        assert p["scope"]["lines_actual"] is None
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.scope.lines_actual is None
+
+    def test_post_impl_non_null_lines_actual_not_coerced(self) -> None:
+        """Coerce does not fire for post-impl stages — non-null passes through."""
+        p = _no_op_payload()
+        # stage2_impl is outside {stage1_pre_flight, stage1_plan}, so the
+        # coerce guard does NOT fire. lines_actual=30 is valid for a post-impl
+        # stage and passes through to the parsed result unchanged.
+        p["stage_reached"] = "stage2_impl"
+        p["scope"]["lines_actual"] = 30
+        result = parse_stdout(_wrap_sentinel(p))
+        assert isinstance(result, AutoDevResult)
+        assert result.status == "no_op"
+        assert result.scope.lines_actual == 30  # not zeroed by coerce
+
+    def test_regression_issue_399_session_8043fe9f_payload(self) -> None:
+        """Exact payload shape from session 8043fe9f that triggered the #399 bug.
+
+        The headless re-run of #143 emitted schema_version=4, status=no_op,
+        stage_reached=stage1_pre_flight with a stray non-null scope.lines_actual.
+        This caused BlockedResult(reason='validation_failed') → PENDING → retry
+        cap → 'failed', burning 3 sessions on already-satisfied work.
+        """
+        payload = {
+            "schema_version": 4,
+            "ticket_id": "GEN-143",
+            "status": "no_op",
+            "stage_reached": "stage1_pre_flight",
+            "scope": {
+                "tier": "small",
+                "files": 0,
+                "lines_estimate": 0,
+                "lines_actual": 0,  # stray non-null: the producer emitted 0, not null
+                "forbidden_touched": False,
+            },
+            "plan_source": "none",
+            "branch": None,
+            "worktree_path": None,
+            "fork_point_sha": None,
+            "commits": [],
+            "pr": None,
+            "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+            "health": {
+                "lowest_agent_confidence": "HIGH",
+                "any_incomplete_risk": False,
+                "shortcuts": [],
+                "recommendation": "PROCEED",
+                "downgrade_applied": False,
+                "fix_loop_escalated": False,
+            },
+            "friction_highlights": [],
+            "blocker": None,
+            "next_actions": ["close_issue_as_completed"],
+        }
+        result = parse_stdout(_wrap_sentinel(payload))
+        assert isinstance(result, AutoDevResult), (
+            f"Expected AutoDevResult, got BlockedResult: {result}"
+        )
+        assert result.status == "no_op"
+        assert result.stage_reached == "stage1_pre_flight"
+        assert result.scope.lines_actual is None
+
+
+# ---------------------------------------------------------------------------
 # blocked + stray next_actions coerce (issue #371 — follow-up to #367/#370)
 # A producer bug emits status=blocked alongside next_actions=['redispatch_ticket']
 # (or other non-user-directed verbs). The §4.3 terminal-reject invariant then


### PR DESCRIPTION
## Summary

Closes #399. A `no_op` sentinel at `stage1_pre_flight`/`stage1_plan` exits before any implementation, so `scope.lines_actual` must be null. The `/auto-dev` producer sometimes emits a non-null value, tripping the §3.3 cross-field invariant → the sentinel fails as `validation_failed` → an already-satisfied ticket gets wedged into `failed`×retries (observed live on #143).

Fix: coerce `scope.lines_actual → null` at the parse boundary when `status=no_op` and `stage_reached ∈ {stage1_pre_flight, stage1_plan}`, mirroring the existing #367/#371 coercions. Logs a WARNING; model-level invariants stay strict (coercion is parse-boundary only).

## Changes
- `src/cw/auto_dev_result.py` — coercion in the `no_op` stray-field block (reuses `_STAGE_REACHED_ALIASES`)
- `tests/test_auto_dev_result.py` — +116 lines regression coverage
- `docs/headless-contract.md` — new "Parse-boundary coercions" table (#367/#371/#399)

## Test plan
- [x] ruff — clean
- [x] mypy — clean
- [x] pytest — 161 passed (6 new)

## Provenance
Implemented by a headless `/auto-dev` worker; the worker's own `git commit` was denied by the auto-mode classifier (`tool_denied`), so the verified work was committed + shipped from the operator session. Surfaced two infra bugs in the process (worker-isolation + idle-watchdog salvage) — filed separately.

🤖 Finalized via operator session after headless tool_denied