### PR TITLE
fix(ci): repair invalid YAML in dispatch-guard workflow

### DIFF
--- a/.github/workflows/dispatch-guard.yml
+++ b/.github/workflows/dispatch-guard.yml
@@ -80,13 +80,13 @@ jobs:
             --label dispatch-drift \
             --body "Commits have landed on \`main\` that touch one or more dispatch-reliability files without a subsequent release being cut.
 
-**Last release tag:** \`${LAST_TAG}\`
+          **Last release tag:** \`${LAST_TAG}\`
 
-**Changed files since that tag:**
-\`\`\`
-${CHANGED_FILES}
-\`\`\`
+          **Changed files since that tag:**
+          \`\`\`
+          ${CHANGED_FILES}
+          \`\`\`
 
-Cut a new release to close this issue automatically.
+          Cut a new release to close this issue automatically.
 
-> Opened automatically by the [Dispatch Guard workflow](/.github/workflows/dispatch-guard.yml). Closes when a release tag is pushed."
+          > Opened automatically by the [Dispatch Guard workflow](/.github/workflows/dispatch-guard.yml). Closes when a release tag is pushed."


### PR DESCRIPTION
## Problem

`.github/workflows/dispatch-guard.yml` reports **"No jobs were run"** and fails on **every** push to `main`. All recent runs show `conclusion: failure` with **0 jobs** and `created == started == updated` to the same second — the fingerprint of a **startup failure**, not a job that ran and failed. (`ci.yml` is unaffected and green.)

## Root cause

The workflow file is **invalid YAML**. In the `Open dispatch-drift issue` step, the multi-line `gh issue create --body "…"` string had its markdown lines at **column 1**, *outside* the `run: |` literal block scalar:

```
ScannerError: while scanning an alias ... found '*'   (line 83)
```

YAML parsed `**Last release tag:**` as a node, where `*` begins a YAML **alias** → parse error. Because GitHub can't parse the file, it **ignores the `on.push.paths` filter** and fails a 0-job run on every push. Confirmed independent of paths: commit `319be6b5` touched `reconcile.py` (a guarded path) and still produced 0 jobs; `53e4ec7` touched none of the guarded paths yet still produced a failed run. Broken since the workflow was introduced in #415.

## Fix

Indent the body lines to the block's 10-space indent so they live inside `run: |`. YAML's literal-block-scalar rule strips exactly that block indent back off, so **the rendered issue body is byte-identical** — verified by parsing the file and checking the `run` script has the markdown back at column 0. All five workflow YAMLs now parse cleanly. Indentation-only change, 7 lines.

https://claude.ai/code/session_01E1STLex6UpfMFGQx3NQkXJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1STLex6UpfMFGQx3NQkXJ)_