### PR TITLE
ops(ci): add dispatch-critical drift guard + release closer

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,6 +6,7 @@
 | `nightly.yml` | 09:00 UTC daily | macOS | cmux integration (requires live cmux daemon) |
 | `nightly-native.yml` | Manual (`workflow_dispatch`) | ubuntu | Full test suite (excl. cmux) + native daemon smoke tests |
 | `release.yml` | Tag push | ubuntu | Build and publish to PyPI |
+| `dispatch-guard.yml` | Push to `main` (dispatch/reconcile/spawn) | ubuntu | Opens a `dispatch-drift` issue when critical files are unreleased; closes on next release |
 
 ## Triggering workflows manually
 

--- a/.github/workflows/dispatch-guard.yml
+++ b/.github/workflows/dispatch-guard.yml
@@ -1,0 +1,92 @@
+name: Dispatch Guard
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - src/cw/dispatch.py
+      - src/cw/reconcile.py
+      - src/cw/spawn.py
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Ensure dispatch-drift label exists
+        run: |
+          gh label create "dispatch-drift" \
+            --description "Unreleased changes to dispatch/reconcile/spawn" \
+            --color "e4e669" \
+            || true
+
+      - name: Check for unreleased changes in critical files
+        id: drift
+        run: |
+          # If no tags exist yet there is no released version to compare against.
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+          if [ -z "$LAST_TAG" ]; then
+            echo "No release tags found — nothing to guard."
+            echo "unreleased=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only "${LAST_TAG}..HEAD" -- \
+            src/cw/dispatch.py \
+            src/cw/reconcile.py \
+            src/cw/spawn.py)
+
+          if [ -n "$CHANGED" ]; then
+            echo "unreleased=true" >> "$GITHUB_OUTPUT"
+            echo "last_tag=${LAST_TAG}" >> "$GITHUB_OUTPUT"
+            {
+              echo "changed_files<<EOF"
+              echo "$CHANGED"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "unreleased=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for existing open dispatch-drift issue
+        id: existing
+        if: steps.drift.outputs.unreleased == 'true'
+        run: |
+          COUNT=$(gh issue list \
+            --label dispatch-drift \
+            --state open \
+            --json number \
+            --jq 'length')
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Open dispatch-drift issue
+        if: >
+          steps.drift.outputs.unreleased == 'true' &&
+          steps.existing.outputs.count == '0'
+        env:
+          LAST_TAG: ${{ steps.drift.outputs.last_tag }}
+          CHANGED_FILES: ${{ steps.drift.outputs.changed_files }}
+        run: |
+          gh issue create \
+            --title "ops(release): unreleased dispatch/reconcile/spawn changes since ${LAST_TAG}" \
+            --label dispatch-drift \
+            --body "Commits have landed on \`main\` that touch one or more dispatch-reliability files without a subsequent release being cut.
+
+**Last release tag:** \`${LAST_TAG}\`
+
+**Changed files since that tag:**
+\`\`\`
+${CHANGED_FILES}
+\`\`\`
+
+Cut a new release to close this issue automatically.
+
+> Opened automatically by the [Dispatch Guard workflow](/.github/workflows/dispatch-guard.yml). Closes when a release tag is pushed."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
@@ -68,3 +69,18 @@ jobs:
             cw init my-project --path /path/to/repo
             cw start my-project
             ```
+
+      - name: Close dispatch-drift issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          gh issue list \
+            --label "dispatch-drift" \
+            --state open \
+            --json number \
+            --jq '.[].number' | \
+          while read -r NUM; do
+            gh issue close "$NUM" \
+              --comment "Closed by release ${RELEASE_TAG} — dispatch/reconcile/spawn changes are now shipped."
+          done


### PR DESCRIPTION
## Summary

- feat(ci): add dispatch-critical drift guard workflow
- feat(ci): close dispatch-drift issues on release
- docs(ci): document dispatch-guard workflow in README

Adds a CI guard that detects drift in dispatch-critical files and opens GitHub issues when drift is detected. The release workflow closes those issues when a release is cut.

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it