### PR TITLE
chore(release): cut 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.14.0] — 2026-05-30
+
+Dispatch-reliability release: the idle watchdog now **auto-recovers** stalled
+headless workers (bounded retries, then parks) and **salvages** a terminal
+sentinel before flagging, so a worker that already shipped is never mis-parked
+as `blocked_on_user`. Plus deterministic sentinel routing, parse-boundary
+coercions, a cross-client `cw queue list`, and watchdog/doctor robustness fixes.
+
+### Added
+
+- **Idle-stall auto-recovery** (#384 → PR #394): the idle watchdog now reverts a
+  provably-idle headless worker to `PENDING` for re-dispatch (capped per tier via
+  `idle_retry_cap_by_tier`), only parking it `BLOCKED_ON_USER` once retries are
+  exhausted — instead of parking on the first stall.
+- **Cross-client `cw queue list`** (#201 → PR #397): `cw queue list` with no
+  CLIENT arg now shows tasks grouped across all configured clients.
+
+### Fixed
+
+- **Idle watchdog salvages terminal sentinels** (#398 → PR #400): a shipped/no_op
+  session idle past the budget is salvaged to `COMPLETED` rather than flagged
+  `BLOCKED_ON_USER`.
+- **Deterministic parse-failure routing** (#263 → PR #396): `schema_version_unsupported`
+  and other deterministic parse failures route to `FAILED` (not an infinite
+  PENDING retry); unknown blocker reasons route to `COMPLETED`.
+- **no_op pre-impl `scope.lines_actual` coercion** (#399 → PR #401): a `no_op` at
+  `stage1_pre_flight`/`stage1_plan` with a stray non-null `lines_actual` is
+  coerced clean at the parse boundary instead of failing `validation_failed`.
+- **blocked + stray `next_actions` coercion** (#371 → PR #376).
+- **Transcript-mtime liveness check** (#340 → PR #383): prevents false-positive
+  watchdog fires on workers that are actively writing their transcript.
+- **`cw doctor` wedge-detection robustness** (#354 → PRs #378/#379): BACKGROUNDED
+  exclusion + subprocess timeouts.
+- **Reviewer stale-ref helper** (#381 → PR #385): `fetch_feature_branch` resolves
+  stale local refs before review.
+- **`_accumulate_task_cost` docstring + is-None guard** (#352 → PR #377).
+
 ## [0.13.0] — 2026-05-29
 
 Minor release hardening the dispatch-reliability path: terminal-sentinel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-workspace"
-version = "0.13.0"
+version = "0.14.0"
 description = "Multi-session workspace orchestrator for Claude Code"
 readme = "README.md"
 authors = [

--- a/src/cw/__init__.py
+++ b/src/cw/__init__.py
@@ -1,3 +1,3 @@
 """claude-workspace: Multi-session workspace orchestrator for Claude Code."""
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "claude-workspace"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Cuts **0.14.0** — the dispatch-reliability release. Bumps `pyproject.toml` + `src/cw/__init__.py` to 0.14.0, regenerates `uv.lock`, and adds the CHANGELOG entry for the 11 PRs merged since 0.13.0.

**Why now:** the installed binary was still 0.13.0, which predates the #384 idle-recovery and #398 salvage fixes — the root cause of the 2026-05-30 fanout-wave mis-flagging cascade (#406). Releasing deploys those fixes.

## Headline changes
- #384 idle-stall **auto-recovery** (bounded retries, then park)
- #398 idle watchdog **salvages** shipped/no_op sentinels (no more false `blocked_on_user`)
- #263 deterministic parse-failure routing → FAILED
- #399 no_op `lines_actual` parse-boundary coercion
- #201 cross-client `cw queue list`
- #340/#354/#371/#381/#352 watchdog/doctor/contract robustness

## Test plan
- [x] versions match (release.sh verifies); pre-commit gates green (ruff/mypy/pytest 1562 passed)

After merge: `./scripts/release.sh 0.14.0` tags + pushes → GitHub Actions builds.