### PR TITLE
fix(doctor): suppress worktree WARN for terminal sessions

### DIFF
--- a/src/cw/doctor.py
+++ b/src/cw/doctor.py
@@ -110,6 +110,13 @@ _CW_PACKAGE_NAME = "claude-workspace"
 # Number of consecutive FRESHNESS_GATE ticks required to declare a loop stall.
 _LOOP_STALL_CONSECUTIVE_TICKS = 3
 
+# Session statuses that represent an expected terminal lifecycle end-state.
+# A missing worktree on a terminal session is normal (cleaned after merge);
+# only non-terminal sessions with missing worktrees indicate a potential fault.
+_TERMINAL_SESSION_STATUSES: frozenset[SessionStatus] = frozenset(
+    {SessionStatus.COMPLETED, SessionStatus.TIMED_OUT}
+)
+
 
 def _check_config_file() -> CheckResult:
     """Verify the clients.yaml exists or that no clients is acceptable."""
@@ -305,15 +312,24 @@ def _check_workspace_paths() -> list[CheckResult]:
 def _check_worktree_paths_sessions(
     state: CwState | None = None,
 ) -> list[CheckResult]:
-    """Verify each session's worktree_path exists. Read-only, warn-only."""
+    """Verify each non-terminal session's worktree_path exists. Read-only, warn-only.
+
+    Terminal sessions (COMPLETED, TIMED_OUT) have their worktrees cleaned up
+    as part of normal lifecycle — a missing path is expected, not a fault.
+    Only non-terminal sessions with a missing worktree path emit a warn.
+    """
     if state is None:
         return []
