### PR TITLE
feat(reconcile): backfill claude_session_id from daemon roster during reconcile

### DIFF
--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -1191,17 +1191,21 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
         # `claude --bg` returns at spawn. Normalize to short id for
         # comparison; otherwise reconcile sees every native session as a
         # phantom because UUID != short-id.
+        _agents = _claude_agents_json()
         native_live = {
-            sid[:8]
-            for a in _claude_agents_json()
-            if isinstance(sid := a.get("sessionId"), str)
+            sid[:8] for a in _agents if isinstance(sid := a.get("sessionId"), str)
+        }
+        surface_to_full = {
+            sid[:8]: sid for a in _agents if isinstance(sid := a.get("sessionId"), str)
         }
         daemon_errored = False
     except (subprocess.CalledProcessError, json.JSONDecodeError, FileNotFoundError):
         native_live = set()
+        surface_to_full = {}
         daemon_errored = True
     if _looks_like_daemon_outage(state, daemon_errored, native_live):
         return ReconcileReport(reverted_ticket_ids=stalled_reverted), []
+    _backfill_claude_session_ids(state, surface_to_full)
 
     # Snapshot sessions that are already TIMED_OUT before the watchdog sweep,
     # so we can detect which sessions were newly reaped by usage_limit_cutoff.

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -292,6 +292,31 @@ def _looks_like_daemon_outage(
     )
 
 
