### PR TITLE
feat(queue): native cw dev-queue wait command for terminal status (#474)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,10 @@ ignore = [
 "src/cw/cw_queue_events_server.py" = ["PLC0415"]
 "src/cw/cw_pr_events_channel.py" = ["PLC0415"]
 "src/cw/cw_queue_events_channel.py" = ["PLC0415"]
+# dev_queue defers the dispatch import to break the dev_queue ↔ dispatch
+# circular dependency. consume_completed_sessions() is a thin wrapper whose
+# deferred body import is the sanctioned mechanism, not a workaround.
+"src/cw/dev_queue.py" = ["PLC0415"]
 # Channel test files guard imports behind pytest.importorskip("starlette"/"mcp"),
 # so module-level imports legitimately follow executable code (E402).
 "tests/test_cw_pr_events_channel.py" = ["E402"]

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -50,6 +50,7 @@ from cw.dev_queue import (
     remove_ticket,
     resolve_client,
     save_dev_queue,
+    wait_for_terminal,
 )
 from cw.dispatch import _DISPATCH_CONSUMER, _apply_events_to_store, run_dispatch_loop
 from cw.doctor import format_report, format_report_json, run_doctor
@@ -1676,6 +1677,11 @@ def dev_queue_run(
 
 _PLAN_DEFAULT_TIMEOUT = 300
 
+_WAIT_DEFAULT_TIMEOUT: int = 300
+_WAIT_EXIT_FAILED: int = 1
+_WAIT_EXIT_BLOCKED: int = 2
+_WAIT_EXIT_TIMEOUT: int = 124
+
 
 def _run_plan_impl(
     *,
@@ -1744,6 +1750,83 @@ def dev_queue_plan(client: str, timeout: int, filter_client: str | None) -> None
     )
     if exit_code != 0:
         raise click.exceptions.Exit(exit_code)
+
+
+@dev_queue.command(name="wait")
+@click.argument("ticket_id")
+@click.option(
+    "--client",
+    "-c",
+    default=None,
+    shell_complete=_complete_client,
+    help="Client name.",
+)
+@click.option(
+    "--timeout",
+    "timeout_seconds",
+    type=float,
+    default=_WAIT_DEFAULT_TIMEOUT,
+    help="Seconds to wait (default: 300).",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    default=False,
+    help="Emit JSON output.",
+)
+@handle_errors
+def dev_queue_wait(
+    ticket_id: str,
+    client: str | None,
+    timeout_seconds: float,
+    output_json: bool,
+) -> None:
+    """Block until a dev-queue ticket reaches terminal status.
+
+    Exits 0 for COMPLETED, 1 for FAILED/CANCELLED, 2 for BLOCKED_ON_USER,
+    and 124 on timeout.
+    """
+    config = load_orchestrator_config()
+    resolved = resolve_client(ticket_id, config, client)
+    try:
+        task = wait_for_terminal(ticket_id, resolved, timeout=timeout_seconds)
+    except TimeoutError:
+        if output_json:
+            click.echo(
+                json.dumps(
+                    {
+                        "ticket_id": ticket_id,
+                        "client": resolved,
+                        "status": "timeout",
+                        "session_id": None,
+                    }
+                )
+            )
+        else:
+            click.echo(f"Timeout waiting for {ticket_id} (>{timeout_seconds:.0f}s)")
+        raise click.exceptions.Exit(_WAIT_EXIT_TIMEOUT) from None
+
+    status_str = task.status.value
+    if output_json:
+        click.echo(
+            json.dumps(
+                {
+                    "ticket_id": ticket_id,
+                    "client": resolved,
+                    "status": status_str,
+                    "session_id": task.session_id,
+                }
+            )
+        )
+    else:
+        click.echo(f"Status: {status_str.upper()}")
+
+    if task.status == QueueItemStatus.COMPLETED:
+        return
+    if task.status == QueueItemStatus.BLOCKED_ON_USER:
+        raise click.exceptions.Exit(_WAIT_EXIT_BLOCKED)
+    raise click.exceptions.Exit(_WAIT_EXIT_FAILED)
 
 
 @dev_queue.command(name="refresh-all")

--- a/src/cw/dev_queue.py
+++ b/src/cw/dev_queue.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import fcntl
 import json
+import time
 from typing import TYPE_CHECKING, Any
 
 from cw.atomic import atomic_write_text
@@ -29,6 +30,17 @@ from cw.models import (
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
+
+_WAIT_POLL_INTERVAL: int = 5
+
+_TERMINAL_STATUSES: frozenset[QueueItemStatus] = frozenset(
+    [
+        QueueItemStatus.COMPLETED,
+        QueueItemStatus.FAILED,
+        QueueItemStatus.CANCELLED,
+        QueueItemStatus.BLOCKED_ON_USER,
+    ]
+)
 
 
 @contextlib.contextmanager
@@ -284,3 +296,63 @@ def list_tickets(client: str | None = None) -> list[TicketTask]:
     if client is None:
         return list(store.tasks)
     return [t for t in store.tasks if t.client == client]
+
+
+def _find_ticket(store: DevQueueStore, ticket_id: str, client: str) -> TicketTask:
+    """Return the TicketTask matching (ticket_id, client) or raise CwError."""
+    matches = [
+        t for t in store.tasks if t.ticket_id == ticket_id and t.client == client
+    ]
+    if not matches:
+        msg = f"No dev-queue task found for ticket '{ticket_id}' in client '{client}'."
+        raise CwError(msg)
+    return matches[0]
+
+
+def consume_completed_sessions() -> int:
+    """Thin wrapper around dispatch.consume_completed_sessions.
+
+    Exists as a named module-level function so that tests can monkeypatch
+    ``cw.dev_queue.consume_completed_sessions`` without depending on a
+    module-level circular import.  The real import is deferred to call time
+    to break the dev_queue ↔ dispatch circular dependency.
+    """
+    from cw.dispatch import consume_completed_sessions as _impl
+
+    return _impl()
+
+
+def wait_for_terminal(
+    ticket_id: str,
+    client: str,
+    *,
+    timeout: float,
+    poll_interval: float = _WAIT_POLL_INTERVAL,
+) -> TicketTask:
+    """Block until the given ticket reaches a terminal status.
+
+    Calls consume_completed_sessions() once per poll tick before reading the
+    queue, so it works whether or not a dispatch loop is active.
+
+    # Why: before #471 merges, TIMED_OUT-but-PR-merged tickets may stay PENDING;
+    # wait will then hit --timeout (exit 124) rather than returning COMPLETED.
+
+    Terminal statuses: COMPLETED, FAILED, CANCELLED, BLOCKED_ON_USER.
+    Raises CwError if the ticket is not found.
+    Raises TimeoutError if *timeout* seconds elapse before a terminal status.
+    """
+    store = load_dev_queue()
+    task = _find_ticket(store, ticket_id, client)
+    if task.status in _TERMINAL_STATUSES:
+        return task
+
+    deadline = time.monotonic() + timeout
+    while True:
+        consume_completed_sessions()
+        store = load_dev_queue()
+        task = _find_ticket(store, ticket_id, client)
+        if task.status in _TERMINAL_STATUSES:
+            return task
+        if time.monotonic() >= deadline:
+            raise TimeoutError
+        time.sleep(poll_interval)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     import pytest
 
     from cw.cmux import FakeCmuxAdapter
+    from cw.models import QueueItemStatus
 
 
 class TestCli:
@@ -4840,7 +4841,7 @@ class TestDevQueueWait:
         self,
         tmp_config_dir: Path,
         ticket_id: str,
-        status: "QueueItemStatus",
+        status: QueueItemStatus,
         session_id: str | None = "sess-wait",
     ) -> None:
         from cw.dev_queue import save_dev_queue
@@ -4873,7 +4874,7 @@ class TestDevQueueWait:
         )
         monkeypatch.setattr(
             "cw.cli.wait_for_terminal",
-            lambda ticket_id, client, timeout: task,
+            lambda _ticket_id, _client, **_kw: task,
         )
         runner = CliRunner()
         result = runner.invoke(
@@ -4896,7 +4897,7 @@ class TestDevQueueWait:
         )
         monkeypatch.setattr(
             "cw.cli.wait_for_terminal",
-            lambda ticket_id, client, timeout: task,
+            lambda _ticket_id, _client, **_kw: task,
         )
         runner = CliRunner()
         result = runner.invoke(
@@ -4918,7 +4919,7 @@ class TestDevQueueWait:
         )
         monkeypatch.setattr(
             "cw.cli.wait_for_terminal",
-            lambda ticket_id, client, timeout: task,
+            lambda _ticket_id, _client, **_kw: task,
         )
         runner = CliRunner()
         result = runner.invoke(
@@ -4940,7 +4941,7 @@ class TestDevQueueWait:
         )
         monkeypatch.setattr(
             "cw.cli.wait_for_terminal",
-            lambda ticket_id, client, timeout: task,
+            lambda _ticket_id, _client, **_kw: task,
         )
         runner = CliRunner()
         result = runner.invoke(
@@ -4954,7 +4955,7 @@ class TestDevQueueWait:
         """TimeoutError from wait_for_terminal → exit _WAIT_EXIT_TIMEOUT (124)."""
         from cw.cli import _WAIT_EXIT_TIMEOUT
 
-        def _raise_timeout(ticket_id: str, client: str, timeout: float) -> None:
+        def _raise_timeout(ticket_id: str, client: str, *, timeout: float) -> None:
             raise TimeoutError
 
         monkeypatch.setattr("cw.cli.wait_for_terminal", _raise_timeout)
@@ -4980,7 +4981,7 @@ class TestDevQueueWait:
         )
         monkeypatch.setattr(
             "cw.cli.wait_for_terminal",
-            lambda ticket_id, client, timeout: task,
+            lambda _ticket_id, _client, **_kw: task,
         )
         runner = CliRunner()
         result = runner.invoke(
@@ -5010,7 +5011,7 @@ class TestDevQueueWait:
         )
         monkeypatch.setattr(
             "cw.cli.wait_for_terminal",
-            lambda ticket_id, client, timeout: task,
+            lambda _ticket_id, _client, **_kw: task,
         )
         runner = CliRunner()
         result = runner.invoke(
@@ -5032,7 +5033,7 @@ class TestDevQueueWait:
 
         from cw.cli import _WAIT_EXIT_TIMEOUT
 
-        def _raise_timeout(ticket_id: str, client: str, timeout: float) -> None:
+        def _raise_timeout(ticket_id: str, client: str, *, timeout: float) -> None:
             raise TimeoutError
 
         monkeypatch.setattr("cw.cli.wait_for_terminal", _raise_timeout)
@@ -5066,7 +5067,7 @@ class TestDevQueueWait:
             status=QueueItemStatus.COMPLETED,
         )
 
-        def _capture(ticket_id: str, client: str, timeout: float) -> TicketTask:
+        def _capture(ticket_id: str, client: str, *, timeout: float) -> TicketTask:
             captured.append(timeout)
             return task
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4826,3 +4826,271 @@ class TestDevQueueStatusWithTick:
         assert "tick-client" in result.output
         assert "claimed=1" in result.output
         assert "skip=cap_full" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TestDevQueueWait (GitHub issue #474)
+# ---------------------------------------------------------------------------
+
+
+class TestDevQueueWait:
+    """Tests for ``cw dev-queue wait``."""
+
+    def _seed_task(
+        self,
+        tmp_config_dir: Path,
+        ticket_id: str,
+        status: "QueueItemStatus",
+        session_id: str | None = "sess-wait",
+    ) -> None:
+        from cw.dev_queue import save_dev_queue
+        from cw.models import DevQueueStore, TicketTask
+
+        store = DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id=ticket_id,
+                    client="genhealth",
+                    status=status,
+                    session_id=session_id,
+                )
+            ]
+        )
+        save_dev_queue(store)
+
+    def test_wait_completed_exit_0(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """COMPLETED ticket → exit 0."""
+        from cw.cli import _WAIT_EXIT_FAILED
+        from cw.models import QueueItemStatus, TicketTask
+
+        task = TicketTask(
+            ticket_id="GEN-10",
+            client="genhealth",
+            status=QueueItemStatus.COMPLETED,
+            session_id="sess-10",
+        )
+        monkeypatch.setattr(
+            "cw.cli.wait_for_terminal",
+            lambda ticket_id, client, timeout: task,
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["dev-queue", "wait", "GEN-10", "--client", "genhealth"]
+        )
+        assert result.exit_code == 0, result.output
+        assert _WAIT_EXIT_FAILED != 0  # sanity: 0 is distinct from FAILED
+
+    def test_wait_failed_exit_1(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FAILED ticket → exit _WAIT_EXIT_FAILED (1)."""
+        from cw.cli import _WAIT_EXIT_FAILED
+        from cw.models import QueueItemStatus, TicketTask
+
+        task = TicketTask(
+            ticket_id="GEN-11",
+            client="genhealth",
+            status=QueueItemStatus.FAILED,
+        )
+        monkeypatch.setattr(
+            "cw.cli.wait_for_terminal",
+            lambda ticket_id, client, timeout: task,
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["dev-queue", "wait", "GEN-11", "--client", "genhealth"]
+        )
+        assert result.exit_code == _WAIT_EXIT_FAILED
+
+    def test_wait_cancelled_exit_1(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CANCELLED ticket → exit _WAIT_EXIT_FAILED (1)."""
+        from cw.cli import _WAIT_EXIT_FAILED
+        from cw.models import QueueItemStatus, TicketTask
+
+        task = TicketTask(
+            ticket_id="GEN-12",
+            client="genhealth",
+            status=QueueItemStatus.CANCELLED,
+        )
+        monkeypatch.setattr(
+            "cw.cli.wait_for_terminal",
+            lambda ticket_id, client, timeout: task,
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["dev-queue", "wait", "GEN-12", "--client", "genhealth"]
+        )
+        assert result.exit_code == _WAIT_EXIT_FAILED
+
+    def test_wait_blocked_on_user_exit_2(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """BLOCKED_ON_USER ticket → exit _WAIT_EXIT_BLOCKED (2)."""
+        from cw.cli import _WAIT_EXIT_BLOCKED
+        from cw.models import QueueItemStatus, TicketTask
+
+        task = TicketTask(
+            ticket_id="GEN-13",
+            client="genhealth",
+            status=QueueItemStatus.BLOCKED_ON_USER,
+        )
+        monkeypatch.setattr(
+            "cw.cli.wait_for_terminal",
+            lambda ticket_id, client, timeout: task,
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["dev-queue", "wait", "GEN-13", "--client", "genhealth"]
+        )
+        assert result.exit_code == _WAIT_EXIT_BLOCKED
+
+    def test_wait_timeout_exit_124(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """TimeoutError from wait_for_terminal → exit _WAIT_EXIT_TIMEOUT (124)."""
+        from cw.cli import _WAIT_EXIT_TIMEOUT
+
+        def _raise_timeout(ticket_id: str, client: str, timeout: float) -> None:
+            raise TimeoutError
+
+        monkeypatch.setattr("cw.cli.wait_for_terminal", _raise_timeout)
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["dev-queue", "wait", "GEN-14", "--client", "genhealth"]
+        )
+        assert result.exit_code == _WAIT_EXIT_TIMEOUT
+
+    def test_wait_json_output_shape(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--json emits all 4 required keys with correct values."""
+        import json as _json
+
+        from cw.models import QueueItemStatus, TicketTask
+
+        task = TicketTask(
+            ticket_id="GEN-15",
+            client="genhealth",
+            status=QueueItemStatus.COMPLETED,
+            session_id="sess-15",
+        )
+        monkeypatch.setattr(
+            "cw.cli.wait_for_terminal",
+            lambda ticket_id, client, timeout: task,
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["dev-queue", "wait", "GEN-15", "--client", "genhealth", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = _json.loads(result.output.strip())
+        assert payload["ticket_id"] == "GEN-15"
+        assert payload["client"] == "genhealth"
+        assert payload["status"] == "completed"
+        assert payload["session_id"] == "sess-15"
+
+    def test_wait_json_session_id_null(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--json emits session_id: null (not omitted) when session_id is None."""
+        import json as _json
+
+        from cw.models import QueueItemStatus, TicketTask
+
+        task = TicketTask(
+            ticket_id="GEN-16",
+            client="genhealth",
+            status=QueueItemStatus.FAILED,
+            session_id=None,
+        )
+        monkeypatch.setattr(
+            "cw.cli.wait_for_terminal",
+            lambda ticket_id, client, timeout: task,
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["dev-queue", "wait", "GEN-16", "--client", "genhealth", "--json"],
+        )
+        from cw.cli import _WAIT_EXIT_FAILED
+
+        assert result.exit_code == _WAIT_EXIT_FAILED
+        payload = _json.loads(result.output.strip())
+        assert "session_id" in payload
+        assert payload["session_id"] is None
+
+    def test_wait_json_timeout(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--json on timeout emits status=timeout with session_id: null."""
+        import json as _json
+
+        from cw.cli import _WAIT_EXIT_TIMEOUT
+
+        def _raise_timeout(ticket_id: str, client: str, timeout: float) -> None:
+            raise TimeoutError
+
+        monkeypatch.setattr("cw.cli.wait_for_terminal", _raise_timeout)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "dev-queue",
+                "wait",
+                "GEN-17",
+                "--client",
+                "genhealth",
+                "--json",
+            ],
+        )
+        assert result.exit_code == _WAIT_EXIT_TIMEOUT
+        payload = _json.loads(result.output.strip())
+        assert payload["status"] == "timeout"
+        assert payload["session_id"] is None
+
+    def test_wait_timeout_option_wiring(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--timeout value is forwarded to wait_for_terminal."""
+        from cw.models import QueueItemStatus, TicketTask
+
+        captured: list[float] = []
+        task = TicketTask(
+            ticket_id="GEN-18",
+            client="genhealth",
+            status=QueueItemStatus.COMPLETED,
+        )
+
+        def _capture(ticket_id: str, client: str, timeout: float) -> TicketTask:
+            captured.append(timeout)
+            return task
+
+        monkeypatch.setattr("cw.cli.wait_for_terminal", _capture)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "dev-queue",
+                "wait",
+                "GEN-18",
+                "--client",
+                "genhealth",
+                "--timeout",
+                "42",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert captured == [42.0]
+
+    def test_wait_exit_codes_match_constants(self) -> None:
+        """Named exit-code constants have the expected integer values."""
+        from cw.cli import _WAIT_EXIT_BLOCKED, _WAIT_EXIT_FAILED, _WAIT_EXIT_TIMEOUT
+
+        assert _WAIT_EXIT_FAILED == 1
+        assert _WAIT_EXIT_BLOCKED == 2
+        assert _WAIT_EXIT_TIMEOUT == 124

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -1172,9 +1172,7 @@ class TestWaitForTerminal:
     @pytest.fixture(autouse=True)
     def _patch_consume(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Stub consume_completed_sessions so tests don't touch event cursor."""
-        monkeypatch.setattr(
-            "cw.dev_queue.consume_completed_sessions", lambda: 0
-        )
+        monkeypatch.setattr("cw.dev_queue.consume_completed_sessions", lambda: 0)
 
     def test_wait_completed_returns_immediately(self, tmp_config_dir: Path) -> None:
         """COMPLETED ticket returns on the first load, no polling."""

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -1138,6 +1138,30 @@ class TestMigrateDevQueue:
 
 
 # ---------------------------------------------------------------------------
+# TestConsumeCompletedSessionsWrapper
+# ---------------------------------------------------------------------------
+
+
+class TestConsumeCompletedSessionsWrapper:
+    """Tests for the consume_completed_sessions wrapper in dev_queue."""
+
+    def test_wrapper_delegates_to_dispatch(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """consume_completed_sessions() delegates to dispatch implementation."""
+        from cw.dev_queue import consume_completed_sessions
+
+        called: list[int] = []
+        monkeypatch.setattr(
+            "cw.dispatch.consume_completed_sessions",
+            lambda: called.append(1) or 3,
+        )
+        result = consume_completed_sessions()
+        assert result == 3
+        assert called == [1]
+
+
+# ---------------------------------------------------------------------------
 # TestWaitForTerminal
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -25,6 +25,7 @@ from cw.dev_queue import (
     resolve_client,
     save_dev_queue,
     save_plan,
+    wait_for_terminal,
 )
 from cw.exceptions import CwError
 from cw.models import (
@@ -1134,3 +1135,158 @@ class TestMigrateDevQueue:
         raw: dict[str, object] = {"schema_version": 1}
         migrated = migrate_dev_queue(raw)
         assert migrated["schema_version"] == DEV_QUEUE_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# TestWaitForTerminal
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForTerminal:
+    """Tests for wait_for_terminal()."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_consume(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub consume_completed_sessions so tests don't touch event cursor."""
+        monkeypatch.setattr(
+            "cw.dev_queue.consume_completed_sessions", lambda: 0
+        )
+
+    def test_wait_completed_returns_immediately(self, tmp_config_dir: Path) -> None:
+        """COMPLETED ticket returns on the first load, no polling."""
+        task = TicketTask(
+            ticket_id="GEN-1",
+            client="genhealth",
+            status=QueueItemStatus.COMPLETED,
+            session_id="sess-1",
+        )
+        store = DevQueueStore(tasks=[task])
+        save_dev_queue(store)
+
+        result = wait_for_terminal("GEN-1", "genhealth", timeout=5, poll_interval=0)
+        assert result.status == QueueItemStatus.COMPLETED
+        assert result.session_id == "sess-1"
+
+    def test_wait_failed_returns_immediately(self, tmp_config_dir: Path) -> None:
+        """FAILED ticket returns immediately."""
+        task = TicketTask(
+            ticket_id="GEN-2",
+            client="genhealth",
+            status=QueueItemStatus.FAILED,
+        )
+        store = DevQueueStore(tasks=[task])
+        save_dev_queue(store)
+
+        result = wait_for_terminal("GEN-2", "genhealth", timeout=5, poll_interval=0)
+        assert result.status == QueueItemStatus.FAILED
+
+    def test_wait_cancelled_returns_immediately(self, tmp_config_dir: Path) -> None:
+        """CANCELLED ticket returns immediately."""
+        task = TicketTask(
+            ticket_id="GEN-3",
+            client="genhealth",
+            status=QueueItemStatus.CANCELLED,
+        )
+        store = DevQueueStore(tasks=[task])
+        save_dev_queue(store)
+
+        result = wait_for_terminal("GEN-3", "genhealth", timeout=5, poll_interval=0)
+        assert result.status == QueueItemStatus.CANCELLED
+
+    def test_wait_blocked_on_user_returns_immediately(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """BLOCKED_ON_USER ticket returns immediately."""
+        task = TicketTask(
+            ticket_id="GEN-4",
+            client="genhealth",
+            status=QueueItemStatus.BLOCKED_ON_USER,
+        )
+        store = DevQueueStore(tasks=[task])
+        save_dev_queue(store)
+
+        result = wait_for_terminal("GEN-4", "genhealth", timeout=5, poll_interval=0)
+        assert result.status == QueueItemStatus.BLOCKED_ON_USER
+
+    def test_wait_already_terminal_at_start(self, tmp_config_dir: Path) -> None:
+        """Already-COMPLETED ticket never enters the polling loop."""
+        task = TicketTask(
+            ticket_id="GEN-5",
+            client="genhealth",
+            status=QueueItemStatus.COMPLETED,
+        )
+        store = DevQueueStore(tasks=[task])
+        save_dev_queue(store)
+
+        # timeout=0 — would immediately time out if polling were entered
+        result = wait_for_terminal("GEN-5", "genhealth", timeout=0, poll_interval=0)
+        assert result.status == QueueItemStatus.COMPLETED
+
+    def test_wait_running_then_completed(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """RUNNING on first tick, COMPLETED on second tick."""
+        task = TicketTask(
+            ticket_id="GEN-6",
+            client="genhealth",
+            status=QueueItemStatus.RUNNING,
+            session_id="sess-6",
+        )
+        store = DevQueueStore(tasks=[task])
+        save_dev_queue(store)
+
+        call_count = 0
+
+        def _side_effect() -> int:
+            nonlocal call_count
+            call_count += 1
+            # On the second consume call, transition the task to COMPLETED
+            if call_count >= 2:
+                updated = load_dev_queue()
+                for t in updated.tasks:
+                    if t.ticket_id == "GEN-6":
+                        t.status = QueueItemStatus.COMPLETED
+                save_dev_queue(updated)
+            return 0
+
+        monkeypatch.setattr("cw.dev_queue.consume_completed_sessions", _side_effect)
+
+        result = wait_for_terminal("GEN-6", "genhealth", timeout=60, poll_interval=0)
+        assert result.status == QueueItemStatus.COMPLETED
+        assert call_count >= 2
+
+    def test_wait_timeout_raises(self, tmp_config_dir: Path) -> None:
+        """Stays RUNNING past timeout → raises TimeoutError."""
+        task = TicketTask(
+            ticket_id="GEN-7",
+            client="genhealth",
+            status=QueueItemStatus.RUNNING,
+        )
+        store = DevQueueStore(tasks=[task])
+        save_dev_queue(store)
+
+        with pytest.raises(TimeoutError):
+            wait_for_terminal("GEN-7", "genhealth", timeout=0, poll_interval=0)
+
+    def test_wait_not_found_raises_cw_error(self, tmp_config_dir: Path) -> None:
+        """Ticket not in queue raises CwError."""
+        store = DevQueueStore(tasks=[])
+        save_dev_queue(store)
+
+        with pytest.raises(CwError, match="No dev-queue task found"):
+            wait_for_terminal("GEN-999", "genhealth", timeout=5, poll_interval=0)
+
+    def test_wait_session_id_none(self, tmp_config_dir: Path) -> None:
+        """session_id=None on a terminal task does not cause errors."""
+        task = TicketTask(
+            ticket_id="GEN-8",
+            client="genhealth",
+            status=QueueItemStatus.COMPLETED,
+            session_id=None,
+        )
+        store = DevQueueStore(tasks=[task])
+        save_dev_queue(store)
+
+        result = wait_for_terminal("GEN-8", "genhealth", timeout=5, poll_interval=0)
+        assert result.status == QueueItemStatus.COMPLETED
+        assert result.session_id is None


### PR DESCRIPTION
## Summary

- Adds `cw dev-queue wait <ticket> [--client/-c] [--timeout] [--json]` command to the `dev-queue` group
- Implements `wait_for_terminal()` helper in `dev_queue.py` with injectable `poll_interval` for testing
- Calls `consume_completed_sessions()` each poll tick so it works without a running dispatch loop
- Discriminated exit codes: COMPLETED→0, FAILED/CANCELLED→1, BLOCKED_ON_USER→2, timeout→124
- `--json` emits stable bespoke shape: `{"ticket_id", "client", "status", "session_id"}`

## Test plan

- [x] `tests/test_dev_queue.py`: unit tests for `wait_for_terminal` with `poll_interval=0` — each terminal status, timeout, not-found, already-terminal-at-start, `session_id=None`, RUNNING→COMPLETED transition
- [x] `tests/test_cli.py`: CliRunner tests — exit codes per status, `--json` shape, `--timeout` wiring, exit code constant values
- [x] 251 targeted tests pass, 1570 full suite pass
- [x] Patch coverage 100% (all new lines covered)
- [x] ruff + mypy --strict clean

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)