### PR TITLE
refactor(cli): move transcript-walking helpers to _util

### DIFF
--- a/src/cw/_util.py
+++ b/src/cw/_util.py
@@ -7,7 +7,9 @@ so those modules load without circular dependencies.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Iterator
 
 
 def _tail_lines(content: str, n: int) -> str:
@@ -35,3 +37,40 @@ def claude_project_dir(path: str | Path) -> Path:
     """
     encoded = str(path).replace("/", "-").replace(".", "-")
     return Path.home() / ".claude" / "projects" / encoded
+
+
+def _iter_assistant_text_blocks(transcript_path: Path) -> Iterator[str]:
+    """Yield each assistant text block from a Claude transcript JSONL file.
+
+    The transcript stores one event per line; ``assistant`` events carry
+    ``message.content`` blocks whose ``text`` fields hold the model output,
+    JSON-escaped (real newlines restored by ``json.loads``). Blocks are
+    yielded in file order. A missing file, an I/O error, or a malformed
+    line/record yields nothing rather than raising — callers treat an empty
+    iteration as "no output available".
+    """
+    if not transcript_path.is_file():
+        return
+    try:
+        with transcript_path.open(encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(record, dict) or record.get("type") != "assistant":
+                    continue
+                message = record.get("message")
+                if not isinstance(message, dict):
+                    continue
+                content = message.get("content")
+                if not isinstance(content, list):
+                    continue
+                for block in content:
+                    if not isinstance(block, dict) or block.get("type") != "text":
+                        continue
+                    text = block.get("text")
+                    if isinstance(text, str):
+                        yield text
+    except OSError:
+        return

--- a/src/cw/_util.py
+++ b/src/cw/_util.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Iterator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 def _tail_lines(content: str, n: int) -> str:

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -16,7 +16,7 @@ import click
 from click.shell_completion import CompletionItem
 
 from cw import __version__
-from cw._util import claude_project_dir
+from cw._util import _iter_assistant_text_blocks, claude_project_dir
 from cw.auto_dev_result import (
     BLOCKER_REASON_NO_RESULT_EMITTED,
     BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED,
@@ -106,7 +106,7 @@ from cw.tui import watch as tui_watch
 from cw.worktree import fast_forward_main
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Callable
 
 
 def handle_errors[**P, R](fn: Callable[P, R]) -> Callable[P, R]:
@@ -1056,43 +1056,6 @@ def _parse_sentinel_from_transcript(
         if extract_block(text) is not None:
             return parse_stdout(text)
     return None
-
-
-def _iter_assistant_text_blocks(transcript_path: Path) -> Iterator[str]:
-    """Yield each assistant text block from a Claude transcript JSONL file.
-
-    The transcript stores one event per line; ``assistant`` events carry
-    ``message.content`` blocks whose ``text`` fields hold the model output,
-    JSON-escaped (real newlines restored by ``json.loads``). Blocks are
-    yielded in file order. A missing file, an I/O error, or a malformed
-    line/record yields nothing rather than raising — callers treat an empty
-    iteration as "no output available".
-    """
-    if not transcript_path.is_file():
-        return
-    try:
-        with transcript_path.open(encoding="utf-8", errors="replace") as handle:
-            for line in handle:
-                try:
-                    record = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if not isinstance(record, dict) or record.get("type") != "assistant":
-                    continue
-                message = record.get("message")
-                if not isinstance(message, dict):
-                    continue
-                content = message.get("content")
-                if not isinstance(content, list):
-                    continue
-                for block in content:
-                    if not isinstance(block, dict) or block.get("type") != "text":
-                        continue
-                    text = block.get("text")
-                    if isinstance(text, str):
-                        yield text
-    except OSError:
-        return
 
 
 def _sentinel_present_in_transcript(

--- a/tests/test__util.py
+++ b/tests/test__util.py
@@ -1,0 +1,71 @@
+"""Tests for cw._util - shared utility helpers."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+class TestIterAssistantTextBlocks:
+    """Tests for _iter_assistant_text_blocks (shared transcript walker)."""
+
+    def test_yields_assistant_text_skipping_other_records(self, tmp_path: Path) -> None:
+        """Yields assistant text blocks in order, skipping non-assistant and
+        malformed records."""
+        from cw._util import _iter_assistant_text_blocks
+
+        transcript = tmp_path / "t.jsonl"
+        records = [
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "ignored"}],
+                    },
+                }
+            ),
+            "{ not valid json",
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "first"},
+                            {"type": "tool_use", "name": "noise"},
+                            {"type": "text", "text": "second"},
+                        ],
+                    },
+                }
+            ),
+        ]
+        transcript.write_text("\n".join(records) + "\n")
+
+        assert list(_iter_assistant_text_blocks(transcript)) == ["first", "second"]
+
+    def test_missing_file_yields_nothing(self, tmp_path: Path) -> None:
+        from cw._util import _iter_assistant_text_blocks
+
+        assert list(_iter_assistant_text_blocks(tmp_path / "nope.jsonl")) == []
+
+    def test_oserror_on_open_yields_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An I/O error mid-read is swallowed — the walker yields nothing."""
+        from cw._util import _iter_assistant_text_blocks
+
+        transcript = tmp_path / "t.jsonl"
+        transcript.write_text('{"type": "assistant"}\n')
+
+        def _boom(*_a: object, **_kw: object) -> None:
+            msg = "boom"
+            raise OSError(msg)
+
+        monkeypatch.setattr("pathlib.Path.open", _boom)
+        assert list(_iter_assistant_text_blocks(transcript)) == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3017,66 +3017,6 @@ class TestParseSentinelFromTranscript:
         assert _parse_sentinel_from_transcript(str(worktree), "uuid-userblock") is None
 
 
-class TestIterAssistantTextBlocks:
-    """Tests for _iter_assistant_text_blocks (shared transcript walker)."""
-
-    def test_yields_assistant_text_skipping_other_records(self, tmp_path: Path) -> None:
-        """Yields assistant text blocks in order, skipping non-assistant and
-        malformed records."""
-        from cw.cli import _iter_assistant_text_blocks
-
-        transcript = tmp_path / "t.jsonl"
-        records = [
-            json.dumps(
-                {
-                    "type": "user",
-                    "message": {
-                        "role": "user",
-                        "content": [{"type": "text", "text": "ignored"}],
-                    },
-                }
-            ),
-            "{ not valid json",
-            json.dumps(
-                {
-                    "type": "assistant",
-                    "message": {
-                        "role": "assistant",
-                        "content": [
-                            {"type": "text", "text": "first"},
-                            {"type": "tool_use", "name": "noise"},
-                            {"type": "text", "text": "second"},
-                        ],
-                    },
-                }
-            ),
-        ]
-        transcript.write_text("\n".join(records) + "\n")
-
-        assert list(_iter_assistant_text_blocks(transcript)) == ["first", "second"]
-
-    def test_missing_file_yields_nothing(self, tmp_path: Path) -> None:
-        from cw.cli import _iter_assistant_text_blocks
-
-        assert list(_iter_assistant_text_blocks(tmp_path / "nope.jsonl")) == []
-
-    def test_oserror_on_open_yields_nothing(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """An I/O error mid-read is swallowed — the walker yields nothing."""
-        from cw.cli import _iter_assistant_text_blocks
-
-        transcript = tmp_path / "t.jsonl"
-        transcript.write_text('{"type": "assistant"}\n')
-
-        def _boom(*_a: object, **_kw: object) -> None:
-            msg = "boom"
-            raise OSError(msg)
-
-        monkeypatch.setattr("pathlib.Path.open", _boom)
-        assert list(_iter_assistant_text_blocks(transcript)) == []
-
-
 class TestCompletion:
     def test_completion_command_bash(self) -> None:
         runner = CliRunner()


### PR DESCRIPTION
## Summary

- fix(_util): use collections.abc.Iterator under TYPE_CHECKING (UP035/TC003)
- chore: impl-complete marker
- refactor(cli): move _iter_assistant_text_blocks to _util
- feat(_util): add _iter_assistant_text_blocks transcript walker

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

Closes #516

🤖 Shipped via /prep-pr + project /ship-it