### PR TITLE
docs: dispatch runbook + session-disposition contract (#538, #539)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,8 @@ cw list
 - **File-based locking**: Prevents concurrent state corruption from parallel session operations.
 - **Event history**: Audit trail for session lifecycle transitions.
 
+**Operator runbooks:** [`docs/dispatch-runbook.md`](docs/dispatch-runbook.md) — end-to-end `cw dev-queue` dispatch procedure. [`docs/session-disposition.md`](docs/session-disposition.md) — how to read a session's outcome from the transcript sentinel.
+
 ---
 
 # Model Usage & Cost Optimization

--- a/docs/dispatch-runbook.md
+++ b/docs/dispatch-runbook.md
@@ -1,0 +1,209 @@
+# cw dev-queue Dispatch Runbook
+
+Operator procedure for driving `cw dev-queue` dispatch end-to-end: enqueue,
+dispatch, monitor, handle gates, and clean up. For the sentinel/disposition
+contract the monitoring step reads, see
+[`docs/session-disposition.md`](session-disposition.md). For the full
+`AUTO_DEV_RESULT` schema and event taxonomy, see
+[`docs/headless-contract.md`](headless-contract.md).
+
+---
+
+## 1. Pre-dispatch: fast-forward main
+
+The freshness gate in `dispatch_tick` skips a ticket with:
+
+```
+WARN: main behind origin, ticket skipped
+```
+
+This fires when the local `main` is behind `origin/main`. Fix it before
+dispatching:
+
+```bash
+git -C <client-repo> pull --ff-only
+```
+
+`cw dev-queue refresh-all` also fast-forwards every configured client repo,
+but it refuses when the working tree has untracked files. The `git pull
+--ff-only` form bypasses that refusal.
+
+---
+
+## 2. Enqueue
+
+```bash
+cw dev-queue add <TICKET-ID> --client <client> [--scope small|large]
+```
+
+`--scope` sets `TicketTask.scope_hint`, the operator tier override that
+bypasses auto-tiering from line counts. Use it when:
+
+- The ticket is deletion-heavy (high line count but small real scope).
+- You know the tier and want to avoid a misclassification penalty.
+- A prior run was mis-tiered and you are re-dispatching.
+
+Scope hint on first dispatch is always `None` until Stage 1 sets it from the
+sentinel; subsequent retries inherit the prior sentinel's `scope.tier`.
+
+---
+
+## 3. Dispatch
+
+```bash
+# Dispatch all pending tasks (up to the concurrency cap)
+cw dev-queue run
+
+# Dispatch one tick and exit
+cw dev-queue run --once
+
+# Override concurrency cap for this run
+cw dev-queue run --max-parallel <n>
+```
+
+The default concurrency cap is `OrchestratorConfig.default_max_parallel`
+(default: `1`). Per-client overrides live in `per_client_max_parallel` in
+`orchestrator.yaml`.
+
+### Lane serialization — cli.py and other shared files
+
+Tickets that touch the same file conflict at merge. `cli.py` is the
+most common collision point. Identify which pending tickets touch it and
+**run them one at a time**: dispatch the first, wait for it to clear, then
+enqueue and dispatch the next.
+
+Do not pre-enqueue all tickets and rely on `--max-parallel 1` if you want
+strict sequencing — `run --once` claims ALL pending tasks up to the cap
+simultaneously. The safe pattern:
+
+```
+enqueue ticket A → dispatch → wait for terminal → enqueue ticket B → dispatch
+```
+
+### Double-spawn-at-cap
+
+`run --once` claims all pending tasks up to `per_client_max_parallel` in one
+tick. If you enqueue N tickets and run once with `--max-parallel N`, all N
+spawn simultaneously. To strictly sequence, do not pre-enqueue the next
+ticket; wait for the prior task to reach a terminal state before adding the
+next.
+
+---
+
+## 4. Monitor
+
+Use `cw dev-queue wait` — the sentinel-aware monitor (#535):
+
+```bash
+cw dev-queue wait <TICKET-ID> --client <client> --timeout <seconds> --json
+```
+
+Exit codes:
+
+- `0` — `shipped` / `no_op` (or `COMPLETED` queue status)
+- `1` — `scope_exceeded` / `forbidden_area` / `FAILED` / `CANCELLED`
+- `2` — `blocked` / any `*_pending_*` status / `BLOCKED_ON_USER`
+- `3` — ATTENTION: transcript stale past idle budget, worker not in daemon roster
+- `124` — hard timeout ceiling reached with no terminal or attention signal
+
+With `--json`, the output is:
+
+```json
+{
+  "ticket_id": "<id>",
+  "client": "<client>",
+  "status": "<queue-task-status>",
+  "session_id": "<session-id>",
+  "state": "terminal|attention|timeout",
+  "sentinel_status": "<AutoDevResult.status or null>",
+  "pr_url": "<url or null>"
+}
+```
+
+`sentinel_status` is non-null only when the sentinel was read directly from
+the transcript (i.e., the sentinel fired before reconcile updated queue
+status). `state=terminal` from a queue-status fast-path leaves
+`sentinel_status: null`.
+
+**Known gap (#542):** when a session is reaped mid-wait, reconcile reverts
+the task to PENDING and clears `session_id`. The wait's spawn-window grace
+(re-poll when `session_id` is None) cannot distinguish a fresh spawn from a
+just-reaped task, so ATTENTION never fires and wait rides to the `--timeout`
+ceiling (exit 124) instead. Workaround: if wait returns 124 on a run that
+should have surfaced ATTENTION, inspect `cw dev-queue status` and the
+transcript directly (see §6 in [`session-disposition.md`](session-disposition.md)).
+
+---
+
+## 5. Handle gates by sentinel status
+
+| Sentinel status | Action |
+|---|---|
+| `shipped` | Done. PR is live with auto-merge enabled; CI wait is orchestrator concern. |
+| `no_op` | Done. Ticket already satisfied; close as completed. |
+| `ambiguities_pending_resolution` | Resolve the ambiguities (post a `Pre-flight Resolutions` comment on the issue), then re-dispatch. |
+| `premises_pending_verification` | Verify the flagged premises, record results on the issue, re-dispatch. |
+| `plan_pending_approval` | Read the plan comment, verify it is faithful to the ticket, post `<!-- auto-dev-plan-approved -->` on the issue, re-dispatch for impl. |
+| `review_pending_approval` | Locate the branch, verify the diff and run gates yourself, then ship (PR + auto-merge). |
+| `plan_unreviewable` / `plan_unsound` | Resolve remaining plan issues. If the pipeline bounces repeatedly on an intricate ticket, use the **spec-driven subagent escape hatch** (§7) rather than retrying. |
+| `validation_failed` | Transient (malformed sentinel); re-dispatch. Use `cw result validate` to inspect the raw JSON before re-dispatch if the failure recurs. |
+| `blocked` | Triage `blocker.reason`. Check `blocker.retry_eligible` and `blocker.recovery_hint`. |
+| `merge_gate_blocked` | A prior pipeline PR is still open. Merge or close it, then re-dispatch. |
+
+---
+
+## 6. Cleanup after terminal (ordering matters)
+
+Wrong ordering leaves phantom PENDING orphans. Follow this sequence:
+
+```bash
+# 1. Mark the cw session completed
+cw done <session-name>
+
+# 2. Stop the live daemon worker (if still running)
+#    cw spawn close refuses an already-completed session — step 1 first.
+cw spawn close <session-id>
+
+# 3. Remove the dev-queue task
+cw dev-queue remove <TICKET-ID> --client <client> --all
+```
+
+If the task is already in a terminal queue status but wedged (e.g.,
+`RUNNING` with no live session), `cw doctor --reap` detects and repairs
+common wedge conditions:
+
+- `wedge/task-running-no-session` — reverts task to PENDING.
+- `wedge/task-running-completed-session` — reverts task to PENDING.
+
+Run `cw doctor --reap --json` for machine-readable output.
+
+---
+
+## 7. Patterns
+
+### Harden before dispatch
+
+Run `/harden-ticket` on a ticket before the first dispatch to surface
+ambiguities and unsound premises upfront. This eliminates the
+ambiguity/plan-review whack-a-mole loop that burns dispatch cycles.
+
+### Spec-driven subagent escape hatch
+
+When the pipeline bounces on an intricate cross-module ticket (repeated
+`plan_unreviewable` / `plan_unsound` / `blocked` with `review_blocked`):
+
+1. Produce a resolved spec manually (or from the last plan comment).
+2. Spawn a fresh-context, worktree-isolated subagent and hand it the spec
+   directly to *execute* — skipping the plan-review gate entirely.
+3. Review and ship the result with your normal gate checklist.
+
+This keeps orchestrator context lean and avoids endless pipeline retries on
+tickets that require human judgment at the planning stage.
+
+---
+
+## 8. Related docs
+
+- [`docs/session-disposition.md`](session-disposition.md) — how to read a session's outcome from the transcript sentinel.
+- [`docs/headless-contract.md`](headless-contract.md) — `AUTO_DEV_RESULT` schema, status enum, `ReapReason` taxonomy, `queue.session_reaped` bus event.
+- [`docs/events.md`](events.md) — event bus reference.

--- a/docs/session-disposition.md
+++ b/docs/session-disposition.md
@@ -40,11 +40,16 @@ as test fixtures or copied from `auto-dev.md` for sentinel-related tickets.
 A naive "first match" false-terminates.
 
 **Rule:** take the **last** block that parses to a real terminal `AutoDevResult`,
-and only trust it after the worker has left the daemon roster. This is what
-`_parse_sentinel_from_transcript` does — it scans all assistant text blocks
-and returns the first parseable result (which lands at the end of the
-transcript, after all fixture/example output that precedes the real emit).
-If you are reading the transcript manually, take the final complete block.
+and only trust it after the worker has left the daemon roster.
+
+Note: `_parse_sentinel_from_transcript` itself scans forward and returns the
+**first** block with sentinel framing. That is safe on its `signal_stop` call
+path (it fires at process exit, when the real emit is normally the only
+sentinel present) — but it is NOT safe for manual disposition of
+sentinel-related tickets whose transcripts contain fixture blocks. When
+dispositioning manually, reuse its JSON-decoding walk
+(`_iter_assistant_text_blocks` + `extract_block`/`parse_stdout`) but take the
+final parseable block, not the first.
 
 ### Gotcha 2 — Sentinels are JSON-escaped in the transcript
 
@@ -64,10 +69,12 @@ does this via `_iter_assistant_text_blocks`. Never regex the raw JSONL.
 which fires only after the first reconcile tick. Before that tick, the field
 is None.
 
-**Rule:** if `claude_session_id` is None, call `_csid_from_transcript(session)`
-(`src/cw/reconcile.py`) to derive it from the transcript filename via the
-surface_ref-prefix glob. Only attempt transcript reads once a csid is
-available.
+**Rule:** locate the transcript via `_locate_session_transcript(session)`
+(`src/cw/reconcile.py`) — it handles `claude_session_id=None` via the
+surface_ref-prefix glob (§1). Note that `_parse_sentinel_from_transcript`
+takes `(cwd, claude_session_id)` and returns None when the csid is None — so
+for a csid-less session, resolve the path first (or derive the csid from the
+transcript filename via `_csid_from_transcript`), then parse.
 
 ---
 
@@ -111,9 +118,9 @@ dispatch tick will re-spawn it.
 
 **Observability:** reconcile emits `queue.session_reaped` on the queue-events
 bus (`cw event tail`) whenever it disposes of a session. The `reason` field
-uses the `ReapReason` taxonomy; see
-[`docs/headless-contract.md §BLOCKED_ON_USER`](headless-contract.md) for the
-full `ReapReason` table. Two hardening measures make false reaps less likely:
+uses the `ReapReason` taxonomy; see the "queue.session_reaped Bus Event"
+section of [`docs/headless-contract.md`](headless-contract.md) for the full
+`ReapReason` table. Two hardening measures make false reaps less likely:
 
 - **Confirm-before-reap** (`OrchestratorConfig.idle_confirm_observations`,
   default `2`): reconcile requires `session.idle_observation_count` to reach

--- a/docs/session-disposition.md
+++ b/docs/session-disposition.md
@@ -1,0 +1,139 @@
+# Session Disposition Contract
+
+How to read a `cw` session's outcome correctly. The three gotchas in this
+document each caused a wrong disposition during the 2026-06-10/11 sprint.
+
+---
+
+## 1. Authoritative source of truth
+
+The terminal `AUTO_DEV_RESULT` sentinel in the session transcript is the
+authoritative outcome. Do not rely on:
+
+- `Session.last_result` — lags reconcile.
+- Queue task status — lags reconcile.
+- Daemon roster presence — cannot distinguish finished from stalled.
+
+Read the sentinel via `_parse_sentinel_from_transcript` (`src/cw/cli.py`),
+which uses `extract_block` + `parse_stdout` from `cw.auto_dev_result`. Never
+apply a raw-text regex to the transcript file.
+
+Transcript location is resolved by `_locate_session_transcript(session)` in
+`src/cw/reconcile.py` (surface_ref-prefix glob, #541):
+
+1. If `session.claude_session_id` is set: `<project_dir>/<csid>.jsonl` directly.
+2. Else if `session.surface_ref` is set: newest `<project_dir>/<surface_ref>*.jsonl`
+   with `mtime > session.started_at`.
+3. Otherwise: None.
+
+Do NOT fall back to an unscoped `*.jsonl` glob — that silently reads a
+different session's transcript in a reused worktree.
+
+---
+
+## 2. The three gotchas
+
+### Gotcha 1 — Fixture/example blocks ≠ the terminal emit
+
+A worker's transcript can contain `<<<AUTO_DEV_RESULT … >>>` blocks it wrote
+as test fixtures or copied from `auto-dev.md` for sentinel-related tickets.
+A naive "first match" false-terminates.
+
+**Rule:** take the **last** block that parses to a real terminal `AutoDevResult`,
+and only trust it after the worker has left the daemon roster. This is what
+`_parse_sentinel_from_transcript` does — it scans all assistant text blocks
+and returns the first parseable result (which lands at the end of the
+transcript, after all fixture/example output that precedes the real emit).
+If you are reading the transcript manually, take the final complete block.
+
+### Gotcha 2 — Sentinels are JSON-escaped in the transcript
+
+Claude stores session transcripts as JSONL. Each line is a JSON object; the
+`assistant` event's `message.content[].text` field holds the model output as
+a JSON string, so the sentinel's quotes and newlines are `\"` and `\n` in the
+raw file. A regex over the raw bytes misses sentinels that are valid only
+after decoding.
+
+**Rule:** `json.loads` each transcript line, extract the `text` field, then
+run `extract_block` against the decoded text. `_parse_sentinel_from_transcript`
+does this via `_iter_assistant_text_blocks`. Never regex the raw JSONL.
+
+### Gotcha 3 — `claude_session_id` is often None on first lookup
+
+`session.claude_session_id` is populated by the backfill inside `reconcile()`,
+which fires only after the first reconcile tick. Before that tick, the field
+is None.
+
+**Rule:** if `claude_session_id` is None, call `_csid_from_transcript(session)`
+(`src/cw/reconcile.py`) to derive it from the transcript filename via the
+surface_ref-prefix glob. Only attempt transcript reads once a csid is
+available.
+
+---
+
+## 3. Sentinel status → operator action
+
+| Status | Action |
+|---|---|
+| `shipped` | Done. PR live with auto-merge enabled. |
+| `no_op` | Done. Ticket already satisfied; close as completed. |
+| `ambiguities_pending_resolution` | Resolve ambiguities posted on the issue; re-dispatch. |
+| `premises_pending_verification` | Verify flagged premises, record on issue; re-dispatch. |
+| `plan_pending_approval` | Read the plan comment, post `<!-- auto-dev-plan-approved -->`; re-dispatch for impl. |
+| `review_pending_approval` | Review the pushed branch diff, run gates, ship (PR + auto-merge). |
+| `merge_gate_blocked` | Prior pipeline PR still open; merge or close it; re-dispatch. |
+| `scope_exceeded` | Scope rejection; close or relax constraint. |
+| `forbidden_area` | Forbidden-area rejection; update constraints or reroute. |
+| `validation_failed` | Transient (malformed sentinel); re-dispatch. Use `cw result validate <json>` to inspect the raw payload if it recurs. |
+| `blocked` | Triage `blocker.reason`, `blocker.retry_eligible`, `blocker.recovery_hint`. |
+
+For the full status-enum semantics and `blocker` shape, see
+[`docs/headless-contract.md §4`](headless-contract.md).
+
+---
+
+## 4. The orphan condition
+
+A session that emits a terminal sentinel (`shipped` / `no_op`) but is reaped
+as idle *before* `reconcile()` consumes the sentinel leaves its dev-queue task
+reverted to **PENDING** — a phantom task for finished work. A subsequent
+dispatch tick will re-spawn it.
+
+**Verify true state:**
+
+1. Read the transcript sentinel directly (§1 above).
+2. Check the PR or issue for completion evidence.
+3. If the work is already done, clean up manually:
+   ```bash
+   cw done <session-name>
+   cw dev-queue remove <TICKET-ID> --client <client> --all
+   ```
+
+**Observability:** reconcile emits `queue.session_reaped` on the queue-events
+bus (`cw event tail`) whenever it disposes of a session. The `reason` field
+uses the `ReapReason` taxonomy; see
+[`docs/headless-contract.md §BLOCKED_ON_USER`](headless-contract.md) for the
+full `ReapReason` table. Two hardening measures make false reaps less likely:
+
+- **Confirm-before-reap** (`OrchestratorConfig.idle_confirm_observations`,
+  default `2`): reconcile requires `session.idle_observation_count` to reach
+  this threshold across consecutive watchdog ticks before dispositing. A single
+  stale tick no longer triggers an immediate reap.
+- **Widened liveness windows** (#544/#548): the per-tier idle-watchdog budgets
+  are wider, reducing the window where a healthy-but-slow session looks idle.
+
+If a reap occurs and you need to force reconcile to re-examine state:
+
+```bash
+cw doctor --reap
+```
+
+---
+
+## 5. Cross-references
+
+- [`docs/dispatch-runbook.md`](dispatch-runbook.md) — full end-to-end dispatch procedure.
+- [`docs/headless-contract.md`](headless-contract.md) — `AUTO_DEV_RESULT` schema, status enum, `ReapReason` taxonomy, `queue.session_reaped` event.
+- `src/cw/cli.py:_parse_sentinel_from_transcript` — transcript sentinel reader.
+- `src/cw/reconcile.py:_locate_session_transcript` — transcript path resolver.
+- `src/cw/reconcile.py:_csid_from_transcript` — claude_session_id derivation.


### PR DESCRIPTION
Closes #538. Closes #539.

The two 1.0 operator docs, written against current main (post-#549/#550):

- **`docs/dispatch-runbook.md`** — end-to-end `cw dev-queue` procedure: ff-main/freshness gate, `--scope` tiering, cli.py lane serialization, double-spawn-at-cap, sentinel-aware `cw dev-queue wait` as THE monitor (with the #542 reaped-mid-wait gap noted), sentinel-status gate handling, cleanup-after-terminal ordering, `cw doctor --reap` wedge repair, harden-before-dispatch + spec-driven-subagent patterns.
- **`docs/session-disposition.md`** — transcript sentinel as source of truth, the three read gotchas (fixture blocks vs terminal emit — including that `_parse_sentinel_from_transcript` is first-match and why that's safe only on the `signal_stop` path; JSON-escaped sentinels; `csid=None` → `_locate_session_transcript`), sentinel-status → operator-action table, the orphan condition with the new `queue.session_reaped` observability and confirm-before-reap hardening.
- CLAUDE.md: two-line operator-runbook pointer.

Ticket-body claims corrected against code: #535 wait is live (not pending), transcript locator is `_locate_session_transcript` (#541), parser first-match behavior verified at `cli.py:1066-1069`, `idle_confirm_observations` default 2, ReapReason 8 values (cross-referenced to headless-contract.md, not duplicated).

Docs-only; gates 1–4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)