### PR TITLE
fix(dispatch+dev_queue): priority-ordered claim and stale-record-safe ticket lookup

### DIFF
--- a/src/cw/dev_queue.py
+++ b/src/cw/dev_queue.py
@@ -299,14 +299,25 @@ def list_tickets(client: str | None = None) -> list[TicketTask]:
 
 
 def _find_ticket(store: DevQueueStore, ticket_id: str, client: str) -> TicketTask:
-    """Return the TicketTask matching (ticket_id, client) or raise CwError."""
+    """Return the TicketTask matching (ticket_id, client) or raise CwError.
+
+    Prefers the most-recent non-terminal (PENDING/RUNNING) record when
+    duplicates exist.
+    # Why: add-after-terminal creates duplicate (client, ticket_id) rows
+    # (structurally removed by #507). Returning the oldest terminal record
+    # would cause wait_for_terminal to resolve immediately on a stale status
+    # while a fresh run of the same ticket is currently RUNNING.
+    """
     matches = [
         t for t in store.tasks if t.ticket_id == ticket_id and t.client == client
     ]
     if not matches:
         msg = f"No dev-queue task found for ticket '{ticket_id}' in client '{client}'."
         raise CwError(msg)
-    return matches[0]
+    active = [t for t in matches if t.status not in _TERMINAL_STATUSES]
+    if active:
+        return active[-1]  # most-recent active record
+    return matches[-1]  # most-recent terminal when no active record exists
 
 
 def consume_completed_sessions() -> int:

--- a/src/cw/dev_queue.py
+++ b/src/cw/dev_queue.py
@@ -303,11 +303,11 @@ def _find_ticket(store: DevQueueStore, ticket_id: str, client: str) -> TicketTas
 
     Prefers the most-recent non-terminal (PENDING/RUNNING) record when
     duplicates exist.
