### PR TITLE
bulletproof(reconcile,cli): precise surface_ref-prefix transcript locator — unify 6 globs (#541)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -95,7 +95,7 @@ from cw.queue import (
 )
 from cw.reconcile import (
     _csid_from_transcript,
-    _session_project_dir,
+    _locate_session_transcript,
     reconcile,
     resolve_headless_budget,
     resolve_idle_watchdog_budget,
@@ -1688,33 +1688,15 @@ def _transcript_age_seconds(
 ) -> float | None:
     """Return seconds since the session's transcript was last written, or None.
 
-    Returns None when the transcript file cannot be located.  Delegates to
-    ``_transcript_recently_active`` semantics but exposes the raw age so the
-    caller can compare against the budget.
+    Returns None when the transcript file cannot be located.  Uses
+    :func:`~cw.reconcile._locate_session_transcript` for precise per-session
+    lookup (surface_ref-prefix glob, #541).
     """
-    project_dir = _session_project_dir(session)
-    if project_dir is None or not project_dir.is_dir():
-        return None
     try:
-        if session.claude_session_id is not None:
-            transcript = project_dir / f"{session.claude_session_id}.jsonl"
-            if not transcript.is_file():
-                return None
-            mtime = datetime.fromtimestamp(transcript.stat().st_mtime, tz=UTC)
-            return (now - mtime).total_seconds()
-
-        # No csid yet — scan for the newest post-spawn .jsonl
-        candidates = sorted(
-            project_dir.glob("*.jsonl"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )
-        if not candidates:
+        transcript = _locate_session_transcript(session)
+        if transcript is None:
             return None
-        newest = candidates[0]
-        mtime = datetime.fromtimestamp(newest.stat().st_mtime, tz=UTC)
-        if mtime <= session.started_at:
-            return None
+        mtime = datetime.fromtimestamp(transcript.stat().st_mtime, tz=UTC)
         return (now - mtime).total_seconds()
     except OSError:
         return None

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -427,29 +427,19 @@ def _assistant_text_from_transcript(path: Path) -> str:
 def _detect_usage_limit(session: Session) -> bool:
     """Return True iff the newest post-start transcript contains a usage-limit message.
 
-    Mirrors the stale-transcript mtime guard from :func:`_salvage_terminal_result`
-    (#358): only trusts output written strictly after ``session.started_at``.
-    Returns False (never raises) when the project dir is absent, no .jsonl files
-    exist, or the transcript predates the session start.
+    Uses :func:`_locate_session_transcript` for precise per-session lookup
+    (surface_ref-prefix glob, #541).  Returns False (never raises) when the
+    project dir is absent, no matching .jsonl exists, or the transcript
+    predates the session start.
     """
-    project_dir = _session_project_dir(session)
-    if project_dir is None or not project_dir.is_dir():
+    transcript = _locate_session_transcript(session)
+    if transcript is None:
         return False
-    candidates = sorted(
-        project_dir.glob("*.jsonl"),
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
-    if not candidates:
-        return False
-    newest = candidates[0]
-    if datetime.fromtimestamp(newest.stat().st_mtime, tz=UTC) <= session.started_at:
-        return False
-    return bool(USAGE_LIMIT_RE.search(_assistant_text_from_transcript(newest)))
+    return bool(USAGE_LIMIT_RE.search(_assistant_text_from_transcript(transcript)))
 
 
 def _salvage_terminal_result(
-    session: Session, *, after: datetime
+    session: Session,
 ) -> tuple[AutoDevResult, str] | None:
     """Recover a terminal-success AUTO_DEV_RESULT from the session's transcript.
 
@@ -457,33 +447,22 @@ def _salvage_terminal_result(
     sitting in ``wait_for_ci``) or crashed before session lifecycle completion
     may have its disposition lost. This recovers it directly from the transcript.
 
-    Returns ``(result, claude_session_id)`` only when the newest transcript
-    in the session's worktree — modified strictly after ``after`` (the session
-    start, guarding the reused-worktree stale-transcript case, #358) — parses
-    to an :class:`AutoDevResult` whose status is in
-    :data:`_SALVAGE_TERMINAL_STATUSES`. Returns ``None`` otherwise.
+    Returns ``(result, claude_session_id)`` only when the transcript located
+    by :func:`_locate_session_transcript` (surface_ref-prefix glob, #541) —
+    which enforces mtime > started_at, guarding the reused-worktree
+    stale-transcript case (#358) — parses to an :class:`AutoDevResult` whose
+    status is in :data:`_SALVAGE_TERMINAL_STATUSES`. Returns ``None``
+    otherwise.
     """
-    project_dir = _session_project_dir(session)
-    if project_dir is None or not project_dir.is_dir():
+    transcript = _locate_session_transcript(session)
+    if transcript is None:
         return None
-    candidates = sorted(
-        project_dir.glob("*.jsonl"),
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
-    if not candidates:
-        return None
-    newest = candidates[0]
-    # Stale-transcript guard (#358): a reused worktree may retain a prior
-    # run's transcript. Only trust output written since this session began.
-    if datetime.fromtimestamp(newest.stat().st_mtime, tz=UTC) <= after:
-        return None
-    result = parse_stdout(_assistant_text_from_transcript(newest))
+    result = parse_stdout(_assistant_text_from_transcript(transcript))
     if (
         isinstance(result, AutoDevResult)
         and result.status in _SALVAGE_TERMINAL_STATUSES
     ):
-        return result, newest.stem
+        return result, transcript.stem
     return None
 
 
@@ -495,40 +474,64 @@ def _session_project_dir(session: Session) -> Path | None:
     return claude_project_dir(worktree)
 
 
-def _csid_from_transcript(session: Session) -> str | None:
-    """Return claude_session_id from the transcript filename, or None.
+def _locate_session_transcript(session: Session) -> Path | None:
+    """Return the session's transcript path, or None if not locatable.
 
-    Fallback for _backfill_claude_session_ids when the session is no longer
-    visible in ``claude agents --json``.  The transcript is named
-    ``<project_dir>/<full-csid>.jsonl`` where ``full-csid[:8] == surface_ref``.
-    Picks the newest match by mtime; returns None if mtime <= started_at
-    (reused-worktree stale-transcript guard, mirrors #372 fix).
+    Resolution order:
+    1. ``claude_session_id`` set and ``<project_dir>/<csid>.jsonl`` exists →
+       return that path directly (mtime guard not needed; csid is exact).
+    2. ``surface_ref`` set → newest ``<project_dir>/<surface_ref>*.jsonl``
+       with mtime strictly after ``session.started_at``, else None
+       (reused-worktree stale-transcript guard, #358/#372).
+    3. No project_dir, or neither identifier set → None.
+
+    The ``surface_ref``-prefix glob in step 2 excludes sibling transcripts
+    from other sessions that share the same project dir (reused worktree).
+    Do NOT fall back to an unscoped ``*.jsonl`` glob — that would silently
+    read a different session's transcript.
     """
     project_dir = _session_project_dir(session)
     if project_dir is None or not project_dir.is_dir():
         return None
     try:
-        candidates = sorted(
-            project_dir.glob(f"{session.surface_ref}*.jsonl"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )
-        if not candidates:
-            return None
-        newest = candidates[0]
-        mtime = datetime.fromtimestamp(newest.stat().st_mtime, tz=UTC)
-        if mtime <= session.started_at:
-            return None
-        csid = newest.stem
-        _log.debug(
-            "Resolved claude_session_id=%s for session %s via transcript fallback",
-            csid,
-            session.id,
-        )
+        if session.claude_session_id is not None:
+            path = project_dir / f"{session.claude_session_id}.jsonl"
+            return path if path.is_file() else None
+        if session.surface_ref is not None:
+            candidates = sorted(
+                project_dir.glob(f"{session.surface_ref}*.jsonl"),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+            if not candidates:
+                return None
+            newest = candidates[0]
+            mtime = datetime.fromtimestamp(newest.stat().st_mtime, tz=UTC)
+            if mtime <= session.started_at:
+                return None
+            return newest
     except OSError:
         return None
-    else:
-        return csid
+    return None
+
+
+def _csid_from_transcript(session: Session) -> str | None:
+    """Return claude_session_id from the transcript filename, or None.
+
+    Thin wrapper around :func:`_locate_session_transcript`.  The transcript
+    is named ``<project_dir>/<full-csid>.jsonl`` where
+    ``full-csid[:8] == surface_ref``; the stem is therefore the full csid.
+    """
+    path = _locate_session_transcript(session)
+    if path is None:
+        return None
+    csid = path.stem
+    _log.debug(
+        "Resolved claude_session_id=%s for session %s via transcript fallback",
+        csid,
+        session.id,
+    )
+    return csid
 
 
 def _detect_post_review_clean(session: Session) -> bool:
@@ -565,35 +568,16 @@ def _transcript_recently_active(
 ) -> bool:
     """Return True if the session's transcript was written within *window_seconds* ago.
 
-    Reuses the project-dir layout from :func:`_salvage_terminal_result`.
-    Returns False — permitting the watchdog to proceed — when no transcript
-    is found (either the session is pre-first-write or path unavailable).
-    See GitHub #340.
+    Uses :func:`_locate_session_transcript` for precise per-session lookup
+    (surface_ref-prefix glob, #541).  Returns False — permitting the watchdog
+    to proceed — when no transcript is found (pre-first-write or path
+    unavailable).  See GitHub #340.
     """
-    project_dir = _session_project_dir(session)
-    if project_dir is None or not project_dir.is_dir():
-        return False
-
     try:
-        if session.claude_session_id is not None:
-            transcript = project_dir / f"{session.claude_session_id}.jsonl"
-            if not transcript.is_file():
-                return False
-            mtime = datetime.fromtimestamp(transcript.stat().st_mtime, tz=UTC)
-            return (now - mtime).total_seconds() < window_seconds
-
-        # claude_session_id not yet recorded — scan for the newest post-spawn .jsonl
-        candidates = sorted(
-            project_dir.glob("*.jsonl"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )
-        if not candidates:
+        transcript = _locate_session_transcript(session)
+        if transcript is None:
             return False
-        newest = candidates[0]
-        mtime = datetime.fromtimestamp(newest.stat().st_mtime, tz=UTC)
-        if mtime <= session.started_at:
-            return False
+        mtime = datetime.fromtimestamp(transcript.stat().st_mtime, tz=UTC)
         return (now - mtime).total_seconds() < window_seconds
     except OSError:
         return False
@@ -611,21 +595,15 @@ def _awaiting_subagent(session: Session, now: datetime) -> bool:
 
     Fail-open to False (permit the watchdog to proceed) on any read/parse error.
     """
-    project_dir = _session_project_dir(session)
-    if project_dir is None or not project_dir.is_dir():
+    # Why: _locate_session_transcript applies the mtime > started_at guard
+    # uniformly (#541).  A stale transcript (from a prior run in a reused
+    # worktree) that previously could cause a false-positive "subagent pending"
+    # signal now returns None → this function returns False (fail-open).
+    # The behavior change is intentional and conservative.
+    transcript = _locate_session_transcript(session)
+    if transcript is None:
         return False
     try:
-        if session.claude_session_id is not None:
-            transcript = project_dir / f"{session.claude_session_id}.jsonl"
-        else:
-            candidates = sorted(
-                project_dir.glob("*.jsonl"),
-                key=lambda p: p.stat().st_mtime,
-                reverse=True,
-            )
-            if not candidates:
-                return False
-            transcript = candidates[0]
         if not transcript.is_file():
             return False
 
@@ -858,7 +836,7 @@ def revert_stalled_headless_sessions(
         # sentinel the worker emitted before stalling (e.g. waiting on CI).
         # If found, the session is dispositioned by that sentinel and its
         # ticket is NOT reverted for re-dispatch. See GitHub issue #372.
-        salvage = _salvage_terminal_result(session, after=session.started_at)
+        salvage = _salvage_terminal_result(session)
         if salvage is not None:
             result, claude_session_id = salvage
             _apply_salvaged_completion(session, result, claude_session_id, now=now)
@@ -1056,7 +1034,7 @@ def flag_silently_idle_daemon_sessions(
         # Before parking or recovering, try to find a terminal-success sentinel
         # the worker emitted while waiting on CI (e.g. shipped-then-wait_for_ci).
         # If found, the session is dispositioned by that sentinel. (#398)
-        salvage = _salvage_terminal_result(session, after=session.started_at)
+        salvage = _salvage_terminal_result(session)
         if salvage is not None:
             result, claude_session_id = salvage
             _apply_salvaged_completion(session, result, claude_session_id, now=now)
@@ -1342,7 +1320,7 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
         # Recover a terminal-success sentinel before declaring the phantom
         # crashed, so already-shipped work is not re-dispatched (#372).
         salvage = (
-            _salvage_terminal_result(session, after=session.started_at)
+            _salvage_terminal_result(session)
             if session.origin is SessionOrigin.DAEMON
             else None
         )

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1338,13 +1338,23 @@ def _no_op_salvage_payload() -> dict[str, Any]:
 
 
 def _write_salvage_transcript(
-    home: Path, worktree: Path, claude_session_id: str, payload: dict[str, Any]
+    home: Path,
+    worktree: Path,
+    claude_session_id: str,
+    payload: dict[str, Any],
+    *,
+    surface_ref: str = "fake-short-id",
 ) -> Path:
     """Write a transcript jsonl under ``home`` carrying a wrapped sentinel.
 
     Mirrors Claude's on-disk layout: ``<home>/.claude/projects/<encoded>/
-    <uuid>.jsonl`` with the encoded path replacing both ``/`` and ``.``
-    with ``-`` (matching Claude Code's actual encoding).
+    <surface_ref>-<uuid>.jsonl`` with the encoded path replacing both ``/``
+    and ``.`` with ``-`` (matching Claude Code's actual encoding).
+
+    ``surface_ref`` is prepended to the filename so that
+    ``_locate_session_transcript``'s surface_ref-prefix glob can find it.
+    The full stem (``<surface_ref>-<uuid>``) becomes the stored
+    ``claude_session_id``.
     """
     encoded = str(worktree).replace("/", "-").replace(".", "-")
     project_dir = home / ".claude" / "projects" / encoded
@@ -1358,7 +1368,8 @@ def _write_salvage_transcript(
             "content": [{"type": "text", "text": sentinel}],
         },
     }
-    path = project_dir / f"{claude_session_id}.jsonl"
+    stem = f"{surface_ref}-{claude_session_id}"
+    path = project_dir / f"{stem}.jsonl"
     path.write_text(json.dumps(record) + "\n")
     return path
 
@@ -1405,7 +1416,7 @@ def test_revert_stalled_salvages_shipped_sentinel(
     assert reloaded.completed_reason == CompletionReason.NORMAL
     assert reloaded.last_result is not None
     assert reloaded.last_result["status"] == "shipped"
-    assert reloaded.claude_session_id == "claude-uuid-1"
+    assert reloaded.claude_session_id == "fake-short-id-claude-uuid-1"
     assert reloaded.cost_usd == 1.5
 
     task = next(t for t in load_dev_queue().tasks if t.ticket_id == "salv-1")
@@ -1579,7 +1590,9 @@ def test_reconcile_crashed_phantom_salvages_shipped_sentinel(
     )
     payload = _shipped_salvage_payload()
     payload["ticket_id"] = "salv-crash"
-    _write_salvage_transcript(home, worktree, "claude-uuid-5", payload)
+    _write_salvage_transcript(
+        home, worktree, "claude-uuid-5", payload, surface_ref="gone-ref"
+    )
     # A second, genuinely-live session keeps the daemon roster non-empty so the
     # transient-outage guard does not trip (it would otherwise abort reconcile
     # when native_live is empty). Its ref IS in the live set, so it is not a
@@ -2714,9 +2727,17 @@ def test_flag_silently_idle_daemon_sessions_respects_per_ticket_override(
 
 
 def _write_idle_transcript(
-    home: Path, worktree: Path, filename: str = "sess.jsonl"
+    home: Path,
+    worktree: Path,
+    filename: str = "fake-short-id-sess.jsonl",
 ) -> Path:
-    """Write a minimal transcript .jsonl under the project dir for *worktree*."""
+    """Write a minimal transcript .jsonl under the project dir for *worktree*.
+
+    Default filename starts with ``fake-short-id`` so that
+    ``_locate_session_transcript``'s surface_ref-prefix glob finds it when the
+    session has ``surface_ref="fake-short-id"`` (the default in
+    ``_mk_headless_daemon_session``).
+    """
     encoded = str(worktree).replace("/", "-").replace(".", "-")
     project_dir = home / ".claude" / "projects" / encoded
     project_dir.mkdir(parents=True, exist_ok=True)
@@ -2746,7 +2767,7 @@ def test_flag_silently_idle_skips_worker_with_recent_transcript(
     state = CwState(sessions=[sess])
     save_state(state)
 
-    transcript = _write_idle_transcript(home, worktree)
+    transcript = _write_idle_transcript(home, worktree, filename="live-ref-sess.jsonl")
     # Stamp at half the liveness window — well within TRANSCRIPT_LIVENESS_WINDOW_SECONDS
     half_window = TRANSCRIPT_LIVENESS_WINDOW_SECONDS // 2
     recent_ts = (now - timedelta(seconds=half_window)).timestamp()
@@ -3413,9 +3434,15 @@ def _write_idle_transcript_with_text(
     home: Path,
     worktree: Path,
     assistant_text: str,
-    filename: str = "sess-486.jsonl",
+    filename: str = "fake-short-id-sess-486.jsonl",
 ) -> Path:
-    """Write a transcript with a single assistant text block under the project dir."""
+    """Write a transcript with a single assistant text block under the project dir.
+
+    Default filename starts with ``fake-short-id`` so that
+    ``_locate_session_transcript``'s surface_ref-prefix glob finds it when the
+    session has ``surface_ref="fake-short-id"`` (the default in
+    ``_mk_headless_daemon_session``).
+    """
     encoded = str(worktree).replace("/", "-").replace(".", "-")
     project_dir = home / ".claude" / "projects" / encoded
     project_dir.mkdir(parents=True, exist_ok=True)
@@ -3471,6 +3498,7 @@ def test_flag_silently_idle_usage_limit_emits_distinct_cause(
         home,
         worktree,
         "You've hit your session limit · resets 5:20pm",
+        filename="ul-ref-sess-486.jsonl",
     )
     after_ts = started_at.timestamp() + 60
     os.utime(str(transcript), (after_ts, after_ts))
@@ -4062,7 +4090,9 @@ def test_salvage_all_terminal_statuses_from_phantom(
         ticket_id, worktree, started_at, surface_ref="gone-ref"
     )
     payload = _make_terminal_payload(status, ticket_id)
-    _write_salvage_transcript(home, worktree, f"uuid-{status}", payload)
+    _write_salvage_transcript(
+        home, worktree, f"uuid-{status}", payload, surface_ref="gone-ref"
+    )
 
     alive = _mk_session("alive-431", surface_ref="live-ref")
     save_state(CwState(sessions=[sess, alive]))
@@ -4131,7 +4161,9 @@ def test_salvage_paused_statuses_from_phantom_route_to_blocked_on_user(
         ticket_id, worktree, started_at, surface_ref="gone-ref"
     )
     payload = _make_terminal_payload(status, ticket_id)
-    _write_salvage_transcript(home, worktree, f"uuid-{status}", payload)
+    _write_salvage_transcript(
+        home, worktree, f"uuid-{status}", payload, surface_ref="gone-ref"
+    )
 
     alive = _mk_session("alive-471", surface_ref="live-ref")
     save_state(CwState(sessions=[sess, alive]))
@@ -6888,3 +6920,329 @@ class TestDetectPostReviewClean:
             started_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
         )
         assert _detect_post_review_clean(sess) is False
+
+
+# ---------------------------------------------------------------------------
+# _locate_session_transcript tests (GitHub #541)
+# ---------------------------------------------------------------------------
+
+
+def _make_locate_session(
+    *,
+    worktree: Path,
+    started_at: datetime,
+    surface_ref: str | None = "abcd1234",
+    claude_session_id: str | None = None,
+) -> Session:
+    """Build a minimal DAEMON ACTIVE session for locate-transcript tests."""
+    return Session(
+        id="test-locate",
+        name="client-a/impl",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        worktree_path=worktree,
+        surface_ref=surface_ref,
+        claude_session_id=claude_session_id,
+        started_at=started_at,
+    )
+
+
+def test_locate_by_csid_returns_path(
+    tmp_path: Path,
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """claude_session_id set and file exists → returns that path."""
+    from cw.reconcile import _locate_session_transcript
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    worktree = tmp_path / "wt-csid"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    sess = _make_locate_session(
+        worktree=worktree,
+        started_at=started_at,
+        claude_session_id="full-csid-uuid",
+    )
+
+    encoded = str(worktree).replace("/", "-").replace(".", "-")
+    project_dir = home / ".claude" / "projects" / encoded
+    project_dir.mkdir(parents=True)
+    transcript = project_dir / "full-csid-uuid.jsonl"
+    transcript.write_text("{}\n")
+
+    result = _locate_session_transcript(sess)
+    assert result == transcript
+
+
+def test_locate_by_csid_missing_file(
+    tmp_path: Path,
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """claude_session_id set but file absent → None."""
+    from cw.reconcile import _locate_session_transcript
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    worktree = tmp_path / "wt-csid-missing"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    sess = _make_locate_session(
+        worktree=worktree,
+        started_at=started_at,
+        claude_session_id="missing-csid",
+    )
+
+    encoded = str(worktree).replace("/", "-").replace(".", "-")
+    project_dir = home / ".claude" / "projects" / encoded
+    project_dir.mkdir(parents=True)
+    # No transcript written.
+
+    result = _locate_session_transcript(sess)
+    assert result is None
+
+
+def test_locate_by_surface_ref_precise_glob(
+    tmp_path: Path,
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """surface_ref set, matching file mtime > started_at → returns Path."""
+    from cw.reconcile import _locate_session_transcript
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    worktree = tmp_path / "wt-sref"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    sess = _make_locate_session(
+        worktree=worktree,
+        started_at=started_at,
+        surface_ref="abcd1234",
+        claude_session_id=None,
+    )
+
+    encoded = str(worktree).replace("/", "-").replace(".", "-")
+    project_dir = home / ".claude" / "projects" / encoded
+    project_dir.mkdir(parents=True)
+    transcript = project_dir / "abcd1234-full-uuid.jsonl"
+    transcript.write_text("{}\n")
+    after_ts = started_at.timestamp() + 60
+    os.utime(str(transcript), (after_ts, after_ts))
+
+    result = _locate_session_transcript(sess)
+    assert result == transcript
+
+
+def test_locate_excludes_sibling_by_prefix(
+    tmp_path: Path,
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reused-worktree scenario: sibling transcript (different surface_ref,
+    mtime NEWER than target's started_at) does NOT win; the target's own
+    transcript is returned.  Proves the prefix-scoping (not just the mtime
+    guard) excludes the sibling.  See GitHub #541.
+    """
+    from cw.reconcile import _locate_session_transcript
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    worktree = tmp_path / "wt-sibling"
+    started_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    sess = _make_locate_session(
+        worktree=worktree,
+        started_at=started_at,
+        surface_ref="abcd1234",
+        claude_session_id=None,
+    )
+
+    encoded = str(worktree).replace("/", "-").replace(".", "-")
+    project_dir = home / ".claude" / "projects" / encoded
+    project_dir.mkdir(parents=True)
+
+    # Sibling transcript: DIFFERENT surface_ref prefix, but mtime AFTER started_at.
+    # If only the mtime guard were applied (not the prefix glob), this would be
+    # picked as the newest candidate.
+    sibling = project_dir / "zzzzzzzz-other-session.jsonl"
+    sibling.write_text("{}\n")
+    sibling_ts = started_at.timestamp() + 120  # newer than target's started_at
+    os.utime(str(sibling), (sibling_ts, sibling_ts))
+
+    # Target transcript: correct surface_ref prefix, mtime after started_at.
+    target = project_dir / "abcd1234-full-uuid.jsonl"
+    target.write_text("{}\n")
+    target_ts = started_at.timestamp() + 60  # after started_at, but older than sibling
+    os.utime(str(target), (target_ts, target_ts))
+
+    result = _locate_session_transcript(sess)
+    # Must return the TARGET transcript, not the newer sibling.
+    assert result == target
+    assert result != sibling
+
+
+def test_locate_stale_mtime_returns_none(
+    tmp_path: Path,
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """surface_ref set, matching file exists but mtime <= started_at → None."""
+    from cw.reconcile import _locate_session_transcript
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    worktree = tmp_path / "wt-stale-sref"
+    started_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    sess = _make_locate_session(
+        worktree=worktree,
+        started_at=started_at,
+        surface_ref="abcd1234",
+        claude_session_id=None,
+    )
+
+    encoded = str(worktree).replace("/", "-").replace(".", "-")
+    project_dir = home / ".claude" / "projects" / encoded
+    project_dir.mkdir(parents=True)
+    transcript = project_dir / "abcd1234-uuid.jsonl"
+    transcript.write_text("{}\n")
+    # Stamp BEFORE started_at.
+    stale_ts = started_at.timestamp() - 3600
+    os.utime(str(transcript), (stale_ts, stale_ts))
+
+    result = _locate_session_transcript(sess)
+    assert result is None
+
+
+def test_locate_no_surface_ref_no_csid(
+    tmp_path: Path,
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both surface_ref and claude_session_id are None → None (no fallback)."""
+    from cw.reconcile import _locate_session_transcript
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    worktree = tmp_path / "wt-no-ids"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    sess = _make_locate_session(
+        worktree=worktree,
+        started_at=started_at,
+        surface_ref=None,
+        claude_session_id=None,
+    )
+
+    encoded = str(worktree).replace("/", "-").replace(".", "-")
+    project_dir = home / ".claude" / "projects" / encoded
+    project_dir.mkdir(parents=True)
+    # Write a transcript that would be picked by an unscoped *.jsonl glob.
+    unscoped = project_dir / "some-uuid.jsonl"
+    unscoped.write_text("{}\n")
+    after_ts = started_at.timestamp() + 60
+    os.utime(str(unscoped), (after_ts, after_ts))
+
+    # Should NOT fall back to unscoped glob — returns None.
+    result = _locate_session_transcript(sess)
+    assert result is None
+
+
+def test_awaiting_subagent_stale_transcript_returns_false(
+    tmp_path: Path,
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stale transcript (mtime <= started_at) with pending tool_use → False.
+
+    Before #541, _awaiting_subagent used an unscoped *.jsonl glob with no
+    mtime guard in the surface_ref branch.  A stale transcript with a pending
+    tool_use tail would have returned True (false-positive watchdog suppression).
+    Now the mtime guard applies uniformly via _locate_session_transcript.
+    """
+    from cw.reconcile import _awaiting_subagent
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    started_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 12, 5, 0, tzinfo=UTC)
+    worktree = tmp_path / "wt-stale-subagent"
+    sess = _make_locate_session(
+        worktree=worktree,
+        started_at=started_at,
+        surface_ref="abcd1234",
+        claude_session_id=None,
+    )
+
+    encoded = str(worktree).replace("/", "-").replace(".", "-")
+    project_dir = home / ".claude" / "projects" / encoded
+    project_dir.mkdir(parents=True)
+
+    # Write a transcript with a pending tool_use tail.
+    record = json.dumps(
+        {
+            "type": "assistant",
+            "timestamp": now.isoformat(),
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "tu1", "name": "Bash"}],
+            },
+        }
+    )
+    transcript = project_dir / "abcd1234-stale.jsonl"
+    transcript.write_text(record + "\n")
+    # Stamp BEFORE started_at — stale transcript guard should fire.
+    stale_ts = started_at.timestamp() - 3600
+    os.utime(str(transcript), (stale_ts, stale_ts))
+
+    # Must return False: stale transcript → helper returns None → fail-open.
+    assert _awaiting_subagent(sess, now) is False
+
+
+def test_csid_from_transcript_via_helper(
+    tmp_path: Path,
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_csid_from_transcript delegates to _locate_session_transcript; returns stem."""
+    from cw.reconcile import _csid_from_transcript
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    worktree = tmp_path / "wt-csid-helper"
+    surface_ref = "abcd1234"
+    full_stem = f"{surface_ref}-full-uuid-xxxx"
+    sess = _make_locate_session(
+        worktree=worktree,
+        started_at=started_at,
+        surface_ref=surface_ref,
+        claude_session_id=None,
+    )
+
+    encoded = str(worktree).replace("/", "-").replace(".", "-")
+    project_dir = home / ".claude" / "projects" / encoded
+    project_dir.mkdir(parents=True)
+    transcript = project_dir / f"{full_stem}.jsonl"
+    transcript.write_text("{}\n")
+    after_ts = started_at.timestamp() + 60
+    os.utime(str(transcript), (after_ts, after_ts))
+
+    result = _csid_from_transcript(sess)
+    assert result == full_stem


### PR DESCRIPTION
## Summary

Unifies the six duplicated "locate this session's transcript" sites into one canonical `reconcile._locate_session_transcript(session)`, using the precise `surface_ref`-prefix glob — so per-session transcript resolution can't read a sibling/older session's transcript in a reused worktree.

- New `_locate_session_transcript`: csid-direct path → newest `<surface_ref>*.jsonl` with `mtime > started_at` → None. **No unscoped `*.jsonl` fallback.**
- Replaced all 5 unscoped `glob("*.jsonl")` sites (reconcile.py salvage/liveness/`_awaiting_subagent`, cli.py `_transcript_age_seconds`); folded `_csid_from_transcript` into a thin wrapper.
- Removed the now-redundant `after` param from `_salvage_terminal_result` (always `session.started_at`, now via the locator).

Net +463/−145 (mostly tests).

## Test plan
- [x] ruff / format / mypy --strict — clean
- [x] pytest (`--extra mcp`) — 1775 passed, coverage 95.99% (≥88), patch coverage 100%
- [x] **Key acceptance test** `test_locate_excludes_sibling_by_prefix`: sibling transcript (different surface_ref, mtime newer than target's started_at) + target transcript → locator returns the TARGET's, proving prefix-scoping (not just the mtime guard) excludes the sibling.
- [x] 0 unscoped per-session `*.jsonl` globs remain in reconcile.py / cli.py.

Implemented from a fully-resolved spec (#541 comments) via a spec-driven subagent; orchestrator-reviewed. Unblocks #544 (idle-watchdog robust liveness).

Closes #541

🤖