### PR TITLE
fix(cli): suppress peek warning when scrollback intentionally bounds window

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -2426,7 +2426,11 @@ def _peek_session(
     for text in _iter_assistant_text_blocks(transcript_path):
         window.extend(text.splitlines())
     content = "\n".join(list(window)[-lines:])
-    if len(window) < lines and content.strip():
+    if (
+        len(window) < lines
+        and content.strip()
+        and not (scrollback and scrollback < lines)
+    ):
         click.echo(
             f"Warning: fewer than {lines} lines available in transcript"
             f" (got {len(window)}).",
@@ -2453,7 +2457,7 @@ def _peek_session(
     "-s",
     default=_PEEK_DEFAULT_SCROLLBACK,
     show_default=True,
-    help="Maximum scrollback depth to search (lines).",
+    help="Max lines of transcript to scan. 0 = no limit (whole transcript).",
 )
 @handle_errors
 def peek(session_name: str, lines: int, scrollback: int) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4596,7 +4596,8 @@ class TestPeek:
     ) -> None:
         # scrollback caps how many trailing transcript lines are considered:
         # with 60 lines but --scrollback 5, only the last 5 are eligible, so
-        # --lines 50 yields 5 and warns about the shortfall.
+        # --lines 50 yields 5. No "fewer than" warning because the user
+        # intentionally capped the window via --scrollback.
         session = self._make_session(tmp_path)
         body = "\n".join(f"line{i}" for i in range(60))
         self._write_transcript(monkeypatch, tmp_path, session, body)
@@ -4608,7 +4609,7 @@ class TestPeek:
         assert result.exit_code == 0, result.output
         emitted = [ln for ln in result.output.splitlines() if ln.startswith("line")]
         assert emitted == ["line55", "line56", "line57", "line58", "line59"]
-        assert "fewer than" in result.stderr
+        assert "fewer than" not in result.stderr
 
     def test_peek_warns_when_fewer_lines_available(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

- Suppresses the "fewer than N lines available" warning in `cw peek` when `--scrollback` is explicitly set to a value smaller than `--lines` — the short window is user-requested, not a transcript shortage
- Documents `--scrollback 0 = no limit (whole transcript)` in the CLI help text

## Details

`_peek_session` emitted the same warning for two distinct situations:
1. The transcript genuinely has fewer lines than `--lines` (useful signal)
2. The user set `--scrollback 5 --lines 50` — the window is intentionally capped (misleading noise)

The fix adds `and not (scrollback and scrollback < lines)` to the warning condition. When scrollback is 0 (no limit), 0 is falsy so the guard is bypassed and the genuine-shortfall warning continues to fire normally.

Closes #517

## Test plan

- [x] `test_peek_scrollback_bounds_window` — updated: asserts warning is suppressed when scrollback < lines
- [x] `test_peek_warns_when_fewer_lines_available` — unchanged: warning still fires for genuine transcript shortfall (default scrollback=200, 3-line transcript)
- [x] All 1744 unit tests pass, coverage 96%

🤖 Generated with [Claude Code](https://claude.ai/claude-code)