### PR TITLE
test: incident-replay fixtures for loop telemetry observability (#462)

### DIFF
--- a/tests/test_observability_incidents.py
+++ b/tests/test_observability_incidents.py
@@ -1,0 +1,280 @@
+"""Incident-replay validation suite for loop telemetry (#462).
+
+One fixture per known incident. Each reconstructs the event/state that
+characterised the incident and asserts the specific telemetry signal that
+MUST light up. These tests are the acceptance bar for the #459/#460
+observability batch — if a fixture cannot make an incident visible, the
+telemetry is incomplete.
+
+Incidents covered:
+  #419 — dispatch stall on stale main (loop-health WARN)
+  #421 — phantom revert of a dirty worktree (session.phantom_reverted)
+  #418 — suppressed salvage of silently_idle session (session.salvage_skipped)
+  #315 — TIMED_OUT session whose branch PR was merged (timed_out-merged WARN)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import freezegun
+
+if TYPE_CHECKING:
+    import pytest
+
+from cw.config import save_state
+from cw.dev_queue import save_dev_queue
+from cw.events import read_events, record_event
+from cw.models import (
+    CwState,
+    DevQueueStore,
+    DispatchSkipReason,
+    OrchestratorConfig,
+    OrchestratorEventType,
+    QueueItemStatus,
+    Session,
+    SessionOrigin,
+    SessionPurpose,
+    SessionStatus,
+    TicketTask,
+)
+from cw.reconcile import (
+    _SILENTLY_IDLE_REASON,
+    reconcile,
+    revert_stalled_headless_sessions,
+)
+
+
+def _make_daemon_session(
+    sid: str,
+    ticket_id: str,
+    client: str = "client-a",
+    surface_ref: str | None = "agent-dead",
+    *,
+    workspace_path: Path | None = None,
+    started_at: datetime | None = None,
+    status: SessionStatus = SessionStatus.ACTIVE,
+) -> Session:
+    """Build a minimal DAEMON-origin session for replay fixtures."""
+    from cw.models import ClientConfig
+
+    return Session(
+        id=sid,
+        name=f"{client}/auto-dev/{ticket_id}",
+        client=client,
+        purpose=SessionPurpose.IMPL,
+        status=status,
+        origin=SessionOrigin.DAEMON,
+        workspace_path=(
+            workspace_path
+            if workspace_path is not None
+            else ClientConfig(
+                name=client, workspace_path=Path("/tmp/ws")
+            ).workspace_path
+        ),
+        surface_ref=surface_ref,
+        started_at=started_at or datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# #419 — Dispatch stall on stale main
+# ---------------------------------------------------------------------------
+
+
+@freezegun.freeze_time("2026-06-05T12:00:00Z")
+def test_incident_419_dispatch_stall_warns(tmp_config_dir: Path) -> None:
+    """Replay #419: 3 consecutive freshness_gate ticks → loop-health WARNs.
+
+    Incident: cw's main branch was behind origin/main, causing every
+    dispatch.tick to carry skip_reason=freshness_gate with pending>0
+    and running=0. The stall was invisible until _check_loop_health (#460)
+    was added.
+    """
+    from cw.doctor import _check_loop_health
+
+    stall_tick = {
+        "client": "client-stall",
+        "pending": 2,
+        "running": 0,
+        "claimed": 0,
+        "cap": 3,
+        "skip_reason": DispatchSkipReason.FRESHNESS_GATE,
+    }
+    for _ in range(3):
+        record_event(OrchestratorEventType.DISPATCH_TICK, stall_tick)
+
+    results = _check_loop_health()
+
+    warn = [r for r in results if r.warn]
+    assert len(warn) == 1, f"Expected 1 warn result, got {warn}"
+    assert "client-stall" in warn[0].name
+    assert "stalled" in warn[0].detail
+
+
+# ---------------------------------------------------------------------------
+# #421 — Phantom revert of a dirty worktree
+# ---------------------------------------------------------------------------
+
+
+def test_incident_421_phantom_dirty_worktree(
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay #421: phantom session with dirty worktree emits phantom_reverted.
+
+    Incident: a DAEMON session disappeared from the daemon roster while its
+    worktree still had uncommitted changes. reconcile() reverted the ticket to
+    PENDING, losing work silently. The session.phantom_reverted event (#459)
+    exposes worktree_dirty so the orchestrator can warn before re-dispatching.
+    """
+    sess = _make_daemon_session("phantom-421", "TICKET-421", surface_ref="dead-agent")
+    save_state(CwState(sessions=[sess]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="TICKET-421",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                )
+            ]
+        )
+    )
+    # Non-empty live set bypasses outage guard; "dead-agent" is still not live.
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
+    # Incident #421: worktree was dirty at the time of phantom revert.
+    monkeypatch.setattr("cw.reconcile._compute_worktree_dirty", lambda *_: True)
+
+    reconcile()
+
+    events = read_events(
+        consumer="test-incident-421",
+        event_types=[OrchestratorEventType.SESSION_PHANTOM_REVERTED],
+    )
+    assert len(events) == 1, f"Expected 1 phantom_reverted event, got {events}"
+    payload = events[0].payload
+    assert payload["session_id"] == "phantom-421"
+    assert payload["ticket_id"] == "TICKET-421"
+    assert payload["worktree_dirty"] is True
+    assert events[0].correlation_id == "TICKET-421"
+
+
+# ---------------------------------------------------------------------------
+# #418 — Suppressed salvage of silently_idle session
+# ---------------------------------------------------------------------------
+
+_FROZEN_418 = "2026-06-05T12:00:00Z"
+_STARTED_LONG_AGO = datetime(2026, 6, 5, 0, 0, 0, tzinfo=UTC)  # 12 h before frozen now
+
+
+@freezegun.freeze_time(_FROZEN_418)
+def test_incident_418_silently_idle_emits_salvage_skipped(
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay #418: silently_idle park-marker session emits session.salvage_skipped.
+
+    Incident: a headless DAEMON session that was parked by
+    flag_silently_idle_daemon_sessions (last_result has paused_status=silently_idle)
+    was being re-timed-out by revert_stalled_headless_sessions instead of being
+    left alone. The SESSION_SALVAGE_SKIPPED event (#459) makes this path visible.
+    """
+    sess = _make_daemon_session(
+        "silently-idle-418", "TICKET-418", started_at=_STARTED_LONG_AGO
+    )
+    sess.last_result = {"paused_status": _SILENTLY_IDLE_REASON}
+    state = CwState(sessions=[sess])
+    monkeypatch.setattr("cw.reconcile._is_headless", lambda *_: True)
+
+    now = datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC)
+    revert_stalled_headless_sessions(state, now=now, config=OrchestratorConfig())
+
+    events = read_events(
+        consumer="test-incident-418-skip",
+        event_types=[OrchestratorEventType.SESSION_SALVAGE_SKIPPED],
+    )
+    assert len(events) == 1, f"Expected 1 salvage_skipped event, got {events}"
+    payload = events[0].payload
+    assert payload["session_id"] == "silently-idle-418"
+    assert payload.get("paused_status") == _SILENTLY_IDLE_REASON
+
+
+@freezegun.freeze_time(_FROZEN_418)
+def test_incident_418_terminal_sentinel_no_salvage_skip(
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Contrast: terminal-sentinel last_result does NOT emit salvage_skipped.
+
+    The salvage_skipped path is gated on paused_status==silently_idle. A session
+    that genuinely shipped (last_result.status=shipped) must not emit the signal —
+    confusing a shipped session with a parked one is a correctness bug.
+    """
+    sess = _make_daemon_session(
+        "shipped-418", "TICKET-418B", started_at=_STARTED_LONG_AGO
+    )
+    # Real terminal sentinel — no paused_status key.
+    sess.last_result = {"status": "shipped", "schema_version": 4}
+    state = CwState(sessions=[sess])
+    monkeypatch.setattr("cw.reconcile._is_headless", lambda *_: True)
+
+    now = datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC)
+    revert_stalled_headless_sessions(state, now=now, config=OrchestratorConfig())
+
+    events = read_events(
+        consumer="test-incident-418-no-skip",
+        event_types=[OrchestratorEventType.SESSION_SALVAGE_SKIPPED],
+    )
+    assert len(events) == 0, (
+        "Expected no salvage_skipped events for terminal-sentinel session, "
+        f"got {events}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #315 — TIMED_OUT session whose branch PR was merged
+# ---------------------------------------------------------------------------
+
+
+@freezegun.freeze_time("2026-06-05T12:00:00Z")
+def test_incident_315_timed_out_merged_warns(
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay #315: TIMED_OUT session with MERGED PR → timed_out-merged WARNs.
+
+    Incident: session e4b91b97 timed out but PR #311 had already merged.
+    The work was done; the session was just flagged as failed. The
+    _check_timed_out_merged check (#460) surfaces this via a doctor WARN.
+    """
+    from cw.doctor import _check_timed_out_merged
+
+    sess = _make_daemon_session(
+        "timed-315",
+        "TICKET-315",
+        status=SessionStatus.TIMED_OUT,
+    )
+    # completed_at must be within the 7-day lookback window.
+    sess.completed_at = datetime(2026, 6, 4, 12, 0, 0, tzinfo=UTC)  # 1 day ago
+    state = CwState(sessions=[sess])
+
+    monkeypatch.setattr(
+        "cw.doctor._sp.run",
+        lambda *_args, **_kwargs: type(
+            "R", (), {"returncode": 0, "stdout": '[{"state":"MERGED"}]'}
+        )(),
+    )
+
+    results = _check_timed_out_merged(state)
+
+    warn = [r for r in results if r.warn]
+    assert len(warn) == 1, f"Expected 1 warn result, got {warn}"
+    assert "timed-315" in warn[0].detail
+    assert "MERGED" in warn[0].detail
+    assert "#315" in warn[0].detail

--- a/tests/test_observability_incidents.py
+++ b/tests/test_observability_incidents.py
@@ -15,6 +15,7 @@ Incidents covered:
 
 from __future__ import annotations
 
+import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -28,6 +29,7 @@ from cw.config import save_state
 from cw.dev_queue import save_dev_queue
 from cw.events import read_events, record_event
 from cw.models import (
+    ClientConfig,
     CwState,
     DevQueueStore,
     DispatchSkipReason,
@@ -58,8 +60,6 @@ def _make_daemon_session(
     status: SessionStatus = SessionStatus.ACTIVE,
 ) -> Session:
     """Build a minimal DAEMON-origin session for replay fixtures."""
-    from cw.models import ClientConfig
-
     return Session(
         id=sid,
         name=f"{client}/auto-dev/{ticket_id}",
@@ -170,6 +170,7 @@ def test_incident_421_phantom_dirty_worktree(
 # ---------------------------------------------------------------------------
 
 _FROZEN_418 = "2026-06-05T12:00:00Z"
+_NOW_418 = datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC)
 _STARTED_LONG_AGO = datetime(2026, 6, 5, 0, 0, 0, tzinfo=UTC)  # 12 h before frozen now
 
 
@@ -192,7 +193,7 @@ def test_incident_418_silently_idle_emits_salvage_skipped(
     state = CwState(sessions=[sess])
     monkeypatch.setattr("cw.reconcile._is_headless", lambda *_: True)
 
-    now = datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC)
+    now = _NOW_418
     revert_stalled_headless_sessions(state, now=now, config=OrchestratorConfig())
 
     events = read_events(
@@ -224,7 +225,7 @@ def test_incident_418_terminal_sentinel_no_salvage_skip(
     state = CwState(sessions=[sess])
     monkeypatch.setattr("cw.reconcile._is_headless", lambda *_: True)
 
-    now = datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC)
+    now = _NOW_418
     revert_stalled_headless_sessions(state, now=now, config=OrchestratorConfig())
 
     events = read_events(
@@ -266,9 +267,9 @@ def test_incident_315_timed_out_merged_warns(
 
     monkeypatch.setattr(
         "cw.doctor._sp.run",
-        lambda *_args, **_kwargs: type(
-            "R", (), {"returncode": 0, "stdout": '[{"state":"MERGED"}]'}
-        )(),
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='[{"state":"MERGED"}]', stderr=""
+        ),
     )
 
     results = _check_timed_out_merged(state)


### PR DESCRIPTION
## Summary

- Adds `tests/test_observability_incidents.py` with one replay fixture per known observability incident
- Each fixture reconstructs the event/state that characterised the incident and asserts the specific telemetry signal that fires
- These tests are the acceptance bar for the #459/#460 observability batch

## Incidents covered

- **#419** — dispatch stall on stale main: records 3 consecutive `freshness_gate` DISPATCH_TICK events, asserts `_check_loop_health` returns a WARN for the client
- **#421** — phantom revert of a dirty worktree: reconcile() with a dead-surface DAEMON session and `_compute_worktree_dirty=True`, asserts `session.phantom_reverted` with `worktree_dirty: true`
- **#418** — suppressed salvage of `silently_idle` session: `revert_stalled_headless_sessions` with a parked session, asserts `session.salvage_skipped`; contrast test verifies a terminal-sentinel session does NOT emit the signal
- **#315** — TIMED_OUT session whose branch PR was merged: `_check_timed_out_merged` with MERGED gh response, asserts timed_out-merged WARN

## Test plan

- [x] `uv run ruff check tests/test_observability_incidents.py` — clean
- [x] `uv run mypy --strict src/` — clean
- [x] `uv run pytest tests/test_observability_incidents.py -v` — 5/5 passed
- [x] No `# noqa` or `# type: ignore`

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)