### PR TITLE
feat(doctor): warn on installed-vs-source cw version drift (deploy-gap detector) (#411)

### DIFF
--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -108,6 +108,9 @@ _CW_VERSION_CHECK_NAME = "cw-version"
 # Reinstall command surfaced in warnings when the installed cw is stale.
 _CW_REINSTALL_CMD = "uv tool install --reinstall claude-workspace"
 
+# Package name used for importlib.metadata lookups.
+_CW_PACKAGE_NAME = "claude-workspace"
+
 # Number of consecutive FRESHNESS_GATE ticks required to declare a loop stall.
 _LOOP_STALL_CONSECUTIVE_TICKS = 3
 
@@ -881,6 +884,21 @@ def _check_bypass_disclaimer() -> CheckResult:
     )
 
 
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse a 'X.Y.Z' version string into a comparable int tuple.
+
+    Returns an empty tuple when the string is absent, too short, or
+    non-numeric — callers treat an empty return as "unparseable".
+    """
+    parts = v.split(".")
+    if len(parts) < _VERSION_PARTS:
+        return ()
+    try:
+        return tuple(int(p) for p in parts[:_VERSION_PARTS])
+    except ValueError:
+        return ()
+
+
 def _check_claude_version() -> CheckResult:
     """Check that the claude binary is reachable and return its version.
 
@@ -916,17 +934,8 @@ def _check_claude_version() -> CheckResult:
 
     # Parse the leading X.Y.Z token from the version line.
     first_token = version_line.split()[0] if version_line else ""
