### PR TITLE
docs(quality-gate): document full CI gate set (#436)

### DIFF
--- a/.claude/project-config.yaml
+++ b/.claude/project-config.yaml
@@ -14,13 +14,23 @@ tracking:
     auto_close_on_complete: true
 
 quality_gates:
-  # Run in order; all must pass before commit/PR. Mirrors CLAUDE.md.
+  # Run in order; all must pass before commit/PR. Mirrors CLAUDE.md AND
+  # .github/workflows/ci.yml exactly — a subset passing locally but CI failing
+  # (e.g. on format or patch coverage) is the failure mode #436 fixes.
   - name: lint
     command: "uv run ruff check src/ tests/"
+  - name: format
+    command: "uv run ruff format --check src/ tests/"
   - name: typecheck
-    command: "uv run mypy src/"
+    command: "uv run mypy --strict src/"
+  - name: hooks
+    command: "uv run pre-commit run --all-files"
   - name: test
-    command: "uv run pytest tests/ -q"
+    command: "uv run pytest tests/ -m 'not integration' --cov=cw --cov-report=xml --cov-fail-under=88"
+  - name: test-integration
+    command: "uv run pytest tests/ -m integration"
+  - name: patch-coverage
+    command: "uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90"
 
 review:
   self_review: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,18 +34,30 @@ uv run pytest tests/ --cov=cw      # Coverage report
 
 ## Quality Gates
 
-Before committing, run all three checks:
+Before committing, run **every** gate CI enforces (`.github/workflows/ci.yml`),
+in order. The first four mirror CI exactly; passing only a subset is the #1
+cause of a green local run that fails CI (see #436):
 
 ```bash
-uv run ruff check src/ tests/ && uv run mypy src/ && uv run pytest tests/ -v
+uv run ruff check src/ tests/                                    # 1. Lint
+uv run ruff format --check src/ tests/                           # 2. Format
+uv run mypy --strict src/                                        # 3. Type check
+uv run pre-commit run --all-files                                # 4. Hooks
+uv run pytest tests/ -m 'not integration' \
+  --cov=cw --cov-report=xml --cov-fail-under=88                  # 5. Unit + total cov ≥88%
+uv run pytest tests/ -m integration                              # 6. tmux integration
+uv run diff-cover coverage.xml --compare-branch=origin/main \
+  --fail-under=90                                                # 7. Patch coverage ≥90%
 ```
 
-Pre-commit hooks enforce this automatically (`uv run pre-commit install`).
+Pre-commit hooks enforce gates 1–4 automatically (`uv run pre-commit install`).
 
 **Requirements:**
 - `ruff check` - **ZERO violations allowed**
-- `mypy` - **ZERO type errors allowed**
+- `ruff format --check` - **ZERO reformats** (run `ruff format` to fix; `ruff check` does NOT enforce formatting)
+- `mypy --strict` - **ZERO type errors allowed**
 - Test suite - **100% pass rate required**
+- Total coverage **≥88%**; new/changed lines (patch coverage) **≥90%** — cover every new branch, including `except`/error paths
 - No suppressions (`# noqa`, `# type: ignore`) without explicit user approval
 
 Report format: Only actionable problems. Zero praise, zero summaries.


### PR DESCRIPTION
## Summary
The documented quality gate listed only `ruff check` / `mypy` / `pytest`, but CI enforces a richer set. Subset-passes-locally-but-CI-fails was hit twice during the 2026-06-02 reliability sprint (#420 on `ruff format`, #427 on `diff-cover` patch coverage).

Brings **CLAUDE.md** (human gate) and **.claude/project-config.yaml** `quality_gates` (headless `/auto-dev` worker gate) into step-for-step parity with `.github/workflows/ci.yml`:
- `ruff format --check` (ruff check does NOT enforce formatting)
- `mypy --strict`
- `pre-commit run --all-files`
- unit tests with `--cov-fail-under=88`
- separate `-m integration` tmux step
- `diff-cover --fail-under=90` patch coverage

Doc/config only — no source changes.

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)