### PR TITLE
feat(status): last-tick summary, last-stage placeholder, and PR role in status output

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -72,6 +72,7 @@ from cw.orchestrate import (
     MissingWorkerEntry,
     OrchestratorStatus,
     WorkerEntry,
+    latest_tick_summary_by_client,
     orchestrator_parent,
     orchestrator_status,
     orchestrator_workers,
@@ -1607,6 +1608,19 @@ def dev_queue_status(client: str | None) -> None:
             f"  {len(completed_tasks):>9}  {len(cancelled_tasks):>9}  {ticket_ids}"
         )
 
+    tick_data = latest_tick_summary_by_client()
+    if tick_data:
+        click.echo("")
+        click.echo("Last dispatch tick per client:")
+        for client_name in clients_seen:
+            if client_name in tick_data:
+                tick = tick_data[client_name]
+                click.echo(
+                    f"  {client_name}: claimed={tick.claimed}  pending={tick.pending}"
+                    f"  running={tick.running}/{tick.cap}"
+                    f"  skip={tick.skip_reason}"
+                )
+
 
 @dev_queue.command(name="run")
 @click.option(
@@ -1779,16 +1793,34 @@ def _format_status_human(status: OrchestratorStatus) -> str:
         for t in status.pending_tickets
     )
 
+    lines.extend(("", "Last dispatch tick:"))
+    if status.last_tick_by_client:
+        for client, tick in sorted(status.last_tick_by_client.items()):
+            lines.append(
+                f"  - {client}  claimed={tick.claimed}  pending={tick.pending}"
+                f"  running={tick.running}/{tick.cap}"
+                f"  skip={tick.skip_reason}"
+                f"  at={tick.tick_at.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+            )
+    else:
+        lines.append("  (no dispatch ticks recorded)")
+
     lines.extend(("", f"Running sessions:  {len(status.running_sessions)}"))
     for s in status.running_sessions:
         line = f"  - {s.id}  {s.name}  status={s.status}"
         if s.last_stage:
             line += f"  last_stage={s.last_stage}"
+        else:
+            _stage_unknown = (
+                "  last_stage=(unknown"
+                " — global auto-dev.md not yet emitting stage events)"
+            )
+            line += _stage_unknown
         lines.append(line)
 
     lines.extend(("", f"Monitored PRs:     {len(status.monitored_prs)}"))
     lines.extend(
-        f"  - {pr.repo}#{pr.pr_number}  status={pr.status}"
+        f"  - {pr.repo}#{pr.pr_number}  role={pr.role}  status={pr.status}"
         f"  unresolved={pr.unresolved_threads}"
         for pr in status.monitored_prs
     )

--- a/src/cw/daemon.py
+++ b/src/cw/daemon.py
@@ -230,7 +230,7 @@ def watch_prs_for_client(
     )
 
     for file_data in monitor_files:
-        active_prs: dict[str, Any] = file_data.get("active", {})
+        active_prs: dict[str, Any] = file_data.get("monitored", {})
         for pr_data in active_prs.values():
             if not isinstance(pr_data, dict):
                 continue

--- a/src/cw/orchestrate.py
+++ b/src/cw/orchestrate.py
@@ -467,7 +467,7 @@ def _load_monitored_prs() -> list[MonitoredPR]:
             raw: dict[str, Any] = json.loads(path.read_text())
         except (OSError, json.JSONDecodeError):
             continue
-        active: dict[str, Any] = raw.get("active", {})
+        active: dict[str, Any] = raw.get("monitored", {})
         for pr_data in active.values():
             if not isinstance(pr_data, dict):
                 continue

--- a/src/cw/orchestrate.py
+++ b/src/cw/orchestrate.py
@@ -369,6 +369,17 @@ class EventSummary(BaseModel):
     created_at: datetime
 
 
+class TickSummary(BaseModel):
+    """Most recent dispatch.tick summary for one client."""
+
+    claimed: int
+    pending: int
+    running: int
+    cap: int
+    skip_reason: str
+    tick_at: datetime
+
+
 class OrchestratorStatus(BaseModel):
     """Snapshot of the orchestrator subsystem.
 
@@ -382,6 +393,7 @@ class OrchestratorStatus(BaseModel):
     monitored_prs: list[MonitoredPR] = Field(default_factory=list)
     recent_events: list[EventSummary] = Field(default_factory=list)
     total_cost_by_client: dict[str, float] = Field(default_factory=dict)
+    last_tick_by_client: dict[str, TickSummary] = Field(default_factory=dict)
 
 
 def _summarise_ticket(task: TicketTask) -> TicketSummary:
@@ -444,6 +456,33 @@ def _summarise_event(event: OrchestratorEvent) -> EventSummary:
     )
 
 
+def _latest_tick_by_client(
+    events: list[OrchestratorEvent],
+) -> dict[str, TickSummary]:
+    """Derive the most recent dispatch.tick per client from an event list."""
+    result: dict[str, TickSummary] = {}
+    for ev in events:
+        if ev.type is not OrchestratorEventType.DISPATCH_TICK:
+            continue
+        client = ev.payload.get("client")
+        if not isinstance(client, str):
+            continue
+        existing = result.get(client)
+        if existing is None or ev.created_at > existing.tick_at:
+            try:
+                result[client] = TickSummary(
+                    claimed=int(ev.payload.get("claimed", 0)),
+                    pending=int(ev.payload.get("pending", 0)),
+                    running=int(ev.payload.get("running", 0)),
+                    cap=int(ev.payload.get("cap", 0)),
+                    skip_reason=str(ev.payload.get("skip_reason", "none")),
+                    tick_at=ev.created_at,
+                )
+            except (TypeError, ValueError):
+                continue
+    return result
+
+
 def _count_unresolved(thread_status: dict[str, Any]) -> int:
     """Return the number of unresolved threads in a thread_status dict."""
     count = 0
@@ -488,6 +527,15 @@ def _load_monitored_prs() -> list[MonitoredPR]:
     return monitored
 
 
+def latest_tick_summary_by_client() -> dict[str, TickSummary]:
+    """Return the most recent dispatch.tick summary per client.
+
+    Uses only DISPATCH_TICK events — no full orchestrator_status() overhead.
+    """
+    events = read_events(event_types=[OrchestratorEventType.DISPATCH_TICK])
+    return _latest_tick_by_client(events)
+
+
 def orchestrator_status() -> OrchestratorStatus:
     """Build a snapshot of pending tickets, running sessions, PRs, events."""
     queue = load_dev_queue()
@@ -499,6 +547,7 @@ def orchestrator_status() -> OrchestratorStatus:
     # summarising the running list.
     all_events = read_events()
     last_stage_by_session = _derive_last_stage_by_session(all_events)
+    last_tick = _latest_tick_by_client(all_events)
 
     state = load_state()
     running = [
@@ -525,6 +574,7 @@ def orchestrator_status() -> OrchestratorStatus:
         monitored_prs=monitored,
         recent_events=recent,
         total_cost_by_client=total_cost,
+        last_tick_by_client=last_tick,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4703,3 +4703,126 @@ class TestDevQueueRunQuiet:
         assert callable(captured_emit[0]), (
             f"Expected callable emit but got: {captured_emit[0]!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests: _format_status_human
+# ---------------------------------------------------------------------------
+
+
+class TestFormatStatusHuman:
+    def test_format_status_human_shows_last_tick_section(self) -> None:
+        """_format_status_human renders last-tick section when data present."""
+        from cw.cli import _format_status_human
+        from cw.orchestrate import OrchestratorStatus, TickSummary
+
+        tick = TickSummary(
+            claimed=2,
+            pending=1,
+            running=2,
+            cap=3,
+            skip_reason="none",
+            tick_at=datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC),
+        )
+        status = OrchestratorStatus(
+            generated_at=datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC),
+            last_tick_by_client={"my-client": tick},
+        )
+        output = _format_status_human(status)
+        assert "Last dispatch tick" in output
+        assert "my-client" in output
+        assert "claimed=2" in output
+        assert "skip=none" in output
+
+    def test_format_status_human_no_last_tick_when_empty(self) -> None:
+        """_format_status_human shows 'no dispatch ticks' when empty."""
+        from cw.cli import _format_status_human
+        from cw.orchestrate import OrchestratorStatus
+
+        status = OrchestratorStatus(
+            generated_at=datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC),
+        )
+        output = _format_status_human(status)
+        assert "no dispatch ticks recorded" in output
+
+    def test_format_status_human_last_stage_placeholder(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """Sessions with no stage events show placeholder text."""
+        from cw.cli import _format_status_human
+        from cw.orchestrate import OrchestratorStatus, SessionSummary
+
+        sess = SessionSummary(
+            id="s1",
+            name="test/impl/s1",
+            client="test",
+            status="active",
+            purpose="impl",
+            started_at=datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC),
+            last_stage=None,
+        )
+        status = OrchestratorStatus(
+            generated_at=datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC),
+            running_sessions=[sess],
+        )
+        output = _format_status_human(status)
+        assert "(unknown — global auto-dev.md not yet emitting stage events)" in output
+
+    def test_format_status_human_monitored_pr_shows_role(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """MonitoredPR line in _format_status_human includes role field."""
+        from cw.cli import _format_status_human
+        from cw.orchestrate import MonitoredPR, OrchestratorStatus
+
+        pr = MonitoredPR(
+            repo="owner/repo",
+            pr_number=42,
+            role="author",
+            status="watching",
+            unresolved_threads=0,
+        )
+        status = OrchestratorStatus(
+            generated_at=datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC),
+            monitored_prs=[pr],
+        )
+        output = _format_status_human(status)
+        assert "role=author" in output
+
+
+class TestDevQueueStatusWithTick:
+    def test_dev_queue_status_shows_last_tick(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """dev-queue status renders last-tick section when tick data present."""
+        from cw.dev_queue import add_ticket
+        from cw.events import record_event
+        from cw.models import OrchestratorEventType, QueueItemStatus, TicketTask
+
+        add_ticket(
+            TicketTask(
+                ticket_id="GEN-999",
+                client="tick-client",
+                priority=5,
+                status=QueueItemStatus.PENDING,
+            )
+        )
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": "tick-client",
+                "claimed": 1,
+                "pending": 0,
+                "running": 1,
+                "cap": 2,
+                "skip_reason": "cap_full",
+            },
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["dev-queue", "status"])
+        assert result.exit_code == 0, result.output
+        assert "Last dispatch tick per client:" in result.output
+        assert "tick-client" in result.output
+        assert "claimed=1" in result.output
+        assert "skip=cap_full" in result.output

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -55,7 +55,7 @@ def _make_monitor_file(
         "delta_findings": delta_findings or [],
     }
     state: dict[str, Any] = {
-        "active": {pr_key: pr_data},
+        "monitored": {pr_key: pr_data},
         "completed": {},
     }
     # filename: owner--repo.json

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -484,6 +484,127 @@ class TestOrchestratorStatus:
         assert snapshot.recent_events[0].payload["ticket_id"] == "GEN-5"
         assert snapshot.recent_events[-1].payload["ticket_id"] == "GEN-24"
 
+    def test_last_tick_by_client_from_dispatch_tick_event(
+        self,
+        tmp_orchestrate_dirs: Path,
+    ) -> None:
+        """dispatch.tick event populates last_tick_by_client in the snapshot."""
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": "test-client",
+                "claimed": 1,
+                "pending": 2,
+                "running": 1,
+                "cap": 2,
+                "skip_reason": "none",
+            },
+        )
+        snapshot = orchestrator_status()
+        assert "test-client" in snapshot.last_tick_by_client
+        tick = snapshot.last_tick_by_client["test-client"]
+        assert tick.claimed == 1
+        assert tick.pending == 2
+        assert tick.running == 1
+        assert tick.cap == 2
+        assert tick.skip_reason == "none"
+        assert tick.tick_at is not None
+
+    def test_last_tick_by_client_multiple_clients(
+        self,
+        tmp_orchestrate_dirs: Path,
+    ) -> None:
+        """Each client gets its own last_tick_by_client entry; latest event wins."""
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": "client-a",
+                "claimed": 1,
+                "pending": 0,
+                "running": 1,
+                "cap": 2,
+                "skip_reason": "none",
+            },
+        )
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": "client-b",
+                "claimed": 0,
+                "pending": 3,
+                "running": 0,
+                "cap": 2,
+                "skip_reason": "no_pending",
+            },
+        )
+        # Second event for client-a — should overwrite the first
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": "client-a",
+                "claimed": 0,
+                "pending": 1,
+                "running": 0,
+                "cap": 2,
+                "skip_reason": "cap_full",
+            },
+        )
+        snapshot = orchestrator_status()
+        assert "client-a" in snapshot.last_tick_by_client
+        assert "client-b" in snapshot.last_tick_by_client
+        # Latest event for client-a wins
+        assert snapshot.last_tick_by_client["client-a"].skip_reason == "cap_full"
+        assert snapshot.last_tick_by_client["client-b"].skip_reason == "no_pending"
+
+    def test_last_tick_by_client_empty_when_no_events(
+        self,
+        tmp_orchestrate_dirs: Path,
+    ) -> None:
+        """No DISPATCH_TICK events → last_tick_by_client is empty."""
+        snapshot = orchestrator_status()
+        assert snapshot.last_tick_by_client == {}
+
+    def test_last_tick_skips_non_string_client(
+        self,
+        tmp_orchestrate_dirs: Path,
+    ) -> None:
+        """DISPATCH_TICK events with non-string client are ignored."""
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": 123,  # non-string — should be skipped
+                "claimed": 1,
+                "pending": 0,
+                "running": 0,
+                "cap": 2,
+                "skip_reason": "none",
+            },
+        )
+        snapshot = orchestrator_status()
+        assert snapshot.last_tick_by_client == {}
+
+    def test_last_tick_skips_bad_numeric_payload(
+        self,
+        tmp_orchestrate_dirs: Path,
+    ) -> None:
+        """DISPATCH_TICK events with non-castable numeric fields are skipped."""
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": "bad-client",
+                "claimed": "not-a-number",
+                "pending": "also-not-a-number",
+                "running": "nope",
+                "cap": "nope",
+                "skip_reason": "none",
+            },
+        )
+        # The event has a valid client but bad numeric fields — raises
+        # ValueError from int() which we catch and skip.
+        snapshot = orchestrator_status()
+        # Skipped due to ValueError — bad-client absent from map.
+        assert "bad-client" not in snapshot.last_tick_by_client
+
     def test_serialises_to_json(
         self,
         tmp_orchestrate_dirs: Path,

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -155,7 +155,7 @@ def _write_monitor_file(
         "thread_status": thread_status or {},
         "delta_findings": [],
     }
-    payload = {"active": {pr_key: pr_data}, "completed": {}}
+    payload = {"monitored": {pr_key: pr_data}, "completed": {}}
     filename = repo.replace("/", "--") + ".json"
     path = review_monitor_dir / filename
     path.write_text(json.dumps(payload, indent=2))
@@ -447,6 +447,25 @@ class TestOrchestratorStatus:
         assert pr.pr_number == 42
         assert pr.unresolved_threads == 1
         assert pr.status == "watching"
+
+    def test_load_monitored_prs_uses_monitored_key(
+        self,
+        tmp_orchestrate_dirs: Path,
+    ) -> None:
+        """_load_monitored_prs reads the 'monitored' key (not 'active')."""
+        review_dir = tmp_orchestrate_dirs / "review-monitor"
+        _write_monitor_file(
+            review_dir,
+            "owner/repo",
+            99,
+            status="watching",
+            role="author",
+        )
+        # After _write_monitor_file update, file uses 'monitored' key.
+        # _load_monitored_prs must read it.
+        snapshot = orchestrator_status()
+        assert len(snapshot.monitored_prs) == 1
+        assert snapshot.monitored_prs[0].pr_number == 99
 
     def test_recent_events_capped(
         self,

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -448,25 +448,6 @@ class TestOrchestratorStatus:
         assert pr.unresolved_threads == 1
         assert pr.status == "watching"
 
-    def test_load_monitored_prs_uses_monitored_key(
-        self,
-        tmp_orchestrate_dirs: Path,
-    ) -> None:
-        """_load_monitored_prs reads the 'monitored' key (not 'active')."""
-        review_dir = tmp_orchestrate_dirs / "review-monitor"
-        _write_monitor_file(
-            review_dir,
-            "owner/repo",
-            99,
-            status="watching",
-            role="author",
-        )
-        # After _write_monitor_file update, file uses 'monitored' key.
-        # _load_monitored_prs must read it.
-        snapshot = orchestrator_status()
-        assert len(snapshot.monitored_prs) == 1
-        assert snapshot.monitored_prs[0].pr_number == 99
-
     def test_recent_events_capped(
         self,
         tmp_orchestrate_dirs: Path,
@@ -604,6 +585,25 @@ class TestOrchestratorStatus:
         snapshot = orchestrator_status()
         # Skipped due to ValueError — bad-client absent from map.
         assert "bad-client" not in snapshot.last_tick_by_client
+
+    def test_load_monitored_prs_uses_monitored_key(
+        self,
+        tmp_orchestrate_dirs: Path,
+    ) -> None:
+        """_load_monitored_prs reads the 'monitored' key (not 'active')."""
+        review_dir = tmp_orchestrate_dirs / "review-monitor"
+        _write_monitor_file(
+            review_dir,
+            "owner/repo",
+            99,
+            status="watching",
+            role="author",
+        )
+        # After _write_monitor_file update, file uses 'monitored' key.
+        # _load_monitored_prs must read it.
+        snapshot = orchestrator_status()
+        assert len(snapshot.monitored_prs) == 1
+        assert snapshot.monitored_prs[0].pr_number == 99
 
     def test_serialises_to_json(
         self,
@@ -1220,7 +1220,7 @@ class TestCliOrchestrateStatusLastStage:
         tmp_orchestrate_dirs: Path,
         workspace: Path,
     ) -> None:
-        """No last_stage token when the session has no stage events."""
+        """Sessions with no stage events show placeholder in last_stage field."""
         save_state(
             CwState(
                 sessions=[
@@ -1232,7 +1232,8 @@ class TestCliOrchestrateStatusLastStage:
         runner = CliRunner()
         result = runner.invoke(main, ["orchestrate", "status"])
         assert result.exit_code == 0, result.output
-        assert "last_stage=" not in result.output
+        expected = "(unknown — global auto-dev.md not yet emitting stage events)"
+        assert expected in result.output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extends `OrchestratorStatus` with `last_tick_by_client: dict[str, TickSummary]` populated from `dispatch.tick` events; surfaced in `cw orchestrate status` (human + `--json`) and `cw dev-queue status`
- Adds `last_stage` rendering in `_format_status_human` with honest placeholder `(unknown — global auto-dev.md not yet emitting stage events)` when `None`
- Adds `role={pr.role}` to `MonitoredPR` rendering line (CI status and mergeable flag out of scope — not persisted)
- Fixes `_load_monitored_prs` reading `"active"` key → `"monitored"` (was silently returning zero PRs)
- Companion fix: `daemon._build_pr_snapshot` had the same `"active"` key bug; PR watchdog was silently processing zero PRs

## Test plan

- [ ] `uv run pytest tests/test_orchestrate.py tests/test_cli.py tests/test_daemon.py` — all new and existing tests pass
- [ ] `uv run mypy --strict src/` — zero type errors
- [ ] `uv run ruff check src/ tests/` — zero violations
- [ ] `cw orchestrate status` human output includes `Last dispatch tick:` section
- [ ] `cw orchestrate status --json` snapshot includes `last_tick_by_client` field

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)