### PR TITLE
chore(release): cut 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,63 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.14.2] — 2026-06-03
+
+Reliability-hardening release: a wave of concurrency, atomicity, and
+crash-safety fixes across the state store, config writes, worktree lifecycle,
+event history, and the reconcile/daemon loops — closing torn-read, TOCTOU, and
+lost-update windows that surface under parallel dispatch.
+
+### Fixed
+
+- **`sessions.json` read-modify-write locking** (#424 → PR #437): the state
+  file is now locked across the full read-modify-write, closing a lost-update
+  window when concurrent session operations raced.
+- **Atomic + locked `clients.yaml` write** (#429 → PR #442): config writes go
+  through an atomic, locked replace so a crash or concurrent writer can't leave
+  a truncated `clients.yaml`.
+- **Atomic hook-context writes + live-session guard** (#427 → PR #440): spawn
+  writes hook context atomically and refuses to overwrite a live session's
+  context.
+- **Event-history hardening** (#433 → PR #449): torn-read, TOCTOU, fsync, and
+  poll-lock fixes in `history.py` and the channel servers.
+- **Worktree dirty-state guards** (#425 → PR #439, #426 → PR #441): dirty-check
+  before force-removing a stale/timed-out worktree, and refuse dirty-worktree
+  reuse in `create_worktree`.
+- **Interactive-start isolation guard** (#428 → PR #448): guard interactive
+  `start` isolation and `fast_forward_main` so an interactive session can't
+  clobber in-flight work.
+- **Reconcile salvage + parked-session skip** (#431 → PR #446): reconcile
+  salvages all terminal statuses and skips parked sessions instead of
+  re-flagging them.
+- **Malformed-roster tolerance + `idle_watchdog=0`** (#432 → PR #443):
+  reconcile tolerates malformed roster JSON and honors `idle_watchdog=0` as
+  "disabled".
+- **Daemon tick guards** (#390 → PR #444): per-client and whole-tick guards in
+  `run_watcher_tick` so one client's failure can't abort the tick.
+- **Sparse sentinel coercion** (#430 → PR #445): legitimate-but-sparse
+  `AutoDevResult` sentinels are coerced rather than rejected.
+- **Dispatch stdout visibility** (#420 → PR #435): operator-visible stdout for
+  `cw dev-queue run`.
+- **Logging handler at entrypoint** (#423 → PR #434): the logging handler is
+  configured once at the CLI entrypoint.
+- **dispatch-guard workflow YAML** (PR #450): repair invalid YAML in the
+  dispatch-guard workflow.
+
+### Documentation
+
+- **Full CI gate set documented** (#436 → PR #447): the quality-gate docs now
+  cover format, `mypy --strict`, pre-commit, coverage thresholds, and
+  diff-cover.
+- **Two-branch model + stale comment** (PR #414): correct the two-branch model
+  in `headless-contract.md` and a stale cmux comment in `worktree.py`.
+
+### Operations
+
+- **Dispatch-critical drift guard + release closer** (PR #415): CI guard for
+  dispatch-critical drift, plus auto-close of `dispatch-drift` issues on
+  release.
+
 ## [0.14.1] — 2026-05-30
 
 Bug-fix release closing dispatch-reliability gaps surfaced by the 2026-05-30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-workspace"
-version = "0.14.1"
+version = "0.14.2"
 description = "Multi-session workspace orchestrator for Claude Code"
 readme = "README.md"
 authors = [

--- a/src/cw/__init__.py
+++ b/src/cw/__init__.py
@@ -1,3 +1,3 @@
 """claude-workspace: Multi-session workspace orchestrator for Claude Code."""
 
-__version__ = "0.14.1"
+__version__ = "0.14.2"

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "claude-workspace"
-version = "0.14.1"
+version = "0.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Cuts **0.14.2**, a reliability-hardening release rolling up the overnight batch of concurrency, atomicity, and crash-safety fixes that landed on `main` after 0.14.1 (#414/#415 + #434–#450). No new features — all bug fixes + CI/infra hardening, so a patch bump.

This commit only bumps the version and changelog; the actual fixes are already merged. Merging this, then pushing the `v0.14.2` tag, triggers `release.yml` (version-match check → quality gates on Linux/macOS → GitHub Release with generated notes → close `dispatch-drift` issues).

## Changes
- `src/cw/__init__.py` + `pyproject.toml` + `uv.lock`: `0.14.1` → `0.14.2`
- `CHANGELOG.md`: new `## [0.14.2] — 2026-06-03` section

## Release contents
**Fixed (concurrency / durability hardening):**
- `sessions.json` read-modify-write locking (#424 → #437)
- Atomic + locked `clients.yaml` write (#429 → #442)
- Atomic hook-context writes + live-session guard (#427 → #440)
- Event-history hardening — torn-read/TOCTOU/fsync/poll-lock (#433 → #449)
- Worktree dirty-state guards (#425 → #439, #426 → #441)
- Interactive-start isolation guard (#428 → #448)
- Reconcile salvage + parked-session skip (#431 → #446)
- Malformed-roster tolerance + `idle_watchdog=0` (#432 → #443)
- Daemon per-client + whole-tick guards (#390 → #444)
- Sparse `AutoDevResult` sentinel coercion (#430 → #445)
- Dispatch stdout visibility (#420 → #435)
- Logging handler at entrypoint (#423 → #434)
- dispatch-guard workflow YAML repair (#450)

**Documentation:** full CI gate set documented (#436 → #447); two-branch model + stale comment fix (#414)

**Operations:** dispatch-critical drift guard + release closer (#415)

## Verification
Ran the CI gates locally on the release diff:
- ✅ `ruff check src/ tests/`
- ✅ `ruff format --check src/ tests/`
- ✅ `mypy --strict src/`
- ✅ `cw.__version__` resolves to `0.14.2` (matches the planned `v0.14.2` tag)

> Note: `pre-commit run --all-files` runs the full pytest suite, which hits a container-only failure — `git commit` in test fixtures fails because this environment's commit-signing server rejects commits outside the managed repo (`signing server returned status 400: missing source`). It's unrelated to this diff (no test logic changed) and won't reproduce in CI, which has no such signing hook.

https://claude.ai/code/session_013xKz886QwkpY8ixNtasSx6

---
_Generated by [Claude Code](https://claude.ai/code/session_013xKz886QwkpY8ixNtasSx6)_