### PR TITLE
chore: mark impl complete for #421

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -216,17 +216,59 @@ values.
   "ticket_id": "<str>",
   "client": "<str>",
   "worktree_dirty": false,
-  "worktree_path": "<str | null>"
+  "worktree_path": "<str | null>",
+  "queue_status": "pending"
 }
 ```
 **Semantics:** Emitted for each DAEMON-origin session that is reaped as a
 phantom (present in state but no longer backed by a live multiplexer surface)
-and whose owning ticket is reverted to PENDING for retry. `worktree_dirty` is
-`true` when `worktree_has_unsaved_work` reports uncommitted changes in the
-session's worktree — operators should inspect before the next dispatch.
-`worktree_path` is the absolute path to the worktree, or `null` when it cannot
-be resolved. `correlation_id` is the `ticket_id`. NOT emitted for USER-origin
-sessions (those are reaped without task revert).
+and whose owning ticket is reverted to PENDING (clean worktree) or routed to
+BLOCKED_ON_USER (dirty worktree, to preserve work for operator inspection).
+`worktree_dirty` is `true` when `worktree_has_unsaved_work` reports uncommitted
+changes in the session's worktree. `worktree_path` is the absolute path to the
+worktree set on the session at time of reap (populated from `session.worktree_path`,
+which is always set for DAEMON sessions; `session.branch` is always `null` for
+DAEMON sessions and is NOT used for path resolution). `queue_status` is
+`"pending"` when the ticket was re-queued for retry or `"blocked_on_user"` when
+it was parked for operator inspection due to a dirty worktree. `correlation_id`
+is the `ticket_id`. NOT emitted for USER-origin sessions (those are reaped
+without task revert).
+
+### `session.needs_attention`
+
+**Emitter:** `flag_silently_idle_daemon_sessions`, `revert_timed_out_tasks`,
+`revert_completed_silent_tasks`, `_salvage_low_path` in `cw.reconcile`
+**Payload:**
+```json
+{
+  "session_id": "<str>",
+  "session_name": "<str>",
+  "client": "<str>",
+  "ticket_id": "<str | null>",
+  "claude_session_id": "<str | null>",
+  "paused_status": "<str>",
+  "breadcrumbs": "<str>",
+  "crashed": false
+}
+```
+**Semantics:** Emitted when a session requires human intervention — the
+orchestrator cannot automatically retry or complete it. `paused_status` is an
+open enum; consumers MUST tolerate unknown values. Known values:
+
+- `"silently_idle"` — DAEMON session is still alive but has been idle longer
+  than the watchdog budget without emitting a sentinel. Operator should inspect
+  and either resume or close the session.
+- `"needs_salvage"` — DAEMON session has commits beyond origin/main but no open
+  PR. The orchestrator cannot auto-salvage (e.g. low confidence or salvage
+  already attempted). Operator should review the branch and open a PR or discard.
+- `"dirty_worktree"` — A phantom-reaped, TIMED_OUT, or COMPLETED session's
+  worktree has uncommitted changes. The owning task has been routed to
+  BLOCKED_ON_USER instead of being re-dispatched to avoid clobbering in-flight
+  work. `breadcrumbs` is the absolute path to the worktree. Operator should
+  review, commit or discard the changes, then manually unblock the task.
+
+`correlation_id` is the `ticket_id` when resolvable, `null` otherwise.
+A push notification is fired for each emission (via `fire_push_notification`).
 
 ### `session.salvage_skipped`
 

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -127,6 +127,10 @@ _SALVAGE_SKIP_REASON = "park_marker_blocks_salvage"
 # Reason tag written to SESSION_COMPLETED events when a TIMED_OUT session's PR
 # was found MERGED via issue-linkage (timed_out-merged auto-complete, #488).
 _TIMED_OUT_MERGED_REASON = "timed_out_merged"
+# Paused-status written to SESSION_NEEDS_ATTENTION events when a session's
+# worktree has unsaved work and the task is routed to BLOCKED_ON_USER instead
+# of being retried automatically (GitHub issue #421).
+_DIRTY_WORKTREE_REASON = "dirty_worktree"
 # Git-state salvage constants (GitHub issue #497).
 _NEEDS_SALVAGE_REASON = "needs_salvage"
 _SALVAGE_KIND_GIT_STATE = "git_state_salvage"
@@ -702,6 +706,26 @@ def _compute_worktree_dirty(client_name: str, branch: str | None) -> bool:
     if not branch:
         return False
     try:
+        client = get_client(client_name)
+        return worktree_has_unsaved_work(client, branch)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _worktree_dirty_by_path(client_name: str, worktree_path: Path | None) -> bool:
+    """Return True if the worktree at *worktree_path* has unsaved work.
+
+    Uses worktree_path (always set on DAEMON sessions) instead of
+    session.branch (always None on DAEMON sessions, making the branch-based
+    check a production no-op).  Mirror _compute_worktree_dirty's fail-safe:
+    returns False on any error, None path, or missing path.
+    """
+    if not worktree_path:
+        return False
+    try:
+        branch = _checked_out_branch(worktree_path)
+        if not branch:
+            return False
         client = get_client(client_name)
         return worktree_has_unsaved_work(client, branch)
     except Exception:  # noqa: BLE001

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -1282,8 +1282,8 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
     # Accumulate data for session.phantom_reverted events (DAEMON-origin only).
     # Emitted after save_state but before dev_queue_lock — see operator resolution
     # in issue #459 for lock-ordering rationale.
-    # (session_id, ticket_id, client, branch)
-    phantom_reverted_data: list[tuple[str, str, str, str | None]] = []
+    # (session_id, ticket_id, client, worktree_path)
+    phantom_reverted_data: list[tuple[str, str, str, Path | None]] = []
     for session in state.sessions:
         if session.id not in phantom_set:
             continue
@@ -1321,7 +1321,7 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
         if ticket_id and session.origin is SessionOrigin.DAEMON:
             ticket_ids_to_revert.append(ticket_id)
             phantom_reverted_data.append(
-                (session.id, ticket_id, session.client, session.branch)
+                (session.id, ticket_id, session.client, session.worktree_path)
             )
         payload: dict[str, object] = {
             "session_id": session.id,
@@ -1337,12 +1337,17 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
     for payload in pending_events:
         record_event(OrchestratorEventType.SESSION_COMPLETED, payload)
 
-    for sess_id, rev_ticket_id, rev_client, rev_branch in phantom_reverted_data:
-        wt_dirty = _compute_worktree_dirty(rev_client, rev_branch)
-        wt_path: str | None = None
-        if rev_branch:
-            with contextlib.suppress(Exception):
-                wt_path = str(worktree_path_for(get_client(rev_client), rev_branch))
+    # Why: dirty-check runs under sessions_lock before the queue mutation, but
+    # the orphaned claude --bg process may still be alive and could write to the
+    # worktree between this check and the BLOCKED_ON_USER routing below (TOCTOU).
+    # The accepted tradeoff is block > clobber — narrow the window, accept the race.
+    dirty_ticket_ids: set[str] = set()
+    for sess_id, rev_ticket_id, rev_client, rev_wt_path in phantom_reverted_data:
+        wt_dirty = _worktree_dirty_by_path(rev_client, rev_wt_path)
+        wt_path_str: str | None = str(rev_wt_path) if rev_wt_path else None
+        if wt_dirty:
+            dirty_ticket_ids.add(rev_ticket_id)
+        queue_status = "blocked_on_user" if wt_dirty else "pending"
         record_event(
             OrchestratorEventType.SESSION_PHANTOM_REVERTED,
             {
@@ -1350,7 +1355,8 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
                 "ticket_id": rev_ticket_id,
                 "client": rev_client,
                 "worktree_dirty": wt_dirty,
-                "worktree_path": wt_path,
+                "worktree_path": wt_path_str,
+                "queue_status": queue_status,
             },
             correlation_id=rev_ticket_id,
         )
@@ -1366,13 +1372,18 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
                 if task.status != QueueItemStatus.RUNNING:
                     continue
                 if task.ticket_id in revert_set:
-                    task.status = QueueItemStatus.PENDING
+                    if task.ticket_id in dirty_ticket_ids:
+                        # Dirty worktree: park for operator inspection rather than
+                        # re-dispatching — clobbering in-flight work is data loss.
+                        task.status = QueueItemStatus.BLOCKED_ON_USER
+                    else:
+                        task.status = QueueItemStatus.PENDING
+                        reverted.append(task.ticket_id)
                     # Drop the stamp from the prior (now-crashed) session so
                     # the next dispatch_tick can re-stamp with the freshly
                     # spawned session_id without a window where the task
                     # carries a stale id. See GitHub issue #97.
                     task.session_id = None
-                    reverted.append(task.ticket_id)
                     changed = True
                 elif task.ticket_id in salvaged_set:
                     # Terminal-success salvage: retire the task instead of
@@ -1412,17 +1423,34 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
     )
 
 
-def _revert_running_tasks_for_sessions(session_ids: set[str]) -> list[str]:
+def _revert_running_tasks_for_sessions(
+    session_ids: set[str],
+    dirty_session_ids: set[str] | None = None,
+) -> list[str]:
     """Revert RUNNING TicketTasks whose ``session_id`` is in *session_ids*.
 
     Shared helper for the per-status revert wrappers. Acquires
     ``dev_queue_lock`` for the read+write window; writes only when at least
-    one task was reverted. Returns the list of reverted ticket IDs.
+    one task was reverted. Returns the list of reverted ticket IDs (PENDING
+    only — BLOCKED_ON_USER tickets are excluded from the return value so they
+    do not enter ReconcileReport.reverted_ticket_ids).
+
+    When *dirty_session_ids* is provided, tasks whose session_id is in the
+    set are routed to BLOCKED_ON_USER instead of PENDING to preserve in-flight
+    worktree state for operator inspection (GitHub issue #421).
+
+    # Why: dirtiness is checked before dev_queue_lock is acquired (in the
+    # callers revert_timed_out_tasks / revert_completed_silent_tasks), but the
+    # orphaned claude --bg process may still be alive and could write to the
+    # worktree between that check and the BLOCKED_ON_USER write below (TOCTOU).
+    # The accepted tradeoff is block > clobber — narrow the window, accept the race.
     """
     if not session_ids:
         return []
 
+    dirty = dirty_session_ids or set()
     reverted: list[str] = []
+    changed = False
     with dev_queue_lock():
         store = load_dev_queue()
         for task in store.tasks:
@@ -1430,10 +1458,14 @@ def _revert_running_tasks_for_sessions(session_ids: set[str]) -> list[str]:
                 continue
             if task.session_id not in session_ids:
                 continue
-            task.status = QueueItemStatus.PENDING
+            if task.session_id in dirty:
+                task.status = QueueItemStatus.BLOCKED_ON_USER
+            else:
+                task.status = QueueItemStatus.PENDING
+                reverted.append(task.ticket_id)
             task.session_id = None
-            reverted.append(task.ticket_id)
-        if reverted:
+            changed = True
+        if changed:
             save_dev_queue(store)
     return reverted
 
@@ -1776,20 +1808,63 @@ def _salvage_low_path(
     fire_push_notification(session.name, session.client)
 
 
+def _build_dirty_session_ids_and_notify(
+    sessions: list[Session],
+) -> set[str]:
+    """Identify sessions with dirty worktrees, emit SESSION_NEEDS_ATTENTION.
+
+    Called before acquiring dev_queue_lock so that dirtiness is assessed
+    outside the lock window (see TOCTOU note in _revert_running_tasks_for_sessions).
+
+    Returns the set of session IDs whose worktrees have unsaved work.
+    Does NOT write session.last_result — this is a queue-level guard, not a
+    park-marker update (to avoid interfering with the existing park-marker logic).
+    """
+    dirty_session_ids: set[str] = set()
+    for session in sessions:
+        if not _worktree_dirty_by_path(session.client, session.worktree_path):
+            continue
+        dirty_session_ids.add(session.id)
+        ticket_id = ticket_id_for_session(session.name)
+        record_event(
+            OrchestratorEventType.SESSION_NEEDS_ATTENTION,
+            {
+                "session_id": session.id,
+                "session_name": session.name,
+                "client": session.client,
+                "ticket_id": ticket_id,
+                "claude_session_id": session.claude_session_id,
+                "paused_status": _DIRTY_WORKTREE_REASON,
+                "breadcrumbs": str(session.worktree_path) if session.worktree_path else "",
+                "crashed": False,
+            },
+        )
+        fire_push_notification(session.name, session.client)
+    return dirty_session_ids
+
+
 def revert_timed_out_tasks() -> list[str]:
     """Revert RUNNING TicketTasks whose owning session is TIMED_OUT.
 
     Called during :func:`reconcile` as a backstop for the case where
     ``signal_stop`` crashed after writing TIMED_OUT status but before
     reverting the dev-queue task. Returns the list of ticket IDs reverted.
+
+    Sessions with dirty worktrees are routed to BLOCKED_ON_USER instead of
+    PENDING, and a SESSION_NEEDS_ATTENTION event is emitted for operator
+    inspection (GitHub issue #421).
     """
     state = load_state()
-    session_ids = {
-        s.id
+    target_sessions = [
+        s
         for s in state.sessions
         if s.status == SessionStatus.TIMED_OUT and s.origin is SessionOrigin.DAEMON
-    }
-    return _revert_running_tasks_for_sessions(session_ids)
+    ]
+    session_ids = {s.id for s in target_sessions}
+    # Compute dirtiness BEFORE acquiring dev_queue_lock (see TOCTOU note in
+    # _revert_running_tasks_for_sessions docstring).
+    dirty_session_ids = _build_dirty_session_ids_and_notify(target_sessions)
+    return _revert_running_tasks_for_sessions(session_ids, dirty_session_ids)
 
 
 def revert_completed_silent_tasks() -> list[str]:
@@ -1799,11 +1874,19 @@ def revert_completed_silent_tasks() -> list[str]:
     without reverting their dev-queue task (e.g. the session wrote COMPLETED
     status but the dispatch consumer had not yet processed it). Returns the
     list of ticket IDs reverted.
+
+    Sessions with dirty worktrees are routed to BLOCKED_ON_USER instead of
+    PENDING, and a SESSION_NEEDS_ATTENTION event is emitted for operator
+    inspection (GitHub issue #421).
     """
     state = load_state()
-    session_ids = {
-        s.id
+    target_sessions = [
+        s
         for s in state.sessions
         if s.status == SessionStatus.COMPLETED and s.origin is SessionOrigin.DAEMON
-    }
-    return _revert_running_tasks_for_sessions(session_ids)
+    ]
+    session_ids = {s.id for s in target_sessions}
+    # Compute dirtiness BEFORE acquiring dev_queue_lock (see TOCTOU note in
+    # _revert_running_tasks_for_sessions docstring).
+    dirty_session_ids = _build_dirty_session_ids_and_notify(target_sessions)
+    return _revert_running_tasks_for_sessions(session_ids, dirty_session_ids)

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -1835,7 +1835,9 @@ def _build_dirty_session_ids_and_notify(
                 "ticket_id": ticket_id,
                 "claude_session_id": session.claude_session_id,
                 "paused_status": _DIRTY_WORKTREE_REASON,
-                "breadcrumbs": str(session.worktree_path) if session.worktree_path else "",
+                "breadcrumbs": str(session.worktree_path)
+                if session.worktree_path
+                else "",
                 "crashed": False,
             },
         )

--- a/tests/test_observability_incidents.py
+++ b/tests/test_observability_incidents.py
@@ -120,16 +120,26 @@ def test_incident_419_dispatch_stall_warns(tmp_config_dir: Path) -> None:
 
 def test_incident_421_phantom_dirty_worktree(
     tmp_config_dir: Path,
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Replay #421: phantom session with dirty worktree emits phantom_reverted.
+    """Replay #421: phantom session with dirty worktree routes ticket to BLOCKED_ON_USER.
 
     Incident: a DAEMON session disappeared from the daemon roster while its
     worktree still had uncommitted changes. reconcile() reverted the ticket to
-    PENDING, losing work silently. The session.phantom_reverted event (#459)
-    exposes worktree_dirty so the orchestrator can warn before re-dispatching.
+    PENDING, losing work silently.
+
+    Fix: dirty worktrees are now routed to BLOCKED_ON_USER for operator
+    inspection. The session.phantom_reverted event carries queue_status=
+    'blocked_on_user' so the operator can see the decision.
+
+    Dirtiness is driven through worktree_path (not session.branch, which is
+    always None for DAEMON sessions — the root cause of the original bug).
     """
+    wt_path = tmp_path / "wt-incident-421"
     sess = _make_daemon_session("phantom-421", "TICKET-421", surface_ref="dead-agent")
+    sess.worktree_path = wt_path
+    sess.branch = None  # Confirms the fix doesn't rely on session.branch
     save_state(CwState(sessions=[sess]))
     save_dev_queue(
         DevQueueStore(
@@ -148,7 +158,16 @@ def test_incident_421_phantom_dirty_worktree(
         lambda: [{"sessionId": "decoy000"}],
     )
     # Incident #421: worktree was dirty at the time of phantom revert.
-    monkeypatch.setattr("cw.reconcile._compute_worktree_dirty", lambda *_: True)
+    # Drive dirtiness through worktree_path (not session.branch).
+    monkeypatch.setattr(
+        "cw.reconcile._checked_out_branch",
+        lambda _p: "auto-dev/TICKET-421",
+    )
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
+    monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: True)
 
     reconcile()
 
@@ -161,7 +180,18 @@ def test_incident_421_phantom_dirty_worktree(
     assert payload["session_id"] == "phantom-421"
     assert payload["ticket_id"] == "TICKET-421"
     assert payload["worktree_dirty"] is True
+    assert payload["queue_status"] == "blocked_on_user"
     assert events[0].correlation_id == "TICKET-421"
+
+    # The ticket must be BLOCKED_ON_USER, preserving the worktree for operator
+    # inspection instead of silently re-dispatching and clobbering the work.
+    from cw.dev_queue import load_dev_queue
+
+    queue = load_dev_queue()
+    task = next(t for t in queue.tasks if t.ticket_id == "TICKET-421")
+    assert task.status == QueueItemStatus.BLOCKED_ON_USER, (
+        f"Expected BLOCKED_ON_USER, got {task.status} — dirty worktree was silently clobbered"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_observability_incidents.py
+++ b/tests/test_observability_incidents.py
@@ -123,7 +123,7 @@ def test_incident_421_phantom_dirty_worktree(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Replay #421: phantom session with dirty worktree routes ticket to BLOCKED_ON_USER.
+    """Replay #421: phantom dirty worktree routes ticket to BLOCKED_ON_USER.
 
     Incident: a DAEMON session disappeared from the daemon roster while its
     worktree still had uncommitted changes. reconcile() reverted the ticket to
@@ -190,7 +190,8 @@ def test_incident_421_phantom_dirty_worktree(
     queue = load_dev_queue()
     task = next(t for t in queue.tasks if t.ticket_id == "TICKET-421")
     assert task.status == QueueItemStatus.BLOCKED_ON_USER, (
-        f"Expected BLOCKED_ON_USER, got {task.status} — dirty worktree was silently clobbered"
+        f"Expected BLOCKED_ON_USER, got {task.status} — "
+        "dirty worktree was silently clobbered"
     )
 
 

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -4956,7 +4956,7 @@ def test_phantom_reverted_event_carries_queue_status_blocked(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """SESSION_PHANTOM_REVERTED event includes queue_status='blocked_on_user' for dirty."""
+    """SESSION_PHANTOM_REVERTED event: queue_status='blocked_on_user' for dirty."""
     wt_dirty = tmp_path / "wt-qs-dirty"
     sess_d = _mk_session("phantom-qs-d", "dead-qs-d")
     sess_d.origin = SessionOrigin.DAEMON
@@ -4979,7 +4979,9 @@ def test_phantom_reverted_event_carries_queue_status_blocked(
         "cw.reconcile._claude_agents_json",
         lambda: [{"sessionId": "decoy000"}],
     )
-    monkeypatch.setattr("cw.reconcile._checked_out_branch", lambda _p: "auto-dev/TICK-QSD")
+    monkeypatch.setattr(
+        "cw.reconcile._checked_out_branch", lambda _p: "auto-dev/TICK-QSD"
+    )
     monkeypatch.setattr(
         "cw.reconcile.get_client",
         lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
@@ -5023,7 +5025,9 @@ def test_phantom_reverted_event_carries_queue_status_pending(
         "cw.reconcile._claude_agents_json",
         lambda: [{"sessionId": "decoy000"}],
     )
-    monkeypatch.setattr("cw.reconcile._checked_out_branch", lambda _p: "auto-dev/TICK-QSC")
+    monkeypatch.setattr(
+        "cw.reconcile._checked_out_branch", lambda _p: "auto-dev/TICK-QSC"
+    )
     monkeypatch.setattr(
         "cw.reconcile.get_client",
         lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
@@ -5050,7 +5054,7 @@ def _mk_daemon_session_with_worktree(
     wt_path: Path,
 ) -> Session:
     """Build a DAEMON session with worktree_path set, branch=None."""
-    sess = Session(
+    return Session(
         id=sid,
         name=f"client-a/auto-dev/{sid}",
         client="client-a",
@@ -5065,7 +5069,6 @@ def _mk_daemon_session_with_worktree(
         worktree_path=wt_path,
         branch=None,  # Always None on DAEMON sessions
     )
-    return sess
 
 
 def test_revert_timed_out_dirty_worktree_routes_to_blocked_on_user(
@@ -5075,7 +5078,9 @@ def test_revert_timed_out_dirty_worktree_routes_to_blocked_on_user(
 ) -> None:
     """TIMED_OUT DAEMON session with dirty worktree routes task to BLOCKED_ON_USER."""
     wt_path = tmp_path / "wt-to-dirty"
-    sess = _mk_daemon_session_with_worktree("to-dirty", SessionStatus.TIMED_OUT, wt_path)
+    sess = _mk_daemon_session_with_worktree(
+        "to-dirty", SessionStatus.TIMED_OUT, wt_path
+    )
     save_state(CwState(sessions=[sess]))
 
     task = TicketTask(
@@ -5086,7 +5091,9 @@ def test_revert_timed_out_dirty_worktree_routes_to_blocked_on_user(
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
-    monkeypatch.setattr("cw.reconcile._checked_out_branch", lambda _p: "auto-dev/to-dirty")
+    monkeypatch.setattr(
+        "cw.reconcile._checked_out_branch", lambda _p: "auto-dev/to-dirty"
+    )
     monkeypatch.setattr(
         "cw.reconcile.get_client",
         lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
@@ -5120,7 +5127,9 @@ def test_revert_timed_out_clean_worktree_routes_to_pending(
 ) -> None:
     """TIMED_OUT DAEMON session with clean worktree routes task to PENDING."""
     wt_path = tmp_path / "wt-to-clean"
-    sess = _mk_daemon_session_with_worktree("to-clean", SessionStatus.TIMED_OUT, wt_path)
+    sess = _mk_daemon_session_with_worktree(
+        "to-clean", SessionStatus.TIMED_OUT, wt_path
+    )
     save_state(CwState(sessions=[sess]))
 
     task = TicketTask(
@@ -5131,7 +5140,9 @@ def test_revert_timed_out_clean_worktree_routes_to_pending(
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
-    monkeypatch.setattr("cw.reconcile._checked_out_branch", lambda _p: "auto-dev/to-clean")
+    monkeypatch.setattr(
+        "cw.reconcile._checked_out_branch", lambda _p: "auto-dev/to-clean"
+    )
     monkeypatch.setattr(
         "cw.reconcile.get_client",
         lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
@@ -5154,7 +5165,9 @@ def test_revert_completed_silent_dirty_worktree_routes_to_blocked_on_user(
 ) -> None:
     """COMPLETED DAEMON session with dirty worktree routes task to BLOCKED_ON_USER."""
     wt_path = tmp_path / "wt-cs-dirty"
-    sess = _mk_daemon_session_with_worktree("cs-dirty", SessionStatus.COMPLETED, wt_path)
+    sess = _mk_daemon_session_with_worktree(
+        "cs-dirty", SessionStatus.COMPLETED, wt_path
+    )
     save_state(CwState(sessions=[sess]))
 
     task = TicketTask(
@@ -5165,7 +5178,9 @@ def test_revert_completed_silent_dirty_worktree_routes_to_blocked_on_user(
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
-    monkeypatch.setattr("cw.reconcile._checked_out_branch", lambda _p: "auto-dev/cs-dirty")
+    monkeypatch.setattr(
+        "cw.reconcile._checked_out_branch", lambda _p: "auto-dev/cs-dirty"
+    )
     monkeypatch.setattr(
         "cw.reconcile.get_client",
         lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
@@ -5188,7 +5203,9 @@ def test_revert_completed_silent_clean_worktree_routes_to_pending(
 ) -> None:
     """COMPLETED DAEMON session with clean worktree routes task to PENDING."""
     wt_path = tmp_path / "wt-cs-clean"
-    sess = _mk_daemon_session_with_worktree("cs-clean", SessionStatus.COMPLETED, wt_path)
+    sess = _mk_daemon_session_with_worktree(
+        "cs-clean", SessionStatus.COMPLETED, wt_path
+    )
     save_state(CwState(sessions=[sess]))
 
     task = TicketTask(
@@ -5199,7 +5216,9 @@ def test_revert_completed_silent_clean_worktree_routes_to_pending(
     )
     save_dev_queue(DevQueueStore(tasks=[task]))
 
-    monkeypatch.setattr("cw.reconcile._checked_out_branch", lambda _p: "auto-dev/cs-clean")
+    monkeypatch.setattr(
+        "cw.reconcile._checked_out_branch", lambda _p: "auto-dev/cs-clean"
+    )
     monkeypatch.setattr(
         "cw.reconcile.get_client",
         lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -4951,17 +4951,12 @@ def test_dirty_phantom_task_not_re_claimable(
     assert updated_task.status == QueueItemStatus.BLOCKED_ON_USER
 
 
-def test_phantom_reverted_event_carries_queue_status(
+def test_phantom_reverted_event_carries_queue_status_blocked(
     tmp_config_dir: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """SESSION_PHANTOM_REVERTED event payload includes queue_status field.
-
-    dirty worktree → queue_status='blocked_on_user'
-    clean worktree → queue_status='pending'
-    """
-    # --- dirty case ---
+    """SESSION_PHANTOM_REVERTED event includes queue_status='blocked_on_user' for dirty."""
     wt_dirty = tmp_path / "wt-qs-dirty"
     sess_d = _mk_session("phantom-qs-d", "dead-qs-d")
     sess_d.origin = SessionOrigin.DAEMON
@@ -4999,7 +4994,13 @@ def test_phantom_reverted_event_carries_queue_status(
     assert len(events) == 1
     assert events[0].payload["queue_status"] == "blocked_on_user"
 
-    # --- clean case ---
+
+def test_phantom_reverted_event_carries_queue_status_pending(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SESSION_PHANTOM_REVERTED event includes queue_status='pending' for clean."""
     wt_clean = tmp_path / "wt-qs-clean"
     sess_c = _mk_session("phantom-qs-c", "dead-qs-c")
     sess_c.origin = SessionOrigin.DAEMON
@@ -5018,7 +5019,15 @@ def test_phantom_reverted_event_carries_queue_status(
             ]
         )
     )
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
     monkeypatch.setattr("cw.reconcile._checked_out_branch", lambda _p: "auto-dev/TICK-QSC")
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
     monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: False)
     reconcile()
 

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -34,6 +34,7 @@ from cw.models import (
 )
 from cw.native_daemon import FakeNativeDaemonClient
 from cw.reconcile import (
+    _DIRTY_WORKTREE_REASON,
     _NEEDS_SALVAGE_REASON,
     _SALVAGE_KIND_GIT_STATE,
     _SALVAGE_SKIP_REASON,
@@ -4658,11 +4659,17 @@ def test_phantom_reverted_event_emitted_with_dirty_worktree(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """DAEMON phantom revert emits session.phantom_reverted with worktree_dirty=True."""
+    """DAEMON phantom revert emits session.phantom_reverted with worktree_dirty=True.
+
+    Uses worktree_path (not session.branch) for dirty detection — DAEMON sessions
+    always have branch=None in production (GitHub issue #421).
+    """
+    wt_path = tmp_path / "wt-pd"
     sess = _mk_session("phantom-dirty", "dead-ref")
     sess.origin = SessionOrigin.DAEMON
     sess.name = "client-a/auto-dev/TICK-PD"
-    sess.branch = "auto-dev/TICK-PD"
+    sess.branch = None  # DAEMON sessions always have branch=None in production
+    sess.worktree_path = wt_path
     save_state(CwState(sessions=[sess]))
 
     task = TicketTask(
@@ -4675,6 +4682,10 @@ def test_phantom_reverted_event_emitted_with_dirty_worktree(
     monkeypatch.setattr(
         "cw.reconcile._claude_agents_json",
         lambda: [{"sessionId": "decoy000"}],
+    )
+    monkeypatch.setattr(
+        "cw.reconcile._checked_out_branch",
+        lambda _p: "auto-dev/TICK-PD",
     )
     monkeypatch.setattr(
         "cw.reconcile.get_client",
@@ -4694,7 +4705,7 @@ def test_phantom_reverted_event_emitted_with_dirty_worktree(
     assert p["ticket_id"] == "TICK-PD"
     assert p["client"] == "client-a"
     assert p["worktree_dirty"] is True
-    assert "worktree_path" in p
+    assert p["worktree_path"] == str(wt_path)
     assert events[0].correlation_id == "TICK-PD"
 
 
@@ -4703,11 +4714,17 @@ def test_phantom_reverted_event_emitted_with_clean_worktree(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """DAEMON phantom revert emits session.phantom_reverted with dirty=False."""
+    """DAEMON phantom revert emits session.phantom_reverted with dirty=False.
+
+    Uses worktree_path (not session.branch) for dirty detection — DAEMON sessions
+    always have branch=None in production (GitHub issue #421).
+    """
+    wt_path = tmp_path / "wt-pc"
     sess = _mk_session("phantom-clean", "dead-ref-2")
     sess.origin = SessionOrigin.DAEMON
     sess.name = "client-a/auto-dev/TICK-PC"
-    sess.branch = "auto-dev/TICK-PC"
+    sess.branch = None  # DAEMON sessions always have branch=None in production
+    sess.worktree_path = wt_path
     save_state(CwState(sessions=[sess]))
 
     task = TicketTask(
@@ -4720,6 +4737,10 @@ def test_phantom_reverted_event_emitted_with_clean_worktree(
     monkeypatch.setattr(
         "cw.reconcile._claude_agents_json",
         lambda: [{"sessionId": "decoy000"}],
+    )
+    monkeypatch.setattr(
+        "cw.reconcile._checked_out_branch",
+        lambda _p: "auto-dev/TICK-PC",
     )
     monkeypatch.setattr(
         "cw.reconcile.get_client",
@@ -4739,7 +4760,7 @@ def test_phantom_reverted_event_emitted_with_clean_worktree(
     assert p["ticket_id"] == "TICK-PC"
     assert p["client"] == "client-a"
     assert p["worktree_dirty"] is False
-    assert "worktree_path" in p
+    assert p["worktree_path"] == str(wt_path)
     assert events[0].correlation_id == "TICK-PC"
 
 
@@ -4765,6 +4786,424 @@ def test_phantom_reverted_not_emitted_for_user_origin(
         event_types=[OrchestratorEventType.SESSION_PHANTOM_REVERTED],
     )
     assert len(events) == 0
+
+
+# ---------------------------------------------------------------------------
+# GitHub issue #421 — phantom-sweep dirty-worktree routing tests
+# ---------------------------------------------------------------------------
+
+
+def test_phantom_dirty_worktree_routes_to_blocked_on_user(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DAEMON session with branch=None but worktree_path set, dirty worktree
+    routes task to BLOCKED_ON_USER, not PENDING.
+
+    This test MUST use worktree_path for dirtiness, NOT session.branch.
+    Asserts session.branch is None so the test fails if impl reads session.branch.
+    """
+    wt_path = tmp_path / "wt-421-dirty"
+    sess = _mk_session("phantom-421-dirty", "dead-ref-421")
+    sess.origin = SessionOrigin.DAEMON
+    sess.name = "client-a/auto-dev/TICK-421D"
+    sess.branch = None  # Always None on DAEMON sessions — impl must NOT use this
+    sess.worktree_path = wt_path
+    save_state(CwState(sessions=[sess]))
+
+    task = TicketTask(
+        ticket_id="TICK-421D",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="phantom-421-dirty",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
+    monkeypatch.setattr(
+        "cw.reconcile._checked_out_branch",
+        lambda _p: "auto-dev/TICK-421D",
+    )
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
+    monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: True)
+
+    report = reconcile()
+
+    # Dirty phantom → BLOCKED_ON_USER, NOT PENDING
+    store = load_dev_queue()
+    updated_task = next(t for t in store.tasks if t.ticket_id == "TICK-421D")
+    assert updated_task.status == QueueItemStatus.BLOCKED_ON_USER
+    assert updated_task.session_id is None  # session stamp cleared
+
+    # BLOCKED_ON_USER ticket must NOT appear in reverted_ticket_ids
+    assert "TICK-421D" not in report.reverted_ticket_ids
+
+    # Assert branch was never consulted (it's None, impl must use worktree_path)
+    state = load_state()
+    matching = [s for s in state.sessions if s.id == "phantom-421-dirty"]
+    assert matching, "session should still be in state after reap"
+    # (session is COMPLETED/CRASHED after phantom reap, branch is still None)
+    assert matching[0].branch is None
+
+
+def test_phantom_clean_worktree_routes_to_pending(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DAEMON session with branch=None and clean worktree routes task to PENDING."""
+    wt_path = tmp_path / "wt-421-clean"
+    sess = _mk_session("phantom-421-clean", "dead-ref-421c")
+    sess.origin = SessionOrigin.DAEMON
+    sess.name = "client-a/auto-dev/TICK-421C"
+    sess.branch = None
+    sess.worktree_path = wt_path
+    save_state(CwState(sessions=[sess]))
+
+    task = TicketTask(
+        ticket_id="TICK-421C",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="phantom-421-clean",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
+    monkeypatch.setattr(
+        "cw.reconcile._checked_out_branch",
+        lambda _p: "auto-dev/TICK-421C",
+    )
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
+    monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: False)
+
+    report = reconcile()
+
+    # Clean phantom → PENDING for retry
+    store = load_dev_queue()
+    updated_task = next(t for t in store.tasks if t.ticket_id == "TICK-421C")
+    assert updated_task.status == QueueItemStatus.PENDING
+    assert updated_task.session_id is None
+
+    # Clean-reverted ticket appears in reverted_ticket_ids
+    assert "TICK-421C" in report.reverted_ticket_ids
+
+
+def test_dirty_phantom_task_not_re_claimable(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After dirty phantom routes to BLOCKED_ON_USER, task stays invisible to dispatch.
+
+    BLOCKED_ON_USER tasks are not claimed by _claim_next_pending (it only
+    claims PENDING tasks), so the dirty worktree is not re-dispatched.
+    """
+    wt_path = tmp_path / "wt-421-nore"
+    sess = _mk_session("phantom-421-nore", "dead-ref-421n")
+    sess.origin = SessionOrigin.DAEMON
+    sess.name = "client-a/auto-dev/TICK-421N"
+    sess.branch = None
+    sess.worktree_path = wt_path
+    save_state(CwState(sessions=[sess]))
+
+    task = TicketTask(
+        ticket_id="TICK-421N",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="phantom-421-nore",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
+    monkeypatch.setattr(
+        "cw.reconcile._checked_out_branch",
+        lambda _p: "auto-dev/TICK-421N",
+    )
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
+    monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: True)
+
+    reconcile()
+
+    # Task is BLOCKED_ON_USER — a subsequent reconcile should not touch it
+    reconcile()
+
+    store = load_dev_queue()
+    updated_task = next(t for t in store.tasks if t.ticket_id == "TICK-421N")
+    assert updated_task.status == QueueItemStatus.BLOCKED_ON_USER
+
+
+def test_phantom_reverted_event_carries_queue_status(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SESSION_PHANTOM_REVERTED event payload includes queue_status field.
+
+    dirty worktree → queue_status='blocked_on_user'
+    clean worktree → queue_status='pending'
+    """
+    # --- dirty case ---
+    wt_dirty = tmp_path / "wt-qs-dirty"
+    sess_d = _mk_session("phantom-qs-d", "dead-qs-d")
+    sess_d.origin = SessionOrigin.DAEMON
+    sess_d.name = "client-a/auto-dev/TICK-QSD"
+    sess_d.branch = None
+    sess_d.worktree_path = wt_dirty
+    save_state(CwState(sessions=[sess_d]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="TICK-QSD",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                )
+            ]
+        )
+    )
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
+    monkeypatch.setattr("cw.reconcile._checked_out_branch", lambda _p: "auto-dev/TICK-QSD")
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
+    monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: True)
+    reconcile()
+
+    events = read_events(
+        consumer="test-qs-dirty",
+        event_types=[OrchestratorEventType.SESSION_PHANTOM_REVERTED],
+    )
+    assert len(events) == 1
+    assert events[0].payload["queue_status"] == "blocked_on_user"
+
+    # --- clean case ---
+    wt_clean = tmp_path / "wt-qs-clean"
+    sess_c = _mk_session("phantom-qs-c", "dead-qs-c")
+    sess_c.origin = SessionOrigin.DAEMON
+    sess_c.name = "client-a/auto-dev/TICK-QSC"
+    sess_c.branch = None
+    sess_c.worktree_path = wt_clean
+    save_state(CwState(sessions=[sess_c]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="TICK-QSC",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                )
+            ]
+        )
+    )
+    monkeypatch.setattr("cw.reconcile._checked_out_branch", lambda _p: "auto-dev/TICK-QSC")
+    monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: False)
+    reconcile()
+
+    events = read_events(
+        consumer="test-qs-clean",
+        event_types=[OrchestratorEventType.SESSION_PHANTOM_REVERTED],
+    )
+    assert len(events) == 1
+    assert events[0].payload["queue_status"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# GitHub issue #421 — sibling revert paths: timed_out + completed_silent
+# ---------------------------------------------------------------------------
+
+
+def _mk_daemon_session_with_worktree(
+    sid: str,
+    status: SessionStatus,
+    wt_path: Path,
+) -> Session:
+    """Build a DAEMON session with worktree_path set, branch=None."""
+    sess = Session(
+        id=sid,
+        name=f"client-a/auto-dev/{sid}",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=status,
+        workspace_path=ClientConfig(
+            name="client-a", workspace_path=Path("/tmp/ws")
+        ).workspace_path,
+        surface_ref=None,
+        started_at=datetime(2026, 4, 19, tzinfo=UTC),
+        worktree_path=wt_path,
+        branch=None,  # Always None on DAEMON sessions
+    )
+    return sess
+
+
+def test_revert_timed_out_dirty_worktree_routes_to_blocked_on_user(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TIMED_OUT DAEMON session with dirty worktree routes task to BLOCKED_ON_USER."""
+    wt_path = tmp_path / "wt-to-dirty"
+    sess = _mk_daemon_session_with_worktree("to-dirty", SessionStatus.TIMED_OUT, wt_path)
+    save_state(CwState(sessions=[sess]))
+
+    task = TicketTask(
+        ticket_id="to-dirty",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="to-dirty",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    monkeypatch.setattr("cw.reconcile._checked_out_branch", lambda _p: "auto-dev/to-dirty")
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
+    monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: True)
+
+    reverted = revert_timed_out_tasks()
+
+    store = load_dev_queue()
+    updated_task = next(t for t in store.tasks if t.ticket_id == "to-dirty")
+    assert updated_task.status == QueueItemStatus.BLOCKED_ON_USER
+    assert updated_task.session_id is None
+    # Dirty ticket not in reverted list
+    assert "to-dirty" not in reverted
+
+    # SESSION_NEEDS_ATTENTION emitted with dirty_worktree paused_status
+    events = read_events(
+        consumer="test-to-dirty-attn",
+        event_types=[OrchestratorEventType.SESSION_NEEDS_ATTENTION],
+    )
+    assert len(events) == 1
+    p = events[0].payload
+    assert p["session_id"] == "to-dirty"
+    assert p["paused_status"] == _DIRTY_WORKTREE_REASON
+
+
+def test_revert_timed_out_clean_worktree_routes_to_pending(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TIMED_OUT DAEMON session with clean worktree routes task to PENDING."""
+    wt_path = tmp_path / "wt-to-clean"
+    sess = _mk_daemon_session_with_worktree("to-clean", SessionStatus.TIMED_OUT, wt_path)
+    save_state(CwState(sessions=[sess]))
+
+    task = TicketTask(
+        ticket_id="to-clean",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="to-clean",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    monkeypatch.setattr("cw.reconcile._checked_out_branch", lambda _p: "auto-dev/to-clean")
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
+    monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: False)
+
+    reverted = revert_timed_out_tasks()
+
+    store = load_dev_queue()
+    updated_task = next(t for t in store.tasks if t.ticket_id == "to-clean")
+    assert updated_task.status == QueueItemStatus.PENDING
+    assert updated_task.session_id is None
+    assert "to-clean" in reverted
+
+
+def test_revert_completed_silent_dirty_worktree_routes_to_blocked_on_user(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """COMPLETED DAEMON session with dirty worktree routes task to BLOCKED_ON_USER."""
+    wt_path = tmp_path / "wt-cs-dirty"
+    sess = _mk_daemon_session_with_worktree("cs-dirty", SessionStatus.COMPLETED, wt_path)
+    save_state(CwState(sessions=[sess]))
+
+    task = TicketTask(
+        ticket_id="cs-dirty",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="cs-dirty",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    monkeypatch.setattr("cw.reconcile._checked_out_branch", lambda _p: "auto-dev/cs-dirty")
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
+    monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: True)
+
+    reverted = revert_completed_silent_tasks()
+
+    store = load_dev_queue()
+    updated_task = next(t for t in store.tasks if t.ticket_id == "cs-dirty")
+    assert updated_task.status == QueueItemStatus.BLOCKED_ON_USER
+    assert updated_task.session_id is None
+    assert "cs-dirty" not in reverted
+
+
+def test_revert_completed_silent_clean_worktree_routes_to_pending(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """COMPLETED DAEMON session with clean worktree routes task to PENDING."""
+    wt_path = tmp_path / "wt-cs-clean"
+    sess = _mk_daemon_session_with_worktree("cs-clean", SessionStatus.COMPLETED, wt_path)
+    save_state(CwState(sessions=[sess]))
+
+    task = TicketTask(
+        ticket_id="cs-clean",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="cs-clean",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    monkeypatch.setattr("cw.reconcile._checked_out_branch", lambda _p: "auto-dev/cs-clean")
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
+    monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: False)
+
+    reverted = revert_completed_silent_tasks()
+
+    store = load_dev_queue()
+    updated_task = next(t for t in store.tasks if t.ticket_id == "cs-clean")
+    assert updated_task.status == QueueItemStatus.PENDING
+    assert updated_task.session_id is None
+    assert "cs-clean" in reverted
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- chore: mark impl complete for #421
- fix(lint): fix ruff E501 and RET504 violations in new test/impl code
- docs(events): document session.needs_attention and queue_status in phantom_reverted
- test: update incident_421 assertions for BLOCKED_ON_USER routing
- fix(reconcile): phantom path uses worktree_path for dirty check, routes dirty tasks to BLOCKED_ON_USER
- feat(reconcile): add _worktree_dirty_by_path helper and _DIRTY_WORKTREE_REASON constant

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

Closes #421

🤖 Shipped via /prep-pr + project /ship-it