### PR TITLE
chore(cleanup): strip residual MultiplexerAdapter from doctor.py + cli.py (#504)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -7,6 +7,7 @@ import json
 import logging
 import subprocess
 import sys
+from collections import deque
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, cast, get_args
@@ -15,7 +16,7 @@ import click
 from click.shell_completion import CompletionItem
 
 from cw import __version__
-from cw._util import _tail_lines, claude_project_dir
+from cw._util import claude_project_dir
 from cw.auto_dev_result import (
     BLOCKER_REASON_NO_RESULT_EMITTED,
     BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED,
@@ -2457,7 +2458,8 @@ def _peek_session(
     than a multiplexer pane — dispatched workers run under the native daemon
     with no pane to scrape (see #504). Only assistant text blocks are
     surfaced; *scrollback* bounds how many trailing transcript output lines
-    are considered before tailing the last *lines* of them.
+    are considered before tailing the last *lines* of them. ``scrollback=0``
+    means "no limit" — keep every output line.
 
     Raises :exc:`cw.exceptions.CwError` when the session is not found,
     is already completed, has no recorded Claude session id, or has no
@@ -2487,17 +2489,23 @@ def _peek_session(
             " transcript once that command is available."
         )
         raise CwError(msg)
-    output_lines: list[str] = []
+    # Bound peak memory to the scrollback window: a long-running session's
+    # transcript can be many MB, but peek only ever shows the tail. The
+    # deque drops older lines as it fills (maxlen=None keeps everything).
+    window: deque[str] = deque(maxlen=scrollback or None)
     for text in _iter_assistant_text_blocks(transcript_path):
-        output_lines.extend(text.splitlines())
-    window = output_lines[-scrollback:] if scrollback else output_lines
-    content = _tail_lines("\n".join(window), lines)
+        window.extend(text.splitlines())
+    content = "\n".join(list(window)[-lines:])
     if len(window) < lines and content.strip():
         click.echo(
             f"Warning: fewer than {lines} lines available in transcript"
             f" (got {len(window)}).",
             err=True,
         )
+    # Why: content is newline-joined with no trailing newline; click.echo
+    # adds exactly one, matching terminal output convention (the old pane
+    # path used nl=False because the adapter returned raw, newline-framed
+    # scrollback).
     click.echo(content)
 
 

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -15,7 +15,7 @@ import click
 from click.shell_completion import CompletionItem
 
 from cw import __version__
-from cw._util import claude_project_dir
+from cw._util import _tail_lines, claude_project_dir
 from cw.auto_dev_result import (
     BLOCKER_REASON_NO_RESULT_EMITTED,
     BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED,
@@ -28,7 +28,6 @@ from cw.auto_dev_result import (
     extract_block,
     parse_stdout,
 )
-from cw.cmux import MultiplexerAdapter, get_cmux_adapter
 from cw.config import (
     get_client,
     init_client,
@@ -107,7 +106,7 @@ from cw.worktree import fast_forward_main
 from cw.wrapper import run_claude_wrapper, signal_idle
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
 
 
 def handle_errors[**P, R](fn: Callable[P, R]) -> Callable[P, R]:
@@ -339,31 +338,26 @@ def doctor(reap: bool, as_json: bool) -> None:
     With ``--reap``, also detects and repairs the following wedge conditions:
 
     \b
-    Class 1 — wedge/pane-idle-but-active
-      Session pane shows an idle shell with no recent worktree activity.
-      Action: mark session COMPLETED, close pane, revert queue task to PENDING.
-      Recipe: cw doctor --reap
-
-    \b
-    Class 2 — wedge/task-running-no-session
+    wedge/task-running-no-session
       Queue task is RUNNING but has no associated live session.
       Action: revert queue task to PENDING.
       Recipe: cw doctor --reap
 
     \b
-    Class 3 — wedge/task-running-completed-session
+    wedge/task-running-completed-session
       Queue task is RUNNING but its session is already COMPLETED.
       Action: revert queue task to PENDING.
       Recipe: cw doctor --reap
 
     \b
-    Class 4 — wedge/repo-ahead-of-queue (advisory only)
+    wedge/repo-ahead-of-queue (advisory only)
       Branch is pushed to remote but queue task is still RUNNING.
       No automatic mutation — inspect and resolve manually.
       Recipe: cw spawn-complete <ticket_id> [--status shipped]
 
-    ``--reap`` also reconciles session state with the live multiplexer,
-    marking phantom sessions COMPLETED and reverting their tickets to PENDING.
+    ``--reap`` also reconciles session state against the native daemon
+    roster, marking phantom sessions COMPLETED and reverting their tickets
+    to PENDING.
     """
     report = run_doctor(reap=reap)
     if as_json:
@@ -1078,8 +1072,24 @@ def _parse_sentinel_from_transcript(
     if not claude_session_id:
         return None
     transcript_path = claude_project_dir(cwd) / f"{claude_session_id}.jsonl"
+    for text in _iter_assistant_text_blocks(transcript_path):
+        if extract_block(text) is not None:
+            return parse_stdout(text)
+    return None
+
+
+def _iter_assistant_text_blocks(transcript_path: Path) -> Iterator[str]:
+    """Yield each assistant text block from a Claude transcript JSONL file.
+
+    The transcript stores one event per line; ``assistant`` events carry
+    ``message.content`` blocks whose ``text`` fields hold the model output,
+    JSON-escaped (real newlines restored by ``json.loads``). Blocks are
+    yielded in file order. A missing file, an I/O error, or a malformed
+    line/record yields nothing rather than raising — callers treat an empty
+    iteration as "no output available".
+    """
     if not transcript_path.is_file():
-        return None
+        return
     try:
         with transcript_path.open(encoding="utf-8", errors="replace") as handle:
             for line in handle:
@@ -1099,11 +1109,10 @@ def _parse_sentinel_from_transcript(
                     if not isinstance(block, dict) or block.get("type") != "text":
                         continue
                     text = block.get("text")
-                    if isinstance(text, str) and extract_block(text) is not None:
-                        return parse_stdout(text)
+                    if isinstance(text, str):
+                        yield text
     except OSError:
-        return None
-    return None
+        return
 
 
 def _sentinel_present_in_transcript(
@@ -2440,12 +2449,19 @@ def _peek_session(
     *,
     lines: int,
     scrollback: int,
-    adapter: MultiplexerAdapter | None = None,
 ) -> None:
     """Emit the last *lines* lines of worker output for *session_name*.
 
+    Worker output is read from the session's Claude transcript
+    (``~/.claude/projects/<encoded-cwd>/<claude_session_id>.jsonl``) rather
+    than a multiplexer pane — dispatched workers run under the native daemon
+    with no pane to scrape (see #504). Only assistant text blocks are
+    surfaced; *scrollback* bounds how many trailing transcript output lines
+    are considered before tailing the last *lines* of them.
+
     Raises :exc:`cw.exceptions.CwError` when the session is not found,
-    is already completed, or its surface is no longer live.
+    is already completed, has no recorded Claude session id, or has no
+    readable transcript.
     """
     state = load_state()
     session = state.find_by_name_or_id(session_name)
@@ -2455,33 +2471,34 @@ def _peek_session(
     if session.status == SessionStatus.COMPLETED:
         msg = (
             f"Session '{session_name}' is completed (status: completed)."
-            " Its surface is no longer available."
-        )
-        raise CwError(msg)
-    if session.surface_ref is None:
-        msg = f"Session '{session_name}' has no surface reference recorded."
-        raise CwError(msg)
-    _adapter = adapter or get_cmux_adapter()
-    live = _adapter.list_surfaces()
-    if session.surface_ref not in live:
-        msg = (
-            f"Surface '{session.surface_ref}' for session '{session_name}' is gone."
-            f" Run 'cw post-mortem {session.id}' for the full transcript"
+            f" Run 'cw post-mortem {session.id}' for its transcript"
             " once that command is available."
         )
         raise CwError(msg)
-    content = _adapter.capture_surface(
-        session.surface_ref, lines=lines, scrollback=scrollback
-    )
-    stripped = content.strip()
-    actual_lines = len(content.splitlines()) if stripped else 0
-    if actual_lines < lines and stripped:
+    if session.claude_session_id is None:
+        msg = f"Session '{session_name}' has no Claude session id recorded."
+        raise CwError(msg)
+    cwd = session.worktree_path or session.workspace_path
+    transcript_path = claude_project_dir(cwd) / f"{session.claude_session_id}.jsonl"
+    if not transcript_path.is_file():
+        msg = (
+            f"Transcript for session '{session_name}' not found at"
+            f" {transcript_path}. Run 'cw post-mortem {session.id}' for the full"
+            " transcript once that command is available."
+        )
+        raise CwError(msg)
+    output_lines: list[str] = []
+    for text in _iter_assistant_text_blocks(transcript_path):
+        output_lines.extend(text.splitlines())
+    window = output_lines[-scrollback:] if scrollback else output_lines
+    content = _tail_lines("\n".join(window), lines)
+    if len(window) < lines and content.strip():
         click.echo(
-            f"Warning: fewer than {lines} lines available in scrollback"
-            f" (got {actual_lines}).",
+            f"Warning: fewer than {lines} lines available in transcript"
+            f" (got {len(window)}).",
             err=True,
         )
-    click.echo(content, nl=False)
+    click.echo(content)
 
 
 @main.command()

--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import importlib.metadata
 import json
-import os
 import subprocess as _sp
 import tomllib
 import urllib.parse
@@ -25,21 +24,18 @@ import yaml
 from pydantic import ValidationError
 
 from cw import __version__
-from cw.cmux import get_backend_adapter
 from cw.config import (
     clients_file,
     load_clients,
     load_state,
     orchestrator_config_file,
-    save_state,
     state_file,
 )
 from cw.dev_queue import dev_queue_lock, load_dev_queue, save_dev_queue
-from cw.events import read_events, record_event
+from cw.events import read_events
 from cw.exceptions import CwError
 from cw.gh import TIMED_OUT_MERGED_LOOKBACK_DAYS, pr_is_merged_for_ticket
 from cw.models import (
-    CompletionReason,
     DispatchSkipReason,
     OrchestratorEventType,
     QueueItemStatus,
@@ -51,7 +47,6 @@ from cw.reconcile import SPAWN_GRACE_SECONDS, reconcile, ticket_id_for_session
 from cw.worktree import _git_dir
 
 if TYPE_CHECKING:
-    from cw.cmux import MultiplexerAdapter
     from cw.models import CwState, DevQueueStore, Session
 
 
@@ -114,13 +109,6 @@ _CW_PACKAGE_NAME = "claude-workspace"
 
 # Number of consecutive FRESHNESS_GATE ticks required to declare a loop stall.
 _LOOP_STALL_CONSECUTIVE_TICKS = 3
-
-# Seconds of worktree inactivity (no non-.git file modified) before a pane
-# showing an idle shell is considered wedged.
-WEDGE_IDLE_MTIME_SECONDS = 300
-
-# Shell command names that indicate a pane is idle (back at prompt).
-_SHELL_COMMANDS: frozenset[str] = frozenset({"bash", "zsh", "fish", "sh", "dash"})
 
 
 def _check_config_file() -> CheckResult:
@@ -354,65 +342,6 @@ def _check_worktree_paths_sessions(
 # ---------------------------------------------------------------------------
 
 
-def _check_wedge_pane_idle(
-    state: CwState,
-    _queue: DevQueueStore,
-    adapter: MultiplexerAdapter,
-) -> list[WedgeFinding]:
-    """Detect panes showing idle shell with no recent worktree file activity.
-
-    Fail-open: if inspect_pane returns {}, skip — missing info must not
-    trigger false-positive findings.
-    """
-    findings: list[WedgeFinding] = []
-    live_statuses = {SessionStatus.ACTIVE, SessionStatus.IDLE}
-    for session in state.sessions:
-        if session.status not in live_statuses:
-            continue
-        if session.surface_ref is None:
-            continue
-        pane_info = adapter.inspect_pane(session.surface_ref)
-        if not pane_info:
-            continue
-        if pane_info.get("cmd") not in _SHELL_COMMANDS:
-            continue
-        worktree = session.worktree_path
-        if worktree is None or not worktree.is_dir():
-            continue
-        cutoff = datetime.now(UTC).timestamp() - WEDGE_IDLE_MTIME_SECONDS
-        recent = False
-        for dirpath, dirnames, filenames in os.walk(worktree):
-            # Exclude .git from mtime scan — git operations update files there
-            # even when no real work is happening.
-            dirnames[:] = [d for d in dirnames if d != ".git"]
-            for fname in filenames:
-                fpath = Path(dirpath) / fname
-                try:
-                    if fpath.stat().st_mtime > cutoff:
-                        recent = True
-                        break
-                except OSError:
-                    continue
-            if recent:
-                break
-        if recent:
-            continue
-        findings.append(
-            WedgeFinding(
-                wedge_class="wedge/pane-idle-but-active",
-                session_id=session.id,
-                ticket_id=ticket_id_for_session(session.name),
-                recipe=(
-                    "Session pane shows idle shell prompt with no recent worktree"
-                    " activity. Run: cw doctor --reap to synthesize completed event"
-                    " and revert queue task."
-                ),
-                state_file=str(state_file()),
-            )
-        )
-    return findings
-
-
 def _check_wedge_task_running_no_session(
     state: CwState,
     queue: DevQueueStore,
@@ -577,77 +506,38 @@ def _check_wedge_repo_ahead(
     return findings
 
 
-def _reap_wedge_findings(
-    findings: list[WedgeFinding],
-    state: CwState,
-    adapter: MultiplexerAdapter,
-) -> None:
+def _reap_wedge_findings(findings: list[WedgeFinding]) -> None:
     """Apply mutations for actionable wedge classes.
 
-    Class-1 (pane-idle-but-active): mark session COMPLETED, close pane,
-    revert queue task to PENDING.
     Class-2 (task-running-no-session): revert queue task to PENDING.
     Class-3 (task-running-completed-session): revert queue task to PENDING.
     Class-4 (repo-ahead-of-queue): advisory only — no mutations.
+
+    The former class-1 (pane-idle-but-active) wedge was removed with the
+    multiplexer substrate — under the native daemon there are no panes to
+    inspect for an idle shell (see #504).
     """
-    session_by_id = {s.id: s for s in state.sessions}
-    now = datetime.now(UTC)
+    revert_ticket_ids: set[str] = {
+        f.ticket_id
+        for f in findings
+        if f.ticket_id and f.wedge_class != "wedge/repo-ahead-of-queue"
+    }
+    if not revert_ticket_ids:
+        return
 
-    # Collect IDs for class-1 sessions and ticket IDs for queue revert (classes 1-3).
-    class1_session_ids: set[str] = set()
-    for f in findings:
-        if f.wedge_class != "wedge/pane-idle-but-active" or f.session_id is None:
-            continue
-        if f.session_id in session_by_id:
-            class1_session_ids.add(f.session_id)
-
-    revert_ticket_ids: set[str] = set()
-    for f in findings:
-        if f.wedge_class == "wedge/repo-ahead-of-queue":
-            continue
-        if f.ticket_id:
-            revert_ticket_ids.add(f.ticket_id)
-
-    # Hold queue lock across BOTH state writes — mutations happen inside the
-    # lock so no reader sees sessions.json=COMPLETED while dev_queue.json=RUNNING.
-    if class1_session_ids or revert_ticket_ids:
-        with dev_queue_lock():
-            if class1_session_ids:
-                for sid in class1_session_ids:
-                    session = session_by_id[sid]
-                    session.status = SessionStatus.COMPLETED
-                    session.completed_reason = CompletionReason.NORMAL
-                    session.completed_at = now
-                save_state(state)
-            if revert_ticket_ids:
-                queue = load_dev_queue()
-                changed = False
-                for task in queue.tasks:
-                    if (
-                        task.ticket_id in revert_ticket_ids
-                        and task.status == QueueItemStatus.RUNNING
-                    ):
-                        task.status = QueueItemStatus.PENDING
-                        task.session_id = None
-                        changed = True
-                if changed:
-                    save_dev_queue(queue)
-
-    # Side effects AFTER both writes succeed.
-    for sid in class1_session_ids:
-        session = session_by_id[sid]
-        record_event(
-            OrchestratorEventType.SESSION_COMPLETED,
-            {
-                "session_id": session.id,
-                "session_name": session.name,
-                "client": session.client,
-                "crashed": False,  # FIX 4: not a crash
-                "ticket_id": ticket_id_for_session(session.name),
-            },
-        )
-        if session.surface_ref is not None:
-            adapter.close(session.surface_ref)
+    with dev_queue_lock():
+        queue = load_dev_queue()
+        changed = False
+        for task in queue.tasks:
+            if (
+                task.ticket_id in revert_ticket_ids
+                and task.status == QueueItemStatus.RUNNING
+            ):
+                task.status = QueueItemStatus.PENDING
+                task.session_id = None
+                changed = True
+        if changed:
+            save_dev_queue(queue)
 
 
 def _check_loop_health() -> list[CheckResult]:
@@ -815,10 +705,8 @@ def run_doctor(*, reap: bool = False) -> DoctorReport:
 
     if link_state is not None:
         report.checks.extend(_check_timed_out_merged(link_state))
-        # Wedge checks: load queue once, run all four checks.
+        # Wedge checks: load queue once, run all three checks.
         queue = load_dev_queue()
-        adapter = get_backend_adapter()
-        report.wedge_findings.extend(_check_wedge_pane_idle(link_state, queue, adapter))
         report.wedge_findings.extend(
             _check_wedge_task_running_no_session(link_state, queue)
         )
@@ -827,7 +715,7 @@ def run_doctor(*, reap: bool = False) -> DoctorReport:
         )
         report.wedge_findings.extend(_check_wedge_repo_ahead(link_state, queue))
         if reap and report.wedge_findings:
-            _reap_wedge_findings(report.wedge_findings, link_state, adapter)
+            _reap_wedge_findings(report.wedge_findings)
 
     if reap:
         report.checks.append(_check_reconcile())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3022,6 +3022,41 @@ class TestParseSentinelFromTranscript:
 class TestIterAssistantTextBlocks:
     """Tests for _iter_assistant_text_blocks (shared transcript walker)."""
 
+    def test_yields_assistant_text_skipping_other_records(self, tmp_path: Path) -> None:
+        """Yields assistant text blocks in order, skipping non-assistant and
+        malformed records."""
+        from cw.cli import _iter_assistant_text_blocks
+
+        transcript = tmp_path / "t.jsonl"
+        records = [
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "ignored"}],
+                    },
+                }
+            ),
+            "{ not valid json",
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "first"},
+                            {"type": "tool_use", "name": "noise"},
+                            {"type": "text", "text": "second"},
+                        ],
+                    },
+                }
+            ),
+        ]
+        transcript.write_text("\n".join(records) + "\n")
+
+        assert list(_iter_assistant_text_blocks(transcript)) == ["first", "second"]
+
     def test_missing_file_yields_nothing(self, tmp_path: Path) -> None:
         from cw.cli import _iter_assistant_text_blocks
 
@@ -4647,6 +4682,37 @@ class TestPeek:
         result = runner.invoke(main, ["peek", "--lines", "50", session.name])
         assert result.exit_code == 0
         assert "fewer than" in result.stderr
+        # The available content is still emitted alongside the warning.
+        assert "line1" in result.output
+        assert "line3" in result.output
+
+    def test_peek_transcript_with_no_assistant_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A transcript holding only non-assistant records → exit 0, no output.
+
+        No assistant text means nothing to surface; peek succeeds quietly
+        rather than erroring, and emits no warning (empty content).
+        """
+        session = self._make_session(tmp_path)
+        fake_home = tmp_path / "fake-home"
+        cwd = session.worktree_path or session.workspace_path
+        encoded = str(cwd).replace("/", "-").replace(".", "-")
+        transcript_dir = fake_home / ".claude" / "projects" / encoded
+        transcript_dir.mkdir(parents=True, exist_ok=True)
+        user_record = {
+            "type": "user",
+            "message": {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        }
+        (transcript_dir / f"{session.claude_session_id}.jsonl").write_text(
+            json.dumps(user_record) + "\n"
+        )
+        monkeypatch.setattr("cw.cli.Path.home", lambda: fake_home)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["peek", session.name])
+        assert result.exit_code == 0, result.output
+        assert result.output.strip() == ""
 
 
 class TestWatchCommand:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
     import click
     import pytest
 
-    from cw.cmux import FakeCmuxAdapter
     from cw.models import QueueItemStatus
 
 
@@ -3020,6 +3019,31 @@ class TestParseSentinelFromTranscript:
         assert _parse_sentinel_from_transcript(str(worktree), "uuid-userblock") is None
 
 
+class TestIterAssistantTextBlocks:
+    """Tests for _iter_assistant_text_blocks (shared transcript walker)."""
+
+    def test_missing_file_yields_nothing(self, tmp_path: Path) -> None:
+        from cw.cli import _iter_assistant_text_blocks
+
+        assert list(_iter_assistant_text_blocks(tmp_path / "nope.jsonl")) == []
+
+    def test_oserror_on_open_yields_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An I/O error mid-read is swallowed — the walker yields nothing."""
+        from cw.cli import _iter_assistant_text_blocks
+
+        transcript = tmp_path / "t.jsonl"
+        transcript.write_text('{"type": "assistant"}\n')
+
+        def _boom(*_a: object, **_kw: object) -> None:
+            msg = "boom"
+            raise OSError(msg)
+
+        monkeypatch.setattr("pathlib.Path.open", _boom)
+        assert list(_iter_assistant_text_blocks(transcript)) == []
+
+
 class TestCompletion:
     def test_completion_command_bash(self) -> None:
         runner = CliRunner()
@@ -4448,19 +4472,21 @@ class TestSpawnCloseTaskCancellation:
 
 
 class TestPeek:
-    """Tests for `cw peek` — read-only session output snapshot."""
+    """Tests for `cw peek` — read-only session output snapshot from transcript."""
 
     def _make_session(
         self,
         tmp_path: Path,
         *,
         status: SessionStatus = SessionStatus.ACTIVE,
-        surface_ref: str | None = "ws:0.1",
+        claude_session_id: str | None = "abc12345",
         sess_id: str = "peeksess",
         name: str = "test-client/impl",
     ) -> Session:
         workspace = tmp_path / "workspace"
         workspace.mkdir(parents=True, exist_ok=True)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir(parents=True, exist_ok=True)
         session = Session(
             id=sess_id,
             name=name,
@@ -4468,41 +4494,67 @@ class TestPeek:
             purpose=SessionPurpose.IMPL,
             status=status,
             workspace_path=workspace,
-            surface_ref=surface_ref,
+            worktree_path=worktree,
+            claude_session_id=claude_session_id,
         )
         state = load_state()
         state.sessions.append(session)
         save_state(state)
         return session
 
-    def test_peek_happy_path(
+    def _write_transcript(
         self,
+        monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        session: Session,
+        text: str,
     ) -> None:
+        """Place a Claude-shaped transcript holding one assistant text block.
 
-        session = self._make_session(tmp_path, surface_ref="ws:0.1")
-        mock_cmux_adapter._live.add("ws:0.1")
-        mock_cmux_adapter.set_surface_content("ws:0.1", "hello world\n")
+        Patches ``Path.home`` so ``claude_project_dir`` resolves under the
+        tmp tree rather than the real ``~/.claude/projects``.
+        """
+        fake_home = tmp_path / "fake-home"
+        cwd = session.worktree_path or session.workspace_path
+        encoded = str(cwd).replace("/", "-").replace(".", "-")
+        transcript_dir = fake_home / ".claude" / "projects" / encoded
+        transcript_dir.mkdir(parents=True, exist_ok=True)
+        record = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": text}],
+            },
+        }
+        (transcript_dir / f"{session.claude_session_id}.jsonl").write_text(
+            json.dumps(record) + "\n"
+        )
+        monkeypatch.setattr("cw.cli.Path.home", lambda: fake_home)
+
+    @staticmethod
+    def _patch_empty_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Point ``Path.home`` at an empty tmp home (no transcript present)."""
+        monkeypatch.setattr("cw.cli.Path.home", lambda: tmp_path / "empty-home")
+
+    def test_peek_happy_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session = self._make_session(tmp_path)
+        self._write_transcript(monkeypatch, tmp_path, session, "hello world")
 
         runner = CliRunner()
-        with patch("cw.cli.get_cmux_adapter", return_value=mock_cmux_adapter):
-            result = runner.invoke(main, ["peek", session.name])
+        result = runner.invoke(main, ["peek", session.name])
         assert result.exit_code == 0, result.output
         assert "hello world" in result.output
 
     def test_peek_by_session_id(
-        self,
-        tmp_path: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        session = self._make_session(tmp_path, surface_ref="ws:0.1", sess_id="abc12345")
-        mock_cmux_adapter._live.add("ws:0.1")
-        mock_cmux_adapter.set_surface_content("ws:0.1", "output via id\n")
+        session = self._make_session(tmp_path, sess_id="id99999")
+        self._write_transcript(monkeypatch, tmp_path, session, "output via id")
 
         runner = CliRunner()
-        with patch("cw.cli.get_cmux_adapter", return_value=mock_cmux_adapter):
-            result = runner.invoke(main, ["peek", session.id])
+        result = runner.invoke(main, ["peek", session.id])
         assert result.exit_code == 0, result.output
         assert "output via id" in result.output
 
@@ -4512,106 +4564,87 @@ class TestPeek:
         assert result.exit_code == 1
         assert "not found" in result.output
 
-    def test_peek_completed_session_exits_1(
-        self,
-        tmp_path: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
-    ) -> None:
-        session = self._make_session(
-            tmp_path, status=SessionStatus.COMPLETED, surface_ref="ws:0.1"
-        )
+    def test_peek_completed_session_exits_1(self, tmp_path: Path) -> None:
+        session = self._make_session(tmp_path, status=SessionStatus.COMPLETED)
         runner = CliRunner()
-        with patch("cw.cli.get_cmux_adapter", return_value=mock_cmux_adapter):
-            result = runner.invoke(main, ["peek", session.name])
+        result = runner.invoke(main, ["peek", session.name])
         assert result.exit_code == 1
         assert "completed" in result.output
 
-    def test_peek_surface_gone_exits_1_with_suggestion(
-        self,
-        tmp_path: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
-    ) -> None:
-        # Session is ACTIVE but surface_ref not in list_surfaces()
-        session = self._make_session(
-            tmp_path, status=SessionStatus.ACTIVE, surface_ref="ws:0.1"
-        )
-        # Don't add surface ref to _live, so list_surfaces() won't find it.
+    def test_peek_no_claude_session_id_exits_1(self, tmp_path: Path) -> None:
+        session = self._make_session(tmp_path, claude_session_id=None)
         runner = CliRunner()
-        with patch("cw.cli.get_cmux_adapter", return_value=mock_cmux_adapter):
-            result = runner.invoke(main, ["peek", session.name])
+        result = runner.invoke(main, ["peek", session.name])
+        assert result.exit_code == 1
+        assert "Claude session id" in result.output
+
+    def test_peek_missing_transcript_exits_1_with_suggestion(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Session is ACTIVE with a claude_session_id, but no transcript exists.
+        session = self._make_session(tmp_path)
+        self._patch_empty_home(monkeypatch, tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(main, ["peek", session.name])
         assert result.exit_code == 1
         assert "post-mortem" in result.output
 
-    def test_peek_default_lines(
-        self,
-        tmp_path: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
+    def test_peek_default_lines_tails_50(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        session = self._make_session(tmp_path, surface_ref="ws:0.1")
-        mock_cmux_adapter._live.add("ws:0.1")
-        mock_cmux_adapter.set_surface_content("ws:0.1", "some content\n")
+        session = self._make_session(tmp_path)
+        body = "\n".join(f"line{i}" for i in range(60))
+        self._write_transcript(monkeypatch, tmp_path, session, body)
 
         runner = CliRunner()
-        with patch("cw.cli.get_cmux_adapter", return_value=mock_cmux_adapter):
-            runner.invoke(main, ["peek", session.name])
-        assert len(mock_cmux_adapter.capture_calls) == 1
-        assert mock_cmux_adapter.capture_calls[0]["lines"] == 50
+        result = runner.invoke(main, ["peek", session.name])
+        assert result.exit_code == 0, result.output
+        emitted = result.output.strip().splitlines()
+        assert len(emitted) == 50
+        assert emitted[-1] == "line59"
+        assert emitted[0] == "line10"
 
     def test_peek_custom_lines(
-        self,
-        tmp_path: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        session = self._make_session(tmp_path, surface_ref="ws:0.1")
-        mock_cmux_adapter._live.add("ws:0.1")
-        mock_cmux_adapter.set_surface_content("ws:0.1", "some content\n")
+        session = self._make_session(tmp_path)
+        body = "\n".join(f"line{i}" for i in range(60))
+        self._write_transcript(monkeypatch, tmp_path, session, body)
 
         runner = CliRunner()
-        with patch("cw.cli.get_cmux_adapter", return_value=mock_cmux_adapter):
-            runner.invoke(main, ["peek", "--lines", "10", session.name])
-        assert mock_cmux_adapter.capture_calls[0]["lines"] == 10
+        result = runner.invoke(main, ["peek", "--lines", "10", session.name])
+        assert result.exit_code == 0, result.output
+        emitted = result.output.strip().splitlines()
+        assert len(emitted) == 10
+        assert emitted[-1] == "line59"
 
-    def test_peek_default_scrollback(
-        self,
-        tmp_path: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
+    def test_peek_scrollback_bounds_window(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        session = self._make_session(tmp_path, surface_ref="ws:0.1")
-        mock_cmux_adapter._live.add("ws:0.1")
-        mock_cmux_adapter.set_surface_content("ws:0.1", "some content\n")
+        # scrollback caps how many trailing transcript lines are considered:
+        # with 60 lines but --scrollback 5, only the last 5 are eligible, so
+        # --lines 50 yields 5 and warns about the shortfall.
+        session = self._make_session(tmp_path)
+        body = "\n".join(f"line{i}" for i in range(60))
+        self._write_transcript(monkeypatch, tmp_path, session, body)
 
         runner = CliRunner()
-        with patch("cw.cli.get_cmux_adapter", return_value=mock_cmux_adapter):
-            runner.invoke(main, ["peek", session.name])
-        assert mock_cmux_adapter.capture_calls[0]["scrollback"] == 200
-
-    def test_peek_custom_scrollback(
-        self,
-        tmp_path: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
-    ) -> None:
-        session = self._make_session(tmp_path, surface_ref="ws:0.1")
-        mock_cmux_adapter._live.add("ws:0.1")
-        mock_cmux_adapter.set_surface_content("ws:0.1", "some content\n")
-
-        runner = CliRunner()
-        with patch("cw.cli.get_cmux_adapter", return_value=mock_cmux_adapter):
-            runner.invoke(main, ["peek", "--scrollback", "500", session.name])
-        assert mock_cmux_adapter.capture_calls[0]["scrollback"] == 500
+        result = runner.invoke(
+            main, ["peek", "--scrollback", "5", "--lines", "50", session.name]
+        )
+        assert result.exit_code == 0, result.output
+        emitted = [ln for ln in result.output.splitlines() if ln.startswith("line")]
+        assert emitted == ["line55", "line56", "line57", "line58", "line59"]
+        assert "fewer than" in result.stderr
 
     def test_peek_warns_when_fewer_lines_available(
-        self,
-        tmp_path: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        session = self._make_session(tmp_path, surface_ref="ws:0.1")
-        mock_cmux_adapter._live.add("ws:0.1")
-        # Only 3 lines of content but we request 50
-        mock_cmux_adapter.set_surface_content("ws:0.1", "line1\nline2\nline3")
+        session = self._make_session(tmp_path)
+        self._write_transcript(monkeypatch, tmp_path, session, "line1\nline2\nline3")
 
         runner = CliRunner()
-        with patch("cw.cli.get_cmux_adapter", return_value=mock_cmux_adapter):
-            result = runner.invoke(main, ["peek", "--lines", "50", session.name])
+        result = runner.invoke(main, ["peek", "--lines", "50", session.name])
         assert result.exit_code == 0
         assert "fewer than" in result.stderr
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING
 from click.testing import CliRunner
 
 from cw.cli import main
-from cw.cmux import FakeCmuxAdapter
 from cw.doctor import CheckResult, DoctorReport, format_report, run_doctor
 
 if TYPE_CHECKING:
@@ -1323,13 +1322,13 @@ class TestWedgeFindingDataclass:
         from cw.doctor import WedgeFinding
 
         wf = WedgeFinding(
-            wedge_class="wedge/pane-idle-but-active",
+            wedge_class="wedge/task-running-no-session",
             session_id="abc",
             ticket_id="123",
             recipe="run cw doctor --reap",
             state_file="/tmp/x.json",
         )
-        assert wf.wedge_class == "wedge/pane-idle-but-active"
+        assert wf.wedge_class == "wedge/task-running-no-session"
         assert wf.session_id == "abc"
         assert wf.ticket_id == "123"
         assert wf.recipe == "run cw doctor --reap"
@@ -1345,7 +1344,7 @@ class TestWedgeFindingDataclass:
         from cw.doctor import DoctorReport, WedgeFinding
 
         wf = WedgeFinding(
-            wedge_class="wedge/pane-idle-but-active",
+            wedge_class="wedge/task-running-no-session",
             session_id="abc",
             ticket_id="123",
             recipe="fix it",
@@ -1357,180 +1356,6 @@ class TestWedgeFindingDataclass:
             wedge_findings=[wf],
         )
         assert report.ok is True
-
-
-class TestWedgePaneIdleButActive:
-    """wedge/pane-idle-but-active detection logic."""
-
-    def _make_active_session(
-        self, tmp_path: Path, *, surface_ref: str | None = "s:0.1"
-    ) -> Session:
-        from datetime import UTC, datetime
-
-        from cw.models import Session, SessionPurpose, SessionStatus
-
-        wt = tmp_path / "worktree"
-        wt.mkdir(parents=True, exist_ok=True)
-        return Session(
-            id="sess-active",
-            name="client-a/auto-dev/TST-1",
-            client="client-a",
-            purpose=SessionPurpose.IMPL,
-            status=SessionStatus.ACTIVE,
-            workspace_path=tmp_path,
-            worktree_path=wt if surface_ref is not None else None,
-            surface_ref=surface_ref,
-            started_at=datetime(2026, 1, 1, tzinfo=UTC),
-        )
-
-    def test_detected_when_shell_and_old_mtime(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
-    ) -> None:
-        import time
-
-        from cw.cmux import FakeCmuxAdapter
-        from cw.config import save_state
-        from cw.dev_queue import save_dev_queue
-        from cw.doctor import _check_wedge_pane_idle
-        from cw.models import CwState, DevQueueStore
-
-        session = self._make_active_session(tmp_path)
-        state = CwState(sessions=[session])
-        save_state(state)
-        save_dev_queue(DevQueueStore(tasks=[]))
-
-        adapter = FakeCmuxAdapter()
-        old_time = time.time() - 700
-        adapter.set_pane_info("s:0.1", {"cmd": "bash", "last_activity": None})
-
-        # Create a file with old mtime
-        test_file = tmp_path / "worktree" / "test.py"
-        test_file.write_text("code")
-        import os
-
-        os.utime(str(test_file), (old_time, old_time))
-
-        queue = DevQueueStore(tasks=[])
-        findings = _check_wedge_pane_idle(state, queue, adapter)
-        assert len(findings) == 1
-        assert findings[0].wedge_class == "wedge/pane-idle-but-active"
-        assert findings[0].session_id == "sess-active"
-
-    def test_not_detected_nonshell_cmd(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
-    ) -> None:
-        import time
-
-        from cw.cmux import FakeCmuxAdapter
-        from cw.doctor import _check_wedge_pane_idle
-        from cw.models import CwState, DevQueueStore
-
-        session = self._make_active_session(tmp_path)
-        state = CwState(sessions=[session])
-
-        adapter = FakeCmuxAdapter()
-        adapter.set_pane_info("s:0.1", {"cmd": "claude", "last_activity": None})
-
-        old_time = time.time() - 700
-        test_file = tmp_path / "worktree" / "test.py"
-        test_file.write_text("code")
-        import os
-
-        os.utime(str(test_file), (old_time, old_time))
-
-        queue = DevQueueStore(tasks=[])
-        findings = _check_wedge_pane_idle(state, queue, adapter)
-        assert findings == []
-
-    def test_not_detected_recent_mtime(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
-    ) -> None:
-        from cw.cmux import FakeCmuxAdapter
-        from cw.doctor import _check_wedge_pane_idle
-        from cw.models import CwState, DevQueueStore
-
-        session = self._make_active_session(tmp_path)
-        state = CwState(sessions=[session])
-
-        adapter = FakeCmuxAdapter()
-        adapter.set_pane_info("s:0.1", {"cmd": "bash", "last_activity": None})
-
-        # File with recent mtime (now)
-        test_file = tmp_path / "worktree" / "test.py"
-        test_file.write_text("fresh code")
-
-        queue = DevQueueStore(tasks=[])
-        findings = _check_wedge_pane_idle(state, queue, adapter)
-        assert findings == []
-
-    def test_not_detected_no_surface_ref(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
-    ) -> None:
-        from cw.cmux import FakeCmuxAdapter
-        from cw.doctor import _check_wedge_pane_idle
-        from cw.models import CwState, DevQueueStore
-
-        session = self._make_active_session(tmp_path, surface_ref=None)
-        state = CwState(sessions=[session])
-
-        adapter = FakeCmuxAdapter()
-        queue = DevQueueStore(tasks=[])
-        findings = _check_wedge_pane_idle(state, queue, adapter)
-        assert findings == []
-
-    def test_git_dir_excluded_from_mtime(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
-    ) -> None:
-        import os
-        import time
-
-        from cw.cmux import FakeCmuxAdapter
-        from cw.doctor import _check_wedge_pane_idle
-        from cw.models import CwState, DevQueueStore
-
-        session = self._make_active_session(tmp_path)
-        state = CwState(sessions=[session])
-
-        adapter = FakeCmuxAdapter()
-        adapter.set_pane_info("s:0.1", {"cmd": "bash", "last_activity": None})
-
-        wt = tmp_path / "worktree"
-        old_time = time.time() - 700
-
-        # Create old non-.git file
-        old_file = wt / "old.py"
-        old_file.write_text("old code")
-        os.utime(str(old_file), (old_time, old_time))
-
-        # Create recent .git/FETCH_HEAD — must be excluded
-        git_dir = wt / ".git"
-        git_dir.mkdir()
-        fetch_head = git_dir / "FETCH_HEAD"
-        fetch_head.write_text("ref")
-        # leave fetch_head with current mtime (recent)
-
-        queue = DevQueueStore(tasks=[])
-        findings = _check_wedge_pane_idle(state, queue, adapter)
-        # .git/ excluded → old.py is only non-.git file → finding IS emitted
-        assert len(findings) == 1
-        assert findings[0].wedge_class == "wedge/pane-idle-but-active"
-
-    def test_inspect_pane_empty_skips(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tmp_config_dir: Path
-    ) -> None:
-        from cw.cmux import FakeCmuxAdapter
-        from cw.doctor import _check_wedge_pane_idle
-        from cw.models import CwState, DevQueueStore
-
-        session = self._make_active_session(tmp_path)
-        state = CwState(sessions=[session])
-
-        adapter = FakeCmuxAdapter()
-        # inspect_pane returns {} (default) — fail-open, skip
-
-        queue = DevQueueStore(tasks=[])
-        findings = _check_wedge_pane_idle(state, queue, adapter)
-        assert findings == []
 
 
 class TestWedgeTaskRunningNoSession:
@@ -2091,75 +1916,15 @@ class TestWedgeReapRecipes:
             started_at=datetime(2026, 1, 1, tzinfo=UTC),
         )
 
-    def test_class1_reap_mutates_session_and_queue(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        tmp_path: Path,
-        tmp_config_dir: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
-    ) -> None:
-        from cw.config import load_state, save_state
-        from cw.dev_queue import load_dev_queue, save_dev_queue
-        from cw.doctor import WedgeFinding, _reap_wedge_findings
-        from cw.models import (
-            CwState,
-            DevQueueStore,
-            QueueItemStatus,
-            SessionStatus,
-            TicketTask,
-        )
-
-        session = self._make_session(tmp_path)
-        state = CwState(sessions=[session])
-        save_state(state)
-
-        task = TicketTask(
-            ticket_id="TST-REAP",
-            client="client-a",
-            status=QueueItemStatus.RUNNING,
-            session_id="reap-sess",
-        )
-        save_dev_queue(DevQueueStore(tasks=[task]))
-
-        from cw.config import state_file as _sf
-
-        finding = WedgeFinding(
-            wedge_class="wedge/pane-idle-but-active",
-            session_id="reap-sess",
-            ticket_id="TST-REAP",
-            recipe="fix",
-            state_file=str(_sf()),
-        )
-
-        _reap_wedge_findings([finding], state, mock_cmux_adapter)
-
-        # session should be COMPLETED
-        reloaded = load_state()
-        sess = next(s for s in reloaded.sessions if s.id == "reap-sess")
-        assert sess.status == SessionStatus.COMPLETED
-
-        # queue task should be PENDING
-        store = load_dev_queue()
-        t = next(t for t in store.tasks if t.ticket_id == "TST-REAP")
-        assert t.status == QueueItemStatus.PENDING
-
-        # adapter.close should have been called
-        assert len(mock_cmux_adapter.calls["close"]) == 1
-
     def test_class2_reap_reverts_queue_only(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
         tmp_config_dir: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
     ) -> None:
-        from cw.config import save_state
         from cw.dev_queue import load_dev_queue, save_dev_queue
         from cw.doctor import WedgeFinding, _reap_wedge_findings
-        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
-
-        state = CwState(sessions=[])
-        save_state(state)
+        from cw.models import DevQueueStore, QueueItemStatus, TicketTask
 
         task = TicketTask(
             ticket_id="TST-C2",
@@ -2179,7 +1944,7 @@ class TestWedgeReapRecipes:
             state_file=str(_sf()),
         )
 
-        _reap_wedge_findings([finding], state, mock_cmux_adapter)
+        _reap_wedge_findings([finding])
 
         store = load_dev_queue()
         t = next(t for t in store.tasks if t.ticket_id == "TST-C2")
@@ -2190,15 +1955,10 @@ class TestWedgeReapRecipes:
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
         tmp_config_dir: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
     ) -> None:
-        from cw.config import save_state
         from cw.dev_queue import load_dev_queue, save_dev_queue
         from cw.doctor import WedgeFinding, _reap_wedge_findings
-        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
-
-        state = CwState(sessions=[])
-        save_state(state)
+        from cw.models import DevQueueStore, QueueItemStatus, TicketTask
 
         task = TicketTask(
             ticket_id="TST-C3",
@@ -2218,7 +1978,7 @@ class TestWedgeReapRecipes:
             state_file=str(_sf()),
         )
 
-        _reap_wedge_findings([finding], state, mock_cmux_adapter)
+        _reap_wedge_findings([finding])
 
         store = load_dev_queue()
         t = next(t for t in store.tasks if t.ticket_id == "TST-C3")
@@ -2229,15 +1989,10 @@ class TestWedgeReapRecipes:
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
         tmp_config_dir: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
     ) -> None:
-        from cw.config import save_state
         from cw.dev_queue import load_dev_queue, save_dev_queue
         from cw.doctor import WedgeFinding, _reap_wedge_findings
-        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
-
-        state = CwState(sessions=[])
-        save_state(state)
+        from cw.models import DevQueueStore, QueueItemStatus, TicketTask
 
         task = TicketTask(
             ticket_id="TST-C4",
@@ -2256,57 +2011,18 @@ class TestWedgeReapRecipes:
             state_file=str(_sf()),
         )
 
-        _reap_wedge_findings([finding], state, mock_cmux_adapter)
+        _reap_wedge_findings([finding])
 
         # advisory only — queue should remain RUNNING
         store = load_dev_queue()
         t = next(t for t in store.tasks if t.ticket_id == "TST-C4")
         assert t.status == QueueItemStatus.RUNNING
 
-    def test_adapter_close_only_for_class1(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        tmp_path: Path,
-        tmp_config_dir: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
-    ) -> None:
-        from cw.config import save_state
-        from cw.dev_queue import save_dev_queue
-        from cw.doctor import WedgeFinding, _reap_wedge_findings
-        from cw.models import CwState, DevQueueStore, QueueItemStatus, TicketTask
-
-        state = CwState(sessions=[])
-        save_state(state)
-
-        task = TicketTask(
-            ticket_id="TST-NCLOSE",
-            client="client-a",
-            status=QueueItemStatus.RUNNING,
-            session_id=None,
-        )
-        save_dev_queue(DevQueueStore(tasks=[task]))
-
-        from cw.config import state_file as _sf
-
-        finding = WedgeFinding(
-            wedge_class="wedge/task-running-no-session",
-            session_id=None,
-            ticket_id="TST-NCLOSE",
-            recipe="fix",
-            state_file=str(_sf()),
-        )
-
-        _reap_wedge_findings([finding], state, mock_cmux_adapter)
-
-        # adapter.close must NOT have been called for class-2
-        assert len(mock_cmux_adapter.calls["close"]) == 0
-
     def test_reap_false_no_mutations(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
         tmp_config_dir: Path,
-        mock_cmux_adapter: FakeCmuxAdapter,
     ) -> None:
         """run_doctor(reap=False) must not trigger _reap_wedge_findings."""
         from cw.config import save_state
@@ -2326,10 +2042,6 @@ class TestWedgeReapRecipes:
         save_dev_queue(DevQueueStore(tasks=[task]))
 
         # Monkeypatch to prevent wedge check from modifying the report
-        monkeypatch.setattr(
-            "cw.doctor._check_wedge_pane_idle",
-            lambda *_a, **_kw: [],
-        )
         monkeypatch.setattr(
             "cw.doctor._check_wedge_task_running_no_session",
             lambda *_a, **_kw: [],
@@ -2403,7 +2115,7 @@ class TestDoctorJsonMode:
         _stub_claude_version_ok(monkeypatch)
 
         wf = WedgeFinding(
-            wedge_class="wedge/pane-idle-but-active",
+            wedge_class="wedge/task-running-no-session",
             session_id="abc",
             ticket_id="123",
             recipe="fix it",


### PR DESCRIPTION
## Summary

- refactor(cli): bound cw peek memory to scrollback window + harden tests (#504)
- chore(cleanup): strip residual MultiplexerAdapter from doctor.py + cli.py (#504)

#167 (multiplexer-removal Phase D) closed with unmet acceptance: `doctor.py` and `cli.py` still wired `MultiplexerAdapter` via pane-based paths. This removes them, unblocking the pure file-deletion in #119 (Phase F).

- **doctor.py** — deleted the pane-idle wedge class (no native analog: the supervisor has no panes) and its class-1 reap path; the three queue/git-based wedge classes survive. `_reap_wedge_findings(findings)` now reverts queue tasks only. Dropped orphaned imports/consts.
- **cli.py** — migrated `cw peek` off pane scrollback to the native session transcript via a shared `_iter_assistant_text_blocks` generator (also consumed by `_parse_sentinel_from_transcript`, no duplicate JSONL walk). Output is bounded to the `--scrollback` window via a `deque`.

Acceptance: no `MultiplexerAdapter` / `get_cmux_adapter` / `get_backend_adapter` references remain in either file.

## Test plan

- [x] ruff check — zero violations
- [x] ruff format --check — clean
- [x] mypy --strict — zero type errors
- [x] pytest — 100% pass; total coverage 95.6% (≥88), patch coverage 100%
- [x] tmux integration — pass
- [x] No regressions in dispatch, reconcile, or other affected modules

Closes #504

🤖 Shipped via /prep-pr + project /ship-it