+    """
     # Why: add-after-terminal creates duplicate (client, ticket_id) rows
     # (structurally removed by #507). Returning the oldest terminal record
     # would cause wait_for_terminal to resolve immediately on a stale status
     # while a fresh run of the same ticket is currently RUNNING.
-    """
     matches = [
         t for t in store.tasks if t.ticket_id == ticket_id and t.client == client
     ]

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -105,12 +105,20 @@ def _claim_next_pending(
                         task.attempts += 1
                         save_dev_queue(store)
                         return task
-        for task in store.tasks:
-            if task.client == client_name and task.status == QueueItemStatus.PENDING:
-                task.status = QueueItemStatus.RUNNING
-                task.attempts += 1
-                save_dev_queue(store)
-                return task
+        pending = sorted(
+            [
+                t
+                for t in store.tasks
+                if t.client == client_name and t.status == QueueItemStatus.PENDING
+            ],
+            key=lambda t: (-t.priority, t.created_at),
+        )
+        if pending:
+            task = pending[0]
+            task.status = QueueItemStatus.RUNNING
+            task.attempts += 1
+            save_dev_queue(store)
+            return task
     return None
 
 

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 from cw.cli import main
 from cw.config import load_orchestrator_config
 from cw.dev_queue import (
+    _find_ticket,
     add_ticket,
     cancel_task_for_session,
     cancel_ticket,
@@ -1312,3 +1313,105 @@ class TestWaitForTerminal:
         result = wait_for_terminal("GEN-8", "genhealth", timeout=5, poll_interval=0)
         assert result.status == QueueItemStatus.COMPLETED
         assert result.session_id is None
+
+
+# ---------------------------------------------------------------------------
+# TestFindTicket
+# ---------------------------------------------------------------------------
+
+
+class TestFindTicket:
+    """Tests for _find_ticket() multi-record disambiguation.
+
+    Regression for GitHub issue #506: when a ticket is re-enqueued after
+    a terminal run, _find_ticket must prefer the active (non-terminal)
+    record over the stale terminal one.
+    """
+
+    def test_find_prefers_active_over_terminal_completed(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """PENDING record returned when COMPLETED + PENDING exist for same ticket."""
+        terminal = TicketTask(
+            ticket_id="GEN-9",
+            client="genhealth",
+            status=QueueItemStatus.COMPLETED,
+        )
+        active = TicketTask(
+            ticket_id="GEN-9",
+            client="genhealth",
+            status=QueueItemStatus.PENDING,
+        )
+        store = DevQueueStore(tasks=[terminal, active])
+        save_dev_queue(store)
+
+        loaded = load_dev_queue()
+        result = _find_ticket(loaded, "GEN-9", "genhealth")
+        assert result.status == QueueItemStatus.PENDING
+
+    def test_find_prefers_running_over_terminal_completed(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """RUNNING record returned when COMPLETED + RUNNING exist for same ticket."""
+        terminal = TicketTask(
+            ticket_id="GEN-10",
+            client="genhealth",
+            status=QueueItemStatus.COMPLETED,
+        )
+        active = TicketTask(
+            ticket_id="GEN-10",
+            client="genhealth",
+            status=QueueItemStatus.RUNNING,
+            session_id="sess-10",
+        )
+        store = DevQueueStore(tasks=[terminal, active])
+        save_dev_queue(store)
+
+        loaded = load_dev_queue()
+        result = _find_ticket(loaded, "GEN-10", "genhealth")
+        assert result.status == QueueItemStatus.RUNNING
+        assert result.session_id == "sess-10"
+
+    def test_find_returns_terminal_when_no_active(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """Terminal record returned when no active record exists (backward compat)."""
+        terminal = TicketTask(
+            ticket_id="GEN-11",
+            client="genhealth",
+            status=QueueItemStatus.COMPLETED,
+        )
+        store = DevQueueStore(tasks=[terminal])
+        save_dev_queue(store)
+
+        loaded = load_dev_queue()
+        result = _find_ticket(loaded, "GEN-11", "genhealth")
+        assert result.status == QueueItemStatus.COMPLETED
+
+    def test_wait_for_terminal_skips_stale_completed_record(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """wait_for_terminal does not resolve immediately on stale COMPLETED record.
+
+        When a ticket was completed then re-enqueued (PENDING), the stale
+        COMPLETED record must not cause wait_for_terminal to return early.
+        The active PENDING record should be returned and polling should proceed.
+        """
+        monkeypatch.setattr("cw.dev_queue.consume_completed_sessions", lambda: 0)
+
+        stale_terminal = TicketTask(
+            ticket_id="GEN-12",
+            client="genhealth",
+            status=QueueItemStatus.COMPLETED,
+        )
+        active_pending = TicketTask(
+            ticket_id="GEN-12",
+            client="genhealth",
+            status=QueueItemStatus.PENDING,
+        )
+        store = DevQueueStore(tasks=[stale_terminal, active_pending])
+        save_dev_queue(store)
+
+        # timeout=0 means it should time out (not resolve early on stale record)
+        with pytest.raises(TimeoutError):
+            wait_for_terminal("GEN-12", "genhealth", timeout=0, poll_interval=0)

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -1372,9 +1372,7 @@ class TestFindTicket:
         assert result.status == QueueItemStatus.RUNNING
         assert result.session_id == "sess-10"
 
-    def test_find_returns_terminal_when_no_active(
-        self, tmp_config_dir: Path
-    ) -> None:
+    def test_find_returns_terminal_when_no_active(self, tmp_config_dir: Path) -> None:
         """Terminal record returned when no active record exists (backward compat)."""
         terminal = TicketTask(
             ticket_id="GEN-11",

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1825,6 +1825,135 @@ class TestClaimNextPendingAttempts:
 
 
 # ---------------------------------------------------------------------------
+# TestClaimNextPendingPriority
+# ---------------------------------------------------------------------------
+
+
+class TestClaimNextPendingPriority:
+    """_claim_next_pending respects priority field (highest claimed first).
+
+    Regression for GitHub issue #506: the fallback FIFO loop ignored the
+    priority field.  Tasks with higher priority must be claimed before
+    lower-priority tasks, regardless of enqueue order.
+    """
+
+    def test_high_priority_claimed_before_low_priority(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """High-priority task enqueued after low-priority is claimed first."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        # Enqueue low-priority first, high-priority second
+        add_ticket(
+            TicketTask(
+                ticket_id="GEN-LOW",
+                client="test-client",
+                priority=0,
+                created_at=datetime.fromisoformat("2026-01-01T00:00:00+00:00"),
+            )
+        )
+        add_ticket(
+            TicketTask(
+                ticket_id="GEN-HIGH",
+                client="test-client",
+                priority=10,
+                created_at=datetime.fromisoformat("2026-01-01T00:01:00+00:00"),
+            )
+        )
+
+        daemon = FakeNativeDaemonClient()
+        dispatch_tick(simple_config, native_daemon=daemon)
+
+        store = load_dev_queue()
+        running = store.running()
+        assert len(running) == 1
+        assert running[0].ticket_id == "GEN-HIGH"
+
+    def test_equal_priority_fifo_order(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """Equal-priority tasks are claimed in FIFO (oldest created_at first)."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        # Enqueue in order: earlier created_at first, later second
+        add_ticket(
+            TicketTask(
+                ticket_id="GEN-FIRST",
+                client="test-client",
+                priority=5,
+                created_at=datetime.fromisoformat("2026-01-01T00:00:00+00:00"),
+            )
+        )
+        add_ticket(
+            TicketTask(
+                ticket_id="GEN-SECOND",
+                client="test-client",
+                priority=5,
+                created_at=datetime.fromisoformat("2026-01-01T00:01:00+00:00"),
+            )
+        )
+
+        daemon = FakeNativeDaemonClient()
+        dispatch_tick(simple_config, native_daemon=daemon)
+
+        store = load_dev_queue()
+        running = store.running()
+        assert len(running) == 1
+        assert running[0].ticket_id == "GEN-FIRST"
+
+    def test_priority_without_use_plan(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        cap2_config: OrchestratorConfig,
+    ) -> None:
+        """Priority respected in fallback loop even when use_plan=False."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+
+        # FIFO backlog: two low-priority tasks enqueued first
+        add_ticket(
+            TicketTask(
+                ticket_id="GEN-BACKLOG-A",
+                client="test-client",
+                priority=0,
+                created_at=datetime.fromisoformat("2026-01-01T00:00:00+00:00"),
+            )
+        )
+        add_ticket(
+            TicketTask(
+                ticket_id="GEN-BACKLOG-B",
+                client="test-client",
+                priority=0,
+                created_at=datetime.fromisoformat("2026-01-01T00:01:00+00:00"),
+            )
+        )
+        # High-priority task added last
+        add_ticket(
+            TicketTask(
+                ticket_id="GEN-URGENT",
+                client="test-client",
+                priority=10,
+                created_at=datetime.fromisoformat("2026-01-01T00:02:00+00:00"),
+            )
+        )
+
+        daemon = FakeNativeDaemonClient()
+        # cap=2 => two claims; URGENT (p=10) + BACKLOG-A (p=0, earlier)
+        spawned = dispatch_tick(cap2_config, native_daemon=daemon).spawned
+        assert spawned == 2
+
+        store = load_dev_queue()
+        running_ids = sorted(t.ticket_id for t in store.running())
+        assert running_ids == ["GEN-BACKLOG-A", "GEN-URGENT"]
+
+
+# ---------------------------------------------------------------------------
 # TestDispatchDoesNotTouchMainCheckout
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- fix(dispatch): sort pending tasks by priority in _claim_next_pending fallback
- fix(dev_queue): prefer active record over stale terminal in _find_ticket
- test: add failing tests for priority dispatch and _find_ticket stale-record fix
- chore: apply ruff format to test_dev_queue.py
- style: fix ruff format in test_dev_queue.py
- style(dev_queue): move # Why: comment outside _find_ticket docstring

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors (22 pre-existing errors unchanged)
- [ ] pytest — 1693 passed (7 new tests added)
- [ ] No regressions in dispatch, reconcile, or other affected modules

Closes #506

🤖 Shipped via /prep-pr + project /ship-it