### PR TITLE
feat(reconcile): emit queue.session_reaped events with reason taxonomy (#380)

### DIFF
--- a/docs/headless-contract.md
+++ b/docs/headless-contract.md
@@ -477,6 +477,36 @@ Emitted on every BLOCKED_ON_USER transition.
 
 **Re-dispatch rule:** never auto-retry BLOCKED_ON_USER tasks. Human must review the Linear/GitHub issue for the posted ambiguities/premises, resolve them, and then re-dispatch manually.
 
+### queue.session_reaped Bus Event (GitHub #380)
+
+Emitted on the **queue-events bus** (`cw event tail`, MCP `queue.session_reaped`) whenever reconcile disposes of a session. The bus server polls `session.reap_reason` off the state snapshot and fires exactly once per new reason stamp.
+
+Event string: `queue.session_reaped`
+
+**Payload:**
+
+| Field | Type | Notes |
+|---|---|---|
+| `session_id` | string | The cw session ID. |
+| `surface_ref` | string \| null | Daemon surface short-id; null when the surface is gone (backstop paths). |
+| `origin` | string | `"daemon"` or `"user"`. |
+| `reason` | string | See ReapReason enum below. |
+| `from_status` | string | Session status before the reap (e.g. `"active"`, `"idle"`). |
+| `to_status` | string | Session status after the reap (e.g. `"completed"`, `"timed_out"`). |
+
+**`reason` values (ReapReason enum):**
+
+| Value | Trigger |
+|---|---|
+| `phantom_surface` | Daemon surface absent from roster (`_reconcile_locked` phantom sweep). |
+| `idle_stall` | Watchdog fired, no usage-limit message found; task reverted to PENDING for retry. |
+| `usage_limit_cutoff` | Watchdog fired; transcript contained a Claude usage-limit message; task reverted for retry. |
+| `retry_cap_parked` | Watchdog fired; retry cap reached; task set BLOCKED_ON_USER. |
+| `wall_clock_budget` | Wall-clock budget exceeded (`revert_stalled_headless_sessions`); task reverted for retry. |
+| `completed_backstop` | Backstop path (`revert_timed_out_tasks` / `revert_completed_silent_tasks`) found a TIMED_OUT or COMPLETED DAEMON session with a still-RUNNING queue task and no prior reap_reason. |
+| `salvage_completed` | Git-state HIGH path: committed branch, no open PR, post-review-clean; draft PR auto-created, task COMPLETED. |
+| `salvage_parked` | Git-state LOW path: committed branch, no open PR, not post-review-clean; task set BLOCKED_ON_USER for human salvage. |
+
 ---
 
 ## 9. Cross-References

--- a/src/cw/cw_queue_events_channel.py
+++ b/src/cw/cw_queue_events_channel.py
@@ -28,8 +28,16 @@ sentinel_status or null)
   and queue.py mark_item_failed(). Subscribers should not assume broader \
 failure coverage.
 - queue.session_idled: session ACTIVE->IDLE (session_id, session_name)