+def _backfill_claude_session_ids(
+    state: CwState, surface_to_full: dict[str, str]
+) -> int:
+    """Backfill claude_session_id from the daemon roster for DAEMON sessions.
+
+    Called once per reconcile tick, after the outage guard. Returns the number
+    of sessions updated; saves state when non-zero.
+    """
+    count = 0
+    for session in state.sessions:
+        if (
+            session.claude_session_id is None
+            and session.surface_ref is not None
+            and session.surface_ref in surface_to_full
+            and session.status in _LIVE_STATUSES
+            and session.origin is SessionOrigin.DAEMON
+        ):
+            session.claude_session_id = surface_to_full[session.surface_ref]
+            count += 1
+    if count:
+        _log.debug("Backfilled claude_session_id for %d session(s)", count)
+        save_state(state)
+    return count
+
+
 def resolve_headless_budget(
     task: TicketTask | None,
     session: Session,

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -4272,6 +4272,181 @@ def test_revert_stalled_skips_parked_silently_idle_session(
 
 
 # ---------------------------------------------------------------------------
+# GitHub issue #403: backfill claude_session_id from daemon roster
+# Workers parked before their first Stop hook never have claude_session_id
+# written by spawn.  _transcript_recently_active and _awaiting_subagent
+# degrade to scan-all without it.  Backfill during reconcile from the same
+# _claude_agents_json() call that builds native_live.
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_claude_session_id_happy_path(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ACTIVE DAEMON session with surface_ref matching roster → claude_session_id backfilled and persisted."""
+    full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
+    short_id = full_uuid[:8]
+    worktree = tmp_path / "wt-backfill"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    sess = _mk_headless_daemon_session("backfill-1", worktree, started_at, surface_ref=short_id)
+    assert sess.claude_session_id is None
+    save_state(CwState(sessions=[sess]))
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}])
+    reconcile()
+    # Reload from disk to verify persistence
+    reloaded = next(s for s in load_state().sessions if s.id == "backfill-1")
+    assert reloaded.claude_session_id == full_uuid
+
+
+def test_backfill_claude_session_id_no_overwrite(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """claude_session_id already set → roster entry does not change it."""
+    full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
+    existing = "existing-uuid"
+    short_id = full_uuid[:8]
+    worktree = tmp_path / "wt-no-overwrite"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    sess = _mk_headless_daemon_session("no-overwrite-1", worktree, started_at, surface_ref=short_id)
+    sess.claude_session_id = existing
+    save_state(CwState(sessions=[sess]))
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}])
+    reconcile()
+    reloaded = next(s for s in load_state().sessions if s.id == "no-overwrite-1")
+    assert reloaded.claude_session_id == existing
+
+
+def test_backfill_claude_session_id_not_in_roster(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """surface_ref absent from roster → claude_session_id stays None."""
+    full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
+    worktree = tmp_path / "wt-not-in-roster"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    sess = _mk_headless_daemon_session("not-in-roster-1", worktree, started_at, surface_ref="deadbeef")
+    save_state(CwState(sessions=[sess]))
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}])
+    reconcile()
+    reloaded = next(s for s in load_state().sessions if s.id == "not-in-roster-1")
+    assert reloaded.claude_session_id is None
+
+
+def test_backfill_claude_session_id_outage(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Roster fetch raises → no backfill, no crash; outage guard holds."""
+    import subprocess as _subprocess
+
+    full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
+    short_id = full_uuid[:8]
+    worktree = tmp_path / "wt-outage"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    sess = _mk_headless_daemon_session("outage-1", worktree, started_at, surface_ref=short_id)
+    save_state(CwState(sessions=[sess]))
+
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise _subprocess.CalledProcessError(1, "claude")
+
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", _raise)
+    # Must not raise
+    reconcile()
+    reloaded = next(s for s in load_state().sessions if s.id == "outage-1")
+    assert reloaded.claude_session_id is None
+
+
+def test_backfill_claude_session_id_same_tick_liveness(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After backfill, _transcript_recently_active uses the by-id path (not scan-all)."""
+    full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
+    short_id = full_uuid[:8]
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    worktree = tmp_path / "wt-liveness"
+    sess = _mk_headless_daemon_session("liveness-1", worktree, started_at, surface_ref=short_id)
+    assert sess.claude_session_id is None
+    save_state(CwState(sessions=[sess]))
+
+    # Write the transcript under the full UUID filename (by-id path)
+    _write_idle_transcript(home, worktree, filename=f"{full_uuid}.jsonl")
+
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}])
+    reconcile()
+
+    # The session should NOT be flagged silently idle — transcript found via by-id path
+    reloaded = next(s for s in load_state().sessions if s.id == "liveness-1")
+    assert reloaded.claude_session_id == full_uuid
+    # Session still ACTIVE — watchdog did not fire
+    assert reloaded.status == SessionStatus.ACTIVE
+
+
+def test_backfill_claude_session_id_guard_branches(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guard branches: surface_ref=None and non-DAEMON sessions are not backfilled."""
+    full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
+    short_id = full_uuid[:8]
+    worktree = tmp_path / "wt-guard"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+
+    # DAEMON ACTIVE but surface_ref=None
+    daemon_no_ref = _mk_headless_daemon_session("guard-no-ref", worktree, started_at, surface_ref=None)
+    assert daemon_no_ref.claude_session_id is None
+
+    # USER ACTIVE with matching surface_ref — should NOT be backfilled
+    user_sess = _mk_session("guard-user", short_id, status=SessionStatus.ACTIVE)
+    # _mk_session defaults to USER origin
+    assert user_sess.origin is SessionOrigin.USER
+
+    save_state(CwState(sessions=[daemon_no_ref, user_sess]))
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}])
+    reconcile()
+
+    state = load_state()
+    reloaded_no_ref = next(s for s in state.sessions if s.id == "guard-no-ref")
+    reloaded_user = next(s for s in state.sessions if s.id == "guard-user")
+    assert reloaded_no_ref.claude_session_id is None
+    assert reloaded_user.claude_session_id is None
+
+
+def test_backfill_claude_session_id_malformed_roster(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-str sessionId in roster is skipped; valid entry still backfills."""
+    full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
+    short_id = full_uuid[:8]
+    worktree = tmp_path / "wt-malformed"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    sess = _mk_headless_daemon_session("malformed-1", worktree, started_at, surface_ref=short_id)
+    save_state(CwState(sessions=[sess]))
+    # Roster has a malformed entry alongside the valid one
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": 12345}, {"sessionId": full_uuid}],
+    )
+    reconcile()
+    reloaded = next(s for s in load_state().sessions if s.id == "malformed-1")
+    assert reloaded.claude_session_id == full_uuid
+
+
+# ---------------------------------------------------------------------------
 # Dot-encoding regression tests (GitHub issue #463)
 # Worktrees under ~/.cw/ contain a dot in the path segment; Claude Code
 # encodes BOTH '/' and '.' as '-'.  The old single-replace produced a

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -4280,26 +4280,37 @@ def test_revert_stalled_skips_parked_silently_idle_session(
 # ---------------------------------------------------------------------------
 
 
+# Frozen time for backfill tests: session started_at is 60s before frozen now
+# (well within HEADLESS_TIMEOUT_SECONDS=3600) so revert_stalled does not fire.
+_BACKFILL_FROZEN_NOW = "2026-06-01T12:00:00+00:00"
+_BACKFILL_STARTED_AT = datetime(2026, 6, 1, 11, 59, 0, tzinfo=UTC)
+
+
+@freezegun.freeze_time(_BACKFILL_FROZEN_NOW)
 def test_backfill_claude_session_id_happy_path(
     tmp_config_dir: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """ACTIVE DAEMON session with surface_ref matching roster → claude_session_id backfilled and persisted."""
+    """ACTIVE DAEMON session matches roster → claude_session_id backfilled."""
     full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
     short_id = full_uuid[:8]
     worktree = tmp_path / "wt-backfill"
-    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    sess = _mk_headless_daemon_session("backfill-1", worktree, started_at, surface_ref=short_id)
+    sess = _mk_headless_daemon_session(
+        "backfill-1", worktree, _BACKFILL_STARTED_AT, surface_ref=short_id
+    )
     assert sess.claude_session_id is None
     save_state(CwState(sessions=[sess]))
-    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}])
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}]
+    )
     reconcile()
     # Reload from disk to verify persistence
     reloaded = next(s for s in load_state().sessions if s.id == "backfill-1")
     assert reloaded.claude_session_id == full_uuid
 
 
+@freezegun.freeze_time(_BACKFILL_FROZEN_NOW)
 def test_backfill_claude_session_id_no_overwrite(
     tmp_config_dir: Path,
     tmp_path: Path,
@@ -4310,16 +4321,20 @@ def test_backfill_claude_session_id_no_overwrite(
     existing = "existing-uuid"
     short_id = full_uuid[:8]
     worktree = tmp_path / "wt-no-overwrite"
-    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    sess = _mk_headless_daemon_session("no-overwrite-1", worktree, started_at, surface_ref=short_id)
+    sess = _mk_headless_daemon_session(
+        "no-overwrite-1", worktree, _BACKFILL_STARTED_AT, surface_ref=short_id
+    )
     sess.claude_session_id = existing
     save_state(CwState(sessions=[sess]))
-    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}])
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}]
+    )
     reconcile()
     reloaded = next(s for s in load_state().sessions if s.id == "no-overwrite-1")
     assert reloaded.claude_session_id == existing
 
 
+@freezegun.freeze_time(_BACKFILL_FROZEN_NOW)
 def test_backfill_claude_session_id_not_in_roster(
     tmp_config_dir: Path,
     tmp_path: Path,
@@ -4328,15 +4343,19 @@ def test_backfill_claude_session_id_not_in_roster(
     """surface_ref absent from roster → claude_session_id stays None."""
     full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
     worktree = tmp_path / "wt-not-in-roster"
-    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    sess = _mk_headless_daemon_session("not-in-roster-1", worktree, started_at, surface_ref="deadbeef")
+    sess = _mk_headless_daemon_session(
+        "not-in-roster-1", worktree, _BACKFILL_STARTED_AT, surface_ref="deadbeef"
+    )
     save_state(CwState(sessions=[sess]))
-    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}])
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}]
+    )
     reconcile()
     reloaded = next(s for s in load_state().sessions if s.id == "not-in-roster-1")
     assert reloaded.claude_session_id is None
 
 
+@freezegun.freeze_time(_BACKFILL_FROZEN_NOW)
 def test_backfill_claude_session_id_outage(
     tmp_config_dir: Path,
     tmp_path: Path,
@@ -4348,8 +4367,9 @@ def test_backfill_claude_session_id_outage(
     full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
     short_id = full_uuid[:8]
     worktree = tmp_path / "wt-outage"
-    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    sess = _mk_headless_daemon_session("outage-1", worktree, started_at, surface_ref=short_id)
+    sess = _mk_headless_daemon_session(
+        "outage-1", worktree, _BACKFILL_STARTED_AT, surface_ref=short_id
+    )
     save_state(CwState(sessions=[sess]))
 
     def _raise(*args: object, **kwargs: object) -> None:
@@ -4362,37 +4382,42 @@ def test_backfill_claude_session_id_outage(
     assert reloaded.claude_session_id is None
 
 
+@freezegun.freeze_time(_BACKFILL_FROZEN_NOW)
 def test_backfill_claude_session_id_same_tick_liveness(
     tmp_config_dir: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """After backfill, _transcript_recently_active uses the by-id path (not scan-all)."""
+    """After backfill, _transcript_recently_active uses the by-id path."""
     full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
     short_id = full_uuid[:8]
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
 
-    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
     worktree = tmp_path / "wt-liveness"
-    sess = _mk_headless_daemon_session("liveness-1", worktree, started_at, surface_ref=short_id)
+    sess = _mk_headless_daemon_session(
+        "liveness-1", worktree, _BACKFILL_STARTED_AT, surface_ref=short_id
+    )
     assert sess.claude_session_id is None
     save_state(CwState(sessions=[sess]))
 
     # Write the transcript under the full UUID filename (by-id path)
     _write_idle_transcript(home, worktree, filename=f"{full_uuid}.jsonl")
 
-    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}])
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}]
+    )
     reconcile()
 
-    # The session should NOT be flagged silently idle — transcript found via by-id path
+    # Session should NOT be flagged silently idle — transcript found via by-id path
     reloaded = next(s for s in load_state().sessions if s.id == "liveness-1")
     assert reloaded.claude_session_id == full_uuid
     # Session still ACTIVE — watchdog did not fire
     assert reloaded.status == SessionStatus.ACTIVE
 
 
+@freezegun.freeze_time(_BACKFILL_FROZEN_NOW)
 def test_backfill_claude_session_id_guard_branches(
     tmp_config_dir: Path,
     tmp_path: Path,
@@ -4402,10 +4427,11 @@ def test_backfill_claude_session_id_guard_branches(
     full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
     short_id = full_uuid[:8]
     worktree = tmp_path / "wt-guard"
-    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
 
     # DAEMON ACTIVE but surface_ref=None
-    daemon_no_ref = _mk_headless_daemon_session("guard-no-ref", worktree, started_at, surface_ref=None)
+    daemon_no_ref = _mk_headless_daemon_session(
+        "guard-no-ref", worktree, _BACKFILL_STARTED_AT, surface_ref=None
+    )
     assert daemon_no_ref.claude_session_id is None
 
     # USER ACTIVE with matching surface_ref — should NOT be backfilled
@@ -4414,7 +4440,9 @@ def test_backfill_claude_session_id_guard_branches(
     assert user_sess.origin is SessionOrigin.USER
 
     save_state(CwState(sessions=[daemon_no_ref, user_sess]))
-    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}])
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}]
+    )
     reconcile()
 
     state = load_state()
@@ -4424,6 +4452,7 @@ def test_backfill_claude_session_id_guard_branches(
     assert reloaded_user.claude_session_id is None
 
 
+@freezegun.freeze_time(_BACKFILL_FROZEN_NOW)
 def test_backfill_claude_session_id_malformed_roster(
     tmp_config_dir: Path,
     tmp_path: Path,
@@ -4433,8 +4462,9 @@ def test_backfill_claude_session_id_malformed_roster(
     full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
     short_id = full_uuid[:8]
     worktree = tmp_path / "wt-malformed"
-    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    sess = _mk_headless_daemon_session("malformed-1", worktree, started_at, surface_ref=short_id)
+    sess = _mk_headless_daemon_session(
+        "malformed-1", worktree, _BACKFILL_STARTED_AT, surface_ref=short_id
+    )
     save_state(CwState(sessions=[sess]))
     # Roster has a malformed entry alongside the valid one
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- test(reconcile): add backfill_claude_session_id tests [RED]
- feat(reconcile): add _backfill_claude_session_ids helper
- feat(reconcile): backfill claude_session_id from daemon roster during reconcile
- chore: mark impl complete for auto-dev resume detector

Fixes #403 — Session.claude_session_id never written for workers parked before first Stop hook. Reconcile now backfills claude_session_id from the daemon roster when it is missing, ensuring workers that were parked before their first Stop hook still get their session ID recorded.

## Test plan

- [x] ruff check — zero violations (src/ tests/)
- [x] mypy --strict — zero type errors
- [x] pytest — 1686 passed, 4 skipped (100% pass rate)
- [x] patch coverage (diff-cover) — 100% on changed lines
- [ ] No regressions in dispatch, reconcile, or other affected modules

Closes #403

🤖 Shipped via /prep-pr + project /ship-it