### PR TITLE
fix(reconcile): add transcript-filename fallback to claude_session_id backfill

### DIFF
--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -309,12 +309,14 @@ def _backfill_claude_session_ids(
         if (
             session.claude_session_id is None
             and session.surface_ref is not None
-            and session.surface_ref in surface_to_full
             and session.status in _LIVE_STATUSES
             and session.origin is SessionOrigin.DAEMON
         ):
-            session.claude_session_id = surface_to_full[session.surface_ref]
-            count += 1
+            from_agents = surface_to_full.get(session.surface_ref)
+            resolved = from_agents or _csid_from_transcript(session)
+            if resolved is not None:
+                session.claude_session_id = resolved
+                count += 1
     if count:
         _log.debug("Backfilled claude_session_id for %d session(s)", count)
         save_state(state)
@@ -491,6 +493,42 @@ def _session_project_dir(session: Session) -> Path | None:
     if worktree is None:
         return None
     return claude_project_dir(worktree)
+
+
+def _csid_from_transcript(session: Session) -> str | None:
+    """Return claude_session_id from the transcript filename, or None.
+
+    Fallback for _backfill_claude_session_ids when the session is no longer
+    visible in ``claude agents --json``.  The transcript is named
+    ``<project_dir>/<full-csid>.jsonl`` where ``full-csid[:8] == surface_ref``.
+    Picks the newest match by mtime; returns None if mtime <= started_at
+    (reused-worktree stale-transcript guard, mirrors #372 fix).
+    """
+    project_dir = _session_project_dir(session)
+    if project_dir is None or not project_dir.is_dir():
+        return None
+    try:
+        candidates = sorted(
+            project_dir.glob(f"{session.surface_ref}*.jsonl"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if not candidates:
+            return None
+        newest = candidates[0]
+        mtime = datetime.fromtimestamp(newest.stat().st_mtime, tz=UTC)
+        if mtime <= session.started_at:
+            return None
+        csid = newest.stem
+        _log.debug(
+            "Resolved claude_session_id=%s for session %s via transcript fallback",
+            csid,
+            session.id,
+        )
+    except OSError:
+        return None
+    else:
+        return csid
 
 
 def _detect_post_review_clean(session: Session) -> bool:

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -4571,7 +4571,10 @@ def test_backfill_claude_session_id_transcript_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """surface_ref absent from agents map but transcript exists → resolved via transcript."""
+    """surface_ref absent from agents map but transcript exists.
+
+    Resolved via transcript fallback.
+    """
     import os
 
     full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
@@ -4585,8 +4588,12 @@ def test_backfill_claude_session_id_transcript_fallback(
         "tx-fallback-1", worktree, _BACKFILL_STARTED_AT, surface_ref=short_id
     )
     save_state(CwState(sessions=[sess]))
-    # Agents map is empty — session has already exited claude agents
-    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [])
+    # Agents returns a non-matching session (daemon reachable, but our session exited)
+    # An empty list would trigger the outage guard and abort reconcile entirely.
+    other_uuid = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json", lambda: [{"sessionId": other_uuid}]
+    )
     # Write transcript named <short_id>-<uuid>.jsonl
     tx_path = _write_idle_transcript(
         home, worktree, filename=f"{transcript_stem}.jsonl"
@@ -4651,7 +4658,11 @@ def test_backfill_claude_session_id_no_transcript_fallback(
         "no-tx-fallback-1", worktree, _BACKFILL_STARTED_AT, surface_ref=short_id
     )
     save_state(CwState(sessions=[sess]))
-    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [])
+    # Non-matching session so outage guard doesn't fire
+    other_uuid = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json", lambda: [{"sessionId": other_uuid}]
+    )
     # Manually create the project dir so it exists but is empty
     encoded = str(worktree).replace("/", "-").replace(".", "-")
     project_dir = home / ".claude" / "projects" / encoded
@@ -4681,7 +4692,11 @@ def test_backfill_claude_session_id_stale_transcript(
         "stale-tx-fallback-1", worktree, _BACKFILL_STARTED_AT, surface_ref=short_id
     )
     save_state(CwState(sessions=[sess]))
-    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [])
+    # Non-matching session so outage guard doesn't fire
+    other_uuid = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json", lambda: [{"sessionId": other_uuid}]
+    )
     tx_path = _write_idle_transcript(
         home, worktree, filename=f"{transcript_stem}.jsonl"
     )