-    wt_paths: list[tuple[str, Path]] = [
-        (s.id, s.worktree_path) for s in state.sessions if s.worktree_path is not None
+    wt_paths: list[tuple[str, Path, SessionStatus]] = [
+        (s.id, s.worktree_path, s.status)
+        for s in state.sessions
+        if s.worktree_path is not None
     ]
     total_checked = len(wt_paths)
     results: list[CheckResult] = []
-    for session_id, wt in wt_paths:
+    for session_id, wt, status in wt_paths:
+        if status in _TERMINAL_SESSION_STATUSES:
+            continue
         if not wt.exists():
             results.append(
                 CheckResult(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2440,6 +2440,190 @@ class TestCheckWorktreePathsSessions:
         names = [c.name for c in report.checks]
         assert "worktree/summary" in names
 
+    def test_completed_session_missing_worktree_no_warn(
+        self, tmp_path: Path
+    ) -> None:
+        from cw.doctor import _check_worktree_paths_sessions
+        from cw.models import CwState, Session, SessionPurpose, SessionStatus
+
+        missing = tmp_path / "gone-completed"
+        session = Session(
+            id="jjj10",
+            name="client/impl",
+            client="client",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.COMPLETED,
+            workspace_path=tmp_path,
+            worktree_path=missing,
+        )
+        results = _check_worktree_paths_sessions(CwState(sessions=[session]))
+        warn_results = [r for r in results if r.warn]
+        assert warn_results == []
+        assert results[-1].name == "worktree/summary"
+
+    def test_timed_out_session_missing_worktree_no_warn(
+        self, tmp_path: Path
+    ) -> None:
+        from cw.doctor import _check_worktree_paths_sessions
+        from cw.models import CwState, Session, SessionPurpose, SessionStatus
+
+        missing = tmp_path / "gone-timed-out"
+        session = Session(
+            id="kkk11",
+            name="client/impl",
+            client="client",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.TIMED_OUT,
+            workspace_path=tmp_path,
+            worktree_path=missing,
+        )
+        results = _check_worktree_paths_sessions(CwState(sessions=[session]))
+        warn_results = [r for r in results if r.warn]
+        assert warn_results == []
+        assert results[-1].name == "worktree/summary"
+
+    def test_active_session_missing_worktree_still_warns(
+        self, tmp_path: Path
+    ) -> None:
+        from cw.doctor import _check_worktree_paths_sessions
+        from cw.models import CwState, Session, SessionPurpose, SessionStatus
+
+        missing = tmp_path / "gone-active"
+        session = Session(
+            id="lll12",
+            name="client/impl",
+            client="client",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.ACTIVE,
+            workspace_path=tmp_path,
+            worktree_path=missing,
+        )
+        results = _check_worktree_paths_sessions(CwState(sessions=[session]))
+        warn_results = [r for r in results if r.warn]
+        assert len(warn_results) == 1
+        assert warn_results[0].name == "worktree/lll12"
+
+    def test_mixed_terminal_missing_active_present_no_warn(
+        self, tmp_path: Path
+    ) -> None:
+        from cw.doctor import _check_worktree_paths_sessions
+        from cw.models import CwState, Session, SessionPurpose, SessionStatus
+
+        present = tmp_path / "present"
+        present.mkdir()
+        missing = tmp_path / "gone"
+        sessions = [
+            Session(
+                id="mmm13",
+                name="client/impl",
+                client="client",
+                purpose=SessionPurpose.IMPL,
+                status=SessionStatus.ACTIVE,
+                workspace_path=tmp_path,
+                worktree_path=present,
+            ),
+            Session(
+                id="nnn14",
+                name="client/idea",
+                client="client",
+                purpose=SessionPurpose.IDEA,
+                status=SessionStatus.COMPLETED,
+                workspace_path=tmp_path,
+                worktree_path=missing,
+            ),
+        ]
+        results = _check_worktree_paths_sessions(CwState(sessions=sessions))
+        warn_results = [r for r in results if r.warn]
+        assert warn_results == []
+
+    def test_mixed_active_missing_and_terminal_missing_only_active_warns(
+        self, tmp_path: Path
+    ) -> None:
+        from cw.doctor import _check_worktree_paths_sessions
+        from cw.models import CwState, Session, SessionPurpose, SessionStatus
+
+        missing_active = tmp_path / "gone-active"
+        missing_completed = tmp_path / "gone-completed"
+        sessions = [
+            Session(
+                id="ooo15",
+                name="client/impl",
+                client="client",
+                purpose=SessionPurpose.IMPL,
+                status=SessionStatus.ACTIVE,
+                workspace_path=tmp_path,
+                worktree_path=missing_active,
+            ),
+            Session(
+                id="ppp16",
+                name="client/idea",
+                client="client",
+                purpose=SessionPurpose.IDEA,
+                status=SessionStatus.COMPLETED,
+                workspace_path=tmp_path,
+                worktree_path=missing_completed,
+            ),
+        ]
+        results = _check_worktree_paths_sessions(CwState(sessions=sessions))
+        warn_results = [r for r in results if r.warn]
+        assert len(warn_results) == 1
+        assert warn_results[0].name == "worktree/ooo15"
+
+    def test_summary_counts_exclude_terminal_missing_from_warn_count(
+        self, tmp_path: Path
+    ) -> None:
+        from cw.doctor import _check_worktree_paths_sessions
+        from cw.models import CwState, Session, SessionPurpose, SessionStatus
+
+        present = tmp_path / "present"
+        present.mkdir()
+        missing_completed = tmp_path / "gone"
+        sessions = [
+            Session(
+                id="qqq17",
+                name="client/impl",
+                client="client",
+                purpose=SessionPurpose.IMPL,
+                status=SessionStatus.ACTIVE,
+                workspace_path=tmp_path,
+                worktree_path=present,
+            ),
+            Session(
+                id="rrr18",
+                name="client/idea",
+                client="client",
+                purpose=SessionPurpose.IDEA,
+                status=SessionStatus.COMPLETED,
+                workspace_path=tmp_path,
+                worktree_path=missing_completed,
+            ),
+        ]
+        results = _check_worktree_paths_sessions(CwState(sessions=sessions))
+        summary = results[-1]
+        assert "0 missing worktrees" in summary.detail
+
+    def test_format_report_no_warn_for_completed_session(
+        self, tmp_path: Path
+    ) -> None:
+        from cw.doctor import _check_worktree_paths_sessions, format_report
+        from cw.models import CwState, Session, SessionPurpose, SessionStatus
+
+        missing = tmp_path / "gone-completed2"
+        session = Session(
+            id="sss19",
+            name="client/impl",
+            client="client",
+            purpose=SessionPurpose.IMPL,
+            status=SessionStatus.COMPLETED,
+            workspace_path=tmp_path,
+            worktree_path=missing,
+        )
+        state = CwState(sessions=[session])
+        results = _check_worktree_paths_sessions(state)
+        report = DoctorReport(version="0.0.0", checks=list(results))
+        rendered = format_report(report)
+        assert "[WARN] worktree/sss19" not in rendered
+
 
 # ---------------------------------------------------------------------------
 # TestCheckLoopHealth

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2440,9 +2440,7 @@ class TestCheckWorktreePathsSessions:
         names = [c.name for c in report.checks]
         assert "worktree/summary" in names
 
-    def test_completed_session_missing_worktree_no_warn(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_session_missing_worktree_no_warn(self, tmp_path: Path) -> None:
         from cw.doctor import _check_worktree_paths_sessions
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
@@ -2461,9 +2459,7 @@ class TestCheckWorktreePathsSessions:
         assert warn_results == []
         assert results[-1].name == "worktree/summary"
 
-    def test_timed_out_session_missing_worktree_no_warn(
-        self, tmp_path: Path
-    ) -> None:
+    def test_timed_out_session_missing_worktree_no_warn(self, tmp_path: Path) -> None:
         from cw.doctor import _check_worktree_paths_sessions
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
@@ -2482,9 +2478,7 @@ class TestCheckWorktreePathsSessions:
         assert warn_results == []
         assert results[-1].name == "worktree/summary"
 
-    def test_active_session_missing_worktree_still_warns(
-        self, tmp_path: Path
-    ) -> None:
+    def test_active_session_missing_worktree_still_warns(self, tmp_path: Path) -> None:
         from cw.doctor import _check_worktree_paths_sessions
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 
@@ -2602,9 +2596,7 @@ class TestCheckWorktreePathsSessions:
         summary = results[-1]
         assert "0 missing worktrees" in summary.detail
 
-    def test_format_report_no_warn_for_completed_session(
-        self, tmp_path: Path
-    ) -> None:
+    def test_format_report_no_warn_for_completed_session(self, tmp_path: Path) -> None:
         from cw.doctor import _check_worktree_paths_sessions, format_report
         from cw.models import CwState, Session, SessionPurpose, SessionStatus
 


### PR DESCRIPTION
## Summary

- fix(doctor): suppress worktree WARN for terminal sessions
- test(doctor): add tests for terminal-session worktree warn suppression

## Details

`cw doctor` was emitting 46 advisory WARNs for completed sessions with missing worktrees. Missing worktrees on COMPLETED/TIMED_OUT sessions is the expected lifecycle end-state (cleaned after merge).

After this fix:
- Terminal sessions (COMPLETED, TIMED_OUT) with missing worktrees are silently skipped
- Non-terminal sessions (ACTIVE, IDLE, BACKGROUNDED) with missing worktrees still warn
- Summary line format unchanged

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors (patch scope; baseline debt pre-existing on main)
- [ ] pytest — 1609 passing, 100% patch coverage
- [ ] No regressions in dispatch, reconcile, or other affected modules

Closes #511

🤖 Shipped via /prep-pr + project /ship-it