### PR TITLE
fix(spawn): inject worktree_path into cw-context.json (#402)

### DIFF
--- a/src/cw/spawn.py
+++ b/src/cw/spawn.py
@@ -158,6 +158,11 @@ def _write_hook_context(
         "purpose": purpose,
         "ticket_id": ticket_id,
         "headless": headless,
+        # Why: the worker's isolation anchor. A headless /auto-dev run reads
+        # this to confirm it operates on its own worktree and never falls back
+        # to a git op against the operator's shared checkout (#402). Resolved
+        # to canonicalize symlinks, matching check_not_main_checkout's compare.
+        "worktree_path": str(worktree.resolve()),
     }
     atomic_write_text(context_path, json.dumps(context, indent=2) + "\n")
 

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -706,6 +706,8 @@ class TestHookContextInjection:
         assert context["client"] == "test-client"
         assert context["purpose"] == "impl"
         assert context["ticket_id"] == "137"
+        # #402: the worker's isolation anchor — its own resolved worktree path.
+        assert context["worktree_path"] == str(worktree.resolve())
 
     def test_ticket_id_optional_writes_null(
         self,


### PR DESCRIPTION
## What

Add `worktree_path` (resolved) to the `cw-context.json` written by `spawn._write_hook_context`, giving a headless `/auto-dev` worker an authoritative record of its own worktree.

## Why

Refs #402 — a headless worker mutated the operator's **shared main checkout** (branch switched out from under the operator; isolation breach). The worker had no anchor to its own worktree, so the skill's fallback path could run a git op against the operator's checkout.

This is the **cw-side complement only**. The load-bearing fix — blocking the headless fallback `git checkout` in the `/auto-dev` skill — lives in a different repo and is tracked in **`global-claude#20`**. Intentionally **not** `Closes #402`: the breach isn't fully resolved until that skill fix lands.

## Changes
- `src/cw/spawn.py` — one key added to the context dict: `"worktree_path": str(worktree.resolve())` (resolved to match `check_not_main_checkout`'s path compare), with a `# Why:` comment.
- `tests/test_spawn.py` — assert the new key in the existing cw-context injection test.

## Gates
- ruff / ruff format / mypy --strict: clean
- `pytest -m 'not integration'` (with `cw[mcp]`): **1836 passed, 95.49% coverage**
- patch coverage: no new uncovered lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)