### PR TITLE
feat(result): add cw result validate CLI subcommand

### DIFF
--- a/.claude/commands/auto-dev.md
+++ b/.claude/commands/auto-dev.md
@@ -1926,6 +1926,16 @@ cw event record stage.entered \
   --payload "{\"session_id\":\"$CW_SESSION\",\"ticket_id\":\"$TICKET\",\"stage\":\"done\",\"prev_stage\":\"s5_ci_waiting\",\"started_at\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" || true
 ```
 
+**Pre-emit validation gate.** Before framing the sentinel block, validate the inner JSON payload with `cw result validate`. A validation failure means the payload is malformed — fix the field errors, do not emit invalid JSON.
+
+```bash
+# Write the payload to a temp file and validate before emission
+printf '%s' "$SENTINEL_JSON" | cw result validate -
+# On success: cw result validate exits 0 and prints normalized JSON to stdout
+# On failure: exits 1 and prints field.path: message lines to stderr
+# Fix all reported errors before proceeding to emit the framed block
+```
+
 ```
 <<<AUTO_DEV_RESULT
 {

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -92,6 +92,7 @@ from cw.queue import (
     remove_item,
 )
 from cw.reconcile import reconcile, resolve_headless_budget, ticket_id_for_session
+from cw.result import result as result_group
 from cw.schema import REGISTRY, format_json, format_tldr
 from cw.session import (
     background_all_sessions,
@@ -2570,3 +2571,8 @@ def schema_show(name: str, fmt: str) -> None:
         click.echo(format_json(model_cls))
     else:
         click.echo(format_tldr(model_cls))
+
+
+# --- Result command group ---
+
+main.add_command(result_group)

--- a/src/cw/result.py
+++ b/src/cw/result.py
@@ -1,0 +1,101 @@
+"""Sentinel validation utilities for cw result subcommands."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+from pydantic import ValidationError
+
+from cw.auto_dev_result import AutoDevResult
+
+
+def validate_payload(payload: dict[str, Any]) -> list[str]:
+    """Validate a raw AutoDevResult payload dict.
+
+    Returns a list of field-error lines ("field.path: message").
+    Empty list means valid.
+    """
+    try:
+        AutoDevResult.model_validate(payload)
+    except ValidationError as exc:
+        lines = []
+        for err in exc.errors():
+            loc = ".".join(str(p) for p in err["loc"])
+            msg = err["msg"]
+            lines.append(f"{loc}: {msg}")
+        return lines
+    else:
+        return []
+
+
+@click.group()
+def result() -> None:
+    """Validate AutoDevResult sentinels before emission.
+
+    Pre-emit gate: validates the inner JSON object (NOT the <<<AUTO_DEV_RESULT>>>
+    framed block) against the authoritative AutoDevResult schema.
+
+    Field rules:
+    - schema_version: int -- must be 1-4
+    - ticket_id: str
+    - status: "shipped" | "no_op" | "plan_pending_approval" |
+      "ambiguities_pending_resolution" | "premises_pending_verification" |
+      "review_pending_approval" | "merge_gate_blocked" | "scope_exceeded" |
+      "forbidden_area" | "blocked"
+    - stage_reached: str literal (see cw schema show auto-dev-result for full list)
+    - scope: {tier, files, lines_estimate, lines_actual, forbidden_touched}
+    - plan_source: "linear_existing" | "github_issue_existing" | "generated" |
+      "free_text" | "none"
+    - branch: str | null
+
+    Constraints (cross-field invariants):
+    - pr: non-null iff status == "shipped"
+    - blocker: non-null iff status == "blocked"
+    - next_actions contains "wait_for_ci" iff status == "shipped"
+    - scope.tier: required when stage_reached not in {stage1_plan, stage1_pre_flight}
+    - scope.lines_actual: required when stage_reached not in
+      {stage1_plan, stage1_pre_flight}
+    - health.lowest_agent_confidence: required when stage_reached not in
+      {stage1_plan, stage1_pre_flight}
+    - branch: null when status in pre-branch statuses (plan_pending_approval, etc.)
+    - health.downgrade_applied: True requires status == "review_pending_approval"
+    - schema_version: v2-introduced statuses require schema_version >= 2
+
+    Use 'cw schema show auto-dev-result' for the full schema reference.
+    """
+
+
+@result.command(name="validate")
+@click.argument("path")
+def result_validate(path: str) -> None:
+    """Validate a candidate sentinel JSON against AutoDevResult schema.
+
+    PATH is a file path or '-' for stdin. The payload must be the inner
+    JSON object only -- do NOT include the <<<AUTO_DEV_RESULT>>> delimiters.
+
+    On success: exits 0, prints normalized JSON to stdout.
+    On failure: exits 1, prints 'field.path: message' lines to stderr.
+    """
+    if path == "-":
+        raw = sys.stdin.read()
+    else:
+        with click.open_file(path, "r") as f:
+            raw = f.read()
+
+    try:
+        payload: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        click.echo(f"json: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+    errors = validate_payload(payload)
+    if errors:
+        for line in errors:
+            click.echo(line, err=True)
+        raise SystemExit(1)
+
+    result_obj = AutoDevResult.model_validate(payload)
+    click.echo(result_obj.model_dump_json(indent=2))

--- a/src/cw/result.py
+++ b/src/cw/result.py
@@ -12,6 +12,10 @@ from pydantic import ValidationError
 from cw.auto_dev_result import AutoDevResult
 
 
+def _format_errors(exc: ValidationError) -> list[str]:
+    return [f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors()]
+
+
 def validate_payload(payload: dict[str, Any]) -> list[str]:
     """Validate a raw AutoDevResult payload dict.
 
@@ -21,14 +25,8 @@ def validate_payload(payload: dict[str, Any]) -> list[str]:
     try:
         AutoDevResult.model_validate(payload)
     except ValidationError as exc:
-        lines = []
-        for err in exc.errors():
-            loc = ".".join(str(p) for p in err["loc"])
-            msg = err["msg"]
-            lines.append(f"{loc}: {msg}")
-        return lines
-    else:
-        return []
+        return _format_errors(exc)
+    return []
 
 
 @click.group()
@@ -89,13 +87,13 @@ def result_validate(path: str) -> None:
         payload: dict[str, Any] = json.loads(raw)
     except json.JSONDecodeError as exc:
         click.echo(f"json: {exc}", err=True)
-        raise SystemExit(1) from exc
+        raise click.exceptions.Exit(1) from exc
 
-    errors = validate_payload(payload)
-    if errors:
-        for line in errors:
+    try:
+        result_obj = AutoDevResult.model_validate(payload)
+    except ValidationError as exc:
+        for line in _format_errors(exc):
             click.echo(line, err=True)
-        raise SystemExit(1)
+        raise click.exceptions.Exit(1) from exc
 
-    result_obj = AutoDevResult.model_validate(payload)
     click.echo(result_obj.model_dump_json(indent=2))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5133,6 +5133,7 @@ class TestDevQueueWait:
 
         assert _WAIT_EXIT_FAILED == 1
         assert _WAIT_EXIT_BLOCKED == 2
+        assert _WAIT_EXIT_TIMEOUT == 124
 
 
 class TestResultValidate:
@@ -5175,17 +5176,16 @@ class TestResultValidate:
         }
 
     def test_valid_json_stdin_exits_zero_with_normalized_json(self) -> None:
-        runner = CliRunner(mix_stderr=False)
+        runner = CliRunner()
         valid_json = json.dumps(self._valid_payload())
         result = runner.invoke(main, ["result", "validate", "-"], input=valid_json)
         assert result.exit_code == 0, result.output
         parsed = json.loads(result.output)
         assert parsed["status"] == "shipped"
 
-    def test_invalid_json_stdin_exits_nonzero_with_error_on_stderr(self) -> None:
-        runner = CliRunner(mix_stderr=False)
+    def test_invalid_json_stdin_exits_nonzero_with_error_in_output(self) -> None:
+        runner = CliRunner()
         bad_payload = json.dumps({"status": "shipped", "schema_version": 1})
         result = runner.invoke(main, ["result", "validate", "-"], input=bad_payload)
         assert result.exit_code != 0
-        assert len(result.stderr) > 0
-        assert _WAIT_EXIT_TIMEOUT == 124
+        assert len(result.output) > 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5133,4 +5133,59 @@ class TestDevQueueWait:
 
         assert _WAIT_EXIT_FAILED == 1
         assert _WAIT_EXIT_BLOCKED == 2
+
+
+class TestResultValidate:
+    def _valid_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": 1,
+            "ticket_id": "GEN-1234",
+            "status": "shipped",
+            "stage_reached": "stage5_post_create",
+            "scope": {
+                "tier": "small",
+                "files": 3,
+                "lines_estimate": 42,
+                "lines_actual": 47,
+                "forbidden_touched": False,
+            },
+            "plan_source": "linear_existing",
+            "branch": "dev/gen-1234-fix-login",
+            "worktree_path": "/tmp/wt/gen-1234",
+            "fork_point_sha": "abc1234",
+            "commits": ["sha1", "sha2"],
+            "pr": {
+                "number": 42,
+                "url": "https://github.com/foo/bar/pull/42",
+                "auto_merge": True,
+                "base": "main",
+            },
+            "review": {"must_fix_initial": 0, "should_fix": 1, "fix_cycles_used": 0},
+            "health": {
+                "lowest_agent_confidence": "MEDIUM",
+                "any_incomplete_risk": False,
+                "shortcuts": [],
+                "recommendation": "PROCEED",
+                "downgrade_applied": False,
+                "fix_loop_escalated": False,
+            },
+            "friction_highlights": [],
+            "blocker": None,
+            "next_actions": ["wait_for_ci"],
+        }
+
+    def test_valid_json_stdin_exits_zero_with_normalized_json(self) -> None:
+        runner = CliRunner(mix_stderr=False)
+        valid_json = json.dumps(self._valid_payload())
+        result = runner.invoke(main, ["result", "validate", "-"], input=valid_json)
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed["status"] == "shipped"
+
+    def test_invalid_json_stdin_exits_nonzero_with_error_on_stderr(self) -> None:
+        runner = CliRunner(mix_stderr=False)
+        bad_payload = json.dumps({"status": "shipped", "schema_version": 1})
+        result = runner.invoke(main, ["result", "validate", "-"], input=bad_payload)
+        assert result.exit_code != 0
+        assert len(result.stderr) > 0
         assert _WAIT_EXIT_TIMEOUT == 124

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5189,3 +5189,20 @@ class TestResultValidate:
         result = runner.invoke(main, ["result", "validate", "-"], input=bad_payload)
         assert result.exit_code != 0
         assert len(result.output) > 0
