### PR TITLE
fix(reconcile): tolerate malformed roster JSON + honor idle_watchdog=0 (#432)

### DIFF
--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -708,7 +708,11 @@ def resolve_idle_watchdog_budget(
     3. config.idle_watchdog_seconds — operator-tunable global default.
     4. IDLE_WATCHDOG_SECONDS — hardcoded fallback.
     """
-    global_default = config.idle_watchdog_seconds or IDLE_WATCHDOG_SECONDS
+    global_default = (
+        IDLE_WATCHDOG_SECONDS
+        if config.idle_watchdog_seconds is None
+        else config.idle_watchdog_seconds
+    )
     if task is None:
         return global_default
     if task.idle_watchdog_override is not None:
@@ -962,7 +966,7 @@ def _reconcile_locked() -> ReconcileReport:
             if isinstance(sid := a.get("sessionId"), str)
         }
         daemon_errored = False
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, json.JSONDecodeError, FileNotFoundError):
         native_live = set()
         daemon_errored = True
     if _looks_like_daemon_outage(state, daemon_errored, native_live):

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -3395,3 +3395,93 @@ def test_flag_silently_idle_recover_skips_non_running_task(
     store = load_dev_queue()
     assert store.tasks[0].status == QueueItemStatus.PENDING
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# GitHub issue #432: malformed roster JSON + FileNotFoundError must not
+# crash reconcile; idle_watchdog_seconds=0 must be honored (not 900 fallback).
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_tolerates_malformed_json_from_claude_agents(
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """json.JSONDecodeError from _claude_agents_json → daemon_errored semantics.
+
+    reconcile() must NOT raise; with live ACTIVE sessions present the outage
+    guard fires and state is left unchanged (#432).
+    """
+    state = CwState(
+        sessions=[
+            _mk_session("s-json", "ref-json"),
+        ]
+    )
+    save_state(state)
+
+    def _bad_json() -> list[dict[str, object]]:
+        msg = "bad json"
+        raise json.JSONDecodeError(msg, "", 0)
+
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", _bad_json)
+
+    # Must not raise
+    report = reconcile()
+
+    assert report.phantom_session_ids == []
+    assert report.phantom_session_names == []
+    # State must be unchanged — no session reaped
+    reloaded = load_state()
+    s = reloaded.find_by_name_or_id("s-json")
+    assert s is not None
+    assert s.status == SessionStatus.ACTIVE
+
+
+def test_reconcile_tolerates_file_not_found_from_claude_agents(
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FileNotFoundError (claude not on PATH) → daemon_errored semantics.
+
+    reconcile() must NOT raise; with live ACTIVE sessions present the outage
+    guard fires and state is left unchanged (#432).
+    """
+    state = CwState(
+        sessions=[
+            _mk_session("s-fnf", "ref-fnf"),
+        ]
+    )
+    save_state(state)
+
+    def _no_binary() -> list[dict[str, object]]:
+        msg = "No such file or directory: 'claude'"
+        raise FileNotFoundError(msg)
+
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", _no_binary)
+
+    # Must not raise
+    report = reconcile()
+
+    assert report.phantom_session_ids == []
+    assert report.phantom_session_names == []
+    # State must be unchanged — no session reaped
+    reloaded = load_state()
+    s = reloaded.find_by_name_or_id("s-fnf")
+    assert s is not None
+    assert s.status == SessionStatus.ACTIVE
+
+
+def test_resolve_idle_watchdog_honors_zero(
+    tmp_config_dir: Path,
+) -> None:
+    """idle_watchdog_seconds=0 is honored as 0, not silently replaced by 900.
+
+    The `or` operator treats 0 as falsy and falls back to the constant.
+    The fix uses an explicit None check so 0 passes through (#432).
+    """
+    config = OrchestratorConfig(idle_watchdog_seconds=0)
+    budget = resolve_idle_watchdog_budget(task=None, config=config)
+    assert budget == 0, (
+        f"idle_watchdog_seconds=0 should be honoured as 0, got {budget} "
+        f"(likely silently fell back to IDLE_WATCHDOG_SECONDS={IDLE_WATCHDOG_SECONDS})"
+    )


### PR DESCRIPTION
Closes #432

## Acceptance

- Malformed JSON from `claude agents --json`: `reconcile()` returns with `daemon_errored` semantics, does NOT raise. Tested by `test_reconcile_tolerates_malformed_json_from_claude_agents`.
- Missing binary (`FileNotFoundError`): same guard fires, no raise. Tested by `test_reconcile_tolerates_file_not_found_from_claude_agents`.
- `idle_watchdog_seconds=0` is honored as 0, not silently replaced by 900. Tested by `test_resolve_idle_watchdog_honors_zero`.
- Existing tests: 1447 passed, 4 skipped.

## Changes

- `src/cw/reconcile.py`: two-line change — broaden `except` clause + fix `or`→`is None` check.
- `tests/test_reconcile.py`: 3 new regression tests.

## Gates

- ruff format: pass
- ruff check: pass
- mypy: pass
- pytest: 1447 passed, 4 skipped, 3 deselected
- diff-cover: 100% (2/2 new lines covered)