### PR TITLE
fix(reconcile): encode dotted worktree paths so idle-watchdog liveness guards find the transcript

### DIFF
--- a/src/cw/_util.py
+++ b/src/cw/_util.py
@@ -7,6 +7,8 @@ circular dependencies — it is imported by both :mod:`cw.cmux` and
 
 from __future__ import annotations
 
+from pathlib import Path
+
 
 def _tail_lines(content: str, n: int) -> str:
     """Return the last *n* lines of *content*, preserving no trailing newline."""
@@ -14,3 +16,22 @@ def _tail_lines(content: str, n: int) -> str:
     if len(all_lines) > n:
         return "\n".join(all_lines[-n:])
     return content.rstrip("\n")
+
+
+def claude_project_dir(path: str | Path) -> Path:
+    """Return the Claude Code project directory for *path*.
+
+    Claude Code encodes a project's working directory into a flat directory
+    name under ``~/.claude/projects/`` by replacing every ``/`` **and** every
+    ``.`` with ``-``.  For example ``/home/u/.cw/wt/abc`` becomes
+    ``-home-u--cw-wt-abc`` (double dash for the dot-prefixed ``.cw``
+    segment).
+
+    Using only ``.replace("/", "-")`` — which was the original single-replace
+    — produces ``-home-u-.cw-wt-abc``, a path that does not exist on disk,
+    causing all transcript-based liveness checks to return ``False`` and the
+    idle watchdog to falsely reap active sessions whose worktrees live under a
+    dotted directory such as ``~/.cw/``.  See GitHub issue #463.
+    """
+    encoded = str(path).replace("/", "-").replace(".", "-")
+    return Path.home() / ".claude" / "projects" / encoded

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -15,6 +15,7 @@ import click
 from click.shell_completion import CompletionItem
 
 from cw import __version__