+
+    def test_malformed_json_stdin_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["result", "validate", "-"], input="not-valid-json{")
+        assert result.exit_code != 0
+        assert "json:" in result.output
+
+    def test_valid_json_file_path_exits_zero(self, tmp_path: "Path") -> None:
+        import pathlib
+
+        payload_file = pathlib.Path(tmp_path) / "payload.json"
+        payload_file.write_text(json.dumps(self._valid_payload()))
+        runner = CliRunner()
+        result = runner.invoke(main, ["result", "validate", str(payload_file)])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed["status"] == "shipped"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5192,11 +5192,12 @@ class TestResultValidate:
 
     def test_malformed_json_stdin_exits_nonzero(self) -> None:
         runner = CliRunner()
-        result = runner.invoke(main, ["result", "validate", "-"], input="not-valid-json{")
+        bad_input = "not-valid-json{"
+        result = runner.invoke(main, ["result", "validate", "-"], input=bad_input)
         assert result.exit_code != 0
         assert "json:" in result.output
 
-    def test_valid_json_file_path_exits_zero(self, tmp_path: "Path") -> None:
+    def test_valid_json_file_path_exits_zero(self, tmp_path: Path) -> None:
         import pathlib
 
         payload_file = pathlib.Path(tmp_path) / "payload.json"

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,0 +1,84 @@
+"""Tests for cw.result — validate_payload helper."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cw.result import validate_payload
+
+
+def _valid_payload() -> dict[str, Any]:
+    """Minimal valid shipped payload for testing."""
+    return {
+        "schema_version": 1,
+        "ticket_id": "GEN-1234",
+        "status": "shipped",
+        "stage_reached": "stage5_post_create",
+        "scope": {
+            "tier": "small",
+            "files": 3,
+            "lines_estimate": 42,
+            "lines_actual": 47,
+            "forbidden_touched": False,
+        },
+        "plan_source": "linear_existing",
+        "branch": "dev/gen-1234-fix-login",
+        "worktree_path": "/tmp/wt/gen-1234",
+        "fork_point_sha": "abc1234",
+        "commits": ["sha1", "sha2"],
+        "pr": {
+            "number": 42,
+            "url": "https://github.com/foo/bar/pull/42",
+            "auto_merge": True,
+            "base": "main",
+        },
+        "review": {"must_fix_initial": 0, "should_fix": 1, "fix_cycles_used": 0},
+        "health": {
+            "lowest_agent_confidence": "MEDIUM",
+            "any_incomplete_risk": False,
+            "shortcuts": [],
+            "recommendation": "PROCEED",
+            "downgrade_applied": False,
+            "fix_loop_escalated": False,
+        },
+        "friction_highlights": [],
+        "blocker": None,
+        "next_actions": ["wait_for_ci"],
+    }
+
+
+class TestValidatePayload:
+    def test_valid_shipped_payload_returns_no_errors(self) -> None:
+        errors = validate_payload(_valid_payload())
+        assert errors == []
+
+    def test_pr_non_null_with_blocked_status_returns_error(self) -> None:
+        payload = _valid_payload()
+        payload["status"] = "blocked"
+        payload["pr"] = {"number": 1, "url": "...", "auto_merge": True, "base": "main"}
+        payload["blocker"] = {"stage": "s2", "reason": "impl_failed", "details": "x"}
+        payload["next_actions"] = []
+        errors = validate_payload(payload)
+        assert any("pr" in e for e in errors)
+
+    def test_bad_stage_reached_returns_error(self) -> None:
+        payload = _valid_payload()
+        payload["stage_reached"] = "not_a_real_stage"
+        errors = validate_payload(payload)
+        assert len(errors) > 0
+
+    def test_lines_actual_non_null_at_stage1_plan_returns_error(self) -> None:
+        payload = _valid_payload()
+        payload["status"] = "plan_pending_approval"
+        payload["stage_reached"] = "stage1_plan"
+        payload["scope"]["tier"] = "large"
+        payload["scope"]["lines_actual"] = 99  # should be null at stage1_plan
+        payload["branch"] = None
+        payload["worktree_path"] = None
+        payload["fork_point_sha"] = None
+        payload["commits"] = []
+        payload["pr"] = None
+        payload["health"]["lowest_agent_confidence"] = "HIGH"
+        payload["next_actions"] = []
+        errors = validate_payload(payload)
+        assert any("lines_actual" in e for e in errors)


### PR DESCRIPTION
## Summary

- feat(result): add cw result validate command with validate_payload helper
- test(result): add validate_payload and TestResultValidate tests (failing)
- docs(auto-dev): insert pre-emit validation step in Structured Output appendix
- test(result): add file-path and malformed-JSON coverage tests
- chore(result): mark impl-complete for ticket #482
- fix(result): fix ruff E501 and UP037 in test_cli.py
- fix(result): use click.exceptions.Exit and eliminate double model_validate

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

Closes #482

🤖 Shipped via /prep-pr + project /ship-it