### PR TITLE
chore(cleanup): remove write-dead Session.last_handoff_path

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -571,10 +571,7 @@ def _display_status() -> None:
     if backgrounded:
         click.echo("Backgrounded:")
         for s in backgrounded:
-            handoff = (
-                f" handoff: {s.last_handoff_path.name}" if s.last_handoff_path else ""
-            )
-            click.echo(f"  {s.name}{handoff}")
+            click.echo(f"  {s.name}")
 
 
 # --- Queue command group ---

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -323,8 +323,6 @@ class Session(BaseModel):
     worktree_path: Path | None = None
     branch: str | None = None
     surface_ref: str | None = None
-    # legacy: write-dead since #246, kept for state compat
-    last_handoff_path: Path | None = None
     claude_session_id: str | None = None
     auto_backgrounded: bool = False
     started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,9 +135,6 @@ def sample_state(sample_client: ClientConfig) -> CwState:
                 workspace_path=sample_client.workspace_path,
                 started_at=datetime(2025, 1, 15, 9, 0, 0, tzinfo=UTC),
                 backgrounded_at=datetime(2025, 1, 15, 11, 0, 0, tzinfo=UTC),
-                last_handoff_path=(
-                    sample_client.workspace_path / ".handoffs" / "session-abc.md"
-                ),
             ),
             Session(
                 id="sess0003",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,7 +99,6 @@ class TestSession:
         assert s.worktree_path is None
         assert s.branch is None
         assert s.surface_ref is None
-        assert s.last_handoff_path is None
         assert s.claude_session_id is None
         assert s.backgrounded_at is None
         assert s.resumed_at is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -105,6 +105,17 @@ class TestSession:
         assert s.completed_reason is None
         assert s.completed_at is None
 
+    def test_legacy_last_handoff_path_ignored_on_load(self) -> None:
+        raw = {
+            "name": "c/impl",
+            "client": "c",
+            "purpose": "impl",
+            "workspace_path": "/dev/null",
+            "last_handoff_path": "/some/old/path/session.md",
+        }
+        s = Session.model_validate(raw)
+        assert not hasattr(s, "last_handoff_path")
+
     def test_claude_session_id_round_trip(self) -> None:
         s = Session(
             id="abcd1234",


### PR DESCRIPTION
## Summary

- test: add regression for legacy last_handoff_path key in state load
- chore(cleanup): remove write-dead Session.last_handoff_path (#505)
- test: drop last_handoff_path refs from test fixtures

## Test plan

- [x] ruff check — zero violations
- [x] mypy — zero type errors
- [x] pytest — 1764 passed, 95.78% coverage, 100% patch coverage
- [x] Regression test: loading old sessions.json with `last_handoff_path` does not error

Closes #505

🤖 Shipped via /prep-pr + project /ship-it