### PR TITLE
fix(dispatch): pin github-issues tracker + tunable idle-watchdog budget

### DIFF
--- a/.claude/project-config.yaml
+++ b/.claude/project-config.yaml
@@ -1,0 +1,35 @@
+# Project tooling config consumed by /auto-dev and related skills.
+# claude-workspace tracks all work in GitHub Issues (this repo), NOT Linear.
+# Without this file, headless /auto-dev workers default to the Linear MCP for
+# ticket resolution, which cannot complete its interactive OAuth in a daemon
+# context and silently stalls until the watchdog reaps them (see the
+# 2026-05-30 fanout-cascade RCA). Pinning github-issues keeps workers on `gh`.
+
+tracking:
+  primary:
+    system: github-issues
+    tool: gh
+    scope: "technical efforts — bugs, features, implementation tasks"
+    auto_create_issues: false
+    auto_close_on_complete: true
+
+quality_gates:
+  # Run in order; all must pass before commit/PR. Mirrors CLAUDE.md.
+  - name: lint
+    command: "uv run ruff check src/ tests/"
+  - name: typecheck
+    command: "uv run mypy src/"
+  - name: test
+    command: "uv run pytest tests/ -q"
+
+review:
+  self_review: true
+  max_cycles: 3
+
+pr:
+  tool: gh
+  auto_create: false
+  branch_pattern: "{type}/{plan_id}"
+
+plan_exit:
+  mode: suggest

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -244,6 +244,13 @@ class OrchestratorConfig(BaseModel):
     idle_watchdog_by_tier: dict[str, int] = Field(
         default_factory=lambda: {"large": 1800}
     )
+    # Global idle-watchdog budget (seconds) applied when a session has no
+    # per-ticket override and no resolvable per-tier budget (e.g. it stalled
+    # before Stage 1 set a scope_hint). ``None`` falls back to the
+    # IDLE_WATCHDOG_SECONDS constant (900s). Raise this so the watchdog does
+    # not reap workers still mid-plan/mid-review — 15 min is too short for a
+    # full plan+review pass. See the 2026-05-30 fanout-cascade RCA.
+    idle_watchdog_seconds: int | None = None
     # Per-tier cap on idle-stall auto-retries before a headless worker is
     # parked BLOCKED_ON_USER for the operator. Keyed by TicketTask.scope_hint;
     # unknown tiers fall back to DEFAULT_IDLE_RETRY_CAP. See GitHub issue #384.

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -668,17 +668,19 @@ def resolve_idle_watchdog_budget(
     Precedence (highest first):
     1. task.idle_watchdog_override — explicit per-ticket escape hatch.
     2. task.scope_hint — look up per-tier default in config.
-    3. IDLE_WATCHDOG_SECONDS — global fallback.
+    3. config.idle_watchdog_seconds — operator-tunable global default.
+    4. IDLE_WATCHDOG_SECONDS — hardcoded fallback.
     """
+    global_default = config.idle_watchdog_seconds or IDLE_WATCHDOG_SECONDS
     if task is None:
-        return IDLE_WATCHDOG_SECONDS
+        return global_default
     if task.idle_watchdog_override is not None:
         return task.idle_watchdog_override
     if task.scope_hint is not None:
         tier_budget = config.idle_watchdog_by_tier.get(task.scope_hint)
         if tier_budget is not None:
             return tier_budget
-    return IDLE_WATCHDOG_SECONDS
+    return global_default
 
 
 def resolve_idle_retry_cap(

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -2251,6 +2251,29 @@ def test_resolve_idle_watchdog_budget_respects_per_tier() -> None:
     assert resolve_idle_watchdog_budget(task, config) == 600
 
 
+def test_resolve_idle_watchdog_budget_global_config_override_no_task() -> None:
+    """config.idle_watchdog_seconds overrides the hardcoded fallback (no task)."""
+    config = OrchestratorConfig(idle_watchdog_seconds=1800)
+    assert resolve_idle_watchdog_budget(None, config) == 1800
+
+
+def test_resolve_idle_watchdog_budget_global_config_override_no_scope_hint() -> None:
+    """A pre-Stage-1 task (no scope_hint) uses the global config override, not
+    the hardcoded 900s — this is the fanout-cascade fix (workers reaped mid-work)."""
+    config = OrchestratorConfig(idle_watchdog_seconds=1800)
+    task = TicketTask(ticket_id="T-1", client="c", scope_hint=None)
+    assert resolve_idle_watchdog_budget(task, config) == 1800
+
+
+def test_resolve_idle_watchdog_budget_per_tier_beats_global_override() -> None:
+    """A resolvable per-tier budget still wins over the global config default."""
+    config = OrchestratorConfig(
+        idle_watchdog_seconds=1800, idle_watchdog_by_tier={"large": 600}
+    )
+    task = TicketTask(ticket_id="T-1", client="c", scope_hint="large")
+    assert resolve_idle_watchdog_budget(task, config) == 600
+
+
 def test_resolve_idle_watchdog_budget_per_ticket_overrides_tier() -> None:
     """idle_watchdog_override beats per-tier dict."""
     config = OrchestratorConfig(idle_watchdog_by_tier={"large": 600})


### PR DESCRIPTION
## Summary

Two root causes from the 2026-05-30 fanout-cascade investigation (the failures earlier mislabeled as a "claude --bg early-stall flake"):

1. **Linear-MCP OAuth hang.** Headless `/auto-dev` workers on claude-workspace reached for the **Linear MCP** at ticket resolution (Stage 0 is Linear-only) and hung on its interactive OAuth — no human in headless → silent stall → watchdog reap, no sentinel. claude-workspace tracks work in **GitHub Issues** but had no `project-config.yaml` to steer workers to `gh`. Adds `.claude/project-config.yaml` pinning `tracking.primary.system: github-issues` (mirrors global-claude, whose workers used `gh` and never touched Linear).

2. **Idle watchdog too aggressive.** Workers actively mid-plan/mid-review were reaped at the hardcoded `IDLE_WATCHDOG_SECONDS = 900` (15 min), with no global config override (only per-tier via `scope_hint`, absent pre-Stage-1). Adds operator-tunable `OrchestratorConfig.idle_watchdog_seconds` (`None` → 900s constant) used as the fallback in `resolve_idle_watchdog_budget`. Operator sets `1800` (30 min) in local `orchestrator.yaml`.

Companion tickets: global-claude#24 (clean-bail on un-authable MCP), plus a github-issues-intake ticket for the Linear-only Stage 0 (filing separately).

## Caveat
Bumping the idle budget is a pragmatic mitigation. If 30-40 min still reaps active workers, the deeper cause is the liveness check (`_awaiting_subagent`/transcript-mtime) failing to see their activity — to be tracked separately.

## Test plan
- [x] ruff / mypy clean
- [x] pytest 1576 passed (3 new resolver tests; existing unchanged since default `None` preserves 900s)
- [ ] **Verify-by-dispatch**: a claude-workspace headless worker resolves the ticket via `gh` (not Linear) after merge

🤖 Shipped via project /ship-it