### PR TITLE
fix(reconcile): widen subagent liveness window 900→1800 — stop false-reaping long quiet tool calls (#544, A of #543)

### DIFF
--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -118,7 +118,11 @@ TRANSCRIPT_LIVENESS_WINDOW_SECONDS = 300
 # A worker awaiting a subagent leaves the parent transcript quiet (subagent output
 # only lands on return). Treat a pending tool_use at the transcript tail as alive
 # for up to this long before concluding the subagent itself is hung. See #384.
-SUBAGENT_LIVENESS_WINDOW_SECONDS = 900
+# 1800 (30 min) — widened from 900 (#544): a large refactor can run a single tool
+# call quietly for 20-30 min; reaping at 15 min false-killed live workers (#543).
+# Data-safety: benefit-of-the-doubt is only extended when a *recent* pending
+# tool_use is present (strong alive signal). No pending tool_use → reaped normally.
+SUBAGENT_LIVENESS_WINDOW_SECONDS = 1800
 
 # Paused-status value written to SESSION_NEEDS_ATTENTION events for sessions
 # the watchdog flags (no sentinel ever emitted, daemon surface still live).

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -3136,16 +3136,84 @@ def test_awaiting_subagent_false_when_pending_tool_use_too_old(
     """Pending tool_use older than SUBAGENT_LIVENESS_WINDOW → hung subagent."""
     from cw.reconcile import SUBAGENT_LIVENESS_WINDOW_SECONDS, _awaiting_subagent
 
+    # Window is 1800 s (30 min) as of #544; tool_use exactly at the boundary
+    # (1800 s old) is expired (< is strict).
+    assert SUBAGENT_LIVENESS_WINDOW_SECONDS == 1800
     now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
     project_dir = tmp_path / "proj"
     project_dir.mkdir()
     transcript = project_dir / "sess-uuid.jsonl"
-    assert SUBAGENT_LIVENESS_WINDOW_SECONDS < 1800
     transcript.write_text(
         json.dumps(
             {
                 "type": "assistant",
-                "timestamp": "2026-01-01T00:30:00Z",
+                "timestamp": "2026-01-01T00:30:00Z",  # exactly 1800 s before now
+                "message": {
+                    "stop_reason": "tool_use",
+                    "content": [{"type": "tool_use", "name": "Agent"}],
+                },
+            }
+        )
+        + "\n"
+    )
+    sess = _make_daemon_session(claude_session_id="sess-uuid")
+    with patch("cw.reconcile._session_project_dir", return_value=project_dir):
+        assert _awaiting_subagent(sess, now) is False
+
+
+def test_awaiting_subagent_true_for_20_min_old_tool_use(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """Pending tool_use ~20 min old is within the 1800 s window → alive (#544).
+
+    A large refactor running a single tool call for 20-30 min must NOT be reaped.
+    The liveness window was raised from 900→1800 s specifically to cover this case.
+    """
+    from cw.reconcile import _awaiting_subagent
+
+    # now=01:00:00, tool_use at 00:40:00 → 20 min = 1200 s < 1800 → alive
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    transcript = project_dir / "sess-uuid.jsonl"
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-01-01T00:40:00Z",  # 20 min = 1200 s before now
+                "message": {
+                    "stop_reason": "tool_use",
+                    "content": [{"type": "tool_use", "name": "Agent"}],
+                },
+            }
+        )
+        + "\n"
+    )
+    sess = _make_daemon_session(claude_session_id="sess-uuid")
+    with patch("cw.reconcile._session_project_dir", return_value=project_dir):
+        assert _awaiting_subagent(sess, now) is True
+
+
+def test_awaiting_subagent_false_for_35_min_old_tool_use(
+    tmp_config_dir: Path, tmp_path: Path
+) -> None:
+    """Pending tool_use ~35 min old is beyond the 1800 s window → reaped (#544).
+
+    The guard must not become permanent: a tool_use older than 1800 s indicates
+    a genuinely hung subagent and the watchdog should still reap it.
+    """
+    from cw.reconcile import _awaiting_subagent
+
+    # now=01:00:00, tool_use at 00:25:00 → 35 min = 2100 s > 1800 → expired
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    transcript = project_dir / "sess-uuid.jsonl"
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-01-01T00:25:00Z",  # 35 min = 2100 s before now
                 "message": {
                     "stop_reason": "tool_use",
                     "content": [{"type": "tool_use", "name": "Agent"}],


### PR DESCRIPTION
## Summary

Split A of #543 (idle-watchdog false-reaps). #541 already made transcript liveness precise; this is the remaining calibration: raise `SUBAGENT_LIVENESS_WINDOW_SECONDS` 900→1800 so a DAEMON worker running a single long tool call (large refactor) quiet for 20-30 min is treated as alive (recent pending `tool_use`) instead of reaped at 15 min.

Only the constant + its comment changed — no reap-logic, write-ordering, transient-outage guard, or retry-cap touched.

## Data-safety
Benefit-of-the-doubt is extended ONLY when a recent pending `tool_use` is present (a strong alive signal). A genuinely-dead worker (no pending tool_use, stale transcript past the elapsed budget) is still reaped. `IDLE_WATCHDOG_SECONDS` (900) and `TRANSCRIPT_LIVENESS_WINDOW_SECONDS` (300) unchanged.

## Test plan
- [x] ruff / format / mypy --strict — clean
- [x] pytest (`--extra mcp`) — 1777 passed, coverage 96.02% (≥88), patch 100%
- [x] New boundary tests: pending tool_use 20 min old → alive (not reaped); 35 min old → reaped (guard not permanent)

Subagent-built (off the dispatch path it fixes), orchestrator-reviewed: confirmed the diff is the constant only. Next: #545 (B, confirm-before-reap).

Closes #544

🤖