### PR TITLE
docs(cw): fix two-branch model in headless-contract.md + stale cmux comment in worktree.py

### DIFF
--- a/docs/headless-contract.md
+++ b/docs/headless-contract.md
@@ -99,7 +99,7 @@ The skill emits **exactly one** sentinel block per invocation. If the parser fin
   },
   "plan_source": "linear_existing",
   "branch": "dev/gen-1234-fix-login",
-  "worktree_path": "/home/matthew/.cw/wt/abc/dev-gen-1234-fix-login",
+  "worktree_path": "/home/matthew/.cw/wt/abc/auto-dev-1234",
   "fork_point_sha": "abc1234",
   "commits": ["sha1", "sha2"],
   "pr": {
@@ -137,8 +137,8 @@ The skill emits **exactly one** sentinel block per invocation. If the parser fin
 | `scope.lines_actual` | int \| null | Actual lines touched; `null` if exited before impl. |
 | `scope.forbidden_touched` | bool | Whether any `--forbidden` area was touched. |
 | `plan_source` | `"linear_existing"` \| `"github_issue_existing"` \| `"generated"` \| `"free_text"` \| `"none"` | How the plan was sourced. `"linear_existing"` and `"github_issue_existing"` are equivalent (the latter is the post-Linear, GitHub-Issues-era label — producers should emit whichever matches their tracker). `"none"` is used for pre-flight exits where no plan was produced. |
-| `branch` | string \| null | Branch name; `null` if exited before branch creation (e.g. `plan_pending_approval`). |
-| `worktree_path` | string \| null | Absolute path; `null` if no worktree was created. |
+| `branch` | string \| null | The **feature branch** where the impl agent pushed (e.g. `dev/<ticket-id>`). `null` if exited before branch creation (e.g. `plan_pending_approval`). Distinct from the cw session branch (`auto-dev/<ticket>`) that hosts the orchestrating skill run. |
+| `worktree_path` | string \| null | Absolute path of the **cw session worktree** (e.g. `~/.cw/wt/<hash>/auto-dev-<ticket>`). This is the worktree that cw creates on the session branch for the skill to run in — not the impl feature branch. `null` if no worktree was created. |
 | `fork_point_sha` | string \| null | Base commit at branch creation. |
 | `commits` | string[] | Commit SHAs created during this run. |
 | `pr` | object \| null | Non-null **only** when `status = shipped`. All other statuses — including `review_pending_approval` (whether reached via the large-scope path or the §5.1 downgrade), `merge_gate_blocked`, `plan_pending_approval`, the rejects, and `blocked` — leave `pr` as `null`. `branch` may still be non-null on these (see `branch` row). |

--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -20,9 +20,9 @@ _log = logging.getLogger(__name__)
 
 # The native spawn backend (``spawn_create_impl`` / ``claude --bg`` with
 # ``cwd=``) has no path-length restriction beyond OS limits (PATH_MAX ~4096).
-# The 64-char threshold is a conservative cap: for any realistic workspace
-# path the full candidate path exceeds 64 chars, so the hash-fallback base
-# (``~/.cw/wt/``) is always used, keeping paths short and predictable.
+# The 64-char threshold is a conservative trigger: for any realistic workspace
+# path the default candidate exceeds this cap, so the hash-fallback base
+# (``~/.cw/wt/``) is used in practice — keeping paths short and predictable.
 _WORKTREE_NAME_CAP = 64
 _HASH_BASE_SEGMENTS = (".cw", "wt")
 # 8 hex chars = 32 bits. For a single-user tool with a handful of

--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -18,13 +18,11 @@ if TYPE_CHECKING:
 _log = logging.getLogger(__name__)
 
 
-# cmux rejects worktree names longer than 64 chars with:
-#   "Invalid worktree name: must be 64 characters or fewer (got N)"
-# The full ``claude -w <path>`` argument is what cmux measures. When the
-# default ``<ws.parent>/.worktrees/<ws.name>/<slug>`` layout would exceed
-# this cap, fall back to a hash-derived short base under ``~/.cw/wt/``
-# so path length stays bounded regardless of client name or workspace
-# nesting depth.
+# The native spawn backend (``spawn_create_impl`` / ``claude --bg`` with
+# ``cwd=``) has no path-length restriction beyond OS limits (PATH_MAX ~4096).
+# The 64-char threshold is a conservative cap: for any realistic workspace
+# path the full candidate path exceeds 64 chars, so the hash-fallback base
+# (``~/.cw/wt/``) is always used, keeping paths short and predictable.
 _WORKTREE_NAME_CAP = 64
 _HASH_BASE_SEGMENTS = (".cw", "wt")
 # 8 hex chars = 32 bits. For a single-user tool with a handful of
@@ -84,10 +82,10 @@ def worktree_path_for(client: ClientConfig, branch: str) -> Path:
     """Return the full worktree path for a branch.
 
     Falls back to a hash-derived short base under ``~/.cw/wt/`` when the
-    default layout would produce a path longer than cmux's 64-char
-    worktree-name cap. An explicit ``client.worktree_base`` is always
-    honoured, even if it produces a path over the cap — user choice
-    wins over the safety net.
+    default layout would produce a path longer than the 64-char path-length
+    threshold. An explicit ``client.worktree_base`` is always honoured, even
+    if it produces a path over the threshold — user choice wins over the
+    safety net.
     """
     slug = slugify_branch(branch)
     base = resolve_worktree_base(client)


### PR DESCRIPTION
## Summary

- Fix `worktree_path` example JSON in `docs/headless-contract.md` to use `auto-dev-<ticket>` namespace (was incorrectly using feature branch namespace)
- Expand `branch` and `worktree_path` field notes to explicitly distinguish cw session worktree from impl feature branch
- Replace stale cmux rationale in `src/cw/worktree.py` block comment with accurate native-backend description
- Update `worktree_path_for` docstring to drop the cmux reference

Closes #408

## Test plan

- [ ] `docs/headless-contract.md` example JSON `worktree_path` shows `auto-dev-<ticket>` path, not feature branch path
- [ ] Field notes for `branch` and `worktree_path` clearly distinguish the two namespaces
- [ ] `src/cw/worktree.py` block comment no longer references cmux
- [ ] All tests pass (`uv run pytest tests/ -v`)
- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate

🤖 Shipped via /prep-pr + project /ship-it