### PR TITLE
fix(worktree): filter .claude/ artifacts and fix unpushed-commits false-positive (#472, #481)

### DIFF
--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -283,7 +283,17 @@ def worktree_has_unsaved_work(client: ClientConfig, branch: str) -> bool:
     # 1. Uncommitted changes check
     try:
         status = _run_git("status", "--porcelain", cwd=wt_path, check=False)
-        if status.stdout.strip():
+        # Filter out cw's own artifacts (.claude/) — these are written fresh
+        # each session and would otherwise trip the dirty check on every retry.
+        # Porcelain format: "XY path" (2-char status + space + path). Rename
+        # entries ("R  old -> new") pass through unchanged; cw artifacts never
+        # appear as renames so they will still be caught by path check.
+        lines = [
+            line
+            for line in status.stdout.splitlines()
+            if not (len(line) > 3 and line[3:].startswith(".claude/"))
+        ]
+        if lines:
             return True
     except (WorktreeError, OSError) as exc:
         _log.warning(
@@ -296,8 +306,12 @@ def worktree_has_unsaved_work(client: ClientConfig, branch: str) -> bool:
         return True
 
     # 2. Unpushed commits check — compare HEAD against origin/<branch>.
-    # First verify that origin/<branch> exists; if not, every HEAD commit is
-    # "unpushed" (conservative).
+    # Three-level fallback when the remote tracking branch is absent:
+    #   1. origin/<branch> present  → git log origin/<branch>..HEAD
+    #   2. origin/<branch> absent   → git log origin/<default_branch>..HEAD
+    #   3. origin/<default_branch> absent (offline) → git log <default_branch>..HEAD
+    # returncode != 0 from a log call means the ref is unknown — fall through
+    # to the next level. The except handler fires on subprocess-level failures.
     try:
         ref_check = _run_git(
             "rev-parse",
@@ -306,20 +320,40 @@ def worktree_has_unsaved_work(client: ClientConfig, branch: str) -> bool:
             cwd=wt_path,
             check=False,
         )
-        if ref_check.returncode != 0:
-            # origin/<branch> unknown — check whether HEAD has any commits
-            head_check = _run_git(
-                "rev-parse", "--verify", "HEAD", cwd=wt_path, check=False
+        if ref_check.returncode == 0:
+            # Level 1: origin/<branch> exists — canonical happy path.
+            log_result = _run_git(
+                "log",
+                f"origin/{branch}..HEAD",
+                "--oneline",
+                cwd=wt_path,
+                check=False,
             )
-            return head_check.returncode == 0 and bool(head_check.stdout.strip())
+            return bool(log_result.stdout.strip())
+
+        # Level 2: origin/<branch> absent — compare against origin/<default_branch>.
+        default_base = f"origin/{client.default_branch}"
         log_result = _run_git(
             "log",
-            f"origin/{branch}..HEAD",
+            f"{default_base}..HEAD",
             "--oneline",
             cwd=wt_path,
             check=False,
         )
-        return bool(log_result.stdout.strip())
+        if log_result.returncode == 0:
+            return bool(log_result.stdout.strip())
+
+        # Level 3: origin/<default_branch> also absent (offline / bare clone) —
+        # fall back to local default branch ref.
+        log_result = _run_git(
+            "log",
+            f"{client.default_branch}..HEAD",
+            "--oneline",
+            cwd=wt_path,
+            check=False,
+        )
+        if log_result.returncode == 0:
+            return bool(log_result.stdout.strip())
     except (WorktreeError, OSError) as exc:
         _log.warning(
             "worktree_has_unsaved_work: log check failed for %s/%s: %s",
@@ -329,6 +363,8 @@ def worktree_has_unsaved_work(client: ClientConfig, branch: str) -> bool:
         )
         # Fail-safe: treat as having unsaved work.
         return True
+    # All refs unresolvable — conservative fail-safe.
+    return True
 
 
 def _fetch_default_branch(client_name: str, default_branch: str, git_dir: Path) -> bool:

--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -25,6 +25,8 @@ _log = logging.getLogger(__name__)
 # (``~/.cw/wt/``) is used in practice — keeping paths short and predictable.
 _WORKTREE_NAME_CAP = 64
 _HASH_BASE_SEGMENTS = (".cw", "wt")
+# Git porcelain v1 format: "XY path" — 2-char status prefix + 1 space = 3 chars.
+_GIT_PORCELAIN_PATH_OFFSET = 3
 # 8 hex chars = 32 bits. For a single-user tool with a handful of
 # clients the collision probability is negligible; raising this value
 # pushes the hashed base closer to _WORKTREE_NAME_CAP and reduces
@@ -262,56 +264,15 @@ def remove_worktree(
     _run_git(*args, cwd=_git_dir(client))
 
 
-def worktree_has_unsaved_work(client: ClientConfig, branch: str) -> bool:
-    """Return True if the worktree for *branch* has unsaved work.
+def _has_unpushed_commits(client: ClientConfig, branch: str, wt_path: Path) -> bool:
+    """Return True if *branch* has commits not on any known base ref.
 
-    "Unsaved" means either:
-    - uncommitted changes (``git status --porcelain`` is non-empty), OR
-    - unpushed commits (``git log origin/<branch>..HEAD`` is non-empty).
-
-    Returns False when the worktree path does not exist (nothing to lose).
-    When ``origin/<branch>`` does not exist, treats all HEAD commits as
-    unpushed (conservative: assume they would be lost).
-
-    Never raises — every git error is swallowed and logged at WARNING level
-    so that a git failure cannot block a cleanup sweep.
+    Three-level fallback:
+    1. ``origin/<branch>`` — canonical; used when the branch was pushed.
+    2. ``origin/<default_branch>`` — fallback when branch has no remote yet.
+    3. Local ``<default_branch>`` — offline / bare-clone fallback.
+    Returns True conservatively on subprocess failure or all-refs-absent.
     """
-    wt_path = worktree_path_for(client, branch)
-    if not wt_path.exists():
-        return False
-
-    # 1. Uncommitted changes check
-    try:
-        status = _run_git("status", "--porcelain", cwd=wt_path, check=False)
-        # Filter out cw's own artifacts (.claude/) — these are written fresh
-        # each session and would otherwise trip the dirty check on every retry.
-        # Porcelain format: "XY path" (2-char status + space + path). Rename
-        # entries ("R  old -> new") pass through unchanged; cw artifacts never
-        # appear as renames so they will still be caught by path check.
-        lines = [
-            line
-            for line in status.stdout.splitlines()
-            if not (len(line) > 3 and line[3:].startswith(".claude/"))
-        ]
-        if lines:
-            return True
-    except (WorktreeError, OSError) as exc:
-        _log.warning(
-            "worktree_has_unsaved_work: status check failed for %s/%s: %s",
-            client.name,
-            branch,
-            exc,
-        )
-        # Fail-safe: treat as having unsaved work so we don't silently destroy.
-        return True
-
-    # 2. Unpushed commits check — compare HEAD against origin/<branch>.
-    # Three-level fallback when the remote tracking branch is absent:
-    #   1. origin/<branch> present  → git log origin/<branch>..HEAD
-    #   2. origin/<branch> absent   → git log origin/<default_branch>..HEAD
-    #   3. origin/<default_branch> absent (offline) → git log <default_branch>..HEAD
-    # returncode != 0 from a log call means the ref is unknown — fall through
-    # to the next level. The except handler fires on subprocess-level failures.
     try:
         ref_check = _run_git(
             "rev-parse",
@@ -365,6 +326,58 @@ def worktree_has_unsaved_work(client: ClientConfig, branch: str) -> bool:
         return True
     # All refs unresolvable — conservative fail-safe.
     return True
+
+
+def worktree_has_unsaved_work(client: ClientConfig, branch: str) -> bool:
+    """Return True if the worktree for *branch* has unsaved work.
+
+    "Unsaved" means either:
+    - uncommitted changes (``git status --porcelain`` is non-empty), OR
+    - unpushed commits (``git log origin/<branch>..HEAD`` is non-empty).
+
+    Returns False when the worktree path does not exist (nothing to lose).
+    When ``origin/<branch>`` does not exist, falls back to comparing against
+    ``origin/<default_branch>`` then the local ``<default_branch>`` ref. If
+    all refs are unresolvable (e.g. offline), returns True conservatively.
+
+    Never raises — every git error is swallowed and logged at WARNING level
+    so that a git failure cannot block a cleanup sweep.
+    """
+    wt_path = worktree_path_for(client, branch)
+    if not wt_path.exists():
+        return False
+
+    # 1. Uncommitted changes check
+    try:
+        status = _run_git("status", "--porcelain", cwd=wt_path, check=False)
+        # Filter out cw's own artifacts (.claude/) — these are written fresh
+        # each session and would otherwise trip the dirty check on every retry.
+        # Porcelain format: "XY path" (2-char status + space + path). Rename
+        # entries ("R  old -> new") pass through unchanged; cw artifacts never
+        # appear as renames so they will still be caught by path check.
+        lines = [
+            line
+            for line in status.stdout.splitlines()
+            if not (
+                len(line) > _GIT_PORCELAIN_PATH_OFFSET
+                and line[_GIT_PORCELAIN_PATH_OFFSET:].startswith(".claude/")
+            )
+        ]
+        if lines:
+            return True
+    except (WorktreeError, OSError) as exc:
+        _log.warning(
+            "worktree_has_unsaved_work: status check failed for %s/%s: %s",
+            client.name,
+            branch,
+            exc,
+        )
+        # Fail-safe: treat as having unsaved work so we don't silently destroy.
+        return True
+
+    # 2. Unpushed commits check — three-level fallback when remote tracking
+    # branch is absent (see _has_unpushed_commits for the strategy).
+    return _has_unpushed_commits(client, branch, wt_path)
 
 
 def _fetch_default_branch(client_name: str, default_branch: str, git_dir: Path) -> bool:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1715,3 +1715,71 @@ class TestWorktreeHasUnsavedWork:
 
         monkeypatch.setattr("cw.worktree._run_git", mock_run)
         assert worktree_has_unsaved_work(client, "auto-dev/offline") is True
+
+    def test_returns_true_when_origin_absent_and_local_default_has_commits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Level 3: origin absent, local default present, has commits → True."""
+        client = self._client(tmp_path)
+        wt_path = tmp_path / "wt" / "auto-dev-level3"
+        wt_path.mkdir(parents=True)
+
+        call_count: list[int] = [0]
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=0, stderr="")
+            if "status" in args:
+                result.stdout = ""  # clean working tree
+            elif "rev-parse" in args:
+                result.returncode = 128  # origin/<branch> does NOT exist
+                result.stdout = ""
+            elif "log" in args:
+                call_count[0] += 1
+                if call_count[0] <= 1:
+                    # Level 2: origin/main absent
+                    result.returncode = 128
+                    result.stdout = ""
+                else:
+                    # Level 3: local main present, commits beyond it
+                    result.returncode = 0
+                    result.stdout = "abc1234 local commit\n"
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert worktree_has_unsaved_work(client, "auto-dev/level3") is True
+
+    def test_returns_false_when_origin_absent_and_local_default_clean(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Level 3: origin absent, local default present, no commits → False."""
+        client = self._client(tmp_path)
+        wt_path = tmp_path / "wt" / "auto-dev-level3-clean"
+        wt_path.mkdir(parents=True)
+
+        call_count: list[int] = [0]
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=0, stderr="")
+            if "status" in args:
+                result.stdout = ""  # clean working tree
+            elif "rev-parse" in args:
+                result.returncode = 128  # origin/<branch> does NOT exist
+                result.stdout = ""
+            elif "log" in args:
+                call_count[0] += 1
+                if call_count[0] <= 1:
+                    # Level 2: origin/main absent
+                    result.returncode = 128
+                    result.stdout = ""
+                else:
+                    # Level 3: local main present, no commits beyond it
+                    result.returncode = 0
+                    result.stdout = ""
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert worktree_has_unsaved_work(client, "auto-dev/level3-clean") is False

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1499,10 +1499,10 @@ class TestWorktreeHasUnsavedWork:
         monkeypatch.setattr("cw.worktree._run_git", mock_run)
         assert worktree_has_unsaved_work(client, "auto-dev/unpushed") is True
 
-    def test_returns_true_when_origin_branch_missing_and_head_exists(
+    def test_returns_false_when_origin_branch_absent_and_at_base(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """No origin/<branch> but HEAD exists → treat all commits as unpushed → True."""
+        """No origin/<branch>, branch sitting at base HEAD with 0 commits → False."""
         client = self._client(tmp_path)
         wt_path = tmp_path / "wt" / "auto-dev-noorigin"
         wt_path.mkdir(parents=True)
@@ -1511,23 +1511,48 @@ class TestWorktreeHasUnsavedWork:
             result = MagicMock(returncode=0, stderr="")
             if "status" in args:
                 result.stdout = ""  # clean working tree
-            elif "rev-parse" in args and "origin/" in " ".join(args):
+            elif "rev-parse" in args and "origin/auto-dev/noorigin" in args:
                 result.returncode = 128  # origin/<branch> does NOT exist
                 result.stdout = ""
-            elif "rev-parse" in args and "HEAD" in args:
-                result.returncode = 0  # HEAD exists
-                result.stdout = "abc1234def567890\n"
+            elif "log" in args and "origin/main" in " ".join(args):
+                result.returncode = 0
+                result.stdout = ""  # 0 commits beyond base
             else:
                 result.stdout = ""
             return result
 
         monkeypatch.setattr("cw.worktree._run_git", mock_run)
-        assert worktree_has_unsaved_work(client, "auto-dev/noorigin") is True
+        assert worktree_has_unsaved_work(client, "auto-dev/noorigin") is False
+
+    def test_returns_true_when_origin_branch_absent_and_commits_beyond_base(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No origin/<branch>, branch has commits beyond base → True."""
+        client = self._client(tmp_path)
+        wt_path = tmp_path / "wt" / "auto-dev-noorigin-commits"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=0, stderr="")
+            if "status" in args:
+                result.stdout = ""  # clean working tree
+            elif "rev-parse" in args and "origin/auto-dev" in " ".join(args):
+                result.returncode = 128  # origin/<branch> does NOT exist
+                result.stdout = ""
+            elif "log" in args and "origin/main" in " ".join(args):
+                result.returncode = 0
+                result.stdout = "abc1234 add feature\n"  # real commit beyond base
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert worktree_has_unsaved_work(client, "auto-dev/noorigin-commits") is True
 
     def test_returns_false_when_origin_missing_and_head_absent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """No origin/<branch> and no HEAD commits → nothing to lose → False."""
+        """No origin/<branch> and no commits beyond base → nothing to lose → False."""
         client = self._client(tmp_path)
         wt_path = tmp_path / "wt" / "auto-dev-empty"
         wt_path.mkdir(parents=True)
@@ -1536,12 +1561,12 @@ class TestWorktreeHasUnsavedWork:
             result = MagicMock(returncode=0, stderr="")
             if "status" in args:
                 result.stdout = ""  # clean working tree
-            elif "rev-parse" in args and "origin/" in " ".join(args):
+            elif "rev-parse" in args and "origin/auto-dev" in " ".join(args):
                 result.returncode = 128  # origin/<branch> does NOT exist
                 result.stdout = ""
-            elif "rev-parse" in args and "HEAD" in args:
-                result.returncode = 128  # no commits yet
-                result.stdout = ""
+            elif "log" in args and "origin/main" in " ".join(args):
+                result.returncode = 0  # origin/main exists
+                result.stdout = ""  # no commits beyond base
             else:
                 result.stdout = ""
             return result
@@ -1614,3 +1639,79 @@ class TestWorktreeHasUnsavedWork:
 
         monkeypatch.setattr("cw.worktree._run_git", mock_run)
         assert worktree_has_unsaved_work(client, "auto-dev/logerr") is True
+
+    # --- #472: .claude/ artifact filter ---
+
+    def test_returns_false_when_only_claude_artifacts_untracked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only .claude/ artifacts untracked (cw writes them) → False."""
+        client = self._client(tmp_path)
+        wt_path = tmp_path / "wt" / "auto-dev-artifacts"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=0, stderr="")
+            if "status" in args:
+                result.stdout = (
+                    "?? .claude/cw-context.json\n?? .claude/settings.local.json\n"
+                )
+            elif "rev-parse" in args:
+                result.returncode = 128
+                result.stdout = ""
+            elif "log" in args and "origin/main" in " ".join(args):
+                result.returncode = 0
+                result.stdout = ""  # no commits beyond base
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert worktree_has_unsaved_work(client, "auto-dev/artifacts") is False
+
+    def test_returns_true_when_claude_artifacts_plus_real_untracked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """.claude/ artifacts + real untracked source file → still True."""
+        client = self._client(tmp_path)
+        wt_path = tmp_path / "wt" / "auto-dev-mixed"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=0, stderr="")
+            if "status" in args:
+                result.stdout = "?? .claude/cw-context.json\n?? src/cw/new_feature.py\n"
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert worktree_has_unsaved_work(client, "auto-dev/mixed") is True
+
+    # --- #481: all refs absent fail-safe ---
+
+    def test_returns_true_when_both_origins_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both origin/<branch> and origin/<default_branch> absent (offline) → True."""
+        client = self._client(tmp_path)
+        wt_path = tmp_path / "wt" / "auto-dev-offline"
+        wt_path.mkdir(parents=True)
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=0, stderr="")
+            if "status" in args:
+                result.stdout = ""  # clean working tree
+            elif "rev-parse" in args:
+                result.returncode = 128  # origin/<branch> does NOT exist
+                result.stdout = ""
+            elif "log" in args:
+                # Both origin refs absent — non-zero for any log call
+                result.returncode = 128
+                result.stdout = ""
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert worktree_has_unsaved_work(client, "auto-dev/offline") is True


### PR DESCRIPTION
## Summary

- fix(worktree): filter .claude/ artifacts from porcelain check and add three-level base-branch fallback (#472, #481)
- test(worktree): cover #472 .claude/ filter and #481 base-branch fallback
- test(worktree): add Level 3 local-ref fallback coverage for #481
- refactor(worktree): extract _has_unpushed_commits helper, update docstring (#481 review)

Fixes two related false-positives in `worktree_has_unsaved_work`:
- #472: `.claude/` artifacts tripped the porcelain dirty check
- #481: Fresh branch with no remote tracking was incorrectly reported as having unpushed work

Closes #481, closes #472.

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it