### PR TITLE
fix(worktree): dirty-check before force-removing stale/timed-out worktree (#425)

### DIFF
--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -32,6 +32,7 @@ from cw.worktree import (
     create_worktree,
     is_main_behind_origin,
     remove_worktree,
+    worktree_has_unsaved_work,
 )
 
 if TYPE_CHECKING:
@@ -235,8 +236,36 @@ def dispatch_tick(
                     # then re-raise into the handler below to revert to PENDING.
                     # Caught narrowly as StaleWorktreeError (not WorktreeError)
                     # so the main-checkout guard never triggers a removal.
-                    with contextlib.suppress(WorktreeError, OSError):
-                        remove_worktree(client, branch, force=True)
+                    #
+                    # Dirty-check guard (#425): if the stale tree contains
+                    # unsaved work, skip the removal and park the task as
+                    # BLOCKED_ON_USER instead of PENDING so the operator can
+                    # inspect. The outer except handler will not overwrite
+                    # BLOCKED_ON_USER (it checks status == RUNNING before
+                    # reverting).
+                    if worktree_has_unsaved_work(client, branch):
+                        _log.warning(
+                            "dispatch: stale worktree %s/%s has unsaved work"
+                            " — leaving for operator inspection; parking as"
+                            " BLOCKED_ON_USER",
+                            client.name,
+                            branch,
+                        )
+                        with dev_queue_lock():
+                            store = load_dev_queue()
+                            for stored_task in store.tasks:
+                                if (
+                                    stored_task.ticket_id == task.ticket_id
+                                    and stored_task.client == client.name
+                                    and stored_task.status == QueueItemStatus.RUNNING
+                                ):
+                                    stored_task.status = QueueItemStatus.BLOCKED_ON_USER
+                                    stored_task.session_id = None
+                                    break
+                            save_dev_queue(store)
+                    else:
+                        with contextlib.suppress(WorktreeError, OSError):
+                            remove_worktree(client, branch, force=True)
                     raise
 
                 # Guard against the #300 regression: if create_worktree

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -56,7 +56,7 @@ from cw.models import (
 )
 from cw.native_daemon import get_native_daemon_client
 from cw.notify import fire_push_notification
-from cw.worktree import remove_worktree
+from cw.worktree import remove_worktree, worktree_has_unsaved_work, worktree_path_for
 
 if TYPE_CHECKING:
     from cw.models import CwState, Session
@@ -498,7 +498,10 @@ def _apply_salvaged_completion(
     session.claude_session_id = claude_session_id
 
 
-def _cleanup_timed_out_worktree(session: Session) -> None:
+def _cleanup_timed_out_worktree(
+    session: Session,
+    ticket_id: str | None = None,
+) -> None:
     """Remove a timed-out session's worktree so the re-dispatch starts clean.
 
     A timed-out DAEMON session has its ``TicketTask`` reverted to PENDING for
@@ -506,6 +509,12 @@ def _cleanup_timed_out_worktree(session: Session) -> None:
     reuse it (or, post-#404, refuse and spin) — either way feeding the retry a
     prior run's branch and commits. Removing it here means the next claim builds
     a fresh worktree from the current default branch. See GitHub issue #404.
+
+    Dirty-check guard (#425): if the worktree contains uncommitted changes or
+    unpushed commits the removal is SKIPPED.  Instead the owning task is flipped
+    from PENDING back to BLOCKED_ON_USER so the operator can inspect the tree
+    before it is removed.  *ticket_id* is required for the BLOCKED_ON_USER flip;
+    when omitted the skip is logged but the queue is not mutated.
 
     Best-effort: every failure is logged and swallowed. Worktree cleanup must
     never abort the reconcile sweep — a missing/renamed client, an
@@ -515,6 +524,29 @@ def _cleanup_timed_out_worktree(session: Session) -> None:
         return
     try:
         client = get_client(session.client)
+        if worktree_has_unsaved_work(client, session.branch):
+            wt_path = str(worktree_path_for(client, session.branch))
+            _log.warning(
+                "worktree_cleanup_skip_dirty: %s/%s has unsaved work"
+                " — leaving worktree at %s for operator inspection"
+                " (ticket=%s)",
+                session.client,
+                session.branch,
+                wt_path,
+                ticket_id,
+            )
+            if ticket_id:
+                with dev_queue_lock():
+                    store = load_dev_queue()
+                    for task in store.tasks:
+                        if (
+                            task.ticket_id == ticket_id
+                            and task.status == QueueItemStatus.PENDING
+                        ):
+                            task.status = QueueItemStatus.BLOCKED_ON_USER
+                            save_dev_queue(store)
+                            break
+            return
         remove_worktree(client, session.branch, force=True)
     except (CwError, OSError) as exc:
         _log.warning(
@@ -639,7 +671,7 @@ def revert_stalled_headless_sessions(
             get_native_daemon_client().stop(session.surface_ref)
         # Stale-worktree cleanup: the task was reverted to PENDING above, so
         # the retry must not inherit this run's worktree state (#404).
-        _cleanup_timed_out_worktree(session)
+        _cleanup_timed_out_worktree(session, ticket_id)
 
     for session, ticket_id, result in salvaged:
         completed_payload: dict[str, object] = {
@@ -820,7 +852,7 @@ def flag_silently_idle_daemon_sessions(
             get_native_daemon_client().stop(session.surface_ref)
         # Stale-worktree cleanup: this task was reverted to PENDING above for
         # re-dispatch, so the retry must start from a fresh worktree (#404).
-        _cleanup_timed_out_worktree(session)
+        _cleanup_timed_out_worktree(session, ticket_id)
         record_event(
             OrchestratorEventType.SESSION_TIMED_OUT,
             {

--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -255,6 +255,75 @@ def remove_worktree(
     _run_git(*args, cwd=_git_dir(client))
 
 
+def worktree_has_unsaved_work(client: ClientConfig, branch: str) -> bool:
+    """Return True if the worktree for *branch* has unsaved work.
+
+    "Unsaved" means either:
+    - uncommitted changes (``git status --porcelain`` is non-empty), OR
+    - unpushed commits (``git log origin/<branch>..HEAD`` is non-empty).
+
+    Returns False when the worktree path does not exist (nothing to lose).
+    When ``origin/<branch>`` does not exist, treats all HEAD commits as
+    unpushed (conservative: assume they would be lost).
+
+    Never raises — every git error is swallowed and logged at WARNING level
+    so that a git failure cannot block a cleanup sweep.
+    """
+    wt_path = worktree_path_for(client, branch)
+    if not wt_path.exists():
+        return False
+
+    # 1. Uncommitted changes check
+    try:
+        status = _run_git("status", "--porcelain", cwd=wt_path, check=False)
+        if status.stdout.strip():
+            return True
+    except (WorktreeError, OSError) as exc:
+        _log.warning(
+            "worktree_has_unsaved_work: status check failed for %s/%s: %s",
+            client.name,
+            branch,
+            exc,
+        )
+        # Fail-safe: treat as having unsaved work so we don't silently destroy.
+        return True
+
+    # 2. Unpushed commits check — compare HEAD against origin/<branch>.
+    # First verify that origin/<branch> exists; if not, every HEAD commit is
+    # "unpushed" (conservative).
+    try:
+        ref_check = _run_git(
+            "rev-parse",
+            "--verify",
+            f"origin/{branch}",
+            cwd=wt_path,
+            check=False,
+        )
+        if ref_check.returncode != 0:
+            # origin/<branch> unknown — check whether HEAD has any commits
+            head_check = _run_git(
+                "rev-parse", "--verify", "HEAD", cwd=wt_path, check=False
+            )
+            return head_check.returncode == 0 and bool(head_check.stdout.strip())
+        log_result = _run_git(
+            "log",
+            f"origin/{branch}..HEAD",
+            "--oneline",
+            cwd=wt_path,
+            check=False,
+        )
+        return bool(log_result.stdout.strip())
+    except (WorktreeError, OSError) as exc:
+        _log.warning(
+            "worktree_has_unsaved_work: log check failed for %s/%s: %s",
+            client.name,
+            branch,
+            exc,
+        )
+        # Fail-safe: treat as having unsaved work.
+        return True
+
+
 def _fetch_default_branch(client_name: str, default_branch: str, git_dir: Path) -> bool:
     """Fetch origin/<default_branch>. Returns True on success, False on failure."""
     if not git_dir.exists():

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1239,6 +1239,88 @@ class TestDispatchTickSpawnErrors:
         assert queue.tasks[0].status == QueueItemStatus.PENDING
         assert queue.tasks[0].session_id is None
 
+    def test_stale_worktree_dirty_blocks_task_and_skips_removal(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """StaleWorktreeError + dirty worktree: removal SKIPPED, task →
+        BLOCKED_ON_USER (#425)."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        add_ticket(TicketTask(ticket_id="GEN-425D", client="test-client"))
+
+        def _stale(*_args: object, **_kwargs: object) -> Path:
+            msg = "Refusing to reuse stale worktree"
+            raise StaleWorktreeError(msg)
+
+        removed: list[str] = []
+
+        def _record_remove(
+            _client: object, branch: str, *, force: bool = False
+        ) -> None:
+            removed.append(branch)
+
+        monkeypatch.setattr("cw.dispatch.create_worktree", _stale)
+        monkeypatch.setattr("cw.dispatch.remove_worktree", _record_remove)
+        monkeypatch.setattr(
+            "cw.dispatch.worktree_has_unsaved_work", lambda _c, _b: True
+        )
+
+        daemon = FakeNativeDaemonClient()
+        spawned = dispatch_tick(simple_config, native_daemon=daemon)
+
+        assert spawned == 0
+        # Removal must NOT have been called
+        assert removed == []
+        # Task must be BLOCKED_ON_USER, not PENDING
+        queue = load_dev_queue()
+        task = queue.tasks[0]
+        assert task.status == QueueItemStatus.BLOCKED_ON_USER
+        assert task.session_id is None
+
+    def test_stale_worktree_clean_removes_and_reverts(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """StaleWorktreeError + clean worktree: removal proceeds, task → PENDING
+        (#425)."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        add_ticket(TicketTask(ticket_id="GEN-425C", client="test-client"))
+
+        def _stale(*_args: object, **_kwargs: object) -> Path:
+            msg = "Refusing to reuse stale worktree"
+            raise StaleWorktreeError(msg)
+
+        removed: list[tuple[str, bool]] = []
+
+        def _record_remove(
+            _client: object, branch: str, *, force: bool = False
+        ) -> None:
+            removed.append((branch, force))
+
+        monkeypatch.setattr("cw.dispatch.create_worktree", _stale)
+        monkeypatch.setattr("cw.dispatch.remove_worktree", _record_remove)
+        monkeypatch.setattr(
+            "cw.dispatch.worktree_has_unsaved_work", lambda _c, _b: False
+        )
+
+        daemon = FakeNativeDaemonClient()
+        spawned = dispatch_tick(simple_config, native_daemon=daemon)
+
+        assert spawned == 0
+        # Removal with force=True must have been called
+        assert removed == [("auto-dev/GEN-425C", True)]
+        # Task reverted to PENDING (existing behaviour)
+        queue = load_dev_queue()
+        task = queue.tasks[0]
+        assert task.status == QueueItemStatus.PENDING
+        assert task.session_id is None
+
 
 # ---------------------------------------------------------------------------
 # TestDispatchTickFreshnessGate

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1144,6 +1144,111 @@ def test_revert_stalled_skips_cleanup_when_no_branch(
 
 
 # ---------------------------------------------------------------------------
+# Dirty-check guard on worktree cleanup (GitHub issue #425): force-remove must
+# be skipped when the worktree has unsaved work; task parks as BLOCKED_ON_USER.
+# ---------------------------------------------------------------------------
+
+
+def test_revert_stalled_skips_removal_and_blocks_task_when_dirty(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Timed-out session with unpushed commits: worktree NOT removed.
+
+    Task must move to BLOCKED_ON_USER, not PENDING (#425).
+    """
+    worktree = tmp_path / "wt-dirty"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session(
+        "dirty-1", worktree, started_at, surface_ref=None
+    )
+    sess.branch = "auto-dev/dirty-1"
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    task = TicketTask(
+        ticket_id="dirty-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="dirty-1",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    removed: list[str] = []
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
+    monkeypatch.setattr(
+        "cw.reconcile.remove_worktree",
+        lambda _client, branch, *, _force=False: removed.append(branch),
+    )
+    # Simulate dirty worktree (has unsaved work)
+    monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: True)
+
+    revert_stalled_headless_sessions(state, now=now, config=OrchestratorConfig())
+
+    # Worktree must NOT have been removed
+    assert removed == []
+    # Task must be BLOCKED_ON_USER (not PENDING)
+    store = load_dev_queue()
+    t = next(t for t in store.tasks if t.ticket_id == "dirty-1")
+    assert t.status == QueueItemStatus.BLOCKED_ON_USER
+
+
+def test_revert_stalled_removes_when_clean(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Timed-out session with clean worktree: removal proceeds as before."""
+    worktree = tmp_path / "wt-cleanX"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session(
+        "cleanX-1", worktree, started_at, surface_ref=None
+    )
+    sess.branch = "auto-dev/cleanX-1"
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    task = TicketTask(
+        ticket_id="cleanX-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="cleanX-1",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    removed: list[tuple[str, str, bool]] = []
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
+    monkeypatch.setattr(
+        "cw.reconcile.remove_worktree",
+        lambda client, branch, *, force=False: removed.append(
+            (client.name, branch, force)
+        ),
+    )
+    # Clean worktree
+    monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: False)
+
+    revert_stalled_headless_sessions(state, now=now, config=OrchestratorConfig())
+
+    # Removal proceeds with force=True
+    assert removed == [("client-a", "auto-dev/cleanX-1", True)]
+    # Task reverted to PENDING (normal timeout path)
+    store = load_dev_queue()
+    t = next(t for t in store.tasks if t.ticket_id == "cleanX-1")
+    assert t.status == QueueItemStatus.PENDING
+
+
+# ---------------------------------------------------------------------------
 # Sentinel-salvage tests (GitHub issue #372): a stalled/crashed session that
 # emitted a terminal-success sentinel must be dispositioned by that sentinel,
 # not mislabeled timed_out/crash, and its ticket must NOT be re-dispatched.

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -24,6 +24,7 @@ from cw.worktree import (
     remove_worktree,
     resolve_worktree_base,
     slugify_branch,
+    worktree_has_unsaved_work,
     worktree_path_for,
 )
 
@@ -1182,3 +1183,189 @@ class TestFetchFeatureBranch:
 
         monkeypatch.setattr("cw.worktree._run_git", mock_run)
         assert fetch_feature_branch(client, "auto-dev/381") is False
+
+
+# ---------------------------------------------------------------------------
+# TestWorktreeHasUnsavedWork (#425)
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeHasUnsavedWork:
+    """Tests for worktree_has_unsaved_work."""
+
+    def _client(self, tmp_path: Path) -> ClientConfig:
+        return ClientConfig(
+            name="test",
+            workspace_path=tmp_path / "ws",
+            worktree_base=tmp_path / "wt",
+        )
+
+    def test_returns_false_when_worktree_path_absent(self, tmp_path: Path) -> None:
+        """No worktree on disk → nothing to lose → False."""
+        client = self._client(tmp_path)
+        # wt_path does NOT exist
+        assert worktree_has_unsaved_work(client, "auto-dev/absent") is False
+
+    def test_returns_true_for_uncommitted_changes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dirty working tree (git status --porcelain non-empty) → True."""
+        client = self._client(tmp_path)
+        wt_path = tmp_path / "wt" / "auto-dev-dirty"
+        wt_path.mkdir(parents=True)
+
+        calls: list[tuple[str, ...]] = []
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            calls.append(args)
+            result = MagicMock(returncode=0, stderr="")
+            if "status" in args:
+                result.stdout = " M some_file.py\n"
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert worktree_has_unsaved_work(client, "auto-dev/dirty") is True
+        # status was the first check — we short-circuit, no log check needed
+        assert any("status" in c for c in calls)
+
+    def test_returns_true_for_unpushed_commits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Clean working tree but commits not yet pushed → True."""
+        client = self._client(tmp_path)
+        wt_path = tmp_path / "wt" / "auto-dev-unpushed"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=0, stderr="")
+            if "status" in args:
+                result.stdout = ""  # clean working tree
+            elif "rev-parse" in args and "origin/" in " ".join(args):
+                result.returncode = 0  # origin/branch exists
+                result.stdout = "abc1234\n"
+            elif "log" in args:
+                result.stdout = "abc1234 add feature\n"  # unpushed commit
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert worktree_has_unsaved_work(client, "auto-dev/unpushed") is True
+
+    def test_returns_true_when_origin_branch_missing_and_head_exists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No origin/<branch> but HEAD exists → treat all commits as unpushed → True."""
+        client = self._client(tmp_path)
+        wt_path = tmp_path / "wt" / "auto-dev-noorigin"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=0, stderr="")
+            if "status" in args:
+                result.stdout = ""  # clean working tree
+            elif "rev-parse" in args and "origin/" in " ".join(args):
+                result.returncode = 128  # origin/<branch> does NOT exist
+                result.stdout = ""
+            elif "rev-parse" in args and "HEAD" in args:
+                result.returncode = 0  # HEAD exists
+                result.stdout = "abc1234def567890\n"
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert worktree_has_unsaved_work(client, "auto-dev/noorigin") is True
+
+    def test_returns_false_when_origin_missing_and_head_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No origin/<branch> and no HEAD commits → nothing to lose → False."""
+        client = self._client(tmp_path)
+        wt_path = tmp_path / "wt" / "auto-dev-empty"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=0, stderr="")
+            if "status" in args:
+                result.stdout = ""  # clean working tree
+            elif "rev-parse" in args and "origin/" in " ".join(args):
+                result.returncode = 128  # origin/<branch> does NOT exist
+                result.stdout = ""
+            elif "rev-parse" in args and "HEAD" in args:
+                result.returncode = 128  # no commits yet
+                result.stdout = ""
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert worktree_has_unsaved_work(client, "auto-dev/empty") is False
+
+    def test_returns_false_for_clean_pushed_worktree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Clean working tree and all commits pushed → False."""
+        client = self._client(tmp_path)
+        wt_path = tmp_path / "wt" / "auto-dev-clean"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=0, stderr="")
+            if "status" in args:
+                result.stdout = ""  # clean
+            elif "rev-parse" in args and "origin/" in " ".join(args):
+                result.returncode = 0  # origin/branch exists
+                result.stdout = "abc1234\n"
+            elif "log" in args:
+                result.stdout = ""  # no unpushed commits
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert worktree_has_unsaved_work(client, "auto-dev/clean") is False
+
+    def test_returns_true_on_status_git_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """git status fails → fail-safe: treat as unsaved to avoid data loss."""
+        client = self._client(tmp_path)
+        wt_path = tmp_path / "wt" / "auto-dev-err"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            if "status" in args:
+                msg = "git status exploded"
+                raise WorktreeError(msg)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert worktree_has_unsaved_work(client, "auto-dev/err") is True
+
+    def test_returns_true_on_log_git_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """git log fails after clean status → fail-safe: treat as unsaved."""
+        client = self._client(tmp_path)
+        wt_path = tmp_path / "wt" / "auto-dev-logerr"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=0, stderr="")
+            if "status" in args:
+                result.stdout = ""  # clean working tree
+            elif "rev-parse" in args and "origin/" in " ".join(args):
+                result.returncode = 0
+                result.stdout = "abc1234\n"
+            elif "log" in args:
+                msg = "git log exploded"
+                raise WorktreeError(msg)
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert worktree_has_unsaved_work(client, "auto-dev/logerr") is True


### PR DESCRIPTION
Closes #425

## Summary

- Adds `worktree_has_unsaved_work(client, branch) -> bool` to `worktree.py`: checks uncommitted changes (`git status --porcelain`) and unpushed commits (`git log origin/<branch>..HEAD`); fails safe (returns True) on any git error; handles missing origin/<branch> conservatively.
- Guards `reconcile._cleanup_timed_out_worktree`: dirty → skip removal, WARNING logged, task flipped from PENDING → BLOCKED_ON_USER for operator inspection; clean → existing force-remove path unchanged.
- Guards `dispatch` StaleWorktreeError handler: dirty → skip removal, task set to BLOCKED_ON_USER (outer except handler checks `status == RUNNING` so it won't overwrite); clean → existing `remove_worktree(force=True)` path unchanged.

## Acceptance

- Timed-out session with unpushed commits: worktree NOT removed, task → BLOCKED_ON_USER, WARNING logged. ✓
- Timed-out session with clean worktree: existing remove + revert path still runs. ✓
- `StaleWorktreeError` dirty path: NOT removed, task → BLOCKED_ON_USER. ✓
- `StaleWorktreeError` clean path: removed with force=True, task → PENDING. ✓
- `worktree_has_unsaved_work` unit-tested for dirty-tree, unpushed-commits, no-origin, and clean conditions. ✓

## Test plan

- [ ] `uv run ruff format --check src/ tests/` — pass
- [ ] `uv run ruff check src/ tests/` — pass
- [ ] `uv run mypy src/` — pass
- [ ] `uv run pytest tests/ -q` — 1424 passed, 4 skipped, 3 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)