### PR TITLE
feat(reconcile): salvage-aware routing for committed-but-no-PR reaped sessions (#497)

### DIFF
--- a/src/cw/gh.py
+++ b/src/cw/gh.py
@@ -7,6 +7,7 @@ import subprocess as _sp
 from typing import Any
 
 _GH_PR_STATE_MERGED = "MERGED"
+_PR_EXISTS_TIMEOUT = 10
 
 # Lookback window for timed_out-merged detection, shared by doctor.py and reconcile.py.
 # Lives here (co-located with pr_is_merged_for_ticket) to avoid a circular import:
@@ -105,3 +106,40 @@ def pr_is_merged_for_ticket(
             return True, True
 
     return False, True
+
+
+def pr_exists_for_branch(
+    branch: str, *, timeout: int = _PR_EXISTS_TIMEOUT
+) -> tuple[bool | None, bool]:
+    """Return (open_pr_exists, gh_available).
+
+    open_pr_exists:
+      True   — an open PR exists for this branch
+      False  — no open PR
+      None   — transient error (timeout, non-zero exit, JSON parse failure)
+
+    gh_available:
+      False  — gh binary not found (FileNotFoundError)
+      True   — binary present (even if the call failed transiently)
+    """
+    try:
+        result = _sp.run(
+            ["gh", "pr", "list", "--head", branch, "--state", "open", "--json", "number"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return None, False
+    except (OSError, _sp.TimeoutExpired):
+        return None, True
+
+    if result.returncode != 0:
+        return None, True
+
+    try:
+        data: list[dict[str, object]] = json.loads(result.stdout)
+        return len(data) > 0, True
+    except (ValueError, AttributeError):
+        return None, True

--- a/src/cw/gh.py
+++ b/src/cw/gh.py
@@ -124,7 +124,17 @@ def pr_exists_for_branch(
     """
     try:
         result = _sp.run(
-            ["gh", "pr", "list", "--head", branch, "--state", "open", "--json", "number"],
+            [
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--state",
+                "open",
+                "--json",
+                "number",
+            ],
             capture_output=True,
             text=True,
             check=False,

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -732,11 +732,9 @@ def revert_stalled_headless_sessions(
         # (#431). Their last_result is {"paused_status": _SILENTLY_IDLE_REASON}
         # and they are BLOCKED_ON_USER in the queue already; wall-clock revert
         # would re-dispatch already-parked work.
-        if (
-            isinstance(session.last_result, dict)
-            and session.last_result.get("paused_status")
-            in (_SILENTLY_IDLE_REASON, _NEEDS_SALVAGE_REASON)
-        ):
+        if isinstance(session.last_result, dict) and session.last_result.get(
+            "paused_status"
+        ) in (_SILENTLY_IDLE_REASON, _NEEDS_SALVAGE_REASON):
             salvage_skip_ticket_id = ticket_id_for_session(session.name)
             actual_paused_status = session.last_result.get("paused_status")
             record_event(

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -1117,7 +1117,7 @@ def reconcile() -> ReconcileReport:
         phantom_session_ids=locked_report.phantom_session_ids,
         phantom_session_names=locked_report.phantom_session_names,
         reverted_ticket_ids=locked_report.reverted_ticket_ids,
-        completed_ticket_ids=completed_ticket_ids,
+        completed_ticket_ids=locked_report.completed_ticket_ids + completed_ticket_ids,
         usage_limited=locked_report.usage_limited,
         salvaged_ticket_ids=salvaged_ticket_ids,
     )
@@ -1604,16 +1604,18 @@ def _salvage_high_path(
         _salvage_low_path(session, ticket_id, branch, str(wt_path))
         return
 
-    # Mark session completed.
+    # Mark session completed — under sessions_lock to prevent concurrent clobber.
     now = datetime.now(UTC)
-    fresh_state = load_state()
-    for s in fresh_state.sessions:
-        if s.id == session.id:
-            s.status = SessionStatus.COMPLETED
-            s.completed_at = now
-            s.completed_reason = CompletionReason.NORMAL
-            break
-    save_state(fresh_state)
+    with sessions_lock():
+        fresh_state = load_state()
+        for s in fresh_state.sessions:
+            if s.id == session.id:
+                if s.status not in (SessionStatus.COMPLETED, SessionStatus.TIMED_OUT):
+                    s.status = SessionStatus.COMPLETED
+                    s.completed_at = now
+                    s.completed_reason = CompletionReason.NORMAL
+                break
+        save_state(fresh_state)
 
     # Update queue task to COMPLETED.
     if ticket_id:
@@ -1626,8 +1628,8 @@ def _salvage_high_path(
                 ):
                     task.status = QueueItemStatus.COMPLETED
                     save_dev_queue(store)
+                    completed_ticket_ids.append(ticket_id)
                     break
-        completed_ticket_ids.append(ticket_id)
 
     # Emit SESSION_COMPLETED event.
     record_event(
@@ -1660,13 +1662,19 @@ def _salvage_low_path(
     """Execute the LOW-confidence flag-only path."""
     breadcrumbs = f"branch={branch} worktree={worktree_path_str}"
 
-    # Update session last_result.
-    fresh_state = load_state()
-    for s in fresh_state.sessions:
-        if s.id == session.id:
-            s.last_result = {"paused_status": _NEEDS_SALVAGE_REASON}
-            break
-    save_state(fresh_state)
+    # Update session last_result — under sessions_lock; idempotency guard suppresses
+    # duplicate writes and the push notification re-fire on subsequent ticks.
+    with sessions_lock():
+        fresh_state = load_state()
+        for s in fresh_state.sessions:
+            if s.id == session.id:
+                if not (
+                    isinstance(s.last_result, dict)
+                    and s.last_result.get("paused_status") == _NEEDS_SALVAGE_REASON
+                ):
+                    s.last_result = {"paused_status": _NEEDS_SALVAGE_REASON}
+                break
+        save_state(fresh_state)
 
     # Route queue task to BLOCKED_ON_USER.
     if ticket_id:

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -32,6 +32,7 @@ import logging
 import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from cw._util import claude_project_dir
@@ -49,9 +50,13 @@ from cw.config import (
     sessions_lock,
 )
 from cw.dev_queue import dev_queue_lock, load_dev_queue, save_dev_queue
-from cw.events import record_event
+from cw.events import read_events, record_event
 from cw.exceptions import USAGE_LIMIT_RE, CwError
-from cw.gh import TIMED_OUT_MERGED_LOOKBACK_DAYS, pr_is_merged_for_ticket
+from cw.gh import (
+    TIMED_OUT_MERGED_LOOKBACK_DAYS,
+    pr_exists_for_branch,
+    pr_is_merged_for_ticket,
+)
 from cw.models import (
     CompletionReason,
     OrchestratorConfig,
@@ -63,11 +68,15 @@ from cw.models import (
 )
 from cw.native_daemon import get_native_daemon_client
 from cw.notify import fire_push_notification
-from cw.worktree import remove_worktree, worktree_has_unsaved_work, worktree_path_for
+from cw.worktree import (
+    _checked_out_branch,
+    _has_commits_beyond_base,
+    remove_worktree,
+    worktree_has_unsaved_work,
+    worktree_path_for,
+)
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from cw.models import CwState, Session
 
 _log = logging.getLogger(__name__)
@@ -118,6 +127,17 @@ _SALVAGE_SKIP_REASON = "park_marker_blocks_salvage"
 # Reason tag written to SESSION_COMPLETED events when a TIMED_OUT session's PR
 # was found MERGED via issue-linkage (timed_out-merged auto-complete, #488).
 _TIMED_OUT_MERGED_REASON = "timed_out_merged"
+# Git-state salvage constants (GitHub issue #497).
+_NEEDS_SALVAGE_REASON = "needs_salvage"
+_SALVAGE_KIND_GIT_STATE = "git_state_salvage"
+_STAGE_REVIEW_COMPLETE = "s3_review_complete"
+_SALVAGE_PR_TITLE_TEMPLATE = "chore: salvage auto-dev branch for #{ticket_id}"
+_SALVAGE_PR_BODY_TEMPLATE = (
+    "Auto-salvaged by reconcile after the session was reaped post-review.\n\n"
+    "The worker reached Stage 3 review (clean) and was reaped before opening a PR. "
+    "Review this branch and merge when satisfied.\n\n"
+    "Ticket: #{ticket_id}"
+)
 
 # Cause tags for SESSION_TIMED_OUT events emitted by the idle watchdog (#486).
 # idle_stall_recovered — watchdog fired but no usage-limit message found.
@@ -187,6 +207,9 @@ class ReconcileReport:
     ``usage_limited`` — True when any reaped session had
     cause=usage_limit_cutoff during this reconcile pass. Signals the
     dispatch loop to enter back-off mode.
+    ``salvaged_ticket_ids`` — ticket IDs auto-completed via the HIGH-path
+    git-state salvage (committed-but-no-PR reaped sessions). Populated by
+    :func:`salvage_committed_no_pr_sessions`. See GitHub issue #497.
     """
 
     phantom_session_ids: list[str] = field(default_factory=list)
@@ -194,6 +217,7 @@ class ReconcileReport:
     reverted_ticket_ids: list[str] = field(default_factory=list)
     completed_ticket_ids: list[str] = field(default_factory=list)
     usage_limited: bool = False
+    salvaged_ticket_ids: list[str] = field(default_factory=list)
 
 
 def compute_drift(
@@ -425,6 +449,32 @@ def _session_project_dir(session: Session) -> Path | None:
     if worktree is None:
         return None
     return claude_project_dir(worktree)
+
+
+def _detect_post_review_clean(session: Session) -> bool:
+    """Return True iff the event bus has a post-review-clean marker for this session.
+
+    Reads STAGE_ENTERED events from the inbox and checks for an event with
+    payload["stage"] == _STAGE_REVIEW_COMPLETE correlated to session.id,
+    with a time-window guard (event after session.started_at).
+
+    Returns False on any error — conservative default.
+    """
+    if session.worktree_path is None:
+        return False
+    try:
+        events = read_events(
+            event_types=[OrchestratorEventType.STAGE_ENTERED],
+            since_ts=session.started_at,
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    for ev in events:
+        session_id = ev.payload.get("session_id")
+        stage = ev.payload.get("stage")
+        if session_id == session.id and stage == _STAGE_REVIEW_COMPLETE:
+            return True
+    return False
 
 
 def _transcript_recently_active(
@@ -684,16 +734,18 @@ def revert_stalled_headless_sessions(
         # would re-dispatch already-parked work.
         if (
             isinstance(session.last_result, dict)
-            and session.last_result.get("paused_status") == _SILENTLY_IDLE_REASON
+            and session.last_result.get("paused_status")
+            in (_SILENTLY_IDLE_REASON, _NEEDS_SALVAGE_REASON)
         ):
             salvage_skip_ticket_id = ticket_id_for_session(session.name)
+            actual_paused_status = session.last_result.get("paused_status")
             record_event(
                 OrchestratorEventType.SESSION_SALVAGE_SKIPPED,
                 {
                     "session_id": session.id,
                     "ticket_id": salvage_skip_ticket_id,
                     "reason": _SALVAGE_SKIP_REASON,
-                    "paused_status": _SILENTLY_IDLE_REASON,
+                    "paused_status": actual_paused_status,
                 },
                 correlation_id=salvage_skip_ticket_id,
             )
@@ -846,7 +898,7 @@ def flag_silently_idle_daemon_sessions(
     native_live: set[str],
     config: OrchestratorConfig,
     task_by_ticket: dict[str, TicketTask] | None = None,
-) -> list[str]:
+) -> tuple[list[str], list[_SalvageCandidate]]:
     """Flag DAEMON RUNNING sessions idle past the watchdog budget with no sentinel.
 
     These are sessions the wrapper never got a chance to signal — typically
@@ -858,7 +910,10 @@ def flag_silently_idle_daemon_sessions(
     (the daemon still has them). Sessions with a dead surface ref are handled
     by the phantom sweep → PENDING for retry.
 
-    Returns list of ticket IDs whose queue task was set to BLOCKED_ON_USER.
+    Returns a tuple of:
+    - list of ticket IDs whose queue task was set to BLOCKED_ON_USER
+    - list of git-state salvage candidates for the post-lock pass:
+      (session_id, ticket_id, branch, worktree_path_str, post_review_clean)
     """
     if task_by_ticket is None:
         task_by_ticket = {t.ticket_id: t for t in load_dev_queue().tasks}
@@ -866,6 +921,9 @@ def flag_silently_idle_daemon_sessions(
     recover: list[tuple[Session, str | None]] = []
     park: list[tuple[Session, str | None]] = []
     salvaged: list[tuple[Session, str | None, AutoDevResult]] = []
+    # Git-state salvage candidates collected under the lock (no git/gh subprocesses).
+    # Tuple: (session_id, ticket_id, branch, worktree_path_str, post_review_clean)
+    salvage_git: list[_SalvageCandidate] = []
     for session in state.sessions:
         if session.origin is not SessionOrigin.DAEMON:
             continue
@@ -899,14 +957,31 @@ def flag_silently_idle_daemon_sessions(
             _apply_salvaged_completion(session, result, claude_session_id, now=now)
             salvaged.append((session, ticket_id, result))
             continue
+        # Git-state salvage: check under lock using only event bus reads (no
+        # git/gh subprocess). Branch and worktree are needed by the post-lock
+        # salvage_committed_no_pr_sessions pass.
+        if session.worktree_path is not None:
+            branch = _checked_out_branch(session.worktree_path)
+            if branch is not None:
+                post_review_clean = _detect_post_review_clean(session)
+                salvage_git.append(
+                    (
+                        session.id,
+                        ticket_id,
+                        branch,
+                        str(session.worktree_path),
+                        post_review_clean,
+                    )
+                )
+                continue
         cap = resolve_idle_retry_cap(task, config)
         if task is not None and task.attempts < cap:
             recover.append((session, ticket_id))
         else:
             park.append((session, ticket_id))
 
-    if not recover and not park and not salvaged:
-        return []
+    if not recover and not park and not salvaged and not salvage_git:
+        return [], []
 
     # Auto-recover: retire the session and revert its task for re-dispatch.
     for session, _ in recover:
@@ -1005,7 +1080,7 @@ def flag_silently_idle_daemon_sessions(
         if session.surface_ref is not None:
             get_native_daemon_client().stop(session.surface_ref)
 
-    return blocked
+    return blocked, salvage_git
 
 
 def reconcile() -> ReconcileReport:
@@ -1030,13 +1105,14 @@ def reconcile() -> ReconcileReport:
     tradeoff for a file-based, single-user tool.
     """
     with sessions_lock():
-        locked_report = _reconcile_locked()
+        locked_report, salvage_git_candidates = _reconcile_locked()
 
     # Post-pass: runs AFTER sessions_lock releases so no gh subprocess
     # executes under the session lock (liveness — #485 SHOULD_FIX 4).
     completed_ticket_ids = complete_timed_out_merged_tasks()
+    salvaged_ticket_ids = salvage_committed_no_pr_sessions(salvage_git_candidates)
 
-    if not completed_ticket_ids:
+    if not completed_ticket_ids and not salvaged_ticket_ids:
         return locked_report
 
     return ReconcileReport(
@@ -1045,15 +1121,23 @@ def reconcile() -> ReconcileReport:
         reverted_ticket_ids=locked_report.reverted_ticket_ids,
         completed_ticket_ids=completed_ticket_ids,
         usage_limited=locked_report.usage_limited,
+        salvaged_ticket_ids=salvaged_ticket_ids,
     )
 
 
-def _reconcile_locked() -> ReconcileReport:
+_SalvageCandidate = tuple[str, str | None, str, str, bool]
+
+
+def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
     """Body of reconcile(), called while sessions_lock is held.
 
     Separated so reconcile() holds exactly one lock acquisition and the
     helpers (revert_stalled_headless_sessions, flag_silently_idle_daemon_sessions)
     can save_state directly without re-acquiring the lock.
+
+    Returns a tuple of (ReconcileReport, salvage_git_candidates) where
+    salvage_git_candidates is the list of git-state salvage candidates for
+    the post-lock pass in salvage_committed_no_pr_sessions.
     """
     state = load_state()
     now = datetime.now(UTC)
@@ -1087,20 +1171,21 @@ def _reconcile_locked() -> ReconcileReport:
         native_live = set()
         daemon_errored = True
     if _looks_like_daemon_outage(state, daemon_errored, native_live):
-        return ReconcileReport(reverted_ticket_ids=stalled_reverted)
+        return ReconcileReport(reverted_ticket_ids=stalled_reverted), []
 
     # Snapshot sessions that are already TIMED_OUT before the watchdog sweep,
     # so we can detect which sessions were newly reaped by usage_limit_cutoff.
     pre_watchdog_timed_out_ids = {
         s.id for s in state.sessions if s.status == SessionStatus.TIMED_OUT
     }
-    silently_idle_ticket_ids = flag_silently_idle_daemon_sessions(
+    idle_result = flag_silently_idle_daemon_sessions(
         state,
         now=now,
         native_live=native_live,
         config=orchestrator_config,
         task_by_ticket=shared_task_by_ticket,
     )
+    silently_idle_ticket_ids, salvage_git_candidates = idle_result
     # Check whether any session newly transitioned to TIMED_OUT has a usage-limit
     # transcript. The _detect_usage_limit I/O cost is minimal (OS-cached files).
     watchdog_usage_limited = any(
@@ -1128,7 +1213,7 @@ def _reconcile_locked() -> ReconcileReport:
         return ReconcileReport(
             reverted_ticket_ids=all_reverted,
             usage_limited=watchdog_usage_limited,
-        )
+        ), salvage_git_candidates
 
     phantom_set = set(drift.phantom_session_ids)
     ticket_ids_to_revert: list[str] = []
@@ -1258,11 +1343,14 @@ def _reconcile_locked() -> ReconcileReport:
         )
     )
 
-    return ReconcileReport(
-        phantom_session_ids=drift.phantom_session_ids,
-        phantom_session_names=phantom_names,
-        reverted_ticket_ids=all_reverted,
-        usage_limited=watchdog_usage_limited,
+    return (
+        ReconcileReport(
+            phantom_session_ids=drift.phantom_session_ids,
+            phantom_session_names=phantom_names,
+            reverted_ticket_ids=all_reverted,
+            usage_limited=watchdog_usage_limited,
+        ),
+        salvage_git_candidates,
     )
 
 
@@ -1396,6 +1484,220 @@ def complete_timed_out_merged_tasks() -> list[str]:
             )
 
     return completed_ids
+
+
+def salvage_committed_no_pr_sessions(
+    candidates: list[_SalvageCandidate],
+) -> list[str]:
+    """Post-pass: git-state salvage for committed-but-no-PR reaped sessions.
+
+    Called from reconcile() AFTER sessions_lock releases — git and gh subprocesses
+    run here, never under the session lock. See GitHub issue #497.
+
+    candidates: list of (session_id, ticket_id, branch, worktree_path_str,
+    post_review_clean) collected by flag_silently_idle_daemon_sessions under lock.
+
+    Returns list of ticket_ids that were auto-completed (HIGH path).
+    """
+    if not candidates:
+        return []
+
+    completed_ticket_ids: list[str] = []
+    state = load_state()
+
+    for (
+        session_id,
+        ticket_id,
+        branch,
+        worktree_path_str,
+        post_review_clean,
+    ) in candidates:
+        session = next((s for s in state.sessions if s.id == session_id), None)
+        if session is None:
+            continue
+
+        wt_path = Path(worktree_path_str)
+
+        # Confirm git-state trigger: commits beyond base AND no open PR.
+        has_commits = _has_commits_beyond_base(wt_path)
+        if not has_commits:
+            # No commits beyond base — not a salvage candidate; fall through to
+            # existing recover/park on the next reconcile tick.
+            continue
+
+        pr_result, gh_available = pr_exists_for_branch(branch)
+        if not gh_available:
+            # gh absent — cannot confirm PR absence; treat as non-candidate.
+            continue
+        if pr_result is None:
+            # Transient error — cannot confirm; treat as non-candidate.
+            continue
+        if pr_result is True:
+            # PR already exists — not our case.
+            continue
+
+        # Confirmed: commits beyond base AND no open PR.
+        if post_review_clean:
+            # HIGH path: automated draft PR.
+            _salvage_high_path(
+                session, ticket_id, branch, wt_path, completed_ticket_ids
+            )
+        else:
+            # LOW path: flag for human salvage.
+            _salvage_low_path(session, ticket_id, branch, worktree_path_str)
+
+    return completed_ticket_ids
+
+
+def _salvage_high_path(
+    session: Session,
+    ticket_id: str | None,
+    branch: str,
+    wt_path: Path,
+    completed_ticket_ids: list[str],
+) -> None:
+    """Execute the HIGH-confidence automated draft PR path."""
+    # Idempotency re-check immediately before creating the PR.
+    pr_result, gh_available = pr_exists_for_branch(branch)
+    if not gh_available or pr_result is True or pr_result is None:
+        # Cannot confirm or PR now exists — downgrade to LOW.
+        _salvage_low_path(session, ticket_id, branch, str(wt_path))
+        return
+
+    # Push branch to origin (no-op if already pushed).
+    try:
+        subprocess.run(
+            ["git", "push", "origin", f"HEAD:refs/heads/{branch}"],
+            cwd=wt_path,
+            capture_output=True,
+            check=True,
+            timeout=60,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        _salvage_low_path(session, ticket_id, branch, str(wt_path))
+        return
+
+    # Create draft PR.
+    title = _SALVAGE_PR_TITLE_TEMPLATE.format(ticket_id=ticket_id or "unknown")
+    body = _SALVAGE_PR_BODY_TEMPLATE.format(ticket_id=ticket_id or "unknown")
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--draft",
+                "--base",
+                "main",
+                "--head",
+                branch,
+                "--title",
+                title,
+                "--body",
+                body,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=60,
+        )
+        pr_url = result.stdout.strip()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        _salvage_low_path(session, ticket_id, branch, str(wt_path))
+        return
+
+    # Mark session completed.
+    now = datetime.now(UTC)
+    fresh_state = load_state()
+    for s in fresh_state.sessions:
+        if s.id == session.id:
+            s.status = SessionStatus.COMPLETED
+            s.completed_at = now
+            s.completed_reason = CompletionReason.NORMAL
+            break
+    save_state(fresh_state)
+
+    # Update queue task to COMPLETED.
+    if ticket_id:
+        with dev_queue_lock():
+            store = load_dev_queue()
+            for task in store.tasks:
+                if (
+                    task.ticket_id == ticket_id
+                    and task.status == QueueItemStatus.RUNNING
+                ):
+                    task.status = QueueItemStatus.COMPLETED
+                    save_dev_queue(store)
+                    break
+        completed_ticket_ids.append(ticket_id)
+
+    # Emit SESSION_COMPLETED event.
+    record_event(
+        OrchestratorEventType.SESSION_COMPLETED,
+        {
+            "session_id": session.id,
+            "session_name": session.name,
+            "client": session.client,
+            "ticket_id": ticket_id,
+            "crashed": False,
+            "salvaged": True,
+            "salvage_kind": _SALVAGE_KIND_GIT_STATE,
+            "draft": True,
+            "pr": pr_url,
+        },
+    )
+
+    # Stop the surface if still running.
+    if session.surface_ref is not None:
+        with contextlib.suppress(Exception):
+            get_native_daemon_client().stop(session.surface_ref)
+
+
+def _salvage_low_path(
+    session: Session,
+    ticket_id: str | None,
+    branch: str,
+    worktree_path_str: str,
+) -> None:
+    """Execute the LOW-confidence flag-only path."""
+    breadcrumbs = f"branch={branch} worktree={worktree_path_str}"
+
+    # Update session last_result.
+    fresh_state = load_state()
+    for s in fresh_state.sessions:
+        if s.id == session.id:
+            s.last_result = {"paused_status": _NEEDS_SALVAGE_REASON}
+            break
+    save_state(fresh_state)
+
+    # Route queue task to BLOCKED_ON_USER.
+    if ticket_id:
+        with dev_queue_lock():
+            store = load_dev_queue()
+            for task in store.tasks:
+                if (
+                    task.ticket_id == ticket_id
+                    and task.status == QueueItemStatus.RUNNING
+                ):
+                    task.status = QueueItemStatus.BLOCKED_ON_USER
+                    save_dev_queue(store)
+                    break
+
+    # Emit SESSION_NEEDS_ATTENTION with breadcrumbs for human salvage.
+    record_event(
+        OrchestratorEventType.SESSION_NEEDS_ATTENTION,
+        {
+            "session_id": session.id,
+            "session_name": session.name,
+            "client": session.client,
+            "ticket_id": ticket_id,
+            "claude_session_id": session.claude_session_id,
+            "paused_status": _NEEDS_SALVAGE_REASON,
+            "breadcrumbs": breadcrumbs,
+            "crashed": False,
+        },
+    )
+    fire_push_notification(session.name, session.client)
 
 
 def revert_timed_out_tasks() -> list[str]:

--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -164,6 +164,30 @@ def _checked_out_branch(wt_path: Path) -> str | None:
     return result.stdout.strip() or None
 
 
+def _has_commits_beyond_base(wt_path: Path) -> bool:
+    """Return True iff the worktree has commits beyond origin/main.
+
+    Runs git log origin/main..HEAD in the worktree cwd. Returns False on
+    any failure — conservative default so uncertainty never triggers salvage.
+
+    # Why: salvage is a side-effecting external write. A false positive
+    # (salvaging a session with no real commits) is worse than a false
+    # negative (missing a salvageable session). Fail safe to False.
+    """
+    if not wt_path.exists():
+        return False
+    try:
+        result = _run_git(
+            "log", "origin/main..HEAD", "--oneline",
+            cwd=wt_path, check=False,
+        )
+    except OSError:
+        return False
+    if result.returncode != 0:
+        return False
+    return bool(result.stdout.strip())
+
+
 def create_worktree(
     client: ClientConfig,
     branch: str,

--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -178,8 +178,11 @@ def _has_commits_beyond_base(wt_path: Path) -> bool:
         return False
     try:
         result = _run_git(
-            "log", "origin/main..HEAD", "--oneline",
-            cwd=wt_path, check=False,
+            "log",
+            "origin/main..HEAD",
+            "--oneline",
+            cwd=wt_path,
+            check=False,
         )
     except OSError:
         return False

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
-from cw.gh import pr_is_merged_for_ticket
+from cw.gh import pr_exists_for_branch, pr_is_merged_for_ticket
 
 if TYPE_CHECKING:
     import pytest
@@ -215,3 +216,60 @@ class TestPrIsMergedForTicket:
         merged, gh_available = pr_is_merged_for_ticket("487")
         assert merged is False
         assert gh_available is True
+
+
+class TestPrExistsForBranch:
+    """Tests for pr_exists_for_branch."""
+
+    def test_open_pr_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """gh pr list returns [{"number": 42}] → (True, True)."""
+        monkeypatch.setattr(
+            "cw.gh._sp.run",
+            lambda *_a, **_kw: _make_run_result(0, json.dumps([{"number": 42}])),
+        )
+        exists, gh_available = pr_exists_for_branch("dev/497")
+        assert exists is True
+        assert gh_available is True
+
+    def test_no_pr_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """gh pr list returns [] → (False, True)."""
+        monkeypatch.setattr(
+            "cw.gh._sp.run",
+            lambda *_a, **_kw: _make_run_result(0, json.dumps([])),
+        )
+        exists, gh_available = pr_exists_for_branch("dev/497")
+        assert exists is False
+        assert gh_available is True
+
+    def test_timeout_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """TimeoutExpired → (None, True)."""
+
+        def _raise(*_a: object, **_kw: object) -> None:
+            raise subprocess.TimeoutExpired(["gh"], 10)
+
+        monkeypatch.setattr("cw.gh._sp.run", _raise)
+        exists, gh_available = pr_exists_for_branch("dev/497")
+        assert exists is None
+        assert gh_available is True
+
+    def test_nonzero_exit_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-zero returncode → (None, True)."""
+        monkeypatch.setattr(
+            "cw.gh._sp.run",
+            lambda *_a, **_kw: _make_run_result(1, ""),
+        )
+        exists, gh_available = pr_exists_for_branch("dev/497")
+        assert exists is None
+        assert gh_available is True
+
+    def test_gh_absent_returns_none_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FileNotFoundError → (None, False)."""
+        monkeypatch.setattr(
+            "cw.gh._sp.run",
+            lambda *_a, **_kw: (_ for _ in ()).throw(FileNotFoundError("gh")),
+        )
+        exists, gh_available = pr_exists_for_branch("dev/497")
+        assert exists is None
+        assert gh_available is False

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -34,8 +34,11 @@ from cw.models import (
 )
 from cw.native_daemon import FakeNativeDaemonClient
 from cw.reconcile import (
+    _NEEDS_SALVAGE_REASON,
+    _SALVAGE_KIND_GIT_STATE,
     _SALVAGE_SKIP_REASON,
     _SILENTLY_IDLE_REASON,
+    _STAGE_REVIEW_COMPLETE,
     HEADLESS_TIMEOUT_SECONDS,
     IDLE_WATCHDOG_SECONDS,
     SPAWN_GRACE_SECONDS,
@@ -50,6 +53,7 @@ from cw.reconcile import (
     revert_completed_silent_tasks,
     revert_stalled_headless_sessions,
     revert_timed_out_tasks,
+    salvage_committed_no_pr_sessions,
 )
 
 
@@ -1868,7 +1872,7 @@ def test_flag_silently_idle_daemon_sessions_transitions_past_budget(
     save_dev_queue(DevQueueStore(tasks=[task]))
 
     with patch("cw.reconcile.fire_push_notification") as mock_notify:
-        blocked = flag_silently_idle_daemon_sessions(
+        blocked, _salvage = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
         )
         mock_notify.assert_called_once_with(sess.name, sess.client)
@@ -1942,7 +1946,7 @@ def test_flag_silently_idle_watchdog_does_not_stop_working_worker(
         patch("cw.reconcile._transcript_recently_active", return_value=True),
         patch("cw.reconcile.get_native_daemon_client", return_value=mock_daemon),
     ):
-        result = flag_silently_idle_daemon_sessions(
+        result, _salvage = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
         )
 
@@ -1994,7 +1998,7 @@ def test_flag_silently_idle_watchdog_no_double_fire_on_crash_recovery(
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
-    blocked = flag_silently_idle_daemon_sessions(
+    blocked, _salvage = flag_silently_idle_daemon_sessions(
         state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
     )
 
@@ -2031,7 +2035,7 @@ def test_flag_silently_idle_daemon_sessions_leaves_under_budget_alone(
     state = CwState(sessions=[sess])
     save_state(state)
 
-    blocked = flag_silently_idle_daemon_sessions(
+    blocked, _salvage = flag_silently_idle_daemon_sessions(
         state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
     )
 
@@ -2064,7 +2068,7 @@ def test_flag_silently_idle_daemon_sessions_skips_session_with_terminal_sentinel
     state = CwState(sessions=[sess])
     save_state(state)
 
-    blocked = flag_silently_idle_daemon_sessions(
+    blocked, _salvage = flag_silently_idle_daemon_sessions(
         state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
     )
 
@@ -2096,7 +2100,7 @@ def test_flag_silently_idle_daemon_sessions_skips_user_origin(
     state = CwState(sessions=[sess])
     save_state(state)
 
-    blocked = flag_silently_idle_daemon_sessions(
+    blocked, _salvage = flag_silently_idle_daemon_sessions(
         state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
     )
 
@@ -2154,7 +2158,7 @@ def test_flag_silently_idle_salvages_shipped_sentinel(
         patch("cw.reconcile._awaiting_subagent", return_value=False),
     ):
         state = load_state()
-        blocked = flag_silently_idle_daemon_sessions(
+        blocked, _salvage = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"fake-short-id"}, config=OrchestratorConfig()
         )
 
@@ -2212,7 +2216,7 @@ def test_flag_silently_idle_salvages_no_op_sentinel(
         patch("cw.reconcile._awaiting_subagent", return_value=False),
     ):
         state = load_state()
-        blocked = flag_silently_idle_daemon_sessions(
+        blocked, _salvage = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"fake-short-id"}, config=OrchestratorConfig()
         )
 
@@ -2272,7 +2276,7 @@ def test_flag_silently_idle_no_salvage_without_sentinel_still_parks(
 
     with patch("cw.reconcile.fire_push_notification"):
         state = load_state()
-        blocked = flag_silently_idle_daemon_sessions(
+        blocked, _salvage = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
         )
 
@@ -2427,7 +2431,7 @@ def test_flag_silently_idle_daemon_sessions_respects_large_tier_override(
     save_dev_queue(DevQueueStore(tasks=[task]))
 
     config = OrchestratorConfig(idle_watchdog_by_tier={"large": 1800})
-    blocked = flag_silently_idle_daemon_sessions(
+    blocked, _salvage = flag_silently_idle_daemon_sessions(
         state, now=now, native_live={"live-ref"}, config=config
     )
 
@@ -2479,7 +2483,7 @@ def test_flag_silently_idle_daemon_sessions_respects_per_ticket_override(
     save_dev_queue(DevQueueStore(tasks=[task]))
 
     config = OrchestratorConfig()
-    blocked = flag_silently_idle_daemon_sessions(
+    blocked, _salvage = flag_silently_idle_daemon_sessions(
         state, now=now, native_live={"live-ref"}, config=config
     )
 
@@ -2531,7 +2535,7 @@ def test_flag_silently_idle_skips_worker_with_recent_transcript(
     recent_ts = (now - timedelta(seconds=half_window)).timestamp()
     os.utime(str(transcript), (recent_ts, recent_ts))
 
-    blocked = flag_silently_idle_daemon_sessions(
+    blocked, _salvage = flag_silently_idle_daemon_sessions(
         state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
     )
 
@@ -2574,7 +2578,7 @@ def test_flag_silently_idle_fires_when_project_dir_missing(
     save_state(state)
 
     with patch("cw.reconcile.fire_push_notification"):
-        blocked = flag_silently_idle_daemon_sessions(
+        blocked, _salvage = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
         )
 
@@ -2620,7 +2624,7 @@ def test_flag_silently_idle_fires_when_session_id_file_missing(
     save_state(state)
 
     with patch("cw.reconcile.fire_push_notification"):
-        blocked = flag_silently_idle_daemon_sessions(
+        blocked, _salvage = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
         )
 
@@ -2666,7 +2670,7 @@ def test_flag_silently_idle_fires_when_transcript_predates_session(
     os.utime(str(transcript), (before_start, before_start))
 
     with patch("cw.reconcile.fire_push_notification"):
-        blocked = flag_silently_idle_daemon_sessions(
+        blocked, _salvage = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
         )
 
@@ -2713,7 +2717,7 @@ def test_flag_silently_idle_fires_on_stale_transcript(
     os.utime(str(transcript), (stale_ts, stale_ts))
 
     with patch("cw.reconcile.fire_push_notification"):
-        blocked = flag_silently_idle_daemon_sessions(
+        blocked, _salvage = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
         )
 
@@ -2759,7 +2763,7 @@ def test_flag_silently_idle_fires_when_no_transcript_in_project_dir(
     save_state(state)
 
     with patch("cw.reconcile.fire_push_notification"):
-        blocked = flag_silently_idle_daemon_sessions(
+        blocked, _salvage = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
         )
 
@@ -2792,7 +2796,7 @@ def test_flag_silently_idle_skips_with_known_session_id_and_recent_transcript(
     recent_ts = (now - timedelta(seconds=30)).timestamp()
     os.utime(str(transcript), (recent_ts, recent_ts))
 
-    blocked = flag_silently_idle_daemon_sessions(
+    blocked, _salvage = flag_silently_idle_daemon_sessions(
         state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
     )
 
@@ -2961,7 +2965,7 @@ def test_flag_silently_idle_skips_worker_awaiting_subagent(
         patch("cw.reconcile._awaiting_subagent", return_value=True),
         patch("cw.reconcile.fire_push_notification") as mock_notify,
     ):
-        blocked = flag_silently_idle_daemon_sessions(
+        blocked, _salvage = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
         )
         mock_notify.assert_not_called()
@@ -3471,7 +3475,7 @@ def test_flag_silently_idle_parks_when_cap_exhausted(
         patch("cw.reconcile.get_native_daemon_client", return_value=mock_daemon),
         patch("cw.reconcile.fire_push_notification") as mock_notify,
     ):
-        blocked = flag_silently_idle_daemon_sessions(
+        blocked, _salvage = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
         )
         mock_daemon.stop.assert_not_called()
@@ -3633,8 +3637,9 @@ def test_flag_silently_idle_recover_skips_non_running_task(
         patch("cw.reconcile._transcript_recently_active", return_value=False),
         patch("cw.reconcile._awaiting_subagent", return_value=False),
         patch("cw.reconcile.get_native_daemon_client", return_value=mock_daemon),
+        patch("cw.reconcile._checked_out_branch", return_value=None),
     ):
-        result = flag_silently_idle_daemon_sessions(
+        result, _salvage = flag_silently_idle_daemon_sessions(
             state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
         )
         # Surface still stopped (recover path, attempts=1 < cap=2)
@@ -4926,3 +4931,860 @@ class TestCompleteTimedOutMergedTasks:
         store = load_dev_queue()
         task = next(t for t in store.tasks if t.ticket_id == ticket_id)
         assert task.status == QueueItemStatus.RUNNING
+
+
+# ---------------------------------------------------------------------------
+# TestSalvageCommittedNoPrSessions (GitHub issue #497)
+# ---------------------------------------------------------------------------
+
+
+def _mk_live_daemon_session_with_worktree(
+    sid: str,
+    worktree: Path,
+    ticket_id: str,
+) -> Session:
+    """Build a live DAEMON ACTIVE session with a headless context and worktree."""
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    sess = Session(
+        id=sid,
+        name=f"client-a/auto-dev/{ticket_id}",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        worktree_path=worktree,
+        surface_ref="live-ref",
+        started_at=started_at,
+    )
+    context_dir = worktree / ".claude"
+    context_dir.mkdir(parents=True, exist_ok=True)
+    (context_dir / "cw-context.json").write_text(
+        '{"headless": true, "session_id": "' + sid + '"}'
+    )
+    return sess
+
+
+def _write_stage_event(
+    session_id: str,
+    stage: str,
+    started_at: datetime,
+    *,
+    offset_seconds: int = 60,
+) -> None:
+    """Write a STAGE_ENTERED event for testing _detect_post_review_clean."""
+    from cw.events import record_event
+    from cw.models import OrchestratorEventType
+
+    record_event(
+        OrchestratorEventType.STAGE_ENTERED,
+        {
+            "session_id": session_id,
+            "stage": stage,
+        },
+    )
+
+
+class TestSalvageCommittedNoPrSessions:
+    """Tests for salvage_committed_no_pr_sessions (GitHub issue #497)."""
+
+    def test_high_path_creates_draft_pr_and_completes_task(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """HIGH path: post-review clean + commits + no PR → draft PR created,
+        task COMPLETED, SESSION_COMPLETED with salvage_kind=git_state_salvage."""
+        worktree = tmp_path / "wt-high"
+        worktree.mkdir(parents=True)
+        ticket_id = "TKT-HIGH"
+        sess = _mk_live_daemon_session_with_worktree("sess-high", worktree, ticket_id)
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id=ticket_id,
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="sess-high",
+                    )
+                ]
+            )
+        )
+
+        # Write a stage event for post-review clean
+        _write_stage_event("sess-high", _STAGE_REVIEW_COMPLETE, sess.started_at)
+
+        push_calls: list[object] = []
+        gh_calls: list[object] = []
+
+        def _fake_subprocess_run(args: list[str], **_kw: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            if args[:2] == ["git", "push"]:
+                push_calls.append(args)
+                result.stdout = ""
+                return result
+            if args[:2] == ["gh", "pr"]:
+                gh_calls.append(args)
+                result.stdout = "https://github.com/org/repo/pull/42\n"
+                return result
+            return result
+
+        monkeypatch.setattr("cw.reconcile._has_commits_beyond_base", lambda _p: True)
+        # First call (pre-check): no PR; second call (idempotency): no PR
+        monkeypatch.setattr(
+            "cw.reconcile.pr_exists_for_branch", lambda _b, **_kw: (False, True)
+        )
+        monkeypatch.setattr("cw.reconcile.subprocess.run", _fake_subprocess_run)
+        monkeypatch.setattr(
+            "cw.reconcile.get_native_daemon_client",
+            MagicMock,
+        )
+
+        candidates = [("sess-high", ticket_id, "dev/high-branch", str(worktree), True)]
+        completed = salvage_committed_no_pr_sessions(candidates)
+
+        assert ticket_id in completed
+
+        store = load_dev_queue()
+        task = next(t for t in store.tasks if t.ticket_id == ticket_id)
+        assert task.status == QueueItemStatus.COMPLETED
+
+        events = read_events(
+            consumer="test-high-path-salvage",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        salvage_events = [
+            e
+            for e in events
+            if e.payload.get("salvage_kind") == _SALVAGE_KIND_GIT_STATE
+        ]
+        assert len(salvage_events) == 1
+        assert salvage_events[0].payload.get("draft") is True
+        assert "github.com" in str(salvage_events[0].payload.get("pr", ""))
+
+        reloaded = load_state()
+        s = next(s for s in reloaded.sessions if s.id == "sess-high")
+        assert s.status == SessionStatus.COMPLETED
+
+    def test_low_path_flags_needs_salvage(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """LOW path: commits + no PR + no post-review clean → needs_salvage,
+        task BLOCKED_ON_USER, SESSION_NEEDS_ATTENTION with breadcrumbs."""
+        worktree = tmp_path / "wt-low"
+        worktree.mkdir(parents=True)
+        ticket_id = "TKT-LOW"
+        sess = _mk_live_daemon_session_with_worktree("sess-low", worktree, ticket_id)
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id=ticket_id,
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="sess-low",
+                    )
+                ]
+            )
+        )
+        # No stage event written → post_review_clean=False
+
+        monkeypatch.setattr("cw.reconcile._has_commits_beyond_base", lambda _p: True)
+        monkeypatch.setattr(
+            "cw.reconcile.pr_exists_for_branch", lambda _b, **_kw: (False, True)
+        )
+        monkeypatch.setattr(
+            "cw.reconcile.fire_push_notification", lambda *_a, **_kw: None
+        )
+
+        candidates = [("sess-low", ticket_id, "dev/low-branch", str(worktree), False)]
+        completed = salvage_committed_no_pr_sessions(candidates)
+
+        assert completed == []
+
+        store = load_dev_queue()
+        task = next(t for t in store.tasks if t.ticket_id == ticket_id)
+        assert task.status == QueueItemStatus.BLOCKED_ON_USER
+
+        events = read_events(
+            consumer="test-low-path-salvage",
+            event_types=[OrchestratorEventType.SESSION_NEEDS_ATTENTION],
+        )
+        attn_events = [
+            e for e in events if e.payload.get("paused_status") == _NEEDS_SALVAGE_REASON
+        ]
+        assert len(attn_events) == 1
+        bc = attn_events[0].payload.get("breadcrumbs", "")
+        assert "dev/low-branch" in str(bc)
+        assert str(worktree) in str(bc)
+
+        reloaded = load_state()
+        s = next(s for s in reloaded.sessions if s.id == "sess-low")
+        lr = s.last_result or {}
+        assert lr.get("paused_status") == _NEEDS_SALVAGE_REASON
+
+    def test_idempotency_recheck_pr_now_exists_downgrades_to_low(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """PR appears on the second pr_exists_for_branch call → downgrade to LOW."""
+        worktree = tmp_path / "wt-idem"
+        worktree.mkdir(parents=True)
+        ticket_id = "TKT-IDEM"
+        sess = _mk_live_daemon_session_with_worktree("sess-idem", worktree, ticket_id)
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id=ticket_id,
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="sess-idem",
+                    )
+                ]
+            )
+        )
+
+        call_count = [0]
+
+        def _pr_exists_side_effect(branch: str, **_kw: object) -> tuple[bool, bool]:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return False, True  # outer check: no PR
+            return True, True  # idempotency re-check: PR now exists
+
+        monkeypatch.setattr("cw.reconcile._has_commits_beyond_base", lambda _p: True)
+        monkeypatch.setattr("cw.reconcile.pr_exists_for_branch", _pr_exists_side_effect)
+        monkeypatch.setattr(
+            "cw.reconcile.fire_push_notification", lambda *_a, **_kw: None
+        )
+
+        candidates = [("sess-idem", ticket_id, "dev/idem-branch", str(worktree), True)]
+        completed = salvage_committed_no_pr_sessions(candidates)
+
+        # Downgraded to LOW — no PR created, task blocked
+        assert completed == []
+        store = load_dev_queue()
+        task = next(t for t in store.tasks if t.ticket_id == ticket_id)
+        assert task.status == QueueItemStatus.BLOCKED_ON_USER
+
+        # No git push attempted
+        # (confirmed by no SESSION_COMPLETED with salvage_kind=git_state_salvage)
+        events = read_events(
+            consumer="test-idem-recheck",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        assert all(
+            e.payload.get("salvage_kind") != _SALVAGE_KIND_GIT_STATE for e in events
+        )
+
+    def test_gh_unavailable_skips_salvage(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """pr_exists_for_branch returns (None, False) → no salvage, no event."""
+        worktree = tmp_path / "wt-gh-absent"
+        worktree.mkdir(parents=True)
+        ticket_id = "TKT-GHABS"
+        sess = _mk_live_daemon_session_with_worktree("sess-ghabs", worktree, ticket_id)
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id=ticket_id,
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="sess-ghabs",
+                    )
+                ]
+            )
+        )
+
+        monkeypatch.setattr("cw.reconcile._has_commits_beyond_base", lambda _p: True)
+        monkeypatch.setattr(
+            "cw.reconcile.pr_exists_for_branch", lambda _b, **_kw: (None, False)
+        )
+
+        candidates = [
+            ("sess-ghabs", ticket_id, "dev/ghabs-branch", str(worktree), True)
+        ]
+        completed = salvage_committed_no_pr_sessions(candidates)
+
+        assert completed == []
+        store = load_dev_queue()
+        task = next(t for t in store.tasks if t.ticket_id == ticket_id)
+        assert task.status == QueueItemStatus.RUNNING  # unchanged
+
+        events = read_events(
+            consumer="test-gh-absent-salvage",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        assert not events
+
+    def test_no_commits_beyond_base_skips_salvage(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """_has_commits_beyond_base returns False → no salvage."""
+        worktree = tmp_path / "wt-no-commits"
+        worktree.mkdir(parents=True)
+        ticket_id = "TKT-NOCOMMITS"
+        sess = _mk_live_daemon_session_with_worktree(
+            "sess-nocommits", worktree, ticket_id
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id=ticket_id,
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="sess-nocommits",
+                    )
+                ]
+            )
+        )
+
+        monkeypatch.setattr("cw.reconcile._has_commits_beyond_base", lambda _p: False)
+
+        candidates = [
+            ("sess-nocommits", ticket_id, "dev/nc-branch", str(worktree), True)
+        ]
+        completed = salvage_committed_no_pr_sessions(candidates)
+
+        assert completed == []
+        store = load_dev_queue()
+        task = next(t for t in store.tasks if t.ticket_id == ticket_id)
+        assert task.status == QueueItemStatus.RUNNING  # unchanged
+
+    def test_worktree_not_deleted_for_salvage_candidates(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sessions in salvage_git list do NOT have remove_worktree called."""
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+        worktree = tmp_path / "wt-nodelete"
+        worktree.mkdir(parents=True)
+        (worktree / ".claude").mkdir()
+        (worktree / ".claude" / "cw-context.json").write_text(
+            '{"headless": true, "session_id": "sess-nodelete"}'
+        )
+
+        ticket_id = "TKT-NODELETE"
+        sess = Session(
+            id="sess-nodelete",
+            name=f"client-a/auto-dev/{ticket_id}",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/tmp/ws"),
+            worktree_path=worktree,
+            surface_ref="live-ref",
+            started_at=started_at,
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id=ticket_id,
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="sess-nodelete",
+                        attempts=5,  # at/above cap → would normally park
+                    )
+                ]
+            )
+        )
+
+        remove_worktree_calls: list[object] = []
+
+        def _mock_remove(*args: object, **kwargs: object) -> None:
+            remove_worktree_calls.append(args)
+
+        monkeypatch.setattr("cw.reconcile.remove_worktree", _mock_remove)
+        # Patch _checked_out_branch to return a valid branch (triggers salvage_git)
+        monkeypatch.setattr(
+            "cw.reconcile._checked_out_branch",
+            lambda _p: "dev/nodelete-branch",
+        )
+        monkeypatch.setattr(
+            "cw.reconcile._salvage_terminal_result", lambda *_a, **_kw: None
+        )
+        monkeypatch.setattr(
+            "cw.reconcile._transcript_recently_active", lambda *_a, **_kw: False
+        )
+        monkeypatch.setattr("cw.reconcile._awaiting_subagent", lambda *_a, **_kw: False)
+
+        state = CwState(sessions=[sess])
+        _, salvage_git = flag_silently_idle_daemon_sessions(
+            state, now=now, native_live={"live-ref"}, config=OrchestratorConfig()
+        )
+
+        # Session ended up in salvage_git, not park
+        assert len(salvage_git) == 1
+        assert salvage_git[0][0] == "sess-nodelete"
+
+        # remove_worktree was NOT called
+        assert remove_worktree_calls == []
+
+    def test_double_fire_guard_skips_needs_salvage_sessions(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        """revert_stalled_headless_sessions skips sessions with
+        last_result={"paused_status": "needs_salvage"}."""
+        worktree = tmp_path / "wt-dblfire"
+        worktree.mkdir(parents=True)
+        (worktree / ".claude").mkdir()
+        (worktree / ".claude" / "cw-context.json").write_text(
+            '{"headless": true, "session_id": "sess-dblfire"}'
+        )
+
+        ticket_id = "TKT-DBLFIRE"
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 2, 0, 0, tzinfo=UTC)
+
+        sess = Session(
+            id="sess-dblfire",
+            name=f"client-a/auto-dev/{ticket_id}",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/tmp/ws"),
+            worktree_path=worktree,
+            surface_ref="live-ref",
+            started_at=started_at,
+            last_result={"paused_status": _NEEDS_SALVAGE_REASON},
+        )
+        state = CwState(sessions=[sess])
+        save_state(state)
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id=ticket_id,
+                        client="client-a",
+                        status=QueueItemStatus.BLOCKED_ON_USER,
+                        session_id="sess-dblfire",
+                    )
+                ]
+            )
+        )
+
+        reverted = revert_stalled_headless_sessions(
+            state, now=now, config=OrchestratorConfig()
+        )
+
+        # Session was skipped — not reverted to PENDING
+        assert ticket_id not in reverted
+        store = load_dev_queue()
+        task = next(t for t in store.tasks if t.ticket_id == ticket_id)
+        assert task.status == QueueItemStatus.BLOCKED_ON_USER
+
+    def test_time_window_stale_event_does_not_trigger_high(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Stale s3_review_complete event (before session.started_at) → LOW path."""
+        from cw.events import record_event as _record_event
+
+        worktree = tmp_path / "wt-timewindow"
+        worktree.mkdir(parents=True)
+        ticket_id = "TKT-TIMEWINDOW"
+        # Session started AFTER the event was recorded
+        # (simulate: event is from a prior session)
+        started_at = datetime(2026, 3, 1, 0, 0, 0, tzinfo=UTC)
+        sess = Session(
+            id="sess-timewindow",
+            name=f"client-a/auto-dev/{ticket_id}",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/tmp/ws"),
+            worktree_path=worktree,
+            surface_ref="live-ref",
+            started_at=started_at,
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id=ticket_id,
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                    )
+                ]
+            )
+        )
+
+        # Write event with a timestamp AFTER session started
+        # (but _detect_post_review_clean uses since_ts=session.started_at
+        #  and checks session_id match)
+        # The event has a DIFFERENT session_id — should not trigger HIGH
+        _record_event(
+            OrchestratorEventType.STAGE_ENTERED,
+            {
+                "session_id": "different-session-id",  # wrong session
+                "stage": _STAGE_REVIEW_COMPLETE,
+            },
+        )
+
+        monkeypatch.setattr("cw.reconcile._has_commits_beyond_base", lambda _p: True)
+        monkeypatch.setattr(
+            "cw.reconcile.pr_exists_for_branch", lambda _b, **_kw: (False, True)
+        )
+        monkeypatch.setattr(
+            "cw.reconcile.fire_push_notification", lambda *_a, **_kw: None
+        )
+
+        # post_review_clean=False (different session_id → _detect_post_review_clean
+        # returns False → LOW path)
+        candidates = [
+            ("sess-timewindow", ticket_id, "dev/tw-branch", str(worktree), False)
+        ]
+        completed = salvage_committed_no_pr_sessions(candidates)
+
+        assert completed == []
+        store = load_dev_queue()
+        task = next(t for t in store.tasks if t.ticket_id == ticket_id)
+        assert task.status == QueueItemStatus.BLOCKED_ON_USER
+
+    def test_session_not_in_state_is_skipped(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Candidate session_id not found in state → silently skipped."""
+        save_state(CwState(sessions=[]))  # empty — no sessions
+        save_dev_queue(DevQueueStore(tasks=[]))
+
+        monkeypatch.setattr("cw.reconcile._has_commits_beyond_base", lambda _p: True)
+        monkeypatch.setattr(
+            "cw.reconcile.pr_exists_for_branch", lambda _b, **_kw: (False, True)
+        )
+
+        candidates = [
+            (
+                "sess-missing",
+                "TKT-MISSING",
+                "dev/missing-branch",
+                str(tmp_path),
+                True,
+            )
+        ]
+        completed = salvage_committed_no_pr_sessions(candidates)
+        assert completed == []
+
+    def test_pr_transient_error_skips_candidate(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """pr_exists_for_branch returns (None, True) → skip candidate."""
+        worktree = tmp_path / "wt-transient"
+        worktree.mkdir(parents=True)
+        ticket_id = "TKT-TRANSIENT"
+        sess = _mk_live_daemon_session_with_worktree(
+            "sess-transient", worktree, ticket_id
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id=ticket_id,
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="sess-transient",
+                    )
+                ]
+            )
+        )
+
+        monkeypatch.setattr("cw.reconcile._has_commits_beyond_base", lambda _p: True)
+        # (None, True) = transient error, gh available
+        monkeypatch.setattr(
+            "cw.reconcile.pr_exists_for_branch", lambda _b, **_kw: (None, True)
+        )
+
+        completed = salvage_committed_no_pr_sessions(
+            [("sess-transient", ticket_id, "dev/t-branch", str(worktree), True)]
+        )
+        assert completed == []
+        store = load_dev_queue()
+        task = next(t for t in store.tasks if t.ticket_id == ticket_id)
+        assert task.status == QueueItemStatus.RUNNING
+
+    def test_pr_already_exists_skips_candidate(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """pr_exists_for_branch returns (True, True) → PR exists, skip."""
+        worktree = tmp_path / "wt-prexists"
+        worktree.mkdir(parents=True)
+        ticket_id = "TKT-PREXISTS"
+        sess = _mk_live_daemon_session_with_worktree(
+            "sess-prexists", worktree, ticket_id
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id=ticket_id,
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="sess-prexists",
+                    )
+                ]
+            )
+        )
+
+        monkeypatch.setattr("cw.reconcile._has_commits_beyond_base", lambda _p: True)
+        monkeypatch.setattr(
+            "cw.reconcile.pr_exists_for_branch", lambda _b, **_kw: (True, True)
+        )
+
+        completed = salvage_committed_no_pr_sessions(
+            [("sess-prexists", ticket_id, "dev/pe-branch", str(worktree), True)]
+        )
+        assert completed == []
+        store = load_dev_queue()
+        task = next(t for t in store.tasks if t.ticket_id == ticket_id)
+        assert task.status == QueueItemStatus.RUNNING
+
+    def test_git_push_failure_downgrades_to_low(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """git push failure in HIGH path → downgrade to LOW (BLOCKED_ON_USER)."""
+        worktree = tmp_path / "wt-pushfail"
+        worktree.mkdir(parents=True)
+        ticket_id = "TKT-PUSHFAIL"
+        sess = _mk_live_daemon_session_with_worktree(
+            "sess-pushfail", worktree, ticket_id
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id=ticket_id,
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="sess-pushfail",
+                    )
+                ]
+            )
+        )
+
+        def _subprocess_push_fails(args: list[str], **_kw: object) -> None:
+            if args[:2] == ["git", "push"]:
+                raise subprocess.CalledProcessError(1, args)
+            msg = f"unexpected call: {args}"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr("cw.reconcile._has_commits_beyond_base", lambda _p: True)
+        monkeypatch.setattr(
+            "cw.reconcile.pr_exists_for_branch", lambda _b, **_kw: (False, True)
+        )
+        monkeypatch.setattr("cw.reconcile.subprocess.run", _subprocess_push_fails)
+        monkeypatch.setattr(
+            "cw.reconcile.fire_push_notification", lambda *_a, **_kw: None
+        )
+
+        completed = salvage_committed_no_pr_sessions(
+            [("sess-pushfail", ticket_id, "dev/pf-branch", str(worktree), True)]
+        )
+        assert completed == []
+        store = load_dev_queue()
+        task = next(t for t in store.tasks if t.ticket_id == ticket_id)
+        assert task.status == QueueItemStatus.BLOCKED_ON_USER
+
+    def test_gh_pr_create_failure_downgrades_to_low(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """gh pr create failure in HIGH path → downgrade to LOW (BLOCKED_ON_USER)."""
+        worktree = tmp_path / "wt-createfail"
+        worktree.mkdir(parents=True)
+        ticket_id = "TKT-CREATEFAIL"
+        sess = _mk_live_daemon_session_with_worktree(
+            "sess-createfail", worktree, ticket_id
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id=ticket_id,
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="sess-createfail",
+                    )
+                ]
+            )
+        )
+
+        def _subprocess_create_fails(args: list[str], **_kw: object) -> MagicMock:
+            if args[:2] == ["git", "push"]:
+                result = MagicMock()
+                result.returncode = 0
+                result.stdout = ""
+                return result
+            if args[:2] == ["gh", "pr"]:
+                raise subprocess.CalledProcessError(1, args)
+            msg = f"unexpected call: {args}"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr("cw.reconcile._has_commits_beyond_base", lambda _p: True)
+        monkeypatch.setattr(
+            "cw.reconcile.pr_exists_for_branch", lambda _b, **_kw: (False, True)
+        )
+        monkeypatch.setattr("cw.reconcile.subprocess.run", _subprocess_create_fails)
+        monkeypatch.setattr(
+            "cw.reconcile.fire_push_notification", lambda *_a, **_kw: None
+        )
+
+        completed = salvage_committed_no_pr_sessions(
+            [("sess-createfail", ticket_id, "dev/cf-branch", str(worktree), True)]
+        )
+        assert completed == []
+        store = load_dev_queue()
+        task = next(t for t in store.tasks if t.ticket_id == ticket_id)
+        assert task.status == QueueItemStatus.BLOCKED_ON_USER
+
+
+# ---------------------------------------------------------------------------
+# TestDetectPostReviewClean
+# ---------------------------------------------------------------------------
+
+
+class TestDetectPostReviewClean:
+    """Unit tests for _detect_post_review_clean."""
+
+    def test_returns_false_when_worktree_path_none(self, tmp_config_dir: Path) -> None:
+        """Session with no worktree_path → False."""
+        from cw.reconcile import _detect_post_review_clean
+
+        sess = Session(
+            id="sess-nopath",
+            name="client-a/sess-nopath",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/tmp/ws"),
+            worktree_path=None,
+            surface_ref="ref",
+            started_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+        )
+        assert _detect_post_review_clean(sess) is False
+
+    def test_returns_true_when_matching_event_present(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Event with correct session_id and stage=s3_review_complete → True."""
+        from cw.events import record_event as _record_event
+        from cw.reconcile import _detect_post_review_clean
+
+        sess = Session(
+            id="sess-match",
+            name="client-a/sess-match",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/tmp/ws"),
+            worktree_path=tmp_path / "wt",
+            surface_ref="ref",
+            started_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+        )
+        _record_event(
+            OrchestratorEventType.STAGE_ENTERED,
+            {"session_id": "sess-match", "stage": _STAGE_REVIEW_COMPLETE},
+        )
+        assert _detect_post_review_clean(sess) is True
+
+    def test_returns_false_when_no_matching_event(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """No matching event → False."""
+        from cw.reconcile import _detect_post_review_clean
+
+        sess = Session(
+            id="sess-nomatch",
+            name="client-a/sess-nomatch",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/tmp/ws"),
+            worktree_path=tmp_path / "wt",
+            surface_ref="ref",
+            started_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+        )
+        # No event written
+        assert _detect_post_review_clean(sess) is False
+
+    def test_returns_false_on_read_events_exception(
+        self, tmp_config_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """read_events raises → safe False."""
+        from cw.reconcile import _detect_post_review_clean
+
+        def _raise(*_a: object, **_kw: object) -> None:
+            msg = "disk error"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr("cw.reconcile.read_events", _raise)
+
+        sess = Session(
+            id="sess-exc",
+            name="client-a/sess-exc",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+            workspace_path=Path("/tmp/ws"),
+            worktree_path=tmp_path / "wt",
+            surface_ref="ref",
+            started_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+        )
+        assert _detect_post_review_clean(sess) is False

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1783,3 +1783,70 @@ class TestWorktreeHasUnsavedWork:
 
         monkeypatch.setattr("cw.worktree._run_git", mock_run)
         assert worktree_has_unsaved_work(client, "auto-dev/level3-clean") is False
+
+
+class TestHasCommitsBeyondBase:
+    """Tests for _has_commits_beyond_base."""
+
+    def test_commits_present_returns_true(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """_run_git returns non-empty stdout → True."""
+        from cw.worktree import _has_commits_beyond_base
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=0)
+            result.stdout = "abc1234 chore: add feature\n"
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert _has_commits_beyond_base(tmp_path) is True
+
+    def test_no_commits_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """_run_git returns empty stdout → False."""
+        from cw.worktree import _has_commits_beyond_base
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=0)
+            result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert _has_commits_beyond_base(tmp_path) is False
+
+    def test_git_failure_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """_run_git returns nonzero exit → False."""
+        from cw.worktree import _has_commits_beyond_base
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock(returncode=128)
+            result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert _has_commits_beyond_base(tmp_path) is False
+
+    def test_nonexistent_path_returns_false(self) -> None:
+        """Path that doesn't exist → False."""
+        from pathlib import Path as _Path
+
+        from cw.worktree import _has_commits_beyond_base
+
+        assert _has_commits_beyond_base(_Path("/nonexistent/path/xyz")) is False
+
+    def test_oserror_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """OSError from _run_git (e.g. git not on PATH) → False."""
+        from cw.worktree import _has_commits_beyond_base
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> None:
+            msg = "git not found"
+            raise OSError(msg)
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+        assert _has_commits_beyond_base(tmp_path) is False


### PR DESCRIPTION
Closes #497.

## What
Routes a reaped DAEMON session that has **commits beyond `origin/main` but no open PR and no terminal sentinel** to a salvage disposition instead of `BLOCKED_ON_USER`:
- **HIGH** (post-review-clean reached, ≥70%) → automated push + `gh pr create --draft` (idempotent, no auto-merge);
- **LOW** / cannot determine → flag-only `needs_salvage` on `SESSION_NEEDS_ATTENTION` for human salvage.

New helpers: `gh.pr_exists_for_branch`, `worktree._has_commits_beyond_base`, `reconcile._detect_post_review_clean` (reads `STAGE_ENTERED` `s3_review_complete` events from the cw event inbox, correlated on `session_id`).

## Provenance — dogfood salvage
This was implemented by an `/auto-dev` worker (3rd dispatch) that passed plan review, implemented, and passed code review (1 fix cycle, `s3_review_complete`), then **was reaped by the idle watchdog before it could open its own PR** — i.e. the exact committed-but-no-PR case #497 exists to salvage. Salvaged by hand here (push + PR) since the feature that would automate this isn't merged yet.

## Verification (re-run locally on this branch)
- ruff / ruff format / mypy --strict: clean
- `pytest -m 'not integration'` (with `cw[mcp]`): **1863 passed, 95.56% coverage**

## Review notes
~1400 lines, mostly tests (`test_reconcile.py` +904). Core logic in `reconcile.py` (+362). Opened **without auto-merge** — sensitive reconcile/dispatch surface, wants human eyes before merge. Built per two rounds of Pre-flight Resolutions on the issue (esp. branch derivation via `_checked_out_branch`, post-pass outside `sessions_lock`, no tentative paused marker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)