-RUNNING->CANCELLED: no event (system-driven cleanup)
-RUNNING->BLOCKED_ON_USER: no event (transient; session will resume)\
+- queue.session_reaped: reconcile disposed of a session (session_id, \
+surface_ref or null, origin, reason, from_status, to_status)
+  reason values: phantom_surface (dead daemon surface), idle_stall (watchdog \
+recover, retried), usage_limit_cutoff (usage-limit hit, retried), \
+retry_cap_parked (retry cap reached, BLOCKED_ON_USER), wall_clock_budget \
+(wall-clock budget exceeded, retried), completed_backstop (backstop revert of \
+TIMED_OUT or COMPLETED session with no prior reason), salvage_completed \
+(git-state HIGH-path auto-PR), salvage_parked (git-state LOW-path flagged \
+for human)
+RUNNING->CANCELLED: no event (system-driven cleanup)\
 """
 
 # MCP types — deferred-import inside functions per project convention

--- a/src/cw/cw_queue_events_server.py
+++ b/src/cw/cw_queue_events_server.py
@@ -42,6 +42,9 @@ class QueueSnapshot(BaseModel):
     task_statuses: dict[str, str] = Field(default_factory=dict)
     task_session_ids: dict[str, str | None] = Field(default_factory=dict)
     session_statuses: dict[str, str] = Field(default_factory=dict)
+    # Tracks the last-seen reap_reason per session so the poller can fire
+    # queue.session_reaped exactly once when reconcile stamps a new reason.
+    session_reap_reasons: dict[str, str] = Field(default_factory=dict)
 
 
 class AckRequest(BaseModel):
@@ -308,6 +311,27 @@ def _compute_session_deltas(
                     "session_name": session.name,
                 }
             )
+        # Emit queue.session_reaped when reconcile stamps a new reap_reason
+        # (first non-None appearance). The reason is persisted on Session so
+        # the poller can read it off the state snapshot rather than needing
+        # out-of-band signalling. See GitHub #380.
+        reap_reason = session.reap_reason
+        if reap_reason is not None:
+            prev_reason = old.session_reap_reasons.get(session.id)
+            if prev_reason is None:
+                events.append(
+                    {
+                        "event": "queue.session_reaped",
+                        "session_id": session.id,
+                        "surface_ref": session.surface_ref,
+                        "origin": str(session.origin),
+                        "reason": str(reap_reason),
+                        "from_status": prev
+                        if prev is not None
+                        else str(session.status),
+                        "to_status": curr,
+                    }
+                )
     return events
 
 
@@ -353,6 +377,11 @@ def _poll_once(old: QueueSnapshot) -> tuple[QueueSnapshot, list[dict[str, Any]]]
         task_statuses={t.ticket_id: str(t.status) for t in store.tasks},
         task_session_ids={t.ticket_id: t.session_id for t in store.tasks},
         session_statuses={s.id: str(s.status) for s in state.sessions},
+        session_reap_reasons={
+            s.id: str(s.reap_reason)
+            for s in state.sessions
+            if s.reap_reason is not None
+        },
     )
     return new_snap, events
 

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -51,11 +51,29 @@ class QueueItemStatus(StrEnum):
     BLOCKED_ON_USER = "blocked_on_user"
 
 
+class ReapReason(StrEnum):
+    """Reason taxonomy for queue.session_reaped bus events.
+
+    Each value maps to exactly one reconcile disposition path. See the
+    reap-site decision table in GitHub issue #380.
+    """
+
+    PHANTOM_SURFACE = "phantom_surface"
+    IDLE_STALL = "idle_stall"
+    USAGE_LIMIT_CUTOFF = "usage_limit_cutoff"
+    RETRY_CAP_PARKED = "retry_cap_parked"
+    WALL_CLOCK_BUDGET = "wall_clock_budget"
+    COMPLETED_BACKSTOP = "completed_backstop"
+    SALVAGE_COMPLETED = "salvage_completed"
+    SALVAGE_PARKED = "salvage_parked"
+
+
 # Schema versions for persisted state. Bump when making a breaking change
 # to the on-disk layout; add a migration in `cw.config.migrate_cw_state`
 # or `cw.dev_queue.migrate_dev_queue` to handle older versions.
 # v6: added Session.idle_observation_count (GitHub #545).
-CW_STATE_SCHEMA_VERSION = 6
+# v7: added Session.reap_reason (GitHub #380).
+CW_STATE_SCHEMA_VERSION = 7
 DEV_QUEUE_SCHEMA_VERSION = 2
 
 
@@ -341,6 +359,11 @@ class Session(BaseModel):
     resumed_at: datetime | None = None
     completed_reason: CompletionReason | None = None
     completed_at: datetime | None = None
+    # Reason written at each reap site so the queue-events bus server can
+    # include it in queue.session_reaped notifications. Finer-grained than
+    # CompletionReason — see ReapReason and GitHub #380. None for sessions
+    # not reaped by reconcile (e.g. user-backgrounded or /session-done'd).
+    reap_reason: ReapReason | None = None
     parent_session_id: str | None = None
     worker_session_ids: list[str] = Field(default_factory=list)
     # Sentinel-block summary parsed from a headless /auto-dev worker's stdout

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -62,6 +62,7 @@ from cw.models import (
     OrchestratorConfig,
     OrchestratorEventType,
     QueueItemStatus,
+    ReapReason,
     SessionOrigin,
     SessionStatus,
     TicketTask,
@@ -849,6 +850,7 @@ def revert_stalled_headless_sessions(
         session.status = SessionStatus.TIMED_OUT
         session.completed_at = now
         session.completed_reason = CompletionReason.TIMED_OUT
+        session.reap_reason = ReapReason.WALL_CLOCK_BUDGET
         pending.append((session, ticket_id))
 
     if not pending and not salvaged:
@@ -1106,13 +1108,20 @@ def flag_silently_idle_daemon_sessions(
         return [], []
 
     # Auto-recover: retire the session and revert its task for re-dispatch.
+    # Compute usage-limit cause before save_state so reap_reason persists.
     for session, _ in recover:
         session.status = SessionStatus.TIMED_OUT
         session.completed_at = now
         session.completed_reason = CompletionReason.TIMED_OUT
+        session.reap_reason = (
+            ReapReason.USAGE_LIMIT_CUTOFF
+            if _detect_usage_limit(session)
+            else ReapReason.IDLE_STALL
+        )
     # Park: flag-only (preserves #348 — no daemon stop, session stays ACTIVE).
     for session, _ in park:
         session.last_result = {"paused_status": _SILENTLY_IDLE_REASON}
+        session.reap_reason = ReapReason.RETRY_CAP_PARKED
 
     # Write session to disk BEFORE queue mutation so a crash between the two
     # leaves state set on disk — watchdog skips on subsequent ticks. (#324, #348)
@@ -1147,6 +1156,8 @@ def flag_silently_idle_daemon_sessions(
 
     # Recovery: stop the dead surface + emit a distinguishable timeout event.
     # Payload mirrors the wall-clock timeout path; cause distinguishes the source.
+    # reap_reason was set (and persisted) in the mutation loop above, so we
+    # read it back rather than re-running _detect_usage_limit here.
     for session, ticket_id in recover:
         if session.surface_ref is not None:
             get_native_daemon_client().stop(session.surface_ref)
@@ -1154,7 +1165,9 @@ def flag_silently_idle_daemon_sessions(
         # re-dispatch, so the retry must start from a fresh worktree (#404).
         _cleanup_timed_out_worktree(session, ticket_id)
         cause = (
-            _CAUSE_USAGE_LIMIT if _detect_usage_limit(session) else _CAUSE_IDLE_STALL
+            _CAUSE_USAGE_LIMIT
+            if session.reap_reason is ReapReason.USAGE_LIMIT_CUTOFF
+            else _CAUSE_IDLE_STALL
         )
         record_event(
             OrchestratorEventType.SESSION_TIMED_OUT,
@@ -1385,6 +1398,7 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
         session.status = SessionStatus.COMPLETED
         session.completed_reason = CompletionReason.CRASHED
         session.completed_at = now
+        session.reap_reason = ReapReason.PHANTOM_SURFACE
         phantom_names.append(session.name)
         if ticket_id and session.origin is SessionOrigin.DAEMON:
             ticket_ids_to_revert.append(ticket_id)
@@ -1774,6 +1788,7 @@ def _salvage_high_path(
                     s.status = SessionStatus.COMPLETED
                     s.completed_at = now
                     s.completed_reason = CompletionReason.NORMAL
+                    s.reap_reason = ReapReason.SALVAGE_COMPLETED
                 break
         save_state(fresh_state)
 
@@ -1836,6 +1851,7 @@ def _salvage_low_path(
                 )
                 if not already_flagged:
                     s.last_result = {"paused_status": _NEEDS_SALVAGE_REASON}
+                    s.reap_reason = ReapReason.SALVAGE_PARKED
                 break
         save_state(fresh_state)
 
@@ -1923,6 +1939,9 @@ def revert_timed_out_tasks() -> list[str]:
     Sessions with dirty worktrees are routed to BLOCKED_ON_USER instead of
     PENDING, and a SESSION_NEEDS_ATTENTION event is emitted for operator
     inspection (GitHub issue #421).
+
+    Sets reap_reason=COMPLETED_BACKSTOP on sessions that lack a reason so
+    the queue-events server can emit queue.session_reaped (#380).
     """
     state = load_state()
     target_sessions = [
@@ -1931,6 +1950,16 @@ def revert_timed_out_tasks() -> list[str]:
         if s.status == SessionStatus.TIMED_OUT and s.origin is SessionOrigin.DAEMON
     ]
     session_ids = {s.id for s in target_sessions}