+from cw._util import claude_project_dir
 from cw.auto_dev_result import (
     BLOCKER_REASON_NO_RESULT_EMITTED,
     BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED,
@@ -1071,10 +1072,7 @@ def _parse_sentinel_from_transcript(
     """
     if not claude_session_id:
         return None
-    encoded = cwd.replace("/", "-").replace(".", "-")
-    transcript_path = (
-        Path.home() / ".claude" / "projects" / encoded / f"{claude_session_id}.jsonl"
-    )
+    transcript_path = claude_project_dir(cwd) / f"{claude_session_id}.jsonl"
     if not transcript_path.is_file():
         return None
     try:

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -31,9 +31,9 @@ import logging
 import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from typing import TYPE_CHECKING
 
+from cw._util import claude_project_dir
 from cw.auto_dev_result import (
     SALVAGE_TERMINAL_STATUSES,
     AutoDevResult,
@@ -63,6 +63,8 @@ from cw.notify import fire_push_notification
 from cw.worktree import remove_worktree, worktree_has_unsaved_work, worktree_path_for
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from cw.models import CwState, Session
 
 _log = logging.getLogger(__name__)
@@ -370,7 +372,7 @@ def _session_project_dir(session: Session) -> Path | None:
     worktree = session.worktree_path
     if worktree is None:
         return None
-    return Path.home() / ".claude" / "projects" / str(worktree).replace("/", "-")
+    return claude_project_dir(worktree)
 
 
 def _transcript_recently_active(

--- a/src/cw/wrapper.py
+++ b/src/cw/wrapper.py
@@ -26,6 +26,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from cw._util import claude_project_dir
 from cw.auto_dev_result import (
     PAUSED_FOR_USER_INPUT_STATUSES,
     USER_DIRECTED_PREFIXES,
@@ -75,11 +76,10 @@ def _detect_claude_session_id(workspace_path: str) -> str | None:
     """Detect the Claude session ID from the most recently modified session file.
 
     Claude stores sessions at ``~/.claude/projects/<encoded-path>/<uuid>.jsonl``
-    where the path encoding replaces ``/`` with ``-`` (e.g. ``/home/foo/bar``
-    becomes ``-home-foo-bar``).
+    where the path encoding replaces both ``/`` and ``.`` with ``-``
+    (e.g. ``/home/foo/.bar`` becomes ``-home-foo--bar``).
     """
-    encoded = workspace_path.replace("/", "-")
-    project_dir = Path.home() / ".claude" / "projects" / encoded
+    project_dir = claude_project_dir(workspace_path)
     if not project_dir.is_dir():
         return None
     candidates = sorted(

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import freezegun
 import pytest
 
+from cw._util import claude_project_dir
 from cw.config import load_state, save_state
 from cw.dev_queue import load_dev_queue, save_dev_queue
 from cw.events import read_events
@@ -1334,9 +1335,10 @@ def _write_salvage_transcript(
     """Write a transcript jsonl under ``home`` carrying a wrapped sentinel.
 
     Mirrors Claude's on-disk layout: ``<home>/.claude/projects/<encoded>/
-    <uuid>.jsonl`` with the encoded path replacing ``/`` with ``-``.
+    <uuid>.jsonl`` with the encoded path replacing both ``/`` and ``.``
+    with ``-`` (matching Claude Code's actual encoding).
     """
-    encoded = str(worktree).replace("/", "-")
+    encoded = str(worktree).replace("/", "-").replace(".", "-")
     project_dir = home / ".claude" / "projects" / encoded
     project_dir.mkdir(parents=True, exist_ok=True)
     body = json.dumps(payload)
@@ -1467,8 +1469,7 @@ def test_revert_stalled_no_salvage_without_sentinel_times_out(
 
     sess = _mk_headless_daemon_session("salv-none", worktree, started_at)
     # Transcript exists but carries no AUTO_DEV_RESULT block.
-    encoded = str(worktree).replace("/", "-")
-    proj = home / ".claude" / "projects" / encoded
+    proj = claude_project_dir(worktree)
     proj.mkdir(parents=True, exist_ok=True)
     (proj / "claude-uuid-3.jsonl").write_text(
         json.dumps(
@@ -2493,7 +2494,7 @@ def _write_idle_transcript(
     home: Path, worktree: Path, filename: str = "sess.jsonl"
 ) -> Path:
     """Write a minimal transcript .jsonl under the project dir for *worktree*."""
-    encoded = str(worktree).replace("/", "-")
+    encoded = str(worktree).replace("/", "-").replace(".", "-")
     project_dir = home / ".claude" / "projects" / encoded
     project_dir.mkdir(parents=True, exist_ok=True)
     path = project_dir / filename
@@ -2597,7 +2598,7 @@ def test_flag_silently_idle_fires_when_session_id_file_missing(
     sess.surface_ref = "live-ref"
     sess.claude_session_id = "missing-uuid"
     # Create project dir but NOT the expected .jsonl.
-    encoded = str(worktree).replace("/", "-")
+    encoded = str(worktree).replace("/", "-").replace(".", "-")
     (home / ".claude" / "projects" / encoded).mkdir(parents=True, exist_ok=True)
 
     save_dev_queue(
@@ -2736,7 +2737,7 @@ def test_flag_silently_idle_fires_when_no_transcript_in_project_dir(
     sess = _mk_headless_daemon_session("no-tx-1", worktree, started_at)
     sess.surface_ref = "live-ref"
     # Create project dir but write no .jsonl files
-    encoded = str(worktree).replace("/", "-")
+    encoded = str(worktree).replace("/", "-").replace(".", "-")
     (home / ".claude" / "projects" / encoded).mkdir(parents=True, exist_ok=True)
 
     save_dev_queue(
@@ -3752,4 +3753,176 @@ def test_revert_stalled_skips_parked_silently_idle_session(
     t = next(t for t in store.tasks if t.ticket_id == "parked-idle")
     assert t.status == QueueItemStatus.BLOCKED_ON_USER, (
         "Queue task must remain BLOCKED_ON_USER, not re-dispatched to PENDING"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dot-encoding regression tests (GitHub issue #463)
+# Worktrees under ~/.cw/ contain a dot in the path segment; Claude Code
+# encodes BOTH '/' and '.' as '-'.  The old single-replace produced a
+# path mismatch that caused all transcript liveness checks to return False,
+# letting the idle watchdog falsely reap actively-working sessions.
+# ---------------------------------------------------------------------------
+
+
+def test_claude_project_dir_encodes_dots_as_dashes() -> None:
+    """claude_project_dir replaces both '/' and '.' with '-' (Issue #463).
+
+    For a worktree at /home/u/.cw/wt/abc/auto-dev-1 the encoded segment
+    must be '-home-u--cw-wt-abc-auto-dev-1' (double dash for '.cw').
+    """
+    from cw._util import claude_project_dir as _cpd
+
+    result = _cpd("/home/u/.cw/wt/abc/auto-dev-1")
+    assert result.name == "-home-u--cw-wt-abc-auto-dev-1", (
+        f"Expected double-dash for .cw segment; got {result.name!r}"
+    )
+
+
+def test_claude_project_dir_matches_verified_real_path() -> None:
+    """Exact encoding match for the worktree documented in GitHub issue #463.
+
+    Real worktree: /home/matthew/.cw/wt/7dc983e2/auto-dev-463
+    Wrong (single replace): -home-matthew-.cw-wt-7dc983e2-auto-dev-463
+    Correct (double replace): -home-matthew--cw-wt-7dc983e2-auto-dev-463
+    """
+    from cw._util import claude_project_dir as _cpd
+
+    result = _cpd("/home/matthew/.cw/wt/7dc983e2/auto-dev-463")
+    assert result.name == "-home-matthew--cw-wt-7dc983e2-auto-dev-463"
+    # Confirm the old single-replace encoding is different (would not exist)
+    wrong = "/home/matthew/.cw/wt/7dc983e2/auto-dev-463".replace("/", "-")
+    assert wrong != result.name
+
+
+def test_transcript_recently_active_finds_dotted_worktree(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_transcript_recently_active returns True for a ~/.cw/-style worktree.
+
+    Regression for Issue #463: the old single-replace produced a path that
+    didn't exist on disk, so the guard always returned False and the watchdog
+    would reap active sessions.
+
+    The worktree path contains a dot segment ('dot-cw') to reproduce the
+    encoding mismatch without depending on the real ~/.cw directory.
+    """
+    from cw.reconcile import _transcript_recently_active
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    # Worktree path with a dot-prefixed segment, mirroring ~/.cw/wt/...
+    worktree = tmp_path / ".dot-cw" / "wt" / "abc123" / "auto-dev-1"
+    worktree.mkdir(parents=True, exist_ok=True)
+
+    # Build the project dir using the CORRECT double-replace encoding.
+    project_dir = claude_project_dir(worktree)
+    project_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write a transcript that is "recent" (mtime = now).
+    session_uuid = "test-uuid-dotted"
+    transcript = project_dir / f"{session_uuid}.jsonl"
+    record = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "still working"}],
+            },
+        }
+    )
+    transcript.write_text(record + "\n")
+
+    sess = Session(
+        id="dotted-wt-sess",
+        name="client-a/auto-dev/DOTTED-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=ClientConfig(
+            name="client-a", workspace_path=tmp_path / "ws"
+        ).workspace_path,
+        worktree_path=worktree,
+        surface_ref="live-ref",
+        started_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+        claude_session_id=session_uuid,
+    )
+
+    now = datetime.now(tz=UTC)
+    # With the correct encoding the transcript is found → recently active.
+    assert _transcript_recently_active(sess, now, window_seconds=60), (
+        "Expected transcript to be found for dotted worktree path; "
+        f"project_dir={project_dir!r} exists={project_dir.is_dir()}"
+    )
+
+
+def test_awaiting_subagent_finds_dotted_worktree(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_awaiting_subagent returns True for a ~/.cw/-style worktree with pending
+    tool_use.
+
+    Regression for Issue #463: single-replace caused _awaiting_subagent to hit
+    its early-exit (project_dir not found), returning False and letting the
+    watchdog fire on a session mid-subagent.
+    """
+    from cw.reconcile import _awaiting_subagent
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    worktree = tmp_path / ".dot-cw" / "wt" / "def456" / "auto-dev-2"
+    worktree.mkdir(parents=True, exist_ok=True)
+
+    project_dir = claude_project_dir(worktree)
+    project_dir.mkdir(parents=True, exist_ok=True)
+
+    session_uuid = "test-uuid-subagent"
+    transcript = project_dir / f"{session_uuid}.jsonl"
+
+    # Transcript ends with a tool_use with no following tool_result → awaiting.
+    tool_use_ts = datetime(2026, 1, 1, 0, 15, 0, tzinfo=UTC).isoformat()
+    record = json.dumps(
+        {
+            "type": "assistant",
+            "timestamp": tool_use_ts,
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "toolu_01", "name": "Task", "input": {}}
+                ],
+            },
+        }
+    )
+    transcript.write_text(record + "\n")
+
+    sess = Session(
+        id="dotted-subagent-sess",
+        name="client-a/auto-dev/DOTTED-2",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=ClientConfig(
+            name="client-a", workspace_path=tmp_path / "ws"
+        ).workspace_path,
+        worktree_path=worktree,
+        surface_ref="live-ref",
+        started_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+        claude_session_id=session_uuid,
+    )
+
+    # now is within SUBAGENT_LIVENESS_WINDOW_SECONDS of the tool_use timestamp
+    now = datetime(2026, 1, 1, 0, 16, 0, tzinfo=UTC)
+    assert _awaiting_subagent(sess, now), (
+        "Expected _awaiting_subagent=True for dotted worktree path; "
+        f"project_dir={project_dir!r} exists={project_dir.is_dir()}"
     )


### PR DESCRIPTION
## Summary

- **Bug**: The idle watchdog (`flag_silently_idle_daemon_sessions`) falsely reaped actively-working headless DAEMON sessions whose worktrees lived under `~/.cw/` (a dotted path segment).
- **Root cause**: `_session_project_dir` (reconcile.py:373) and `_detect_claude_session_id` (wrapper.py:81) encoded project paths using only `.replace("/", "-")`, while Claude Code encodes with **both** `.replace("/", "-").replace(".", "-")`. The mismatch meant `project_dir.is_dir()` always returned False for `~/.cw/`-style worktrees, so both `_transcript_recently_active` and `_awaiting_subagent` hit their early-exit and returned False — letting the watchdog fire on a live session.
- **Fix**: Extracted a shared `claude_project_dir(path)` helper into `cw._util` (the no-circular-dep utility module) applying both replacements. Routed all three encoding sites — `reconcile.py`, `wrapper.py`, and `cli.py` — through the single helper. `cli.py` was already correct but is now DRY.

**Verified evidence**: for worktree `/home/matthew/.cw/wt/7dc983e2/auto-dev-463`, the old single-replace produced `…-home-matthew-.cw-wt-7dc983e2-auto-dev-463` (does not exist on disk); the correct encoding is `…-home-matthew--cw-wt-7dc983e2-auto-dev-463` (double dash for `.cw`).

## Files changed

- `src/cw/_util.py` — new `claude_project_dir()` helper with full docstring explaining the encoding
- `src/cw/reconcile.py` — import helper; use in `_session_project_dir`; move `Path` to `TYPE_CHECKING` (no longer used at runtime)
- `src/cw/wrapper.py` — import helper; use in `_detect_claude_session_id`; update docstring
- `src/cw/cli.py` — import helper; use in `_read_sentinel_from_transcript` (was already correct, now DRY)
- `tests/test_reconcile.py` — update `_write_salvage_transcript`, `_write_idle_transcript`, and inline encoded paths to use correct double-replace; add 4 regression tests

## Regression tests added

1. `test_claude_project_dir_encodes_dots_as_dashes` — asserts `/home/u/.cw/wt/abc/auto-dev-1` → `-home-u--cw-wt-abc-auto-dev-1`
2. `test_claude_project_dir_matches_verified_real_path` — exact match for the Issue #463 worktree; confirms old single-replace differs
3. `test_transcript_recently_active_finds_dotted_worktree` — creates a real project dir with double-replace encoding and asserts `_transcript_recently_active` returns True (would have returned False before the fix)
4. `test_awaiting_subagent_finds_dotted_worktree` — same setup, asserts `_awaiting_subagent` returns True for a pending tool_use (would have returned False before the fix)

## Test plan

- [x] `uv run ruff check src/ tests/` — 0 violations
- [x] `uv run ruff format --check src/ tests/` — 0 reformats
- [x] `uv run mypy --strict src/` — 0 type errors
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] `uv run pytest tests/ -m 'not integration' --cov=cw --cov-report=xml` — 1511 passed (total coverage 85.31%; pre-existing below-88% condition, unchanged from main)
- [x] `uv run pytest tests/ -m integration` — 1 passed, 6 skipped (tmux available)
- [x] `uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90` — **100% patch coverage** (10 new lines, 0 missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)