### PR TITLE
fix(cli): configure logging handler at entrypoint (#423)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -143,10 +143,41 @@ def _complete_session(
     ]
 
 
+_LOG_FORMAT = "%(levelname)s %(name)s %(message)s"
+
+_VERBOSE_DEBUG_THRESHOLD = 2
+
+
+def _configure_logging(verbose: int) -> None:
+    """Install a single stderr logging handler for the CLI process.
+
+    Uses ``basicConfig`` *without* ``force`` on purpose: when a test harness
+    (pytest) has already attached handlers to the root logger, ``basicConfig``
+    is a no-op, so the harness keeps full control of log capture. In a real
+    ``cw`` process the root logger starts empty, so a stderr handler is
+    installed once at the requested level. ``-v`` -> INFO, ``-vv`` -> DEBUG.
+    """
+    if verbose >= _VERBOSE_DEBUG_THRESHOLD:
+        level = logging.DEBUG
+    elif verbose == 1:
+        level = logging.INFO
+    else:
+        level = logging.WARNING
+    logging.basicConfig(level=level, stream=sys.stderr, format=_LOG_FORMAT)
+
+
 @click.group()
 @click.version_option(version=__version__, prog_name="cw")
-def main() -> None:
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    default=0,
+    help="Increase log verbosity (-v INFO, -vv DEBUG).",
+)
+def main(verbose: int) -> None:
     """Claude Workspace - multi-session orchestrator for Claude Code."""
+    _configure_logging(verbose)
 
 
 @main.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import io
 import json
+import logging
+import subprocess
+import sys
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
@@ -14,6 +19,7 @@ from freezegun import freeze_time
 from cw.cli import (
     _complete_client,
     _complete_session,
+    _configure_logging,
     _display_sessions,
     _display_status,
     main,
@@ -34,7 +40,7 @@ from cw.models import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
     from pathlib import Path
 
     import click
@@ -203,6 +209,83 @@ class TestCli:
         assert result.exit_code == 0
         assert "Note: cw daemon's PR-dispatch role is deprecated as of 0.11." in (
             result.output
+        )
+
+
+class TestLogging:
+    """Logging handler configuration at the CLI entrypoint (#423).
+
+    These tests drive ``_configure_logging`` against a root logger whose
+    handlers have been cleared to simulate a fresh ``cw`` process. They
+    deliberately do NOT rely on global log capture under pytest, and they
+    restore the root logger's handlers/level afterward so they never leak
+    state into the rest of the suite (the ``force=True`` regression that
+    hung the suite).
+    """
+
+    @staticmethod
+    @contextmanager
+    def _fresh_root_logger() -> Iterator[logging.Logger]:
+        root = logging.getLogger()
+        saved_handlers = root.handlers[:]
+        saved_level = root.level
+        root.handlers.clear()
+        try:
+            yield root
+        finally:
+            root.handlers.clear()
+            root.handlers.extend(saved_handlers)
+            root.setLevel(saved_level)
+
+    def test_installs_stderr_handler_by_default(self) -> None:
+        with self._fresh_root_logger() as root:
+            _configure_logging(0)
+            stream_handlers = [
+                h
+                for h in root.handlers
+                if isinstance(h, logging.StreamHandler) and h.stream is sys.stderr
+            ]
+            assert stream_handlers, "no stderr handler installed"
+            assert root.level == logging.WARNING
+
+    def test_verbose_flag_sets_info_level(self) -> None:
+        with self._fresh_root_logger() as root:
+            _configure_logging(1)
+            assert root.level == logging.INFO
+
+    def test_double_verbose_flag_sets_debug_level(self) -> None:
+        with self._fresh_root_logger() as root:
+            _configure_logging(2)
+            assert root.level == logging.DEBUG
+
+    def test_emitted_warning_reaches_stderr(self) -> None:
+        """A WARNING emitted after configuration is written to stderr."""
+        with self._fresh_root_logger():
+            stream = io.StringIO()
+            with patch.object(sys, "stderr", stream):
+                _configure_logging(0)
+                logging.getLogger("cw.test_sentinel").warning("sentinel-423")
+        assert "sentinel-423" in stream.getvalue()
+
+    def test_no_handler_installed_at_import_time(self) -> None:
+        """Importing cw.cli must NOT configure logging.
+
+        Checked in a fresh subprocess so the assertion observes a pristine
+        interpreter and never mutates this process's ``sys.modules`` / logging
+        state. An in-process pop+reimport of ``cw.cli`` corrupts the rest of
+        the suite, so isolation via subprocess is required here.
+        """
+        code = (
+            "import logging, cw.cli, sys; "
+            "sys.exit(1 if logging.getLogger().handlers else 0)"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"cw.cli configured logging at import time: {result.stderr.decode()}"
         )
 
 


### PR DESCRIPTION
## Summary
Installs a logging sink at the CLI entrypoint. Before this, `basicConfig`/`addHandler`/`StreamHandler`/`NullHandler` appeared **zero times** in `src/`, so every `_log.exception/.warning` across daemon, dispatch, and reconcile was silently discarded at runtime. This is the floor beneath the silent-stall (#420) and daemon-dies-quietly (#390) reports.

## Changes
- `_configure_logging(verbose)` helper installs a single stderr handler in the Click group entrypoint.
- Global `-v/--verbose` count flag: `-v` → INFO, `-vv` → DEBUG.
- `basicConfig` called **without** `force=` so a test harness that already holds root handlers keeps control of log capture (the ticket's explicit requirement).

## Acceptance
- Handler configured exactly once at the entrypoint; a WARNING emitted after config reaches stderr (`test_emitted_warning_reaches_stderr`).
- `-v` → INFO, `-vv` → DEBUG (covered).
- No `basicConfig` at import time — verified in a subprocess for true isolation.

## Verification
- `ruff check src/ tests/` — clean
- `mypy src/` — clean
- `pytest tests/` — **1400 passed, 4 skipped** (1395 baseline + 5 new), 13.3s, no hang

> Note: the original draft used `basicConfig(force=True)`, which seized logging from pytest and hung the suite; and an in-process `sys.modules` pop+reimport import-time test that polluted later tests. Both were corrected — full-suite green.

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)