### PR TITLE
chore(release): cut 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.14.1] — 2026-05-30
+
+Bug-fix release closing dispatch-reliability gaps surfaced by the 2026-05-30
+fanout-cascade RCA: a re-dispatched ticket can no longer inherit a prior run's
+worktree state, and the idle-watchdog budget is now operator-tunable so workers
+mid-plan/review aren't reaped at 15 minutes.
+
+### Fixed
+
+- **Stale-worktree reuse** (#404 → PR #410): `create_worktree` verifies the
+  existing worktree is checked out on the requested branch before reusing it,
+  raising `StaleWorktreeError` on a mismatch (wrong branch, detached HEAD, or not
+  a registered worktree). The dispatch loop catches it, force-removes the stale
+  tree, and reverts the task to `PENDING` so the retry rebuilds clean — closing
+  an infinite-respawn window. `reconcile` also reaps a timed-out session's
+  worktree on both the wall-clock-timeout and idle-stall-recover paths.
+
+### Added
+
+- **Tunable idle-watchdog budget** (#412): new `idle_watchdog_seconds` key in
+  `orchestrator.yaml` overrides the hardcoded 900s (15 min) global default —
+  15 min was reaping headless workers still mid-plan/mid-review. Falls back to
+  the constant when unset; per-ticket and per-tier overrides still take
+  precedence. Also adds `.claude/project-config.yaml` pinning
+  `tracking.primary.system: github-issues` for this repo.
+
 ## [0.14.0] — 2026-05-30
 
 Dispatch-reliability release: the idle watchdog now **auto-recovers** stalled

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-workspace"
-version = "0.14.0"
+version = "0.14.1"
 description = "Multi-session workspace orchestrator for Claude Code"
 readme = "README.md"
 authors = [

--- a/src/cw/__init__.py
+++ b/src/cw/__init__.py
@@ -1,3 +1,3 @@
 """claude-workspace: Multi-session workspace orchestrator for Claude Code."""
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "claude-workspace"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Bug-fix release of the dispatch-reliability fixes merged since 0.14.0:

- **#404** (PR #410) — stale-worktree branch verification + force-remove on reuse + reap-on-timeout (closes the cross-ticket isolation / infinite-respawn window).
- **#412** — operator-tunable `idle_watchdog_seconds` in `orchestrator.yaml` + a `github-issues` `project-config.yaml` for this repo.

Cutting + reinstalling closes the deploy gap that left the running binary on 0.14.0 (hardcoded 900s idle budget, no config field) — the live cause of headless workers being reaped at 15 min (#406/#411).

After merge: `scripts/release.sh 0.14.1` tags `v0.14.1` → GitHub Actions builds → `uv tool install --reinstall`.

## Test plan
- [x] version consistent across pyproject / `__init__.py` / uv.lock (0.14.1)
- [x] ruff + mypy clean; pytest 1576 passed
- [x] CHANGELOG updated

🤖 Shipped via project /ship-it