@@ -4689,9 +4704,7 @@ def test_backfill_claude_session_id_stale_transcript(
     stale_mtime = _BACKFILL_STARTED_AT.timestamp()
     os.utime(tx_path, (stale_mtime, stale_mtime))
     reconcile()
-    reloaded = next(
-        s for s in load_state().sessions if s.id == "stale-tx-fallback-1"
-    )
+    reloaded = next(s for s in load_state().sessions if s.id == "stale-tx-fallback-1")
     assert reloaded.claude_session_id is None
 
 

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -4558,6 +4558,144 @@ def test_backfill_claude_session_id_malformed_roster(
 
 
 # ---------------------------------------------------------------------------
+# Transcript-filename fallback tests (GitHub issue #522)
+# When cw dev-queue wait drives a long run with no reconcile ticks, the
+# session exits claude agents before backfill fires.  The transcript file
+# persists, so _csid_from_transcript provides a last-resort resolution.
+# ---------------------------------------------------------------------------
+
+
+@freezegun.freeze_time(_BACKFILL_FROZEN_NOW)
+def test_backfill_claude_session_id_transcript_fallback(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """surface_ref absent from agents map but transcript exists → resolved via transcript."""
+    import os
+
+    full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
+    short_id = full_uuid[:8]  # "04bf1c48"
+    transcript_stem = f"{short_id}-{full_uuid}"
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    worktree = tmp_path / "wt-tx-fallback"
+    sess = _mk_headless_daemon_session(
+        "tx-fallback-1", worktree, _BACKFILL_STARTED_AT, surface_ref=short_id
+    )
+    save_state(CwState(sessions=[sess]))
+    # Agents map is empty — session has already exited claude agents
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [])
+    # Write transcript named <short_id>-<uuid>.jsonl
+    tx_path = _write_idle_transcript(
+        home, worktree, filename=f"{transcript_stem}.jsonl"
+    )
+    # Mtime must be after started_at
+    after_started = _BACKFILL_STARTED_AT.timestamp() + 1
+    os.utime(tx_path, (after_started, after_started))
+    reconcile()
+    reloaded = next(s for s in load_state().sessions if s.id == "tx-fallback-1")
+    assert reloaded.claude_session_id == transcript_stem
+
+
+@freezegun.freeze_time(_BACKFILL_FROZEN_NOW)
+def test_backfill_claude_session_id_agents_primary_over_transcript(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agents map takes priority over transcript when both are present."""
+    import os
+
+    full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
+    short_id = full_uuid[:8]
+    transcript_stem = f"{short_id}-different-uuid-xxxx"
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    worktree = tmp_path / "wt-agents-primary"
+    sess = _mk_headless_daemon_session(
+        "agents-primary-1", worktree, _BACKFILL_STARTED_AT, surface_ref=short_id
+    )
+    save_state(CwState(sessions=[sess]))
+    # Agents map has the real uuid
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json", lambda: [{"sessionId": full_uuid}]
+    )
+    # Transcript with a different stem — should NOT win
+    tx_path = _write_idle_transcript(
+        home, worktree, filename=f"{transcript_stem}.jsonl"
+    )
+    after_started = _BACKFILL_STARTED_AT.timestamp() + 1
+    os.utime(tx_path, (after_started, after_started))
+    reconcile()
+    reloaded = next(s for s in load_state().sessions if s.id == "agents-primary-1")
+    # Agents map value wins
+    assert reloaded.claude_session_id == full_uuid
+
+
+@freezegun.freeze_time(_BACKFILL_FROZEN_NOW)
+def test_backfill_claude_session_id_no_transcript_fallback(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """surface_ref absent from agents map and no transcript → csid stays None."""
+    short_id = "04bf1c48"
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    worktree = tmp_path / "wt-no-tx"
+    sess = _mk_headless_daemon_session(
+        "no-tx-fallback-1", worktree, _BACKFILL_STARTED_AT, surface_ref=short_id
+    )
+    save_state(CwState(sessions=[sess]))
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [])
+    # Manually create the project dir so it exists but is empty
+    encoded = str(worktree).replace("/", "-").replace(".", "-")
+    project_dir = home / ".claude" / "projects" / encoded
+    project_dir.mkdir(parents=True, exist_ok=True)
+    reconcile()
+    reloaded = next(s for s in load_state().sessions if s.id == "no-tx-fallback-1")
+    assert reloaded.claude_session_id is None
+
+
+@freezegun.freeze_time(_BACKFILL_FROZEN_NOW)
+def test_backfill_claude_session_id_stale_transcript(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Transcript mtime <= started_at (stale reused-worktree) → csid stays None."""
+    import os
+
+    full_uuid = "04bf1c48-6b3a-401b-bc3a-0d61b5b7a6ac"
+    short_id = full_uuid[:8]
+    transcript_stem = f"{short_id}-{full_uuid}"
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    worktree = tmp_path / "wt-stale-tx"
+    sess = _mk_headless_daemon_session(
+        "stale-tx-fallback-1", worktree, _BACKFILL_STARTED_AT, surface_ref=short_id
+    )
+    save_state(CwState(sessions=[sess]))
+    monkeypatch.setattr("cw.reconcile._claude_agents_json", lambda: [])
+    tx_path = _write_idle_transcript(
+        home, worktree, filename=f"{transcript_stem}.jsonl"
+    )
+    # Mtime exactly == started_at (not strictly after) — stale guard fires
+    stale_mtime = _BACKFILL_STARTED_AT.timestamp()
+    os.utime(tx_path, (stale_mtime, stale_mtime))
+    reconcile()
+    reloaded = next(
+        s for s in load_state().sessions if s.id == "stale-tx-fallback-1"
+    )
+    assert reloaded.claude_session_id is None
+
+
+# ---------------------------------------------------------------------------
 # Dot-encoding regression tests (GitHub issue #463)
 # Worktrees under ~/.cw/ contain a dot in the path segment; Claude Code
 # encodes BOTH '/' and '.' as '-'.  The old single-replace produced a


### PR DESCRIPTION
## Summary

- fix(reconcile): add transcript-filename fallback to claude_session_id backfill (#522)
- test(reconcile): add transcript-fallback tests for _backfill_claude_session_ids (#522)

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

Closes #522

🤖 Shipped via /prep-pr + project /ship-it