### PR TITLE
fix(worktree): verify branch on reuse + reap worktree on timeout (#404)

### DIFF
--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import time
 from typing import TYPE_CHECKING
@@ -10,6 +11,7 @@ from cw.auto_dev_result import AutoDevResult, parse_stdout
 from cw.config import load_clients, load_orchestrator_config, load_state, save_state
 from cw.dev_queue import dev_queue_lock, load_dev_queue, load_plan, save_dev_queue
 from cw.events import advance_cursor, read_events, record_event
+from cw.exceptions import StaleWorktreeError, WorktreeError
 from cw.models import (
     OrchestratorEventType,
     QueueItemStatus,
@@ -19,7 +21,12 @@ from cw.models import (
 from cw.native_daemon import get_native_daemon_client
 from cw.reconcile import AUTO_DEV_LABEL_PREFIX, reconcile, ticket_id_for_session
 from cw.spawn import spawn_create_impl
-from cw.worktree import check_not_main_checkout, create_worktree, is_main_behind_origin
+from cw.worktree import (
+    check_not_main_checkout,
+    create_worktree,
+    is_main_behind_origin,
+    remove_worktree,
+)
 
 if TYPE_CHECKING:
     from cw.models import (
@@ -188,7 +195,21 @@ def dispatch_tick(
                 # dispatch made an empty directory and relied on
                 # ``claude -w`` to turn it into a worktree, which never
                 # worked because that flag takes a name rather than a path.
-                worktree_path = create_worktree(client, branch)
+                try:
+                    worktree_path = create_worktree(client, branch)
+                except StaleWorktreeError:
+                    # A stale worktree (wrong branch / not a worktree) refused
+                    # reuse (#404). No session exists yet, so reconcile's
+                    # TIMED_OUT cleanup will never fire for it — without
+                    # removing it here the task reverts to PENDING and re-hits
+                    # the same stale tree every tick (an infinite spin). Force-
+                    # remove it (best-effort) so the next claim rebuilds fresh,
+                    # then re-raise into the handler below to revert to PENDING.
+                    # Caught narrowly as StaleWorktreeError (not WorktreeError)
+                    # so the main-checkout guard never triggers a removal.
+                    with contextlib.suppress(WorktreeError, OSError):
+                        remove_worktree(client, branch, force=True)
+                    raise
 
                 # Guard against the #300 regression: if create_worktree
                 # returns the main checkout path (degenerate path-computation

--- a/src/cw/exceptions.py
+++ b/src/cw/exceptions.py
@@ -26,6 +26,19 @@ class MissingWorkspaceError(WorktreeError):
     __slots__ = ()
 
 
+class StaleWorktreeError(WorktreeError):
+    """A pre-existing worktree is checked out on a branch other than requested.
+
+    Raised only by ``create_worktree``'s idempotent-reuse guard (#404). Kept
+    distinct from the base :class:`WorktreeError` so the dispatch loop can
+    force-remove the stale tree and let the task retry — without conflating it
+    with other git failures (notably the main-checkout guard) that must never
+    trigger a removal.
+    """
+
+    __slots__ = ()
+
+
 class HookContextConflictError(CwError):
     """A user-owned ``.claude/settings.local.json`` already exists.
 

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -518,6 +518,10 @@ def _cleanup_timed_out_worktree(session: Session) -> None:
             session.branch,
             exc,
         )
+    else:
+        # Audit breadcrumb for a destructive (force=True) removal — a skip is
+        # logged above, so a successful reap leaves a matching record (#404).
+        _log.info("worktree_cleanup_ok: %s/%s", session.client, session.branch)
 
 
 def revert_stalled_headless_sessions(

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -28,6 +28,7 @@ targets.
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -35,9 +36,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from cw.auto_dev_result import AutoDevResult, parse_stdout
-from cw.config import load_orchestrator_config, load_state, save_state
+from cw.config import get_client, load_orchestrator_config, load_state, save_state
 from cw.dev_queue import dev_queue_lock, load_dev_queue, save_dev_queue
 from cw.events import record_event
+from cw.exceptions import CwError
 from cw.models import (
     CompletionReason,
     OrchestratorConfig,
@@ -49,9 +51,12 @@ from cw.models import (
 )
 from cw.native_daemon import get_native_daemon_client
 from cw.notify import fire_push_notification
+from cw.worktree import remove_worktree
 
 if TYPE_CHECKING:
     from cw.models import CwState, Session
+
+_log = logging.getLogger(__name__)
 
 
 # Session-name prefix for DAEMON sessions spawned by the dispatch loop. The
@@ -488,6 +493,33 @@ def _apply_salvaged_completion(
     session.claude_session_id = claude_session_id
 
 
+def _cleanup_timed_out_worktree(session: Session) -> None:
+    """Remove a timed-out session's worktree so the re-dispatch starts clean.
+
+    A timed-out DAEMON session has its ``TicketTask`` reverted to PENDING for
+    re-dispatch. If its worktree is left on disk, ``create_worktree`` would
+    reuse it (or, post-#404, refuse and spin) — either way feeding the retry a
+    prior run's branch and commits. Removing it here means the next claim builds
+    a fresh worktree from the current default branch. See GitHub issue #404.
+
+    Best-effort: every failure is logged and swallowed. Worktree cleanup must
+    never abort the reconcile sweep — a missing/renamed client, an
+    already-gone directory, or a git error is non-fatal.
+    """
+    if not session.branch:
+        return
+    try:
+        client = get_client(session.client)
+        remove_worktree(client, session.branch, force=True)
+    except (CwError, OSError) as exc:
+        _log.warning(
+            "worktree_cleanup_skip: %s/%s: %s",
+            session.client,
+            session.branch,
+            exc,
+        )
+
+
 def revert_stalled_headless_sessions(
     state: CwState,
     *,
@@ -596,6 +628,9 @@ def revert_stalled_headless_sessions(
         record_event(OrchestratorEventType.SESSION_TIMED_OUT, payload)
         if session.surface_ref is not None:
             get_native_daemon_client().stop(session.surface_ref)
+        # Stale-worktree cleanup: the task was reverted to PENDING above, so
+        # the retry must not inherit this run's worktree state (#404).
+        _cleanup_timed_out_worktree(session)
 
     for session, ticket_id, result in salvaged:
         completed_payload: dict[str, object] = {
@@ -772,6 +807,9 @@ def flag_silently_idle_daemon_sessions(
     for session, ticket_id in recover:
         if session.surface_ref is not None:
             get_native_daemon_client().stop(session.surface_ref)
+        # Stale-worktree cleanup: this task was reverted to PENDING above for
+        # re-dispatch, so the retry must start from a fresh worktree (#404).
+        _cleanup_timed_out_worktree(session)
         record_event(
             OrchestratorEventType.SESSION_TIMED_OUT,
             {

--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -145,6 +145,20 @@ def check_not_main_checkout(worktree_path: Path, client: ClientConfig) -> None:
         raise WorktreeError(msg)
 
 
+def _checked_out_branch(wt_path: Path) -> str | None:
+    """Return the branch checked out in *wt_path*, or None.
+
+    None means *wt_path* is not a registered git worktree or is in
+    detached-HEAD state (``git branch --show-current`` prints nothing).
+    Never raises — the idempotent-reuse guard in :func:`create_worktree`
+    decides what a non-matching value means.
+    """
+    result = _run_git("branch", "--show-current", cwd=wt_path, check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
 def create_worktree(
     client: ClientConfig,
     branch: str,
@@ -153,7 +167,10 @@ def create_worktree(
 ) -> Path:
     """Create a git worktree for the given branch.
 
-    Returns the worktree path. Idempotent: returns existing path if already created.
+    Returns the worktree path. Idempotent: returns the existing path when it is
+    already a worktree on *branch*. A pre-existing directory checked out on a
+    *different* branch is treated as stale and raises :exc:`WorktreeError`
+    rather than being reused (see below).
     """
     wt_path = worktree_path_for(client, branch)
     git_cwd = _git_dir(client)
@@ -161,6 +178,24 @@ def create_worktree(
     check_not_main_checkout(wt_path, client)
 
     if wt_path.exists():
+        # Idempotent reuse is only safe when the existing worktree is still on
+        # the branch we were asked for. A stale worktree left by a prior failed
+        # dispatch (crash before reconcile's TIMED_OUT cleanup, see #404) can
+        # carry a different branch — and thus a prior run's commits — into the
+        # new session. Silently reusing it feeds the worker the wrong context
+        # and has caused cross-ticket isolation breaches (#402). Refuse on
+        # mismatch: the dispatch loop reverts the task to PENDING and reconcile
+        # removes the stale tree so the retry starts clean.
+        current_branch = _checked_out_branch(wt_path)
+        if current_branch != branch:
+            found = current_branch or "(none / detached HEAD / not a worktree)"
+            msg = (
+                f"Refusing to reuse stale worktree at {wt_path}: expected "
+                f"branch {branch!r} but found {found}. Remove it "
+                f"(`git worktree remove --force {wt_path}`) or run "
+                f"`cw doctor --reap`, then re-dispatch."
+            )
+            raise WorktreeError(msg)
         return wt_path
 
     wt_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -10,7 +10,7 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from cw.exceptions import MissingWorkspaceError, WorktreeError
+from cw.exceptions import MissingWorkspaceError, StaleWorktreeError, WorktreeError
 
 if TYPE_CHECKING:
     from cw.models import ClientConfig
@@ -149,11 +149,16 @@ def _checked_out_branch(wt_path: Path) -> str | None:
     """Return the branch checked out in *wt_path*, or None.
 
     None means *wt_path* is not a registered git worktree or is in
-    detached-HEAD state (``git branch --show-current`` prints nothing).
-    Never raises — the idempotent-reuse guard in :func:`create_worktree`
-    decides what a non-matching value means.
+    detached-HEAD state (``git branch --show-current`` prints nothing or
+    exits non-zero), or git itself could not be invoked. Never raises — the
+    idempotent-reuse guard in :func:`create_worktree` treats every None as a
+    refuse-to-reuse signal, so swallowing an ``OSError`` here (e.g. a missing
+    git binary) is correct: the worktree cannot be trusted either way.
     """
-    result = _run_git("branch", "--show-current", cwd=wt_path, check=False)
+    try:
+        result = _run_git("branch", "--show-current", cwd=wt_path, check=False)
+    except OSError:
+        return None
     if result.returncode != 0:
         return None
     return result.stdout.strip() or None
@@ -169,8 +174,8 @@ def create_worktree(
 
     Returns the worktree path. Idempotent: returns the existing path when it is
     already a worktree on *branch*. A pre-existing directory checked out on a
-    *different* branch is treated as stale and raises :exc:`WorktreeError`
-    rather than being reused (see below).
+    *different* branch (or not a worktree at all) is treated as stale and
+    raises :exc:`StaleWorktreeError` rather than being reused (see below).
     """
     wt_path = worktree_path_for(client, branch)
     git_cwd = _git_dir(client)
@@ -191,11 +196,10 @@ def create_worktree(
             found = current_branch or "(none / detached HEAD / not a worktree)"
             msg = (
                 f"Refusing to reuse stale worktree at {wt_path}: expected "
-                f"branch {branch!r} but found {found}. Remove it "
-                f"(`git worktree remove --force {wt_path}`) or run "
-                f"`cw doctor --reap`, then re-dispatch."
+                f"branch {branch!r} but found {found}. Remove it with "
+                f"`git worktree remove --force {wt_path}`, then re-dispatch."
             )
-            raise WorktreeError(msg)
+            raise StaleWorktreeError(msg)
         return wt_path
 
     wt_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -19,7 +19,7 @@ from cw.dispatch import (
     persist_last_result,
 )
 from cw.events import read_events, record_event
-from cw.exceptions import WorktreeError
+from cw.exceptions import StaleWorktreeError, WorktreeError
 from cw.models import (
     ClientConfig,
     CwState,
@@ -1162,6 +1162,81 @@ class TestDispatchTickSpawnErrors:
             for record in caplog.records
             if record.name == "cw.dispatch" and record.levelno >= logging.ERROR
         ), "expected ERROR log from cw.dispatch mentioning 'spawn failed'"
+
+    def test_stale_worktree_error_force_removes_then_reverts(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A StaleWorktreeError from create_worktree force-removes the stale
+        tree (so the next tick rebuilds fresh) and reverts the task to PENDING.
+
+        Without the removal the task would re-claim and re-hit the same stale
+        worktree every tick — an infinite spin, because no session is created
+        here for reconcile's TIMED_OUT cleanup to act on (#404).
+        """
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        add_ticket(TicketTask(ticket_id="GEN-404S", client="test-client"))
+
+        def _stale(*_args: object, **_kwargs: object) -> Path:
+            msg = "Refusing to reuse stale worktree"
+            raise StaleWorktreeError(msg)
+
+        removed: list[tuple[str, bool]] = []
+
+        def _record_remove(
+            _client: object, branch: str, *, force: bool = False
+        ) -> None:
+            removed.append((branch, force))
+
+        monkeypatch.setattr("cw.dispatch.create_worktree", _stale)
+        monkeypatch.setattr("cw.dispatch.remove_worktree", _record_remove)
+
+        daemon = FakeNativeDaemonClient()
+        spawned = dispatch_tick(simple_config, native_daemon=daemon)
+
+        assert spawned == 0
+        assert daemon.spawn_calls == []
+        # Stale tree force-removed for the ticket's branch before the revert.
+        assert removed == [("auto-dev/GEN-404S", True)]
+
+        queue = load_dev_queue()
+        task = queue.tasks[0]
+        assert task.status == QueueItemStatus.PENDING
+        assert task.session_id is None
+
+    def test_stale_worktree_removal_failure_still_reverts(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If the force-remove itself fails, the loop still survives and reverts
+        the task to PENDING — removal is best-effort (#404)."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        add_ticket(TicketTask(ticket_id="GEN-404F", client="test-client"))
+
+        def _stale(*_args: object, **_kwargs: object) -> Path:
+            msg = "Refusing to reuse stale worktree"
+            raise StaleWorktreeError(msg)
+
+        def _remove_boom(*_args: object, **_kwargs: object) -> None:
+            msg = "git worktree remove failed"
+            raise WorktreeError(msg)
+
+        monkeypatch.setattr("cw.dispatch.create_worktree", _stale)
+        monkeypatch.setattr("cw.dispatch.remove_worktree", _remove_boom)
+
+        daemon = FakeNativeDaemonClient()
+        spawned = dispatch_tick(simple_config, native_daemon=daemon)
+
+        assert spawned == 0
+        queue = load_dev_queue()
+        assert queue.tasks[0].status == QueueItemStatus.PENDING
+        assert queue.tasks[0].session_id is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 from cw.config import load_state, save_state
 from cw.dev_queue import load_dev_queue, save_dev_queue
 from cw.events import read_events
+from cw.exceptions import WorktreeError
 from cw.models import (
     ClientConfig,
     CompletionReason,
@@ -1039,6 +1040,107 @@ def test_revert_stalled_headless_sessions_stops_daemon_surface(
     revert_stalled_headless_sessions(state, now=now, config=OrchestratorConfig())
 
     assert short_id in daemon.stop_calls
+
+
+# ---------------------------------------------------------------------------
+# Stale-worktree cleanup on timeout (GitHub issue #404): a timed-out session's
+# task is reverted to PENDING, so its worktree must be removed or the retry
+# would inherit this run's branch/commits.
+# ---------------------------------------------------------------------------
+
+
+def test_revert_stalled_cleans_up_worktree(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wall-clock timeout removes the stale worktree so re-dispatch is clean."""
+    worktree = tmp_path / "wt-cleanup"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session(
+        "clean-1", worktree, started_at, surface_ref=None
+    )
+    sess.branch = "auto-dev/clean-1"
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    removed: list[tuple[str, str, bool]] = []
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
+    monkeypatch.setattr(
+        "cw.reconcile.remove_worktree",
+        lambda client, branch, *, force=False: removed.append(
+            (client.name, branch, force)
+        ),
+    )
+
+    revert_stalled_headless_sessions(state, now=now, config=OrchestratorConfig())
+
+    assert removed == [("client-a", "auto-dev/clean-1", True)]
+
+
+def test_revert_stalled_worktree_cleanup_is_best_effort(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A worktree-removal failure must not abort the timeout sweep (#404)."""
+    worktree = tmp_path / "wt-boom"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("boom-1", worktree, started_at, surface_ref=None)
+    sess.branch = "auto-dev/boom-1"
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    def boom(client: ClientConfig, branch: str, *, force: bool = False) -> None:
+        msg = "git worktree remove exploded"
+        raise WorktreeError(msg)
+
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
+    monkeypatch.setattr("cw.reconcile.remove_worktree", boom)
+
+    revert_stalled_headless_sessions(state, now=now, config=OrchestratorConfig())
+
+    assert sess.status == SessionStatus.TIMED_OUT
+
+
+def test_revert_stalled_skips_cleanup_when_no_branch(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session with no branch attempts no worktree cleanup (#404)."""
+    worktree = tmp_path / "wt-nobranch"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session(
+        "nobranch-1", worktree, started_at, surface_ref=None
+    )
+    # branch left as the model default (None)
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    calls: list[str] = []
+
+    def record_get_client(name: str) -> ClientConfig:
+        calls.append(name)
+        return ClientConfig(name=name, workspace_path=tmp_path / "ws")
+
+    monkeypatch.setattr("cw.reconcile.get_client", record_get_client)
+
+    revert_stalled_headless_sessions(state, now=now, config=OrchestratorConfig())
+
+    assert calls == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -2936,6 +2936,123 @@ def test_flag_silently_idle_auto_recovers_under_cap(
     assert events[0].payload["cause"] == "idle_stall_recovered"
 
 
+def test_flag_silently_idle_recover_cleans_up_worktree(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """Idle-stall recover (the second cleanup call site) removes the stale
+    worktree so the re-dispatched ticket starts clean (#404)."""
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    sess = Session(
+        id="hang-wt",
+        name="client-a/auto-dev/HANG-WT",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        worktree_path=Path("/tmp/wt"),
+        branch="auto-dev/HANG-WT",
+        surface_ref="live-ref",
+        started_at=started_at,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="HANG-WT",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="hang-wt",
+                    attempts=1,  # < cap → recover path
+                )
+            ]
+        )
+    )
+
+    removed: list[tuple[str, str, bool]] = []
+    with (
+        patch("cw.reconcile._transcript_recently_active", return_value=False),
+        patch("cw.reconcile._awaiting_subagent", return_value=False),
+        patch("cw.reconcile.get_native_daemon_client", return_value=MagicMock()),
+        patch("cw.reconcile.fire_push_notification"),
+        patch(
+            "cw.reconcile.get_client",
+            lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+        ),
+        patch(
+            "cw.reconcile.remove_worktree",
+            lambda client, branch, *, force=False: removed.append(
+                (client.name, branch, force)
+            ),
+        ),
+    ):
+        flag_silently_idle_daemon_sessions(
+            state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+        )
+
+    assert removed == [("client-a", "auto-dev/HANG-WT", True)]
+    assert sess.status == SessionStatus.TIMED_OUT
+
+
+def test_flag_silently_idle_recover_skips_cleanup_when_no_branch(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """Recover with no branch on the session attempts no worktree cleanup (#404)."""
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    sess = Session(
+        id="hang-nb",
+        name="client-a/auto-dev/HANG-NB",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        worktree_path=Path("/tmp/wt"),
+        # branch left as the model default (None)
+        surface_ref="live-ref",
+        started_at=started_at,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="HANG-NB",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="hang-nb",
+                    attempts=1,
+                )
+            ]
+        )
+    )
+
+    calls: list[str] = []
+
+    def record_get_client(name: str) -> ClientConfig:
+        calls.append(name)
+        return ClientConfig(name=name, workspace_path=tmp_path / "ws")
+
+    with (
+        patch("cw.reconcile._transcript_recently_active", return_value=False),
+        patch("cw.reconcile._awaiting_subagent", return_value=False),
+        patch("cw.reconcile.get_native_daemon_client", return_value=MagicMock()),
+        patch("cw.reconcile.fire_push_notification"),
+        patch("cw.reconcile.get_client", record_get_client),
+    ):
+        flag_silently_idle_daemon_sessions(
+            state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+        )
+
+    assert calls == []
+    assert sess.status == SessionStatus.TIMED_OUT
+
+
 def test_flag_silently_idle_parks_when_cap_exhausted(
     tmp_config_dir: Path, tmp_path: Path
 ) -> None:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -175,7 +175,8 @@ class TestCreateWorktree:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """If worktree path already exists, return it without running git."""
+        """Existing worktree on the requested branch is reused after a single
+        branch-verification call — no ``worktree add`` (#404)."""
         client = ClientConfig(
             name="test",
             workspace_path=tmp_path / "ws",
@@ -184,17 +185,64 @@ class TestCreateWorktree:
         wt_path = tmp_path / "wt" / "feat-search"
         wt_path.mkdir(parents=True)
 
-        # Should NOT call git at all
         calls: list[tuple[str, ...]] = []
 
         def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
             calls.append(args)
-            return MagicMock(returncode=0, stdout="", stderr="")
+            # _checked_out_branch queries the current branch; it matches.
+            return MagicMock(returncode=0, stdout="feat/search\n", stderr="")
 
         monkeypatch.setattr("cw.worktree._run_git", mock_run)
         result = create_worktree(client, "feat/search")
         assert result == wt_path
-        assert len(calls) == 0
+        # Only the branch-verification call; no worktree-add.
+        assert calls == [("branch", "--show-current")]
+
+    def test_existing_worktree_wrong_branch_raises(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A pre-existing worktree on a *different* branch is stale: refuse to
+        reuse it rather than feed the worker a prior run's commits (#404)."""
+        client = ClientConfig(
+            name="test",
+            workspace_path=tmp_path / "ws",
+            worktree_base=tmp_path / "wt",
+        )
+        wt_path = tmp_path / "wt" / "auto-dev-399"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            # Existing worktree is checked out on a different branch.
+            return MagicMock(returncode=0, stdout="auto-dev/201\n", stderr="")
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        with pytest.raises(WorktreeError, match="stale worktree"):
+            create_worktree(client, "auto-dev/399")
+
+    def test_existing_path_not_a_worktree_raises(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A leftover plain directory (not a registered worktree, or detached
+        HEAD) is treated as stale and refused (#404)."""
+        client = ClientConfig(
+            name="test",
+            workspace_path=tmp_path / "ws",
+            worktree_base=tmp_path / "wt",
+        )
+        wt_path = tmp_path / "wt" / "auto-dev-399"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            # `git branch --show-current` fails: not a git worktree.
+            return MagicMock(returncode=128, stdout="", stderr="not a git repo")
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        with pytest.raises(WorktreeError, match="stale worktree"):
+            create_worktree(client, "auto-dev/399")
 
     def test_creates_new_branch(
         self,

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from cw.exceptions import WorktreeError
+from cw.exceptions import StaleWorktreeError, WorktreeError
 from cw.models import ClientConfig
 from cw.worktree import (
     _fetch_default_branch,
@@ -195,8 +195,9 @@ class TestCreateWorktree:
         monkeypatch.setattr("cw.worktree._run_git", mock_run)
         result = create_worktree(client, "feat/search")
         assert result == wt_path
-        # Only the branch-verification call; no worktree-add.
-        assert calls == [("branch", "--show-current")]
+        # The behavior under test: an on-branch worktree is reused without a
+        # `worktree add`. Assert that, not the exact verification command.
+        assert not any("add" in call for call in calls)
 
     def test_existing_worktree_wrong_branch_raises(
         self,
@@ -218,7 +219,7 @@ class TestCreateWorktree:
             return MagicMock(returncode=0, stdout="auto-dev/201\n", stderr="")
 
         monkeypatch.setattr("cw.worktree._run_git", mock_run)
-        with pytest.raises(WorktreeError, match="stale worktree"):
+        with pytest.raises(StaleWorktreeError, match="stale worktree"):
             create_worktree(client, "auto-dev/399")
 
     def test_existing_path_not_a_worktree_raises(
@@ -226,8 +227,8 @@ class TestCreateWorktree:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A leftover plain directory (not a registered worktree, or detached
-        HEAD) is treated as stale and refused (#404)."""
+        """A leftover plain directory (``git branch --show-current`` exits
+        non-zero) is treated as stale and refused (#404)."""
         client = ClientConfig(
             name="test",
             workspace_path=tmp_path / "ws",
@@ -241,7 +242,57 @@ class TestCreateWorktree:
             return MagicMock(returncode=128, stdout="", stderr="not a git repo")
 
         monkeypatch.setattr("cw.worktree._run_git", mock_run)
-        with pytest.raises(WorktreeError, match="stale worktree"):
+        with pytest.raises(StaleWorktreeError, match="stale worktree"):
+            create_worktree(client, "auto-dev/399")
+
+    def test_existing_worktree_detached_head_raises(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Detached HEAD: ``git branch --show-current`` exits 0 with empty
+        stdout. _checked_out_branch maps that to None, which mismatches any
+        requested branch and is refused (#404). Distinct code path from the
+        non-zero-returncode case above."""
+        client = ClientConfig(
+            name="test",
+            workspace_path=tmp_path / "ws",
+            worktree_base=tmp_path / "wt",
+        )
+        wt_path = tmp_path / "wt" / "auto-dev-399"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            # Detached HEAD: success exit, but no current branch name.
+            return MagicMock(returncode=0, stdout="\n", stderr="")
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        with pytest.raises(StaleWorktreeError, match="detached HEAD"):
+            create_worktree(client, "auto-dev/399")
+
+    def test_existing_worktree_git_unavailable_raises_stale_not_oserror(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If git itself cannot be invoked (OSError), _checked_out_branch
+        swallows it and returns None, so create_worktree raises
+        StaleWorktreeError rather than letting the OSError leak to the caller
+        — honouring the helper's no-raise contract (#404)."""
+        client = ClientConfig(
+            name="test",
+            workspace_path=tmp_path / "ws",
+            worktree_base=tmp_path / "wt",
+        )
+        wt_path = tmp_path / "wt" / "auto-dev-399"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            msg = "git binary not found"
+            raise FileNotFoundError(msg)
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        with pytest.raises(StaleWorktreeError):
             create_worktree(client, "auto-dev/399")
 
     def test_creates_new_branch(


### PR DESCRIPTION
## Summary

Closes #404. `create_worktree` reused an existing worktree directory unconditionally, so a re-dispatched ticket could inherit a prior run's branch/commits (the #399↔#201 cross-ticket isolation breach; precondition for #402).

**Fix (two halves):**
- `create_worktree` verifies the existing worktree is checked out on the requested branch before reusing it; mismatch / detached-HEAD / not-a-worktree raises `StaleWorktreeError`.
- `reconcile` removes a timed-out DAEMON session's worktree (best-effort, `force=True`) on both PENDING-reverting paths (wall-clock timeout + idle-stall recover), so retries start clean. **This half fixes the observed symptom**; the branch check is defense-in-depth for the cross-branch/orphaned-dir case.

**Review-team fixes (2nd commit):**
- Closed a spin window — a `StaleWorktreeError` at spawn time now force-removes the stale tree in dispatch before reverting to PENDING (no owning session exists for reconcile to clean, so it would otherwise re-hit the same tree every tick). Caught narrowly as `StaleWorktreeError` so the main-checkout guard never triggers a removal.
- `_checked_out_branch` no longer leaks `OSError` (missing git binary) — honest no-raise contract.
- Added idle-recover-path cleanup tests (the higher-frequency call site).
- Audit breadcrumb (`worktree_cleanup_ok`) on successful force-removal.
- Dropped a misleading `cw doctor --reap` hint; decoupled a brittle test; added detached-HEAD + git-unavailable cases.

**Deferred:** Performance flagged `load_clients()` re-reading `clients.yaml` per timed-out session in the sweep — negligible for a single-user tool; not worth the helper-signature churn now.

## Test plan

- [x] ruff check — zero violations
- [x] mypy — zero type errors
- [x] pytest — 1573 passed (6 new)
- [x] Reviewed by 6-agent review team; all actionable findings resolved or consciously deferred

🤖 Shipped via project /ship-it