### PR TITLE
chore(release): cw 1.0.0 — migration guide, changelog, version stamp (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,11 @@ and the reap path has been bulletproofed end-to-end (#543).
   `idle_confirm_observations` (default: 2) consecutive idle observations before
   triggering an idle-stall reap. `Session.idle_observation_count` (schema v6)
   tracks the accumulating count.
-- **Widened liveness windows** (#544): transcript-mtime and roster-liveness
-  windows tuned for the native-supervisor latency profile — eliminates
-  false-positive reaps on workers that are legitimately between tool calls.
+- **Widened subagent-liveness window** (#544): `SUBAGENT_LIVENESS_WINDOW_SECONDS`
+  raised 900 s → 1800 s so a single long quiet tool call or in-flight subagent
+  is not reaped as idle. The transcript-mtime window and elapsed budgets are
+  unchanged, and roster presence is deliberately NOT treated as proof-of-life
+  (a dead worker can linger in the roster).
 - **Unified transcript locator via `surface_ref`-prefix glob** (#541): precise
   liveness check resolves the transcript path from the daemon session id prefix
   rather than scanning all transcripts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,71 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-06-11
+
+First stable release: the multiplexer layer (cmux/tmux) is deleted entirely,
+workers spawn via `claude --bg` and are tracked by the native daemon roster,
+and the reap path has been bulletproofed end-to-end (#543).
+
+### Architecture
+
+- **Native supervisor replaces multiplexer layer** (#119/#521): cmux/tmux
+  adapters, the `MultiplexerAdapter` abstraction, and all wrapper shims are
+  deleted. Workers spawn via `claude --bg`; liveness tracked through
+  `~/.claude/daemon/roster.json`. No external multiplexer required.
+
+### Added
+
+- **Observable reaps: `queue.session_reaped` + `ReapReason` taxonomy**
+  (#380): the reconciler emits a structured `queue.session_reaped` event for
+  every reap decision, carrying one of eight `ReapReason` values
+  (`phantom_surface`, `idle_stall`, `usage_limit_cutoff`, `retry_cap_parked`,
+  `wall_clock_budget`, `completed_backstop`, `salvage_completed`,
+  `salvage_parked`). `Session.reap_reason` (schema v7) records the reason on
+  the session object.
+- **Confirm-before-reap** (#545): idle watchdog waits for
+  `idle_confirm_observations` (default: 2) consecutive idle observations before
+  triggering an idle-stall reap. `Session.idle_observation_count` (schema v6)
+  tracks the accumulating count.
+- **Widened liveness windows** (#544): transcript-mtime and roster-liveness
+  windows tuned for the native-supervisor latency profile — eliminates
+  false-positive reaps on workers that are legitimately between tool calls.
+- **Unified transcript locator via `surface_ref`-prefix glob** (#541): precise
+  liveness check resolves the transcript path from the daemon session id prefix
+  rather than scanning all transcripts.
+- **Sentinel-aware `cw dev-queue wait`** (#535): `wait` detects
+  `AUTO_DEV_RESULT` sentinels in the transcript directly, eliminating
+  false-timeout (exit 124) for long-running workers whose reconcile cycle
+  hasn't fired yet.
+- **`cw result validate`** (#482): pre-emit gate validates a candidate
+  `AutoDevResult` JSON object against the authoritative schema.
+- **`cw schema`**: inspect Pydantic model schemas for `AutoDevResult`,
+  `TicketTask`, and `Session` directly from the CLI.
+
+### Schema
+
+- **v5** (#119/#521): cleared legacy multiplexer `surface_ref` values on
+  upgrade. Auto-migrates on first load.
+- **v6** (#545): added `Session.idle_observation_count`. Purely additive;
+  defaults to `0`.
+- **v7** (#380): added `Session.reap_reason`. Purely additive; defaults to
+  `None`.
+
+### Documentation
+
+- **Operator runbooks** (#538/#539): `docs/dispatch-runbook.md` (end-to-end
+  `cw dev-queue` dispatch procedure) and `docs/session-disposition.md` (how to
+  read a session's outcome from the transcript sentinel).
+- **`docs/MIGRATION-0.x-to-1.0.md`**: updated to cover the v5→v7 schema
+  chain, the new 1.0 contract surface, and the `cw daemon` deprecation shim.
+
+### Known issues
+
+- **#542**: `cw dev-queue wait` can ride to the hard timeout (exit 124) instead
+  of returning exit 3 (ATTENTION) when a session is reaped mid-wait. The
+  sentinel-aware path only catches successful sentinels; a reap-during-wait
+  is not yet signalled early.
+
 ## [0.14.2] — 2026-06-03
 
 Reliability-hardening release: a wave of concurrency, atomicity, and

--- a/docs/MIGRATION-0.x-to-1.0.md
+++ b/docs/MIGRATION-0.x-to-1.0.md
@@ -20,6 +20,29 @@ compatibility. On first load after upgrading, cw automatically:
    8-char hex daemon session ids are preserved unchanged.
 3. Bumps the schema version to 5.
 
+### Schema version chain
+
+The state file schema has moved through three steps since the multiplexer
+deletion:
+
+- **v5** (#119/#521): cleared legacy multiplexer `surface_ref` values on first
+  load (the migration described above).
+- **v6** (#545): added `Session.idle_observation_count` — the count of
+  consecutive idle observations before a confirm-before-reap decision is made.
+  Purely additive; old state files load with a default of `0`.
+- **v7** (#380): added `Session.reap_reason` — the `ReapReason` enum value
+  recorded when a session is reaped by the reconciler. Purely additive; old
+  state files load with `None`.
+
+v6 and v7 carry no migration steps: the new fields default safely, so old
+state files load without user action.
+
+### `cw daemon`
+
+`cw daemon` is a **deprecated shim** — it emits a deprecation notice and
+exits. The PR-dispatch/watch role it once held has been replaced by the
+cw-pr-events channel-based orchestrator. Use `cw orchestrator-start` instead.
+
 ### Worktree paths
 
 **Worktrees stay exactly where they are.** cw still creates them via
@@ -27,33 +50,41 @@ compatibility. On first load after upgrading, cw automatically:
 If you used a custom `worktree_base` in 0.x your worktrees remain under that
 path.
 
-## What `cw doctor` now checks
+## New in 1.0
 
-`cw doctor` verifies that every session carrying a `worktree_path` still has
-that path on disk. Sessions where `worktree_path` is `None` are skipped
-silently.
+Brief summaries below; the linked docs have the authoritative detail.
 
-Example output when worktrees are present and healthy:
-
-```
-  [OK] worktree/summary — 3 sessions checked, 0 missing worktrees
-```
-
-Example output when a worktree was deleted manually:
-
-```
-  [WARN] worktree/a1b2c3d4 — path does not exist: /home/user/ws/.worktrees/client/feature
-  [OK]   worktree/summary — 2 sessions checked, 1 missing worktrees
-```
-
-The check is **read-only and warn-only**: cw never moves or recreates a
-missing worktree. A missing worktree is informational — you may have
-intentionally deleted a finished branch. No manual action is required unless
-you want to resume that session, in which case create a new worktree and
-update the session's `worktree_path` by editing
-`~/.local/share/cw/sessions.json` directly.
+- **`cw schema`** — inspect Pydantic model schemas for `AutoDevResult`,
+  `TicketTask`, and `Session` directly from the CLI (`cw schema list`,
+  `cw schema show <name>`).
+- **`cw result validate`** (#482) — pre-emit gate: validates a candidate
+  `AutoDevResult` JSON object against the authoritative schema before the
+  worker emits the sentinel block. See `cw result validate --help`.
+- **Sentinel-aware `cw dev-queue wait`** (#535) — `wait` now detects
+  `AUTO_DEV_RESULT` sentinels in the transcript directly rather than relying
+  solely on task-status polling, eliminating false-timeout (exit 124) for
+  long-running healthy workers whose reconcile cycle hasn't fired yet.
+- **`queue.session_reaped` bus events + `ReapReason` taxonomy** (#380) — the
+  reconciler emits a structured `queue.session_reaped` event for every reap
+  decision, carrying one of eight `ReapReason` values
+  (`phantom_surface`, `idle_stall`, `usage_limit_cutoff`, `retry_cap_parked`,
+  `wall_clock_budget`, `completed_backstop`, `salvage_completed`,
+  `salvage_parked`). See [`docs/headless-contract.md`](headless-contract.md)
+  for the full event schema.
+- **Confirm-before-reap** (#545) — the idle watchdog waits for
+  `idle_confirm_observations` (default: 2) consecutive idle observations before
+  triggering an idle-stall reap, reducing false-positive reaps on workers that
+  are legitimately between tool calls.
+- **Widened liveness windows** (#544) — transcript-mtime and roster-liveness
+  windows are tuned for the native-supervisor latency profile; workers writing
+  slowly to their transcript are no longer false-positively reaped.
+- **Operator docs** (#538/#539) — `docs/dispatch-runbook.md` covers the
+  end-to-end `cw dev-queue` dispatch procedure;
+  `docs/session-disposition.md` explains how to read a session's outcome from
+  the transcript sentinel. See those files for the full reference.
 
 ## What you need to do
 
 Nothing. Worktrees stay where they are. The `surface_ref` migration runs
-automatically on first `load_state()` call after upgrading to 1.0.
+automatically on first `load_state()` call after upgrading to 1.0. The v6/v7
+schema additions are purely additive and require no manual action.

--- a/docs/MIGRATION-0.x-to-1.0.md
+++ b/docs/MIGRATION-0.x-to-1.0.md
@@ -75,9 +75,10 @@ Brief summaries below; the linked docs have the authoritative detail.
   `idle_confirm_observations` (default: 2) consecutive idle observations before
   triggering an idle-stall reap, reducing false-positive reaps on workers that
   are legitimately between tool calls.
-- **Widened liveness windows** (#544) — transcript-mtime and roster-liveness
-  windows are tuned for the native-supervisor latency profile; workers writing
-  slowly to their transcript are no longer false-positively reaped.
+- **Widened subagent-liveness window** (#544) —
+  `SUBAGENT_LIVENESS_WINDOW_SECONDS` raised 900 s → 1800 s so a single long
+  quiet tool call or in-flight subagent is not reaped as idle; the
+  transcript-mtime window and elapsed budgets are unchanged.
 - **Operator docs** (#538/#539) — `docs/dispatch-runbook.md` covers the
   end-to-end `cw dev-queue` dispatch procedure;
   `docs/session-disposition.md` explains how to read a session's outcome from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-workspace"
-version = "0.14.2"
+version = "1.0.0"
 description = "Multi-session workspace orchestrator for Claude Code"
 readme = "README.md"
 authors = [

--- a/src/cw/__init__.py
+++ b/src/cw/__init__.py
@@ -1,3 +1,3 @@
 """claude-workspace: Multi-session workspace orchestrator for Claude Code."""
 
-__version__ = "0.14.2"
+__version__ = "1.0.0"

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "claude-workspace"
-version = "0.14.2"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #120. The 1.0 stamp — final PR of the native-supervisor + reap-path-bulletproofing program.

- **docs/MIGRATION-0.x-to-1.0.md**: schema narrative corrected to the v5→v6→v7 chain (v6 `idle_observation_count` #545, v7 `reap_reason` #380 — both additive, no user action); "New in 1.0" section (`cw schema`, `cw result validate` #482, sentinel-aware `wait` #535, `queue.session_reaped` + ReapReason #380, confirm-before-reap #545, subagent-liveness window #544); `cw daemon` documented as deprecated shim → `cw orchestrator-start`; no backend-selection/extras text (cmux/tmux deleted, not optional).
- **CHANGELOG.md**: 1.0.0 entry (architecture, added, schema, docs, known issue #542).
- **Version stamp**: pyproject + `src/cw/__init__.py` 0.14.2 → 1.0.0, uv.lock regenerated — same file set as prior release bumps (verified against the 0.14.1/0.14.2 bump commits).

Post-merge (orchestrator, not this PR): `git tag v1.0.0` + GitHub release matching the v0.14.x pattern.

#247 deferred post-1.0 (blocked on #116, doesn't touch the 1.0 contract surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)