### PR TITLE
fix(config): atomic + locked clients.yaml write (#429)

### DIFF
--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import subprocess
+from io import StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -67,6 +68,7 @@ DEV_PLAN_FILE = STATE_DIR / "dev_plan.json"
 DEV_PLAN_LOCK = STATE_DIR / ".dev_plan.lock"
 DEV_PLAN_OUTPUT_DIR = STATE_DIR / "plan_output"
 SESSIONS_LOCK = STATE_DIR / ".sessions.lock"
+CLIENTS_LOCK = CONFIG_DIR / ".clients.yaml.lock"
 
 _DEFAULT_ORCHESTRATOR_YAML = """\
 tick_interval_seconds: 30
@@ -146,6 +148,10 @@ def sessions_lock_file() -> Path:
     return SESSIONS_LOCK
 
 
+def clients_lock_file() -> Path:
+    return CLIENTS_LOCK
+
+
 @contextlib.contextmanager
 def sessions_lock() -> Iterator[None]:
     """Acquire an exclusive file lock over the sessions.json write window.
@@ -159,6 +165,28 @@ def sessions_lock() -> Iterator[None]:
     """
     state_dir().mkdir(parents=True, exist_ok=True)
     lock_path = sessions_lock_file()
+    fd = lock_path.open("w")
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        fd.close()
+
+
+@contextlib.contextmanager
+def clients_lock() -> Iterator[None]:
+    """Acquire an exclusive file lock over the clients.yaml write window.
+
+    Mirror of ``sessions_lock``. Hold this across every load→mutate→write
+    sequence in ``init_client`` (and any future client-mutating command) so
+    concurrent ``cw client add`` processes cannot clobber each other's edits
+    (last-writer-wins data loss). The lock is advisory (``fcntl.flock``) and
+    per-open-fd, so sequential re-acquisitions in the same process are safe.
+    Do NOT nest: acquiring while already holding will deadlock.
+    """
+    config_dir().mkdir(parents=True, exist_ok=True)
+    lock_path = clients_lock_file()
     fd = lock_path.open("w")
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
@@ -461,40 +489,42 @@ def init_client(
     config_dir().mkdir(parents=True, exist_ok=True)
     clients_path = clients_file()
 
-    # Round-trip parse-modify-write with ruamel.yaml (preserves comments)
-    rt = YAML(typ="rt")
-    rt.default_flow_style = False
+    with clients_lock():
+        # Round-trip parse-modify-write with ruamel.yaml (preserves comments)
+        rt = YAML(typ="rt")
+        rt.default_flow_style = False
 
-    if clients_path.exists():
-        content = clients_path.read_text()
-        doc = rt.load(content) if content.strip() else rt.load(_EMPTY_CLIENTS_DOC)
-    else:
-        doc = rt.load(_EMPTY_CLIENTS_DOC)
+        if clients_path.exists():
+            content = clients_path.read_text()
+            doc = rt.load(content) if content.strip() else rt.load(_EMPTY_CLIENTS_DOC)
+        else:
+            doc = rt.load(_EMPTY_CLIENTS_DOC)
 
-    if not isinstance(doc, dict) or "clients" not in doc:
-        msg = (
-            f"{clients_path} exists but has no 'clients:' key."
-            " Add 'clients:' manually or delete the file to recreate."
-        )
-        raise CwError(msg)
+        if not isinstance(doc, dict) or "clients" not in doc:
+            msg = (
+                f"{clients_path} exists but has no 'clients:' key."
+                " Add 'clients:' manually or delete the file to recreate."
+            )
+            raise CwError(msg)
 
-    clients_map = doc["clients"]
-    if clients_map is None:
-        clients_map = CommentedMap()
-        doc["clients"] = clients_map
+        clients_map = doc["clients"]
+        if clients_map is None:
+            clients_map = CommentedMap()
+            doc["clients"] = clients_map
 
-    if name in clients_map:
-        msg = f"Client '{name}' already exists in {clients_path}"
-        raise CwError(msg)
+        if name in clients_map:
+            msg = f"Client '{name}' already exists in {clients_path}"
+            raise CwError(msg)
 
-    # Build the new client entry
-    entry = CommentedMap()
-    entry["workspace_path"] = str(workspace_path)
-    entry["default_branch"] = default_branch
-    if auto_purposes:
-        entry["auto_purposes"] = auto_purposes
+        # Build the new client entry
+        entry = CommentedMap()
+        entry["workspace_path"] = str(workspace_path)
+        entry["default_branch"] = default_branch
+        if auto_purposes:
+            entry["auto_purposes"] = auto_purposes
 
-    clients_map[name] = entry
+        clients_map[name] = entry
 
-    with clients_path.open("w") as f:
-        rt.dump(doc, f)
+        buf = StringIO()
+        rt.dump(doc, buf)
+        atomic_write_text(clients_path, buf.getvalue())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,7 @@ def tmp_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr("cw.config.DEV_PLAN_LOCK", state_dir / ".dev_plan.lock")
     monkeypatch.setattr("cw.config.DEV_PLAN_OUTPUT_DIR", state_dir / "plan_output")
     monkeypatch.setattr("cw.config.SESSIONS_LOCK", state_dir / ".sessions.lock")
+    monkeypatch.setattr("cw.config.CLIENTS_LOCK", config_dir / ".clients.yaml.lock")
 
     # Redirect the native-daemon roster path so tests don't read the
     # user's real ~/.claude/daemon/roster.json. RealNativeDaemonClient

--- a/tests/test_clients_lock.py
+++ b/tests/test_clients_lock.py
@@ -1,0 +1,179 @@
+"""Tests for clients.yaml atomic write and file-locking (clients_lock).
+
+Verifies that:
+- A concurrent reader never observes a truncated/empty clients.yaml.
+- Two concurrent client-add operations both persist (no lost update).
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cw.config import clients_lock, init_client, load_clients
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class TestClientsLockConcurrency:
+    def test_concurrent_client_adds_both_survive(
+        self,
+        tmp_config_dir: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """Two threads calling init_client concurrently must both persist.
+
+        init_client acquires clients_lock() internally, so callers do NOT
+        wrap it in an additional lock — that would deadlock (flock is
+        per open-file-description, and a second LOCK_EX on the same file
+        in the same process blocks forever).
+        """
+        repo_a = make_git_repo("project-a")
+        repo_b = make_git_repo("project-b")
+        barrier = threading.Barrier(2)
+        errors: list[Exception] = []
+
+        def add(name: str, repo: Path) -> None:
+            barrier.wait()
+            try:
+                init_client(name, repo)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        t1 = threading.Thread(target=add, args=("project-a", repo_a))
+        t2 = threading.Thread(target=add, args=("project-b", repo_b))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert not errors, f"init_client raised: {errors}"
+        clients = load_clients()
+        assert "project-a" in clients, "project-a was lost"
+        assert "project-b" in clients, "project-b was lost"
+
+    def test_sequential_adds_succeed(
+        self,
+        tmp_config_dir: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """Sequential init_client calls work without deadlock."""
+        repo_a = make_git_repo("alpha")
+        repo_b = make_git_repo("beta")
+
+        init_client("alpha", repo_a)
+        init_client("beta", repo_b)
+
+        clients = load_clients()
+        assert "alpha" in clients
+        assert "beta" in clients
+
+
+class TestClientsAtomicWrite:
+    def test_reader_never_sees_empty_file(
+        self,
+        tmp_config_dir: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """Concurrent reader must not observe empty/partial clients.yaml.
+
+        Writes go through init_client which uses atomic_write_text internally,
+        so a reader polling the file should never observe a zero-byte file.
+        """
+        repo = make_git_repo("slow-project")
+        empty_snapshots: list[bool] = []
+        stop = threading.Event()
+
+        def reader() -> None:
+            import cw.config as cfg
+
+            while not stop.is_set():
+                path = cfg.clients_file()
+                if path.exists():
+                    text = path.read_text()
+                    if text.strip() == "" and path.stat().st_size == 0:
+                        empty_snapshots.append(True)
+
+        t = threading.Thread(target=reader, daemon=True)
+        t.start()
+        try:
+            # init_client acquires clients_lock and does atomic_write_text
+            init_client("slow-project", repo)
+        finally:
+            stop.set()
+            t.join(timeout=2)
+
+        assert not empty_snapshots, (
+            "concurrent reader observed empty clients.yaml during write"
+        )
+
+    def test_clients_lock_context_manager_is_importable(self) -> None:
+        """clients_lock must be importable from cw.config."""
+        from cw.config import clients_lock as cl
+
+        assert callable(cl)
+
+    def test_clients_lock_path_constant_exists(self) -> None:
+        """CLIENTS_LOCK path constant must exist in cw.config."""
+        import cw.config as cfg
+
+        assert hasattr(cfg, "CLIENTS_LOCK")
+        assert isinstance(cfg.CLIENTS_LOCK, Path)
+
+    def test_clients_lock_file_in_config_dir(
+        self,
+        tmp_config_dir: Path,
+    ) -> None:
+        """CLIENTS_LOCK must live in the config directory, not state dir."""
+        import cw.config as cfg
+
+        assert cfg.CLIENTS_LOCK.parent == cfg.CONFIG_DIR
+
+    def test_clients_lock_file_created_under_tmp(
+        self,
+        tmp_config_dir: Path,
+    ) -> None:
+        """Acquiring the lock must not write to the user's real config dir."""
+        import cw.config as cfg
+
+        # After acquiring, the lock file should be inside tmp_path
+        with clients_lock():
+            pass
+        lock_path = cfg.CLIENTS_LOCK
+        assert str(tmp_config_dir) in str(lock_path), (
+            f"Lock file {lock_path} is outside tmp_path {tmp_config_dir}"
+        )
+
+    @pytest.mark.parametrize("n_threads", [5, 10])
+    def test_many_concurrent_adds_all_survive(
+        self,
+        tmp_config_dir: Path,
+        make_git_repo: Callable[[str], Path],
+        n_threads: int,
+    ) -> None:
+        """N concurrent init_client calls each adding a distinct client; all survive."""
+        repos = [make_git_repo(f"repo-{i}") for i in range(n_threads)]
+        barrier = threading.Barrier(n_threads)
+        errors: list[Exception] = []
+
+        def add(i: int) -> None:
+            barrier.wait()
+            try:
+                init_client(f"repo-{i}", repos[i])
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=add, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Some threads raised: {errors}"
+        clients = load_clients()
+        for i in range(n_threads):
+            assert f"repo-{i}" in clients, f"repo-{i} was lost"


### PR DESCRIPTION
Closes #429

## Summary

- `clients.yaml` writes are now atomic: `init_client` dumps to a `StringIO` buffer and calls `atomic_write_text` (temp file + `os.rename`), so concurrent readers never observe a truncated or empty file
- `clients_lock()` context manager added (mirror of `sessions_lock()` from #424), backed by `fcntl.flock` on `CONFIG_DIR/.clients.yaml.lock`, serializing concurrent `cw client add` calls so no update is lost
- `CLIENTS_LOCK` path constant added beside `SESSIONS_LOCK`; `conftest.py` monkeypatches it to `tmp_path` so tests never touch the user's real config dir

## Acceptance

- Atomic write: `test_reader_never_sees_empty_file` — background reader thread polled `clients.yaml` while `init_client` wrote; zero empty snapshots observed
- No lost update: `test_concurrent_client_adds_both_survive` and `test_many_concurrent_adds_all_survive[5/10]` — N concurrent `init_client` calls all persisted

## Full suite

1444 passed, 4 skipped, 3 deselected in 14.01s — `ruff format` clean, `ruff check` clean, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)