### PR TITLE
fix(dispatch+cli): route clean-exit paused sentinels to BLOCKED_ON_USER (#489)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -20,6 +20,7 @@ from cw.auto_dev_result import (
     BLOCKER_REASON_NO_RESULT_EMITTED,
     BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED,
     BLOCKER_REASON_VALIDATION_FAILED,
+    PAUSED_FOR_USER_INPUT_STATUSES,
     SALVAGE_TERMINAL_STATUSES,
     AutoDevResult,
     BlockedResult,
@@ -1009,7 +1010,9 @@ def _apply_sentinel_to_task(
             return
 
         if isinstance(sentinel, AutoDevResult):
-            if sentinel.status in _TERMINAL_NO_RETRY_STATUSES:
+            if sentinel.status in PAUSED_FOR_USER_INPUT_STATUSES:
+                target.status = QueueItemStatus.BLOCKED_ON_USER
+            elif sentinel.status in _TERMINAL_NO_RETRY_STATUSES:
                 target.status = QueueItemStatus.COMPLETED
             elif sentinel.status == "blocked":
                 retry = (

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -7,7 +7,11 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
-from cw.auto_dev_result import AutoDevResult, parse_stdout
+from cw.auto_dev_result import (
+    PAUSED_FOR_USER_INPUT_STATUSES,
+    AutoDevResult,
+    parse_stdout,
+)
 from cw.config import (
     load_clients,
     load_orchestrator_config,
@@ -501,7 +505,19 @@ def _apply_events_to_store(
                 and task.session_id != event_session_id
             ):
                 continue
-            task.status = QueueItemStatus.COMPLETED
+            state = load_state()
+            session = next(
+                (s for s in state.sessions if s.id == event_session_id),
+                None,
+            )
+            if (
+                session is not None
+                and isinstance(session.last_result, dict)
+                and session.last_result.get("status") in PAUSED_FOR_USER_INPUT_STATUSES
+            ):
+                task.status = QueueItemStatus.BLOCKED_ON_USER
+            else:
+                task.status = QueueItemStatus.COMPLETED
             sid = event_session_id if isinstance(event_session_id, str) else None
             _accumulate_task_cost(task, sid)
             completed += 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1612,17 +1612,17 @@ class TestSignalStop:
         task = next(t for t in store.tasks if t.ticket_id == self.SEED_TICKET_ID)
         assert task.status == QueueItemStatus.COMPLETED
 
-    def test_signal_stop_premises_pending_v2_marks_task_completed(
+    def test_signal_stop_premises_pending_v2_marks_task_blocked_on_user(
         self,
         tmp_config_dir: Path,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """premises_pending_verification at schema_version=2 → COMPLETED.
+        """premises_pending_verification at schema_version=2 → BLOCKED_ON_USER.
 
         Regression for GitHub issue #316: schema_version<4 gate caused
         validation_failed BlockedResult → retry loop. After fix, parses
-        as AutoDevResult → COMPLETED.
+        as AutoDevResult → BLOCKED_ON_USER (not COMPLETED). See #489.
         """
         import datetime as dt
 
@@ -1675,17 +1675,18 @@ class TestSignalStop:
 
         store = load_dev_queue()
         task = next(t for t in store.tasks if t.ticket_id == self.SEED_TICKET_ID)
-        assert task.status == QueueItemStatus.COMPLETED
+        assert task.status == QueueItemStatus.BLOCKED_ON_USER
 
-    def test_signal_stop_ambiguities_pending_v2_marks_task_completed(
+    def test_signal_stop_ambiguities_pending_v2_marks_task_blocked_on_user(
         self,
         tmp_config_dir: Path,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """ambiguities_pending_resolution at schema_version=2 → COMPLETED.
+        """ambiguities_pending_resolution at schema_version=2 → BLOCKED_ON_USER.
 
-        Regression for GitHub issue #316.
+        Regression for GitHub issue #316. Paused sentinels must not be
+        routed to COMPLETED — they require human attention. See #489.
         """
         import datetime as dt
 
@@ -1738,7 +1739,7 @@ class TestSignalStop:
 
         store = load_dev_queue()
         task = next(t for t in store.tasks if t.ticket_id == self.SEED_TICKET_ID)
-        assert task.status == QueueItemStatus.COMPLETED
+        assert task.status == QueueItemStatus.BLOCKED_ON_USER
 
     def test_signal_stop_validation_failed_reverts_to_pending_under_cap(
         self,

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -647,6 +647,130 @@ class TestConsumeCompletesTasks:
         assert completed == 1
         assert load_dev_queue().tasks[0].status == QueueItemStatus.COMPLETED
 
+    def test_consume_paused_status_routes_to_blocked_on_user(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """SESSION_COMPLETED with paused last_result routes task to BLOCKED_ON_USER.
+
+        When a wrapper-path session ends with a paused sentinel
+        (premises_pending_verification or ambiguities_pending_resolution),
+        the task must become BLOCKED_ON_USER, not COMPLETED. See #489.
+        """
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        task = TicketTask(
+            ticket_id="GEN-489A",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+            session_id="sess-489a",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        sess = Session(
+            id="sess-489a",
+            name="test-client/auto-dev/GEN-489A",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=sample_client_config.workspace_path,
+            last_result={"status": "premises_pending_verification", "schema_version": 4},
+        )
+        save_state(CwState(sessions=[sess]))
+
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {"ticket_id": "GEN-489A", "session_id": "sess-489a"},
+        )
+
+        completed = consume_completed_sessions()
+        assert completed == 1
+        assert load_dev_queue().tasks[0].status == QueueItemStatus.BLOCKED_ON_USER
+
+    def test_consume_non_paused_status_routes_to_completed(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """SESSION_COMPLETED with a non-paused last_result routes task to COMPLETED.
+
+        Verifies the paused-status guard does not affect normal shipped/no_op
+        outcomes. See #489.
+        """
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        task = TicketTask(
+            ticket_id="GEN-489B",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+            session_id="sess-489b",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        sess = Session(
+            id="sess-489b",
+            name="test-client/auto-dev/GEN-489B",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=sample_client_config.workspace_path,
+            last_result={"status": "shipped", "schema_version": 4},
+        )
+        save_state(CwState(sessions=[sess]))
+
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {"ticket_id": "GEN-489B", "session_id": "sess-489b"},
+        )
+
+        completed = consume_completed_sessions()
+        assert completed == 1
+        assert load_dev_queue().tasks[0].status == QueueItemStatus.COMPLETED
+
+    def test_consume_null_last_result_routes_to_completed(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """SESSION_COMPLETED with last_result=None routes task to COMPLETED.
+
+        Sessions that did not emit a sentinel (e.g. interactive) have
+        last_result=None; they must fall through to COMPLETED. See #489.
+        """
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        task = TicketTask(
+            ticket_id="GEN-489C",
+            client="test-client",
+            status=QueueItemStatus.RUNNING,
+            session_id="sess-489c",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        sess = Session(
+            id="sess-489c",
+            name="test-client/auto-dev/GEN-489C",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=sample_client_config.workspace_path,
+            last_result=None,
+        )
+        save_state(CwState(sessions=[sess]))
+
+        record_event(
+            OrchestratorEventType.SESSION_COMPLETED,
+            {"ticket_id": "GEN-489C", "session_id": "sess-489c"},
+        )
+
+        completed = consume_completed_sessions()
+        assert completed == 1
+        assert load_dev_queue().tasks[0].status == QueueItemStatus.COMPLETED
+
     def test_consume_advances_cursor(
         self,
         tmp_dispatch_dirs: Path,

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -676,7 +676,10 @@ class TestConsumeCompletesTasks:
             purpose=SessionPurpose.IMPL,
             status=SessionStatus.ACTIVE,
             workspace_path=sample_client_config.workspace_path,
-            last_result={"status": "premises_pending_verification", "schema_version": 4},
+            last_result={
+                "status": "premises_pending_verification",
+                "schema_version": 4,
+            },
         )
         save_state(CwState(sessions=[sess]))
 


### PR DESCRIPTION
## Summary

Completes the paused-routing half of #471 across **both** completion paths. A
clean-exit worker with a paused sentinel (`premises_pending_verification` /
`ambiguities_pending_resolution`) was being mislabeled `COMPLETED` instead of
`BLOCKED_ON_USER`.

Pre-flight hardening determined the bug spans two sites (the ticket named only one):

- **`cli.py` `_apply_sentinel_to_task`** (Stop-hook path — the observed failure,
  session 8499a83f / ticket 481): added a `PAUSED_FOR_USER_INPUT_STATUSES` branch
  **before** the `_TERMINAL_NO_RETRY_STATUSES` check (paused is a subset, so order
  matters) → routes to `BLOCKED_ON_USER`.
- **`dispatch.py` `_apply_events_to_store`** (wrapper `signal_completed` path,
  where the task is still RUNNING at event-consumption): consults the session's
  persisted `last_result` dict and routes a paused status to `BLOCKED_ON_USER`,
  else `COMPLETED`. Reuses the shared `PAUSED_FOR_USER_INPUT_STATUSES` frozenset.

## Tests

- Flipped the two existing `test_cli.py` paused-status assertions from `COMPLETED`
  to `BLOCKED_ON_USER` (they asserted the buggy behavior).
- Added `test_dispatch.py` coverage for the wrapper path: paused `last_result`
  → BLOCKED_ON_USER; non-paused terminal → COMPLETED; `last_result=None` → COMPLETED.

Patch coverage 100%; full suite green (95.45% with mcp extras).

Closes #489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
