### PR TITLE
fix(session,worktree): guard interactive start isolation + fast_forward_main (#428)

### DIFF
--- a/src/cw/session.py
+++ b/src/cw/session.py
@@ -26,7 +26,7 @@ from cw.native_daemon import NativeDaemonClient, get_native_daemon_client
 from cw.prompts import build_session_context, get_purpose_prompt
 from cw.reconcile import reconcile
 from cw.spawn import _write_hook_context
-from cw.worktree import create_worktree, remove_worktree
+from cw.worktree import check_not_main_checkout, create_worktree, remove_worktree
 
 # Purposes that receive worktree cwd (impl works on the feature branch,
 # idea brainstorms within it; debt stays on the main workspace).
@@ -110,12 +110,14 @@ def start_session(
             raise CwError(msg)
         click.echo(f"Creating worktree for branch '{branch}'...")
         worktree_path = create_worktree(client, branch)
+        check_not_main_checkout(worktree_path, client)
         worktree_branch = branch
         client = client.model_copy(update={"workspace_path": worktree_path})
         click.echo(f"Worktree ready: {worktree_path}")
     elif worktree:
         click.echo(f"Creating worktree for branch '{worktree}'...")
         worktree_path = create_worktree(client, worktree)
+        check_not_main_checkout(worktree_path, client)
         click.echo(f"Worktree ready: {worktree_path}")
 
     # Check for existing backgrounded session — resume it rather than spawning.

--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -435,7 +435,9 @@ def fast_forward_main(client: ClientConfig) -> tuple[str, str]:
 
     Runs ``git pull --ff-only origin <default_branch>`` in the client's git
     directory.  Raises :exc:`MissingWorkspaceError` if the workspace directory
-    does not exist, or :exc:`WorktreeError` if the pull fails (non-zero exit).
+    does not exist, or :exc:`WorktreeError` if the pull fails (non-zero exit)
+    or if the checkout is not on ``default_branch`` or has uncommitted changes
+    — both conditions risk mutating the index unexpectedly (#428).
 
     Returns:
         ``(before_sha, after_sha)`` — the SHA before and after the pull.
@@ -446,6 +448,29 @@ def fast_forward_main(client: ClientConfig) -> tuple[str, str]:
         msg = f"workspace missing for {client.name} ({git_dir})"
         raise MissingWorkspaceError(msg)
     default_branch = client.default_branch
+
+    # Guard 1: ensure the checkout is on the expected default branch.
+    current_branch = _run_git(
+        "symbolic-ref", "--short", "HEAD", cwd=git_dir
+    ).stdout.strip()
+    if current_branch != default_branch:
+        msg = (
+            f"Refusing to fast-forward {client.name}: HEAD is on "
+            f"'{current_branch}', expected '{default_branch}'. "
+            f"Switch to '{default_branch}' before refreshing."
+        )
+        raise WorktreeError(msg)
+
+    # Guard 2: ensure the working tree is clean.
+    status_out = _run_git("status", "--porcelain", cwd=git_dir).stdout.strip()
+    if status_out:
+        msg = (
+            f"Refusing to fast-forward {client.name}: working tree is dirty "
+            f"(git status --porcelain reported changes). "
+            f"Commit or stash changes before refreshing."
+        )
+        raise WorktreeError(msg)
+
     before_sha = _run_git("rev-parse", default_branch, cwd=git_dir).stdout.strip()
     _run_git("pull", "--ff-only", "origin", default_branch, cwd=git_dir)
     after_sha = _run_git("rev-parse", default_branch, cwd=git_dir).stdout.strip()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1597,3 +1597,81 @@ class TestStartSessionParentLinkage:
             )
 
         assert create_worktree_calls == []
+
+
+# ---------------------------------------------------------------------------
+# TestStartSessionIsolationGuard (#428)
+# ---------------------------------------------------------------------------
+
+
+class TestStartSessionIsolationGuard:
+    """start_session must call check_not_main_checkout after create_worktree (#428)."""
+
+    def _write_clients_file(
+        self, tmp_config_dir: Path, sample_client: ClientConfig
+    ) -> None:
+        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
+        clients_file.write_text(
+            f"clients:\n"
+            f"  test-client:\n"
+            f"    workspace_path: {sample_client.workspace_path}\n"
+        )
+
+    def test_start_with_worktree_raises_when_worktree_is_main_checkout(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """cw start --worktree raises WorktreeError when create_worktree returns
+        the main checkout path (#428)."""
+        from cw.exceptions import WorktreeError
+
+        self._write_clients_file(tmp_config_dir, sample_client)
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
+
+        # Simulate degenerate create_worktree returning the workspace itself.
+        monkeypatch.setattr(
+            "cw.session.create_worktree",
+            lambda _client, _branch: sample_client.workspace_path,
+        )
+        # check_not_main_checkout is NOT mocked — it must fire for real.
+
+        with pytest.raises(WorktreeError, match="main checkout"):
+            start_session(
+                "test-client",
+                "impl",
+                worktree="feat/x",
+                native_daemon=mock_native_daemon,
+            )
+
+    def test_worktree_client_raises_when_worktree_is_main_checkout(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """cw start (worktree-mode client) raises WorktreeError when create_worktree
+        returns the main checkout path (#428)."""
+        from cw.exceptions import WorktreeError
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        clients_file = tmp_config_dir / ".config" / "cw" / "clients.yaml"
+        clients_file.write_text(
+            f"clients:\n  wt-client:\n    repo_path: {repo}\n    branch: wt-client\n"
+        )
+
+        # Simulate degenerate create_worktree returning repo itself.
+        monkeypatch.setattr(
+            "cw.session.create_worktree",
+            lambda _client, _branch: repo,
+        )
+        monkeypatch.setattr("cw.session._write_hook_context", _noop)
+        monkeypatch.setattr("cw.session._attach_session", _noop)
+
+        with pytest.raises(WorktreeError, match="main checkout"):
+            start_session("wt-client", "impl", native_daemon=mock_native_daemon)

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1048,6 +1048,40 @@ class TestIsMainBehindOrigin:
 class TestFastForwardMain:
     """Tests for fast_forward_main."""
 
+    @staticmethod
+    def _clean_on_branch_mock(
+        default_branch: str,
+        old_sha: str,
+        new_sha: str | None = None,
+    ) -> object:
+        """Return a _run_git mock for a clean, on-branch checkout.
+
+        Handles symbolic-ref, status --porcelain, rev-parse (before/after),
+        and pull in the correct order.
+        """
+        _pull_called = [False]
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock()
+            result.stderr = ""
+            if "symbolic-ref" in args:
+                result.stdout = default_branch + "\n"
+            elif "status" in args and "--porcelain" in args:
+                result.stdout = ""  # clean
+            elif "pull" in args:
+                _pull_called[0] = True
+                result.stdout = ""
+            elif "rev-parse" in args:
+                # first rev-parse = before, second = after
+                result.stdout = (
+                    old_sha if not _pull_called[0] else (new_sha or old_sha)
+                ) + "\n"
+            else:
+                result.stdout = ""
+            return result
+
+        return mock_run
+
     def test_already_up_to_date_returns_same_sha(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1061,13 +1095,10 @@ class TestFastForwardMain:
         )
         sha = "abc123def456abc123def456abc123def456abc1"
 
-        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
-            result = MagicMock()
-            result.stdout = sha + "\n"
-            result.stderr = ""
-            return result
-
-        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        monkeypatch.setattr(
+            "cw.worktree._run_git",
+            self._clean_on_branch_mock("main", sha),
+        )
 
         before, after = fast_forward_main(client)
         assert before == sha
@@ -1086,22 +1117,11 @@ class TestFastForwardMain:
         )
         old_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         new_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-        call_count = 0
 
-        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
-            nonlocal call_count
-            call_count += 1
-            result = MagicMock()
-            result.stderr = ""
-            if "rev-parse" in args and call_count == 1:
-                result.stdout = old_sha + "\n"
-            elif "pull" in args:
-                result.stdout = ""
-            else:
-                result.stdout = new_sha + "\n"
-            return result
-
-        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        monkeypatch.setattr(
+            "cw.worktree._run_git",
+            self._clean_on_branch_mock("main", old_sha, new_sha),
+        )
 
         before, after = fast_forward_main(client)
         assert before == old_sha
@@ -1121,18 +1141,22 @@ class TestFastForwardMain:
             default_branch="main",
         )
         old_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        call_count = 0
 
         def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                result = MagicMock()
+            result = MagicMock()
+            result.stderr = ""
+            if "symbolic-ref" in args:
+                result.stdout = "main\n"
+            elif "status" in args and "--porcelain" in args:
+                result.stdout = ""  # clean
+            elif "rev-parse" in args:
                 result.stdout = old_sha + "\n"
-                result.stderr = ""
-                return result
-            msg = "would clobber existing tag"
-            raise _WorktreeError(msg)
+            elif "pull" in args:
+                msg = "would clobber existing tag"
+                raise _WorktreeError(msg)
+            else:
+                result.stdout = ""
+            return result
 
         monkeypatch.setattr("cw.worktree._run_git", mock_run)
 
@@ -1156,6 +1180,116 @@ class TestFastForwardMain:
 
         with pytest.raises(MissingWorkspaceError, match="absent-client"):
             fast_forward_main(client)
+
+    def test_off_branch_skips_pull_and_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ff on wrong branch skips pull and raises WorktreeError.
+
+        No mutation must occur: pull must NOT be called (#428).
+        """
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        client = ClientConfig(
+            name="test-client",
+            workspace_path=ws,
+            default_branch="main",
+        )
+        pull_called = [False]
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            if "pull" in args:
+                pull_called[0] = True
+            result = MagicMock()
+            result.stderr = ""
+            if "symbolic-ref" in args:
+                result.stdout = "feature/topic\n"  # wrong branch
+            elif "status" in args and "--porcelain" in args:
+                result.stdout = ""
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+
+        with pytest.raises(WorktreeError, match="main"):
+            fast_forward_main(client)
+
+        assert not pull_called[0], "pull must NOT be called when off-branch"
+
+    def test_dirty_checkout_skips_pull_and_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ff on a dirty main checkout skips pull and raises WorktreeError.
+
+        No mutation must occur: pull must NOT be called (#428).
+        """
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        client = ClientConfig(
+            name="test-client",
+            workspace_path=ws,
+            default_branch="main",
+        )
+        pull_called = [False]
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            if "pull" in args:
+                pull_called[0] = True
+            result = MagicMock()
+            result.stderr = ""
+            if "symbolic-ref" in args:
+                result.stdout = "main\n"  # correct branch
+            elif "status" in args and "--porcelain" in args:
+                result.stdout = " M modified_file.py\n"  # dirty
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+
+        with pytest.raises(WorktreeError, match="dirty"):
+            fast_forward_main(client)
+
+        assert not pull_called[0], "pull must NOT be called when checkout is dirty"
+
+    def test_clean_on_branch_fast_forwards(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Clean, on-branch checkout fast-forwards as before (#428 regression guard)."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        client = ClientConfig(
+            name="test-client",
+            workspace_path=ws,
+            default_branch="main",
+        )
+        old_sha = "cccccccccccccccccccccccccccccccccccccccc"
+        new_sha = "dddddddddddddddddddddddddddddddddddddddd"
+        pull_called = [False]
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock()
+            result.stderr = ""
+            if "symbolic-ref" in args:
+                result.stdout = "main\n"
+            elif "status" in args and "--porcelain" in args:
+                result.stdout = ""  # clean
+            elif "pull" in args:
+                pull_called[0] = True
+                result.stdout = ""
+            elif "rev-parse" in args:
+                result.stdout = (old_sha if not pull_called[0] else new_sha) + "\n"
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+
+        before, after = fast_forward_main(client)
+        assert before == old_sha
+        assert after == new_sha
+        assert pull_called[0], "pull MUST be called for clean on-branch checkout"
 
 
 class TestFetchDefaultBranch:


### PR DESCRIPTION
Closes #428

## Summary

- `start_session` now calls `check_not_main_checkout` immediately after each `create_worktree` call (both the `is_worktree_client` and `--worktree` code paths), mirroring the guard already present in the dispatch path.
- `fast_forward_main` now checks `git symbolic-ref --short HEAD == default_branch` and `git status --porcelain` is empty before running `git pull --ff-only`; an off-branch or dirty checkout raises `WorktreeError` without touching the index.

## Acceptance

- `cw start` against a main-checkout path raises via `check_not_main_checkout` (tested: `TestStartSessionIsolationGuard`)
- `fast_forward_main` on a checkout that's off-branch skips pull and raises, without mutating the index (tested: `test_off_branch_skips_pull_and_raises`)
- `fast_forward_main` on a dirty checkout skips pull and raises, without mutating the index (tested: `test_dirty_checkout_skips_pull_and_raises`)
- `fast_forward_main` on a clean, on-branch checkout fast-forwards as before (tested: `test_clean_on_branch_fast_forwards`)

## Gates

Full suite: 1504 passed, 4 skipped — ruff_format=p ruff=p mypy=p pytest=1504 passed diff_cover=100%