+    # Stamp reap_reason on any session that does not already have one (sessions
+    # reaching this backstop path may have been set TIMED_OUT by signal_stop
+    # without a reap_reason — mark them now so the bus server has a reason).
+    state_changed = False
+    for s in target_sessions:
+        if s.reap_reason is None:
+            s.reap_reason = ReapReason.COMPLETED_BACKSTOP
+            state_changed = True
+    if state_changed:
+        save_state(state)
     # Compute dirtiness BEFORE acquiring dev_queue_lock (see TOCTOU note in
     # _revert_running_tasks_for_sessions docstring).
     dirty_session_ids = _build_dirty_session_ids_and_notify(target_sessions)
@@ -1948,6 +1977,9 @@ def revert_completed_silent_tasks() -> list[str]:
     Sessions with dirty worktrees are routed to BLOCKED_ON_USER instead of
     PENDING, and a SESSION_NEEDS_ATTENTION event is emitted for operator
     inspection (GitHub issue #421).
+
+    Sets reap_reason=COMPLETED_BACKSTOP on sessions that lack a reason so
+    the queue-events server can emit queue.session_reaped (#380).
     """
     state = load_state()
     target_sessions = [
@@ -1956,6 +1988,17 @@ def revert_completed_silent_tasks() -> list[str]:
         if s.status == SessionStatus.COMPLETED and s.origin is SessionOrigin.DAEMON
     ]
     session_ids = {s.id for s in target_sessions}
+    # Stamp reap_reason on any session that does not already have one (sessions
+    # reaching this backstop path may have completed via signal_stop or
+    # salvage without a reap_reason — mark them now so the bus server has a
+    # reason to include in queue.session_reaped).
+    state_changed = False
+    for s in target_sessions:
+        if s.reap_reason is None:
+            s.reap_reason = ReapReason.COMPLETED_BACKSTOP
+            state_changed = True
+    if state_changed:
+        save_state(state)
     # Compute dirtiness BEFORE acquiring dev_queue_lock (see TOCTOU note in
     # _revert_running_tasks_for_sessions docstring).
     dirty_session_ids = _build_dirty_session_ids_and_notify(target_sessions)

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -1940,8 +1940,10 @@ def revert_timed_out_tasks() -> list[str]:
     PENDING, and a SESSION_NEEDS_ATTENTION event is emitted for operator
     inspection (GitHub issue #421).
 
-    Sets reap_reason=COMPLETED_BACKSTOP on sessions that lack a reason so
-    the queue-events server can emit queue.session_reaped (#380).
+    Sets reap_reason=COMPLETED_BACKSTOP only on sessions whose RUNNING
+    dev-queue task is actually being reverted, so the queue-events server
+    can emit queue.session_reaped (#380) without false events on the happy
+    path (sessions whose task already completed normally are not stamped).
     """
     state = load_state()
     target_sessions = [
@@ -1950,12 +1952,24 @@ def revert_timed_out_tasks() -> list[str]:
         if s.status == SessionStatus.TIMED_OUT and s.origin is SessionOrigin.DAEMON
     ]
     session_ids = {s.id for s in target_sessions}
-    # Stamp reap_reason on any session that does not already have one (sessions
-    # reaching this backstop path may have been set TIMED_OUT by signal_stop
-    # without a reap_reason — mark them now so the bus server has a reason).
+    # Pre-read the dev queue (no lock) to identify which sessions have a
+    # RUNNING task that will actually be reverted.  Only those sessions get
+    # the COMPLETED_BACKSTOP stamp so we avoid emitting false reap events for
+    # sessions whose task already completed normally via the happy path.
+    # Why: this read is outside dev_queue_lock, so a task could flip from
+    # RUNNING to another status between here and the locked revert below —
+    # TOCTOU accepted (same pattern as the dirty-check in
+    # _revert_running_tasks_for_sessions); worst case is a missed or early
+    # event, no data loss.
+    store = load_dev_queue()
+    backstop_session_ids = {
+        t.session_id
+        for t in store.tasks
+        if t.status == QueueItemStatus.RUNNING and t.session_id in session_ids
+    }
     state_changed = False
     for s in target_sessions:
-        if s.reap_reason is None:
+        if s.reap_reason is None and s.id in backstop_session_ids:
             s.reap_reason = ReapReason.COMPLETED_BACKSTOP
             state_changed = True
     if state_changed:
@@ -1978,8 +1992,10 @@ def revert_completed_silent_tasks() -> list[str]:
     PENDING, and a SESSION_NEEDS_ATTENTION event is emitted for operator
     inspection (GitHub issue #421).
 
-    Sets reap_reason=COMPLETED_BACKSTOP on sessions that lack a reason so
-    the queue-events server can emit queue.session_reaped (#380).
+    Sets reap_reason=COMPLETED_BACKSTOP only on sessions whose RUNNING
+    dev-queue task is actually being reverted, so the queue-events server
+    can emit queue.session_reaped (#380) without false events on the happy
+    path (sessions whose task already completed normally are not stamped).
     """
     state = load_state()
     target_sessions = [
@@ -1988,13 +2004,24 @@ def revert_completed_silent_tasks() -> list[str]:
         if s.status == SessionStatus.COMPLETED and s.origin is SessionOrigin.DAEMON
     ]
     session_ids = {s.id for s in target_sessions}
-    # Stamp reap_reason on any session that does not already have one (sessions
-    # reaching this backstop path may have completed via signal_stop or
-    # salvage without a reap_reason — mark them now so the bus server has a
-    # reason to include in queue.session_reaped).
+    # Pre-read the dev queue (no lock) to identify which sessions have a
+    # RUNNING task that will actually be reverted.  Only those sessions get
+    # the COMPLETED_BACKSTOP stamp so we avoid emitting false reap events for
+    # sessions whose task already completed normally via the happy path.
+    # Why: this read is outside dev_queue_lock, so a task could flip from
+    # RUNNING to another status between here and the locked revert below —
+    # TOCTOU accepted (same pattern as the dirty-check in
+    # _revert_running_tasks_for_sessions); worst case is a missed or early
+    # event, no data loss.
+    store = load_dev_queue()
+    backstop_session_ids = {
+        t.session_id
+        for t in store.tasks
+        if t.status == QueueItemStatus.RUNNING and t.session_id in session_ids
+    }
     state_changed = False
     for s in target_sessions:
-        if s.reap_reason is None:
+        if s.reap_reason is None and s.id in backstop_session_ids:
             s.reap_reason = ReapReason.COMPLETED_BACKSTOP
             state_changed = True
     if state_changed:

--- a/tests/test_channels_queue_events.py
+++ b/tests/test_channels_queue_events.py
@@ -41,7 +41,9 @@ from cw.models import (
     CwState,
     DevQueueStore,
     QueueItemStatus,
+    ReapReason,
     Session,
+    SessionOrigin,
     SessionPurpose,
     SessionStatus,
     TicketTask,
@@ -1115,3 +1117,143 @@ class TestPollOnceLockGuard:
         assert len(enqueued) == 1, (
             f"Expected 1 enqueued event, got {len(enqueued)}: {broadcast_calls}"
         )
+
+
+# ---------------------------------------------------------------------------
+# TestSessionReapedDeltaDetection (GitHub #380)
+# ---------------------------------------------------------------------------
+
+
+def _make_reaped_session(
+    session_id: str,
+    status: SessionStatus,
+    reap_reason: ReapReason,
+    surface_ref: str | None = "fake-ref",
+    origin: SessionOrigin = SessionOrigin.DAEMON,
+) -> Session:
+    from pathlib import Path
+
+    return Session(
+        id=session_id,
+        name=f"test-client/auto-dev/{session_id}",
+        client="test-client",
+        purpose=SessionPurpose.IMPL,
+        status=status,
+        origin=origin,
+        workspace_path=Path("/tmp/test"),
+        started_at=datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC),
+        surface_ref=surface_ref,
+        reap_reason=reap_reason,
+    )
+
+
+class TestSessionReapedDeltaDetection:
+    """queue.session_reaped fires when a new reap_reason appears on a session."""
+
+    def test_new_reap_reason_produces_session_reaped(self) -> None:
+        sess = _make_reaped_session(
+            "s-reaped-1",
+            SessionStatus.COMPLETED,
+            ReapReason.PHANTOM_SURFACE,
+        )
+        old = QueueSnapshot(session_statuses={"s-reaped-1": "active"})
+        state = CwState(sessions=[sess])
+        events = _compute_session_deltas(old, state)
+        reaped = [e for e in events if e.get("event") == "queue.session_reaped"]
+        assert len(reaped) == 1
+        ev = reaped[0]
+        assert ev["session_id"] == "s-reaped-1"
+        assert ev["reason"] == "phantom_surface"
+        assert ev["to_status"] == "completed"
+
+    def test_session_reaped_payload_fields_present(self) -> None:
+        sess = _make_reaped_session(
+            "s-reaped-payload",
+            SessionStatus.TIMED_OUT,
+            ReapReason.WALL_CLOCK_BUDGET,
+            surface_ref="abc12345",
+        )
+        old = QueueSnapshot(session_statuses={"s-reaped-payload": "active"})
+        state = CwState(sessions=[sess])
+        events = _compute_session_deltas(old, state)
+        ev = next(e for e in events if e.get("event") == "queue.session_reaped")
+        assert ev["session_id"] == "s-reaped-payload"
+        assert ev["surface_ref"] == "abc12345"
+        assert ev["origin"] == "daemon"
+        assert ev["reason"] == "wall_clock_budget"
+        assert ev["from_status"] == "active"
+        assert ev["to_status"] == "timed_out"
+
+    def test_already_seen_reap_reason_produces_no_event(self) -> None:
+        sess = _make_reaped_session(
+            "s-reaped-seen",
+            SessionStatus.COMPLETED,
+            ReapReason.IDLE_STALL,
+        )
+        # Snapshot already shows the reason → no new event
+        old = QueueSnapshot(
+            session_statuses={"s-reaped-seen": "completed"},
+            session_reap_reasons={"s-reaped-seen": "idle_stall"},
+        )
+        state = CwState(sessions=[sess])
+        events = _compute_session_deltas(old, state)
+        reaped = [e for e in events if e.get("event") == "queue.session_reaped"]
+        assert reaped == []
+
+    def test_null_surface_ref_included_in_payload(self) -> None:
+        sess = _make_reaped_session(
+            "s-reaped-no-ref",
+            SessionStatus.TIMED_OUT,
+            ReapReason.COMPLETED_BACKSTOP,
+            surface_ref=None,
+        )
+        old = QueueSnapshot(session_statuses={"s-reaped-no-ref": "timed_out"})
+        state = CwState(sessions=[sess])
+        events = _compute_session_deltas(old, state)
+        ev = next(e for e in events if e.get("event") == "queue.session_reaped")
+        assert ev["surface_ref"] is None
+
+    def test_session_without_reap_reason_produces_no_event(self) -> None:
+        """Sessions with reap_reason=None never produce queue.session_reaped."""
+        sess = _make_session("s-no-reason", SessionStatus.COMPLETED)
+        old = QueueSnapshot(session_statuses={"s-no-reason": "active"})
+        state = CwState(sessions=[sess])
+        events = _compute_session_deltas(old, state)
+        reaped = [e for e in events if e.get("event") == "queue.session_reaped"]
+        assert reaped == []
+
+    def test_snapshot_includes_reap_reason_field(self) -> None:
+        """_poll_once snapshot includes session_reap_reasons dict."""
+        from cw.config import save_state
+        from cw.dev_queue import save_dev_queue
+
+        sess = _make_reaped_session(
+            "s-snap",
+            SessionStatus.COMPLETED,
+            ReapReason.SALVAGE_COMPLETED,
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(DevQueueStore())
+
+        from cw.cw_queue_events_server import _poll_once
+
+        new_snap, _ = _poll_once(QueueSnapshot())
+        assert "s-snap" in new_snap.session_reap_reasons
+        assert new_snap.session_reap_reasons["s-snap"] == "salvage_completed"
+
+    def test_each_reason_value_produces_event(self) -> None:
+        """All ReapReason enum values produce a queue.session_reaped event."""
+        for reason in ReapReason:
+            sess = _make_reaped_session(
+                f"s-all-{reason}",
+                SessionStatus.COMPLETED,
+                reason,
+            )
+            old = QueueSnapshot(
+                session_statuses={f"s-all-{reason}": "active"},
+            )
+            state = CwState(sessions=[sess])
+            events = _compute_session_deltas(old, state)
+            reaped = [e for e in events if e.get("event") == "queue.session_reaped"]
+            assert len(reaped) == 1, f"Expected 1 event for reason={reason}"
+            assert reaped[0]["reason"] == str(reason)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -846,14 +846,16 @@ class TestMigrateCwState:
         migrated = migrate_cw_state(raw)
         assert migrated["sessions"][0]["surface_ref"] is None
 
-    def test_migrate_bumps_schema_version_to_six(self) -> None:
-        """After migration, schema_version must equal 6."""
+    def test_migrate_bumps_schema_version_to_current(self) -> None:
+        """After migration, schema_version must equal CW_STATE_SCHEMA_VERSION."""
+        from cw.models import CW_STATE_SCHEMA_VERSION
+
         raw: dict[str, object] = {
             "schema_version": 4,
             "sessions": [],
         }
         migrated = migrate_cw_state(raw)
-        assert migrated["schema_version"] == 6
+        assert migrated["schema_version"] == CW_STATE_SCHEMA_VERSION
 
     def test_migrate_round_trip_clears_legacy_surface_ref(
         self, tmp_config_dir: Path
@@ -906,10 +908,10 @@ class TestMigrateCwState:
         assert content["schema_version"] == 4
         assert content["sessions"][0]["surface_ref"] == "ws:0.2"
 
-    def test_loaded_state_has_none_surface_ref_and_version_six(
+    def test_loaded_state_has_none_surface_ref_and_current_version(
         self, tmp_config_dir: Path
     ) -> None:
-        """Loaded state after migration has surface_ref=None and schema_version=6."""
+        """Loaded state after migration has surface_ref=None and current version."""
         import json
 
         state_dir = tmp_config_dir / ".local" / "share" / "cw"
@@ -931,8 +933,10 @@ class TestMigrateCwState:
                 }
             )
         )
+        from cw.models import CW_STATE_SCHEMA_VERSION
+
         loaded = load_state()
-        assert loaded.schema_version == 6
+        assert loaded.schema_version == CW_STATE_SCHEMA_VERSION
         assert loaded.sessions[0].surface_ref is None
 
     def test_backup_is_idempotent(self, tmp_config_dir: Path) -> None:

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -26,6 +26,7 @@ from cw.models import (
     OrchestratorConfig,
     OrchestratorEventType,
     QueueItemStatus,
+    ReapReason,
     Session,
     SessionOrigin,
     SessionPurpose,
@@ -3046,7 +3047,7 @@ def test_confirm_before_reap_v5_state_round_trips(
 ) -> None:
     """v5 state payload (no idle_observation_count key) round-trips through load.
 
-    Counter defaults 0; schema_version stamped 6 after migration. (#545)
+    Counter defaults 0; schema_version stamped 7 after migration. (#545, #380)
     """
     import json
 
@@ -3070,7 +3071,7 @@ def test_confirm_before_reap_v5_state_round_trips(
         )
     )
     loaded = load_state()
-    assert loaded.schema_version == 6
+    assert loaded.schema_version == 7
     assert loaded.sessions[0].idle_observation_count == 0
 
 
@@ -7912,3 +7913,448 @@ def test_csid_from_transcript_via_helper(
 
     result = _csid_from_transcript(sess)
     assert result == full_stem
+
+
+# ---------------------------------------------------------------------------
+# ReapReason taxonomy tests (GitHub #380)
+# One test per reap-site decision-table row.
+# ---------------------------------------------------------------------------
+
+
+def test_reap_reason_phantom_surface(
+    tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_reconcile_locked phantom sweep sets reap_reason=phantom_surface."""
+    sess = _mk_session("phantom-s1", "dead-ref")
+    sess.origin = SessionOrigin.DAEMON
+    sess.name = "client-a/auto-dev/PHANTOM-1"
+    save_state(CwState(sessions=[sess]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="PHANTOM-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="phantom-s1",
+                )
+            ]
+        )
+    )
+    monkeypatch.setattr(
+        "cw.reconcile._claude_agents_json",
+        lambda: [{"sessionId": "decoy000"}],
+    )
+
+    reconcile()
+
+    reloaded = load_state()
+    s = reloaded.find_by_name_or_id("phantom-s1")
+    assert s is not None
+    assert s.reap_reason == ReapReason.PHANTOM_SURFACE
+
+
+def test_reap_reason_wall_clock_budget(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """revert_stalled_headless_sessions sets reap_reason=wall_clock_budget."""
+    worktree = tmp_path / "wt-wc"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+    assert (now - started_at).total_seconds() > HEADLESS_TIMEOUT_SECONDS
+
+    sess = _mk_headless_daemon_session("wc-budget-1", worktree, started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+
+    revert_stalled_headless_sessions(state, now=now, config=OrchestratorConfig())
+
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "wc-budget-1")
+    assert s.reap_reason == ReapReason.WALL_CLOCK_BUDGET
+
+
+def test_reap_reason_idle_stall(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """Recover path (no usage limit) sets reap_reason=idle_stall."""
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    sess = Session(
+        id="idle-stall-1",
+        name="client-a/auto-dev/IDLE-STALL-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        worktree_path=Path("/tmp/wt"),
+        surface_ref="live-ref",
+        started_at=started_at,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="IDLE-STALL-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="idle-stall-1",
+                    attempts=1,  # < DEFAULT_IDLE_RETRY_CAP → recover path
+                )
+            ]
+        )
+    )
+
+    with (
+        patch("cw.reconcile._transcript_recently_active", return_value=False),
+        patch("cw.reconcile._awaiting_subagent", return_value=False),
+        patch("cw.reconcile._detect_usage_limit", return_value=False),
+        patch("cw.reconcile.get_native_daemon_client", return_value=MagicMock()),
+        patch("cw.reconcile.fire_push_notification"),
+    ):
+        flag_silently_idle_daemon_sessions(
+            state,
+            now=now,
+            native_live={"live-ref"},
+            config=OrchestratorConfig(idle_confirm_observations=1),
+        )
+
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "idle-stall-1")
+    assert s.reap_reason == ReapReason.IDLE_STALL
+
+
+def test_reap_reason_usage_limit_cutoff(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """flag_silently_idle recover branch with usage limit sets
+    reap_reason=usage_limit_cutoff."""
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    sess = Session(
+        id="usage-limit-1",
+        name="client-a/auto-dev/USAGE-LIMIT-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        worktree_path=Path("/tmp/wt"),
+        surface_ref="live-ref",
+        started_at=started_at,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="USAGE-LIMIT-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="usage-limit-1",
+                    attempts=1,  # < cap → recover path
+                )
+            ]
+        )
+    )
+
+    with (
+        patch("cw.reconcile._transcript_recently_active", return_value=False),
+        patch("cw.reconcile._awaiting_subagent", return_value=False),
+        patch("cw.reconcile._detect_usage_limit", return_value=True),
+        patch("cw.reconcile.get_native_daemon_client", return_value=MagicMock()),
+        patch("cw.reconcile.fire_push_notification"),
+    ):
+        flag_silently_idle_daemon_sessions(
+            state,
+            now=now,
+            native_live={"live-ref"},
+            config=OrchestratorConfig(idle_confirm_observations=1),
+        )
+
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "usage-limit-1")
+    assert s.reap_reason == ReapReason.USAGE_LIMIT_CUTOFF
+
+
+def test_reap_reason_retry_cap_parked(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """flag_silently_idle park branch (cap reached) sets
+    reap_reason=retry_cap_parked."""
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    sess = Session(
+        id="cap-parked-1",
+        name="client-a/auto-dev/CAP-PARKED-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        surface_ref="live-ref",
+        started_at=started_at,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="CAP-PARKED-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="cap-parked-1",
+                    attempts=2,  # at DEFAULT_IDLE_RETRY_CAP → park path
+                )
+            ]
+        )
+    )
+
+    with (
+        patch("cw.reconcile._transcript_recently_active", return_value=False),
+        patch("cw.reconcile._awaiting_subagent", return_value=False),
+        patch("cw.reconcile.fire_push_notification"),
+    ):
+        flag_silently_idle_daemon_sessions(
+            state,
+            now=now,
+            native_live={"live-ref"},
+            config=OrchestratorConfig(idle_confirm_observations=1),
+        )
+
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "cap-parked-1")
+    assert s.reap_reason == ReapReason.RETRY_CAP_PARKED
+
+
+def test_reap_reason_completed_backstop_timed_out(
+    tmp_config_dir: Path,
+) -> None:
+    """revert_timed_out_tasks backstop sets reap_reason=completed_backstop on sessions
+    without a prior reap_reason."""
+    sess = Session(
+        id="backstop-to-1",
+        name="client-a/auto-dev/BACKSTOP-TO-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.TIMED_OUT,
+        workspace_path=Path("/tmp/ws"),
+        started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        completed_at=datetime(2026, 1, 1, 1, tzinfo=UTC),
+        completed_reason=CompletionReason.TIMED_OUT,
+        # reap_reason intentionally None — simulates signal_stop path
+    )
+    save_state(CwState(sessions=[sess]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="BACKSTOP-TO-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="backstop-to-1",
+                )
+            ]
+        )
+    )
+
+    revert_timed_out_tasks()
+
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "backstop-to-1")
+    assert s.reap_reason == ReapReason.COMPLETED_BACKSTOP
+
+
+def test_reap_reason_completed_backstop_completed(
+    tmp_config_dir: Path,
+) -> None:
+    """revert_completed_silent_tasks backstop sets reap_reason=completed_backstop."""
+    sess = Session(
+        id="backstop-c-1",
+        name="client-a/auto-dev/BACKSTOP-C-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.COMPLETED,
+        workspace_path=Path("/tmp/ws"),
+        started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        completed_at=datetime(2026, 1, 1, 1, tzinfo=UTC),
+        completed_reason=CompletionReason.NORMAL,
+        # reap_reason intentionally None
+    )
+    save_state(CwState(sessions=[sess]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="BACKSTOP-C-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="backstop-c-1",
+                )
+            ]
+        )
+    )
+
+    revert_completed_silent_tasks()
+
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "backstop-c-1")
+    assert s.reap_reason == ReapReason.COMPLETED_BACKSTOP
+
+
+def test_reap_reason_salvage_completed(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_salvage_high_path sets reap_reason=salvage_completed on the session."""
+    worktree = tmp_path / "wt-salv-comp"
+    worktree.mkdir(parents=True)
+    ticket_id = "SALV-COMP-1"
+
+    sess = Session(
+        id="salv-comp-1",
+        name=f"client-a/auto-dev/{ticket_id}",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        worktree_path=worktree,
+        surface_ref="live-ref-sc",
+        started_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    save_state(CwState(sessions=[sess]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id=ticket_id,
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="salv-comp-1",
+                )
+            ]
+        )
+    )
+
+    def _fake_subprocess_run(args: list[str], **_kw: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "https://github.com/org/repo/pull/99\n"
+        return result
+
+    monkeypatch.setattr("cw.reconcile._has_commits_beyond_base", lambda _p: True)
+    monkeypatch.setattr(
+        "cw.reconcile.pr_exists_for_branch", lambda _b, **_kw: (False, True)
+    )
+    monkeypatch.setattr("cw.reconcile.subprocess.run", _fake_subprocess_run)
+    monkeypatch.setattr("cw.reconcile.get_native_daemon_client", MagicMock)
+
+    candidates = [("salv-comp-1", ticket_id, "dev/salv-comp", str(worktree), True)]
+    salvage_committed_no_pr_sessions(candidates)
+
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "salv-comp-1")
+    assert s.reap_reason == ReapReason.SALVAGE_COMPLETED
+
+
+def test_reap_reason_salvage_parked(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_salvage_low_path sets reap_reason=salvage_parked on the session."""
+    worktree = tmp_path / "wt-salv-park"
+    worktree.mkdir(parents=True)
+    ticket_id = "SALV-PARK-1"
+
+    sess = Session(
+        id="salv-park-1",
+        name=f"client-a/auto-dev/{ticket_id}",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        worktree_path=worktree,
+        surface_ref="live-ref-sp",
+        started_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    save_state(CwState(sessions=[sess]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id=ticket_id,
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="salv-park-1",
+                )
+            ]
+        )
+    )
+
+    monkeypatch.setattr("cw.reconcile._has_commits_beyond_base", lambda _p: True)
+    monkeypatch.setattr(
+        "cw.reconcile.pr_exists_for_branch", lambda _b, **_kw: (False, True)
+    )
+    monkeypatch.setattr("cw.reconcile.fire_push_notification", lambda *_a, **_kw: None)
+
+    candidates = [("salv-park-1", ticket_id, "dev/salv-park", str(worktree), False)]
+    salvage_committed_no_pr_sessions(candidates)
+
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "salv-park-1")
+    assert s.reap_reason == ReapReason.SALVAGE_PARKED
+
+
+def test_reap_reason_not_overwritten_by_backstop(
+    tmp_config_dir: Path,
+) -> None:
+    """revert_timed_out_tasks backstop does NOT overwrite an existing reap_reason."""
+    sess = Session(
+        id="backstop-skip-1",
+        name="client-a/auto-dev/BACKSTOP-SKIP-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.TIMED_OUT,
+        workspace_path=Path("/tmp/ws"),
+        started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        completed_at=datetime(2026, 1, 1, 1, tzinfo=UTC),
+        completed_reason=CompletionReason.TIMED_OUT,
+        reap_reason=ReapReason.WALL_CLOCK_BUDGET,  # already set by reconcile
+    )
+    save_state(CwState(sessions=[sess]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="BACKSTOP-SKIP-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="backstop-skip-1",
+                )
+            ]
+        )
+    )
+
+    revert_timed_out_tasks()
+
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "backstop-skip-1")
+    # Must remain WALL_CLOCK_BUDGET, not be overwritten with COMPLETED_BACKSTOP
+    assert s.reap_reason == ReapReason.WALL_CLOCK_BUDGET

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -8358,3 +8358,87 @@ def test_reap_reason_not_overwritten_by_backstop(
     s = next(s for s in reloaded.sessions if s.id == "backstop-skip-1")
     # Must remain WALL_CLOCK_BUDGET, not be overwritten with COMPLETED_BACKSTOP
     assert s.reap_reason == ReapReason.WALL_CLOCK_BUDGET
+
+
+def test_reap_reason_not_stamped_when_task_already_completed_timed_out(
+    tmp_config_dir: Path,
+) -> None:
+    """revert_timed_out_tasks must NOT stamp reap_reason when the session's
+    dev-queue task is already COMPLETED (happy-path completion) — only sessions
+    whose task is still RUNNING get the COMPLETED_BACKSTOP stamp."""
+    sess = Session(
+        id="backstop-to-noop-1",
+        name="client-a/auto-dev/BACKSTOP-TO-NOOP-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.TIMED_OUT,
+        workspace_path=Path("/tmp/ws"),
+        started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        completed_at=datetime(2026, 1, 1, 1, tzinfo=UTC),
+        completed_reason=CompletionReason.TIMED_OUT,
+        # reap_reason intentionally None — simulates signal_stop path
+    )
+    save_state(CwState(sessions=[sess]))
+    # Task is already COMPLETED, NOT RUNNING — the session completed normally.
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="BACKSTOP-TO-NOOP-1",
+                    client="client-a",
+                    status=QueueItemStatus.COMPLETED,
+                    session_id="backstop-to-noop-1",
+                )
+            ]
+        )
+    )
+
+    revert_timed_out_tasks()
+
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "backstop-to-noop-1")
+    # Task was not RUNNING so no revert happened — reap_reason must stay None.
+    assert s.reap_reason is None
+
+
+def test_reap_reason_not_stamped_when_task_already_completed_completed_silent(
+    tmp_config_dir: Path,
+) -> None:
+    """revert_completed_silent_tasks must NOT stamp reap_reason when the
+    session's dev-queue task is already COMPLETED (happy-path completion) —
+    only sessions whose task is still RUNNING get the COMPLETED_BACKSTOP stamp."""
+    sess = Session(
+        id="backstop-c-noop-1",
+        name="client-a/auto-dev/BACKSTOP-C-NOOP-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.COMPLETED,
+        workspace_path=Path("/tmp/ws"),
+        started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        completed_at=datetime(2026, 1, 1, 1, tzinfo=UTC),
+        completed_reason=CompletionReason.NORMAL,
+        # reap_reason intentionally None
+    )
+    save_state(CwState(sessions=[sess]))
+    # Task is already COMPLETED, NOT RUNNING — the session completed normally.
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="BACKSTOP-C-NOOP-1",
+                    client="client-a",
+                    status=QueueItemStatus.COMPLETED,
+                    session_id="backstop-c-noop-1",
+                )
+            ]
+        )
+    )
+
+    revert_completed_silent_tasks()
+
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "backstop-c-noop-1")
+    # Task was not RUNNING so no revert happened — reap_reason must stay None.
+    assert s.reap_reason is None


