### PR TITLE
docs(#518): add --extra mcp to quality-gate 5 (CI coverage parity)

### DIFF
--- a/.claude/project-config.yaml
+++ b/.claude/project-config.yaml
@@ -26,7 +26,7 @@ quality_gates:
   - name: hooks
     command: "uv run pre-commit run --all-files"
   - name: test
-    command: "uv run pytest tests/ -m 'not integration' --cov=cw --cov-report=xml --cov-fail-under=88"
+    command: "uv run --extra mcp pytest tests/ -m 'not integration' --cov=cw --cov-report=xml --cov-fail-under=88"
   - name: test-integration
     command: "uv run pytest tests/ -m integration"
   - name: patch-coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ uv run ruff check src/ tests/                                    # 1. Lint
 uv run ruff format --check src/ tests/                           # 2. Format
 uv run mypy --strict src/                                        # 3. Type check
 uv run pre-commit run --all-files                                # 4. Hooks
-uv run pytest tests/ -m 'not integration' \
+uv run --extra mcp pytest tests/ -m 'not integration' \
   --cov=cw --cov-report=xml --cov-fail-under=88                  # 5. Unit + total cov ≥88%
 uv run pytest tests/ -m integration                              # 6. tmux integration
 uv run diff-cover coverage.xml --compare-branch=origin/main \


### PR DESCRIPTION
## Summary

Gate 5 in CLAUDE.md (and `.claude/project-config.yaml`) omitted `--extra mcp`, so a fresh local run reports ~86.6% and fails `--cov-fail-under=88`, while CI (`uv sync --dev --extra mcp`) passes at 95.6%. Adds the extra to the documented command for parity.

## Notes

Implemented by /auto-dev (#518); the worker completed the change but mis-emitted its final sentinel (`stage4_merge_gate` vs the valid `stage4a_merge_gate`), so it blocked instead of opening this PR. Shipped manually. The skill-doc literal bug that caused that is being fixed separately.

Doc/config only — no code paths touched.

Closes #518

🤖 Shipped manually after /auto-dev sentinel-emit drift