-    parts = first_token.split(".")
-    if len(parts) < _VERSION_PARTS:
-        return CheckResult(
-            "claude-version",
-            ok=True,
-            warn=True,
-            detail=f"could not parse version: {version_line}",
-        )
-    try:
-        parsed = tuple(int(p) for p in parts[:3])
-    except (ValueError, AttributeError):
+    parsed = _parse_version(first_token)
+    if not parsed:
         return CheckResult(
             "claude-version",
             ok=True,
@@ -957,7 +966,7 @@ def _check_cw_version() -> CheckResult:
     source or when the source path is stale/unreadable.
     """
     try:
-        dist = importlib.metadata.distribution("claude-workspace")
+        dist = importlib.metadata.distribution(_CW_PACKAGE_NAME)
     except importlib.metadata.PackageNotFoundError:
         return CheckResult(
             _CW_VERSION_CHECK_NAME,
@@ -982,7 +991,7 @@ def _check_cw_version() -> CheckResult:
             _CW_VERSION_CHECK_NAME,
             ok=True,
             warn=False,
-            detail="installed from registry; skipping source check",
+            detail="malformed direct_url.json; skipping source check",
         )
 
     url = direct_url.get("url", "")
@@ -1020,17 +1029,10 @@ def _check_cw_version() -> CheckResult:
             detail=f"could not read source version from {pyproject_path}",
         )
 
-    installed_version_str = importlib.metadata.version("claude-workspace")
+    installed_version_str = importlib.metadata.version(_CW_PACKAGE_NAME)
 
-    def _parse(v: str) -> tuple[int, ...]:
-        parts = v.split(".")
-        try:
-            return tuple(int(p) for p in parts[:_VERSION_PARTS])
-        except ValueError:
-            return ()
-
-    installed_ver = _parse(installed_version_str)
-    source_ver = _parse(source_version_str)
+    installed_ver = _parse_version(installed_version_str)
+    source_ver = _parse_version(source_version_str)
 
     if not installed_ver or not source_ver:
         return CheckResult(

--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -10,9 +10,12 @@ assert on specific checks.
 
 from __future__ import annotations
 
+import importlib.metadata
 import json
 import os
 import subprocess as _sp
+import tomllib
+import urllib.parse
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -98,6 +101,12 @@ _MIN_CLAUDE_VERSION = (2, 1, 139)
 
 # Number of components (major.minor.patch) required in a version string.
 _VERSION_PARTS = 3
+
+# Check name for the installed-vs-source cw version drift detector.
+_CW_VERSION_CHECK_NAME = "cw-version"
+
+# Reinstall command surfaced in warnings when the installed cw is stale.
+_CW_REINSTALL_CMD = "uv tool install --reinstall claude-workspace"
 
 # Number of consecutive FRESHNESS_GATE ticks required to declare a loop stall.
 _LOOP_STALL_CONSECUTIVE_TICKS = 3
@@ -812,6 +821,7 @@ def run_doctor(*, reap: bool = False) -> DoctorReport:
 
     report.checks.append(_check_bypass_disclaimer())
     report.checks.append(_check_claude_version())
+    report.checks.append(_check_cw_version())
     report.checks.append(_check_daemon_reachable())
     report.checks.extend(_check_loop_health())
     report.checks.extend(_check_workspace_paths())
@@ -936,6 +946,120 @@ def _check_claude_version() -> CheckResult:
         )
 
     return CheckResult("claude-version", ok=True, detail=version_line)
+
+
+def _check_cw_version() -> CheckResult:
+    """Check whether the installed cw matches the source repo's pyproject.toml version.
+
+    Silent-skips (ok=True, warn=False) for registry/PyPI installs and when
+    package metadata is absent — source-version comparison only makes sense
+    for local installs. Warns (ok=True, warn=True) when installed is behind
+    source or when the source path is stale/unreadable.
+    """
+    try:
+        dist = importlib.metadata.distribution("claude-workspace")
+    except importlib.metadata.PackageNotFoundError:
+        return CheckResult(
+            _CW_VERSION_CHECK_NAME,
+            ok=True,
+            warn=False,
+            detail="installed from registry; skipping source check",
+        )
+
+    direct_url_text = dist.read_text("direct_url.json")
+    if direct_url_text is None:
+        return CheckResult(
+            _CW_VERSION_CHECK_NAME,
+            ok=True,
+            warn=False,
+            detail="installed from registry; skipping source check",
+        )
+
+    try:
+        direct_url: dict[str, object] = json.loads(direct_url_text)
+    except json.JSONDecodeError:
+        return CheckResult(
+            _CW_VERSION_CHECK_NAME,
+            ok=True,
+            warn=False,
+            detail="installed from registry; skipping source check",
+        )
+
+    url = direct_url.get("url", "")
+    if not isinstance(url, str) or not url.startswith("file://"):
+        return CheckResult(
+            _CW_VERSION_CHECK_NAME,
+            ok=True,
+            warn=False,
+            detail="installed from registry; skipping source check",
+        )
+
+    source_path = Path(urllib.parse.urlparse(url).path)
+
+    if not source_path.exists():
+        return CheckResult(
+            _CW_VERSION_CHECK_NAME,
+            ok=True,
+            warn=True,
+            detail=(
+                f"source path {source_path} no longer exists"
+                f" — run `{_CW_REINSTALL_CMD}`"
+            ),
+        )
+
+    pyproject_path = source_path / "pyproject.toml"
+    try:
+        with pyproject_path.open("rb") as fh:
+            pyproject = tomllib.load(fh)
+        source_version_str: str = pyproject["project"]["version"]
+    except (FileNotFoundError, KeyError, tomllib.TOMLDecodeError, OSError):
+        return CheckResult(
+            _CW_VERSION_CHECK_NAME,
+            ok=True,
+            warn=True,
+            detail=f"could not read source version from {pyproject_path}",
+        )
+
+    installed_version_str = importlib.metadata.version("claude-workspace")
+
+    def _parse(v: str) -> tuple[int, ...]:
+        parts = v.split(".")
+        try:
+            return tuple(int(p) for p in parts[:_VERSION_PARTS])
+        except ValueError:
+            return ()
+
+    installed_ver = _parse(installed_version_str)
+    source_ver = _parse(source_version_str)
+
+    if not installed_ver or not source_ver:
+        return CheckResult(
+            _CW_VERSION_CHECK_NAME,
+            ok=True,
+            warn=True,
+            detail=(
+                f"could not compare versions:"
+                f" installed={installed_version_str} source={source_version_str}"
+            ),
+        )
+
+    if installed_ver < source_ver:
+        return CheckResult(
+            _CW_VERSION_CHECK_NAME,
+            ok=True,
+            warn=True,
+            detail=(
+                f"installed {installed_version_str} < source {source_version_str}"
+                f" — run `{_CW_REINSTALL_CMD}`"
+            ),
+        )
+
+    return CheckResult(
+        _CW_VERSION_CHECK_NAME,
+        ok=True,
+        warn=False,
+        detail=f"installed {installed_version_str} matches source",
+    )
 
 
 def _check_daemon_reachable() -> CheckResult:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -3236,13 +3236,14 @@ class TestCheckCwVersion:
         source_dir = tmp_path / "claude-workspace"
         source_dir.mkdir()
         (source_dir / "pyproject.toml").write_text(
-            '[project]\nname = "claude-workspace"\nversion = "dev"\n'
+            '[project]\nname = "claude-workspace"\nversion = "0.14.dev1"\n'
         )
         self._patch_dist(
             monkeypatch,
             direct_url_text=json.dumps({"url": f"file://{source_dir}"}),
         )
-        monkeypatch.setattr(importlib.metadata, "version", lambda _pkg: "dev")
+        # "0.14.dev1" → 3 parts but "dev1" is non-numeric → ValueError in _parse_version
+        monkeypatch.setattr(importlib.metadata, "version", lambda _pkg: "0.14.dev1")
         result = _check_cw_version()
         assert result.ok is True
         assert result.warn is True

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -3031,3 +3031,230 @@ class TestCheckTimedOutMerged:
         monkeypatch.setattr("cw.doctor._sp.run", _raise_timeout)
         results = _check_timed_out_merged(state)
         assert not any(r.warn for r in results)
+
+
+# ---------------------------------------------------------------------------
+# _check_cw_version: installed-vs-source version drift detector
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCwVersion:
+    """Direct tests for _check_cw_version via monkeypatched importlib.metadata."""
+
+    def _patch_dist(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        direct_url_text: str | None,
+    ) -> None:
+        import importlib.metadata
+
+        class FakeDist:
+            def read_text(self, filename: str) -> str | None:
+                if filename == "direct_url.json":
+                    return direct_url_text
+                return None
+
+        monkeypatch.setattr(importlib.metadata, "distribution", lambda _pkg: FakeDist())
+
+    def test_package_not_found_skips_silently(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PackageNotFoundError → ok=True, warn=False (registry/unknown install)."""
+        import importlib.metadata
+
+        from cw.doctor import _check_cw_version
+
+        def _raise(_pkg: str) -> object:
+            raise importlib.metadata.PackageNotFoundError(_pkg)
+
+        monkeypatch.setattr(importlib.metadata, "distribution", _raise)
+        result = _check_cw_version()
+        assert result.ok is True
+        assert result.warn is False
+        assert "registry" in result.detail
+
+    def test_registry_install_no_direct_url_skips_silently(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """direct_url.json absent (None) → ok=True, warn=False."""
+        from cw.doctor import _check_cw_version
+
+        self._patch_dist(monkeypatch, direct_url_text=None)
+        result = _check_cw_version()
+        assert result.ok is True
+        assert result.warn is False
+
+    def test_registry_install_https_url_skips_silently(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """direct_url.json with https:// URL → ok=True, warn=False."""
+        import json
+
+        from cw.doctor import _check_cw_version
+
+        self._patch_dist(
+            monkeypatch,
+            direct_url_text=json.dumps(
+                {
+                    "url": "https://files.pythonhosted.org/packages/claude-workspace-0.14.2.tar.gz"
+                }
+            ),
+        )
+        result = _check_cw_version()
+        assert result.ok is True
+        assert result.warn is False
+
+    def test_stale_source_path_warns_with_reinstall(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-existent source path → ok=True, warn=True, detail names path."""
+        import json
+
+        from cw.doctor import _CW_REINSTALL_CMD, _check_cw_version
+
+        missing_path = "/nonexistent/path/to/claude-workspace"
+        self._patch_dist(
+            monkeypatch,
+            direct_url_text=json.dumps({"url": f"file://{missing_path}"}),
+        )
+        result = _check_cw_version()
+        assert result.ok is True
+        assert result.warn is True
+        assert missing_path in result.detail
+        assert _CW_REINSTALL_CMD in result.detail
+
+    def test_missing_pyproject_warns(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Source path exists but pyproject.toml missing → ok=True, warn=True."""
+        import json
+
+        from cw.doctor import _check_cw_version
+
+        source_dir = tmp_path / "claude-workspace"
+        source_dir.mkdir()
+        self._patch_dist(
+            monkeypatch,
+            direct_url_text=json.dumps({"url": f"file://{source_dir}"}),
+        )
+        result = _check_cw_version()
+        assert result.ok is True
+        assert result.warn is True
+
+    def test_installed_behind_source_warns(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """installed 0.13.0 < source 0.14.2 → ok=True, warn=True with reinstall cmd."""
+        import importlib.metadata
+        import json
+
+        from cw.doctor import _CW_REINSTALL_CMD, _check_cw_version
+
+        source_dir = tmp_path / "claude-workspace"
+        source_dir.mkdir()
+        (source_dir / "pyproject.toml").write_text(
+            '[project]\nname = "claude-workspace"\nversion = "0.14.2"\n'
+        )
+        self._patch_dist(
+            monkeypatch,
+            direct_url_text=json.dumps({"url": f"file://{source_dir}"}),
+        )
+        monkeypatch.setattr(importlib.metadata, "version", lambda _pkg: "0.13.0")
+        result = _check_cw_version()
+        assert result.ok is True
+        assert result.warn is True
+        assert "0.13.0" in result.detail
+        assert "0.14.2" in result.detail
+        assert _CW_REINSTALL_CMD in result.detail
+
+    def test_installed_matches_source_ok(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """installed 0.14.2 == source 0.14.2 → ok=True, warn=False."""
+        import importlib.metadata
+        import json
+
+        from cw.doctor import _check_cw_version
+
+        source_dir = tmp_path / "claude-workspace"
+        source_dir.mkdir()
+        (source_dir / "pyproject.toml").write_text(
+            '[project]\nname = "claude-workspace"\nversion = "0.14.2"\n'
+        )
+        self._patch_dist(
+            monkeypatch,
+            direct_url_text=json.dumps({"url": f"file://{source_dir}"}),
+        )
+        monkeypatch.setattr(importlib.metadata, "version", lambda _pkg: "0.14.2")
+        result = _check_cw_version()
+        assert result.ok is True
+        assert result.warn is False
+
+    def test_installed_ahead_of_source_ok(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """installed 0.14.3 > source 0.14.2 → ok=True, warn=False (dev scenario)."""
+        import importlib.metadata
+        import json
+
+        from cw.doctor import _check_cw_version
+
+        source_dir = tmp_path / "claude-workspace"
+        source_dir.mkdir()
+        (source_dir / "pyproject.toml").write_text(
+            '[project]\nname = "claude-workspace"\nversion = "0.14.2"\n'
+        )
+        self._patch_dist(
+            monkeypatch,
+            direct_url_text=json.dumps({"url": f"file://{source_dir}"}),
+        )
+        monkeypatch.setattr(importlib.metadata, "version", lambda _pkg: "0.14.3")
+        result = _check_cw_version()
+        assert result.ok is True
+        assert result.warn is False
+
+    def test_invalid_json_in_direct_url_skips_silently(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed direct_url.json → ok=True, warn=False (silent skip)."""
+        from cw.doctor import _check_cw_version
+
+        self._patch_dist(monkeypatch, direct_url_text="not-valid-json{")
+        result = _check_cw_version()
+        assert result.ok is True
+        assert result.warn is False
+
+    def test_unparseable_version_warns(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Non-numeric version strings → ok=True, warn=True with 'could not compare'."""
+        import importlib.metadata
+        import json
+
+        from cw.doctor import _check_cw_version
+
+        source_dir = tmp_path / "claude-workspace"
+        source_dir.mkdir()
+        (source_dir / "pyproject.toml").write_text(
+            '[project]\nname = "claude-workspace"\nversion = "dev"\n'
+        )
+        self._patch_dist(
+            monkeypatch,
+            direct_url_text=json.dumps({"url": f"file://{source_dir}"}),
+        )
+        monkeypatch.setattr(importlib.metadata, "version", lambda _pkg: "dev")
+        result = _check_cw_version()
+        assert result.ok is True
+        assert result.warn is True
+        assert "could not compare" in result.detail
+
+    def test_check_included_in_run_doctor(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_config_dir: Path
+    ) -> None:
+        """_check_cw_version is wired into run_doctor output."""
+        from cw.doctor import _CW_VERSION_CHECK_NAME, run_doctor
+
+        _stub_claude_version_ok(monkeypatch)
+        report = run_doctor()
+        check_names = [c.name for c in report.checks]
+        assert _CW_VERSION_CHECK_NAME in check_names


### PR DESCRIPTION
Implements #411 — a `cw-version` doctor check that warns when the installed cw is behind the source `pyproject.toml` version (deploy-gap detector).

Per the pre-flight resolutions on #411:
- Source = source-repo `pyproject.toml` version (no git-tag path); semver-tuple `<` compare, warn-only when installed is behind.
- Source-path discovery via `importlib.metadata.distribution(...).read_text("direct_url.json")`.
- Two-tier error handling mirroring `_check_claude_version` (registry install → silent skip; local install but source missing/unparseable → warn).
- **Stale/deleted source path** (ambiguity resolved during the run): explicit detection → `ok=True, warn=True` with an actionable `uv tool install --reinstall` hint (via the `_CW_REINSTALL_CMD` constant).
- Version-string compare only; same-version-stale-code (#473) and the RECORD-hash bonus are out of scope.

**Salvage note:** the auto-dev worker completed implementation + Stage 3 review (2 MUST_FIX resolved) and reached the merge gate, then hit a global session-usage limit before opening the PR. This PR ships that completed, reviewed work. Files: `doctor.py` + `test_doctor.py` only.

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)