### PR DESCRIPTION
Closes #380. Unblocks #546 (C of #543).

Reconciliation previously mutated sessions.json/dev_queue.json silently — `cw status` counts shifted with no explanation and `cw event tail`/`wait` saw nothing. This makes every reap legible on the queue-events bus.

## Changes
- `ReapReason` StrEnum (8 values) + `Session.reap_reason: ReapReason | None` persisted at every reap site; schema v6 → v7 (purely additive — pydantic default covers v6 files).
- `flag_silently_idle_daemon_sessions`: usage-limit detection computed once in the mutation loop (before `save_state`) and read back for the SESSION_TIMED_OUT cause — single source of truth, no behavior change.
- Bus server (`cw_queue_events_server.py`): snapshot tracks last-seen reap reasons; first non-None appearance emits `queue.session_reaped` with `{session_id, surface_ref (nullable), origin, reason, from_status, to_status}`.
- Backstop wrappers stamp `completed_backstop` only on sessions whose RUNNING task is actually being reverted (pre-lock read, TOCTOU-accepted like the existing dirty check) — no false events on the happy path.
- `_CHANNEL_INSTRUCTIONS` (public MCP contract) rewritten for the new event + reason values; `docs/headless-contract.md` documents event string, payload, and taxonomy.

## Reap-site decision table
- `_reconcile_locked` phantom sweep → `phantom_surface`
- idle-watchdog recover → `idle_stall` / `usage_limit_cutoff` (#499 split preserved)
- idle-watchdog park → `retry_cap_parked`
- `revert_stalled_headless_sessions` → `wall_clock_budget`
- `revert_timed_out_tasks` / `revert_completed_silent_tasks` (reverted only) → `completed_backstop`
- `_salvage_high_path` → `salvage_completed`; `_salvage_low_path` → `salvage_parked`
- EXCLUDED (no event): transient-outage guard, #545 counter-deferral, #545 counter-reset

Zero behavior change to when/whether reaps fire; orchestrator inbox (`OrchestratorEventType`, `events.py`), `task.attempts`, dispatch.py untouched.

## Tests
One test per decision-table row + not-overwritten guard + 2 happy-path regression tests (no stamp when task already COMPLETED); 7 bus-delta tests (emit-once, payload, null surface_ref, idempotency). Gates: ruff/format/mypy --strict/pre-commit clean; 1805 unit tests pass; 96.02% total / 100% patch coverage; integration pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)