### PR TITLE
fix(ship-it): emit Closes #<ticket> trailer from cw-context.json (#491)

### DIFF
--- a/.claude/commands/ship-it.md
+++ b/.claude/commands/ship-it.md
@@ -36,6 +36,24 @@ TITLE=$(git log --format='%s' -1)
 RANGE_BODY=$(git log --format='- %s' "origin/main..HEAD")
 ```
 
+Build a `Closes #<n>` trailer when this is an orchestrated run (#491). `cw`
+drops the ticket id in `.claude/cw-context.json` for every auto-dev worktree, so
+read it from there — no branch-name parsing. Only emit the trailer for a
+GitHub-numeric id (so the PR auto-closes the issue and feeds the
+`closedByPullRequestsReferences` linkage that reconcile/doctor merged-detection
+keys on). Interactive runs (no `cw-context.json`) and Linear ids (closed via
+Linear status, not GitHub) get no trailer:
+
+```bash
+CLOSES_TRAILER=""
+if [ -f .claude/cw-context.json ]; then
+  TICKET_ID=$(jq -r '.ticket_id // empty' .claude/cw-context.json 2>/dev/null)
+  if printf '%s' "$TICKET_ID" | grep -qE '^[0-9]+$'; then
+    CLOSES_TRAILER="Closes #${TICKET_ID}"
+  fi
+fi
+```
+
 Create the PR with `gh pr create`:
 
 ```bash
@@ -54,6 +72,8 @@ $RANGE_BODY
 - [ ] mypy — zero type errors
 - [ ] pytest — 100% pass rate
 - [ ] No regressions in dispatch, reconcile, or other affected modules
+
+${CLOSES_TRAILER}
 
 🤖 Shipped via /prep-pr + project /ship-it
 EOF


### PR DESCRIPTION
## Summary

The `/ship-it` PR-body template (invoked by `/prep-pr` → `/auto-dev`) emitted
**no `Closes #<ticket>` trailer**, so orchestrated auto-dev PRs did not
auto-close their issues and left GitHub's `closedByPullRequestsReferences`
empty — the exact linkage that reconcile/doctor merged-detection (#487/#488)
keys on. The trailer was only present on PRs whose bodies were hand-written
(#493, #495), which is the inconsistency #491 was filed to fix.

## Change

`.claude/commands/ship-it.md` Step 3 now reads the ticket id from
`.claude/cw-context.json` — the correlation file `cw` already drops in every
auto-dev worktree (`spawn.py`) — and appends `Closes #<id>` for GitHub-numeric
ids. No branch-name parsing, no plumbing through auto-dev/prep-pr.

- Interactive USER-origin runs have no `cw-context.json` → no trailer (unchanged).
- Linear ids (closed via Linear status, not GitHub) are non-numeric → no trailer.
- Command files are read live, so this is effective on the next orchestrated
  run with no reinstall.

## Test plan

- [ ] Skill-file (markdown/bash) change — no Python gates apply.
- [ ] Next cw-orchestrated auto-dev PR carries `Closes #<id>` and auto-closes its issue.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
