### PR TITLE
feat(install): agent-onboarding wiring — MCP registration, cw allowlist, SessionStart hook, CLAUDE.md snippet (#509)

### DIFF
--- a/config/CONFIG_REFERENCE.md
+++ b/config/CONFIG_REFERENCE.md
@@ -276,6 +276,13 @@ are `null` when not applicable.
 }
 ```
 
+## MCP Server Configuration
+
+`cw init` automatically writes `cw-queue-events` and `cw-pr-events` entries into
+`<workspace>/.mcp.json`. The files `config/cw-queue-events.mcp.json.example` and
+`config/cw-pr-events.mcp.json.example` are for manual wiring only and are not
+required when using `cw init`.
+
 ## Managing Configuration
 
 ```bash

--- a/config/cw-pr-events.mcp.json.example
+++ b/config/cw-pr-events.mcp.json.example
@@ -2,7 +2,7 @@
   "mcpServers": {
     "cw-pr-events": {
       "command": "cw",
-      "args": ["pr-channel", "proxy", "--client-id", "your-session-id"],
+      "args": ["pr-channel", "proxy", "--client-id", "<client-name>"],
       "env": {
         "CW_PR_EVENTS_BASE_URL": "http://127.0.0.1:8788"
       }

--- a/config/cw-queue-events.mcp.json.example
+++ b/config/cw-queue-events.mcp.json.example
@@ -2,7 +2,7 @@
   "mcpServers": {
     "cw-queue-events": {
       "command": "cw",
-      "args": ["queue-channel", "proxy", "--client-id", "your-session-id"],
+      "args": ["queue-channel", "proxy", "--client-id", "<client-name>"],
       "env": {
         "CW_QUEUE_EVENTS_BASE_URL": "http://127.0.0.1:8789"
       }

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -122,6 +122,31 @@ cw init my-project --path /path/to/your/repo
 
 This creates `~/.config/cw/clients.yaml` with your project configuration.
 
+#### What `cw init` wires
+
+By default, `cw init` also runs four agent-onboarding steps against the target
+workspace:
+
+- **MCP servers** (`.mcp.json`) — merges `cw-queue-events` and `cw-pr-events`
+  entries so background agents receive queue and PR events via MCP.
+- **Bash allowlist** (`~/.claude/settings.json`) — adds `"Bash(cw:*)"` to
+  `permissions.allow` so agents can call `cw` commands without prompting.
+- **SessionStart hook** (`<workspace>/.claude/settings.json`) — adds
+  `cw orchestrate status --json || true` so each new Claude session sees the
+  current dispatch state.
+- **CLAUDE.md snippet** — appends a brief `<!-- cw-onboarding -->` section
+  documenting the MCP channels (only when `cw schema list` is available).
+
+All four steps are idempotent — re-running `cw init` or `cw init --onboard-only`
+is safe.
+
+**Flags:**
+
+- `--no-onboarding` — skip all four onboarding steps (useful for scripted
+  installs where you manage these files yourself).
+- `--onboard-only` — re-run onboarding only; skip creating a new client entry
+  (client must already exist in `clients.yaml`).
+
 ### 3. Enable Shell Completion
 
 ```bash

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -129,13 +129,18 @@ workspace:
 
 - **MCP servers** (`.mcp.json`) — merges `cw-queue-events` and `cw-pr-events`
   entries so background agents receive queue and PR events via MCP.
+  The files `config/cw-queue-events.mcp.json.example` and
+  `config/cw-pr-events.mcp.json.example` are for manual wiring only; `cw init`
+  generates these entries automatically.
 - **Bash allowlist** (`~/.claude/settings.json`) — adds `"Bash(cw:*)"` to
   `permissions.allow` so agents can call `cw` commands without prompting.
 - **SessionStart hook** (`<workspace>/.claude/settings.json`) — adds
   `cw orchestrate status --json || true` so each new Claude session sees the
   current dispatch state.
-- **CLAUDE.md snippet** — appends a brief `<!-- cw-onboarding -->` section
-  documenting the MCP channels (only when `cw schema list` is available).
+- **CLAUDE.md snippet** (`<workspace>/.claude/CLAUDE.md`) — appends a brief
+  `<!-- cw-onboarding -->` section documenting the MCP channels and `cw schema`
+  usage. When `cw schema list` is unavailable the snippet is still written but
+  the schema-specific lines are omitted.
 
 All four steps are idempotent — re-running `cw init` or `cw init --onboard-only`
 is safe.

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -72,6 +72,7 @@ from cw.models import (
 )
 from cw.native_daemon import NativeDaemonClient, get_native_daemon_client
 from cw.onboarding import (
+    CW_ALLOWLIST_ENTRY,
     install_claude_md_snippet,
     install_cw_allowlist,
     install_sessionstart_hook,
@@ -418,6 +419,18 @@ def upgrade_workers() -> None:
         raise click.exceptions.Exit(result.returncode)
 
 
+def _run_onboarding_steps(workspace: Path, name: str) -> None:
+    """Call all four onboarding functions and print the four status lines."""
+    register_mcp_servers(workspace, name)
+    install_cw_allowlist()
+    install_sessionstart_hook(workspace)
+    install_claude_md_snippet(workspace)
+    click.echo("  .mcp.json         — MCP servers registered")
+    click.echo(f"  ~/.claude/settings.json — {CW_ALLOWLIST_ENTRY} allow entry added")
+    click.echo("  .claude/settings.json  — SessionStart hook added")
+    click.echo("  CLAUDE.md              — cw snippet appended")
+
+
 @main.command(name="init")
 @click.argument("name", required=False, default=None)
 @click.option(
@@ -468,6 +481,10 @@ def init(
     Re-run onboarding for an existing client:
       cw init my-project --onboard-only
     """
+    if no_onboarding and onboard_only:
+        msg = "--no-onboarding and --onboard-only are mutually exclusive"
+        raise CwError(msg)
+
     if onboard_only:
         if name is None:
             msg = "Name is required with --onboard-only"
@@ -480,15 +497,8 @@ def init(
             )
             raise CwError(msg)
         workspace = client.workspace_path
-        register_mcp_servers(workspace, name)
-        install_cw_allowlist()
-        install_sessionstart_hook(workspace)
-        install_claude_md_snippet(workspace)
         click.echo(f"Onboarding complete for '{name}'.")
-        click.echo("  .mcp.json         — MCP servers registered")
-        click.echo("  ~/.claude/settings.json — Bash(cw:*) allow entry added")
-        click.echo("  .claude/settings.json  — SessionStart hook added")
-        click.echo("  CLAUDE.md              — cw snippet appended")
+        _run_onboarding_steps(workspace, name)
         return
 
     if name is None:
@@ -518,16 +528,9 @@ def init(
     click.echo(f"Added client '{name}' to configuration.")
 
     if not no_onboarding:
-        register_mcp_servers(path, name)
-        install_cw_allowlist()
-        install_sessionstart_hook(path)
-        install_claude_md_snippet(path)
         click.echo()
         click.echo("Agent onboarding:")
-        click.echo("  .mcp.json         — MCP servers registered")
-        click.echo("  ~/.claude/settings.json — Bash(cw:*) allow entry added")
-        click.echo("  .claude/settings.json  — SessionStart hook added")
-        click.echo("  CLAUDE.md              — cw snippet appended")
+        _run_onboarding_steps(path, name)
 
     click.echo()
     click.echo("Next steps:")

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -421,14 +421,24 @@ def upgrade_workers() -> None:
 
 def _run_onboarding_steps(workspace: Path, name: str) -> None:
     """Call all four onboarding functions and print the four status lines."""
-    register_mcp_servers(workspace, name)
-    install_cw_allowlist()
-    install_sessionstart_hook(workspace)
-    install_claude_md_snippet(workspace)
-    click.echo("  .mcp.json         — MCP servers registered")
-    click.echo(f"  ~/.claude/settings.json — {CW_ALLOWLIST_ENTRY} allow entry added")
-    click.echo("  .claude/settings.json  — SessionStart hook added")
-    click.echo("  CLAUDE.md              — cw snippet step run")
+    mcp_changed = register_mcp_servers(workspace, name)
+    allow_changed = install_cw_allowlist()
+    hook_changed = install_sessionstart_hook(workspace)
+    md_changed = install_claude_md_snippet(workspace)
+    mcp_status = "registered" if mcp_changed else "already configured"
+    click.echo(f"  .mcp.json              — MCP servers {mcp_status}")
+    click.echo(
+        f"  ~/.claude/settings.json — {CW_ALLOWLIST_ENTRY} allow entry "
+        f"{'added' if allow_changed else 'already configured'}"
+    )
+    click.echo(
+        f"  .claude/settings.json  — SessionStart hook "
+        f"{'added' if hook_changed else 'already configured'}"
+    )
+    click.echo(
+        f"  .claude/CLAUDE.md      — cw snippet "
+        f"{'written' if md_changed else 'already configured'}"
+    )
 
 
 @main.command(name="init")

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -428,7 +428,7 @@ def _run_onboarding_steps(workspace: Path, name: str) -> None:
     click.echo("  .mcp.json         — MCP servers registered")
     click.echo(f"  ~/.claude/settings.json — {CW_ALLOWLIST_ENTRY} allow entry added")
     click.echo("  .claude/settings.json  — SessionStart hook added")
-    click.echo("  CLAUDE.md              — cw snippet appended")
+    click.echo("  CLAUDE.md              — cw snippet step run")
 
 
 @main.command(name="init")
@@ -497,8 +497,8 @@ def init(
             )
             raise CwError(msg)
         workspace = client.workspace_path
-        click.echo(f"Onboarding complete for '{name}'.")
         _run_onboarding_steps(workspace, name)
+        click.echo(f"Onboarding complete for '{name}'.")
         return
 
     if name is None:

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -71,6 +71,12 @@ from cw.models import (
     TicketTask,
 )
 from cw.native_daemon import NativeDaemonClient, get_native_daemon_client
+from cw.onboarding import (
+    install_claude_md_snippet,
+    install_cw_allowlist,
+    install_sessionstart_hook,
+    register_mcp_servers,
+)
 from cw.orchestrate import (
     MissingWorkerEntry,
     OrchestratorStatus,
@@ -427,12 +433,25 @@ def upgrade_workers() -> None:
     default=None,
     help="Comma-separated session purposes (e.g. impl,idea,debt).",
 )
+@click.option(
+    "--no-onboarding/--onboarding",
+    default=False,
+    help="Skip all agent-onboarding steps (MCP servers, allowlist, hooks, CLAUDE.md).",
+)
+@click.option(
+    "--onboard-only",
+    is_flag=True,
+    default=False,
+    help="Run onboarding steps only; skip init_client (client must already exist).",
+)
 @handle_errors
 def init(
     name: str | None,
     path: Path | None,
     branch: str,
     purposes: str | None,
+    no_onboarding: bool,
+    onboard_only: bool,
 ) -> None:
     """Initialize a new client configuration.
 
@@ -444,7 +463,34 @@ def init(
     \b
     Interactive (human-friendly):
       cw init
+
+    \b
+    Re-run onboarding for an existing client:
+      cw init my-project --onboard-only
     """
+    if onboard_only:
+        if name is None:
+            msg = "Name is required with --onboard-only"
+            raise CwError(msg)
+        cfg = load_clients()
+        client = cfg.get(name)
+        if client is None:
+            msg = (
+                f"Client '{name}' not found — run 'cw init {name} --path <repo>' first"
+            )
+            raise CwError(msg)
+        workspace = client.workspace_path
+        register_mcp_servers(workspace, name)
+        install_cw_allowlist()
+        install_sessionstart_hook(workspace)
+        install_claude_md_snippet(workspace)
+        click.echo(f"Onboarding complete for '{name}'.")
+        click.echo("  .mcp.json         — MCP servers registered")
+        click.echo("  ~/.claude/settings.json — Bash(cw:*) allow entry added")
+        click.echo("  .claude/settings.json  — SessionStart hook added")
+        click.echo("  CLAUDE.md              — cw snippet appended")
+        return
+
     if name is None:
         # Interactive mode
         name = click.prompt("Client name")
@@ -470,6 +516,19 @@ def init(
     init_client(name, path, default_branch=branch, auto_purposes=purpose_list)
 
     click.echo(f"Added client '{name}' to configuration.")
+
+    if not no_onboarding:
+        register_mcp_servers(path, name)
+        install_cw_allowlist()
+        install_sessionstart_hook(path)
+        install_claude_md_snippet(path)
+        click.echo()
+        click.echo("Agent onboarding:")
+        click.echo("  .mcp.json         — MCP servers registered")
+        click.echo("  ~/.claude/settings.json — Bash(cw:*) allow entry added")
+        click.echo("  .claude/settings.json  — SessionStart hook added")
+        click.echo("  CLAUDE.md              — cw snippet appended")
+
     click.echo()
     click.echo("Next steps:")
     click.echo(f"  cw start {name}              # Start a session")

--- a/src/cw/onboarding.py
+++ b/src/cw/onboarding.py
@@ -31,11 +31,14 @@ _PR_EVENTS_BASE_URL = "http://127.0.0.1:8788"
 _CLAUDE_MD_MARKER = "<!-- cw-onboarding -->"
 
 
-def register_mcp_servers(workspace_path: Path, client_name: str) -> None:
+def register_mcp_servers(workspace_path: Path, client_name: str) -> bool:
     """Merge cw-queue-events and cw-pr-events into ``<workspace>/.mcp.json``.
 
     Existing entries are preserved (skip-if-present semantics per key).
     Absent file is treated as ``{}``. Writes are atomic.
+    Unparseable existing file → emit manual instruction, leave untouched.
+
+    Returns True if anything was written, False if already configured.
     """
     mcp_path = workspace_path / ".mcp.json"
 
@@ -43,17 +46,25 @@ def register_mcp_servers(workspace_path: Path, client_name: str) -> None:
     if mcp_path.exists():
         try:
             existing = json.loads(mcp_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
+        except json.JSONDecodeError:
+            click.echo(
+                f"cw init: could not parse {mcp_path} — "
+                'add "cw-queue-events" and "cw-pr-events" to mcpServers manually.'
+            )
+            return False
+        except OSError:
             existing = {}
 
     servers: dict[str, Any] = existing.setdefault("mcpServers", {})
 
+    changed = False
     if "cw-queue-events" not in servers:
         servers["cw-queue-events"] = {
             "command": "cw",
             "args": ["queue-channel", "proxy", "--client-id", client_name],
             "env": {"CW_QUEUE_EVENTS_BASE_URL": _QUEUE_EVENTS_BASE_URL},
         }
+        changed = True
 
     if "cw-pr-events" not in servers:
         servers["cw-pr-events"] = {
@@ -61,25 +72,29 @@ def register_mcp_servers(workspace_path: Path, client_name: str) -> None:
             "args": ["pr-channel", "proxy", "--client-id", client_name],
             "env": {"CW_PR_EVENTS_BASE_URL": _PR_EVENTS_BASE_URL},
         }
+        changed = True
 
-    atomic_write_text(mcp_path, json.dumps(existing, indent=2) + "\n")
+    if changed:
+        atomic_write_text(mcp_path, json.dumps(existing, indent=2) + "\n")
+
+    return changed
 
 
 CW_ALLOWLIST_ENTRY = "Bash(cw:*)"
 
 
-def install_cw_allowlist() -> None:
+def install_cw_allowlist() -> bool:
     """Merge ``Bash(cw:*)`` into ``~/.claude/settings.json`` allow list.
 
     Skip-if-present. Unparseable JSON → emit manual instruction, return early
     (no raise, no write).
-    """
-    path = _CLAUDE_SETTINGS_PATH
 
+    Returns True if anything was written, False if already configured.
+    """
     raw = ""
-    if path.exists():
+    if _CLAUDE_SETTINGS_PATH.exists():
         try:
-            raw = path.read_text(encoding="utf-8")
+            raw = _CLAUDE_SETTINGS_PATH.read_text(encoding="utf-8")
         except OSError:
             raw = ""
 
@@ -92,28 +107,31 @@ def install_cw_allowlist() -> None:
                 "cw init: could not parse ~/.claude/settings.json — "
                 f'add "{CW_ALLOWLIST_ENTRY}" to permissions.allow manually.'
             )
-            return
+            return False
 
     permissions: dict[str, Any] = data.setdefault("permissions", {})
     allow: list[Any] = permissions.setdefault("allow", [])
 
-    entry = CW_ALLOWLIST_ENTRY
-    if entry not in allow:
-        allow.append(entry)
+    if CW_ALLOWLIST_ENTRY in allow:
+        return False
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write_text(path, json.dumps(data, indent=2) + "\n")
+    allow.append(CW_ALLOWLIST_ENTRY)
+    _CLAUDE_SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(_CLAUDE_SETTINGS_PATH, json.dumps(data, indent=2) + "\n")
+    return True
 
 
 _SESSIONSTART_COMMAND = "cw orchestrate status --json || true"
 
 
-def install_sessionstart_hook(workspace_path: Path) -> None:
+def install_sessionstart_hook(workspace_path: Path) -> bool:
     """Add the ``cw orchestrate status`` SessionStart hook to the workspace settings.
 
     Target: ``<workspace>/.claude/settings.json`` (NOT ``.local.json``).
     Duplicate-detection traverses hooks.SessionStart entries; skip-if-present.
     Creates ``<workspace>/.claude/`` if absent.
+
+    Returns True if anything was written, False if already configured.
     """
     claude_dir = workspace_path / ".claude"
     settings_path = claude_dir / "settings.json"
@@ -132,44 +150,48 @@ def install_sessionstart_hook(workspace_path: Path) -> None:
             )
             data = {}
 
-    target_command = _SESSIONSTART_COMMAND
-
     # Duplicate detection: traverse hooks.SessionStart[*].hooks[*].command
     hooks: dict[str, Any] = data.setdefault("hooks", {})
     for item in hooks.get("SessionStart", []):
         for hook in item.get("hooks", []):
-            if hook.get("command") == target_command:
-                return  # already present
+            if hook.get("command") == _SESSIONSTART_COMMAND:
+                return False  # already present
 
     # Build or extend the hooks structure.
     session_start: list[Any] = hooks.setdefault("SessionStart", [])
     session_start.append(
         {
             "matcher": "",
-            "hooks": [{"type": "command", "command": target_command}],
+            "hooks": [{"type": "command", "command": _SESSIONSTART_COMMAND}],
         }
     )
 
     atomic_write_text(settings_path, json.dumps(data, indent=2) + "\n")
+    return True
 
 
-def install_claude_md_snippet(workspace_path: Path) -> None:
-    """Append a cw-onboarding snippet to ``<workspace>/CLAUDE.md``.
+def install_claude_md_snippet(workspace_path: Path) -> bool:
+    """Append a cw-onboarding snippet to ``<workspace>/.claude/CLAUDE.md``.
 
-    Runs ``cw schema list`` first; if it fails (cw schema not available),
-    emits a warning and returns. Idempotent via the ``<!-- cw-onboarding -->``
-    marker.
+    Always writes the snippet body (idempotent via the ``<!-- cw-onboarding -->``
+    marker). Runs ``cw schema list`` as a probe; on non-zero exit, schema lines
+    are omitted from the snippet but the snippet is still written.
+    Creates ``<workspace>/.claude/`` if absent.
+
+    Returns True if anything was written, False if already configured.
     """
-    result = subprocess.run(
-        ["cw", "schema", "list"],
-        capture_output=True,
-        check=False,
+    schema_ok = (
+        subprocess.run(
+            ["cw", "schema", "list"],
+            capture_output=True,
+            check=False,
+        ).returncode
+        == 0
     )
-    if result.returncode != 0:
-        click.echo("cw init: cw schema list unavailable — skipping CLAUDE.md snippet.")
-        return
 
-    claude_md = workspace_path / "CLAUDE.md"
+    claude_dir = workspace_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    claude_md = claude_dir / "CLAUDE.md"
 
     existing_text = ""
     if claude_md.exists():
@@ -179,10 +201,15 @@ def install_claude_md_snippet(workspace_path: Path) -> None:
             existing_text = ""
 
     if _CLAUDE_MD_MARKER in existing_text:
-        return  # already onboarded
+        return False  # already onboarded
 
-    _queue_port = _QUEUE_EVENTS_BASE_URL.rsplit(":", 1)[-1]
-    _pr_port = _PR_EVENTS_BASE_URL.rsplit(":", 1)[-1]
+    queue_port = _QUEUE_EVENTS_BASE_URL.rsplit(":", 1)[-1]
+    pr_port = _PR_EVENTS_BASE_URL.rsplit(":", 1)[-1]
+    schema_lines = (
+        "- Run `cw schema <command>` for machine-readable output schemas;\n"
+        "  most cw commands accept `--json`.\n"
+        "- Example: `cw schema list` shows all available schemas.\n"
+    )
     snippet = (
         "\n"
         f"{_CLAUDE_MD_MARKER}\n"
@@ -191,12 +218,15 @@ def install_claude_md_snippet(workspace_path: Path) -> None:
         "This workspace is managed by `cw`. Background sessions receive tasks\n"
         "via the MCP channels wired in `.mcp.json`.\n"
         "\n"
-        f"- Queue events: `cw-queue-events` MCP server (port {_queue_port})\n"
-        f"- PR events: `cw-pr-events` MCP server (port {_pr_port})\n"
+        f"- Queue events: `cw-queue-events` MCP server (port {queue_port})\n"
+        f"- PR events: `cw-pr-events` MCP server (port {pr_port})\n"
         "- Dispatch status: `cw orchestrate status` (SessionStart hook)\n"
+        + (schema_lines if schema_ok else "")
     )
 
     try:
         atomic_write_text(claude_md, existing_text + snippet)
     except OSError as exc:
-        click.echo(f"cw init: could not write CLAUDE.md snippet: {exc}")
+        click.echo(f"cw init: could not write .claude/CLAUDE.md snippet: {exc}")
+        return False
+    return True

--- a/src/cw/onboarding.py
+++ b/src/cw/onboarding.py
@@ -1,0 +1,188 @@
+"""Agent-onboarding helpers wired into ``cw init``.
+
+Each function is idempotent — safe to call multiple times. Skip-if-present
+semantics avoid clobbering user customisations on re-runs.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import click
+
+from cw.atomic import atomic_write_text
+
+# Path to Claude Code user settings — enables test monkeypatching without
+# module-local patching. Mirrors the pattern in doctor.py:93.
+_CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+
+# Base URLs for the two MCP proxy channels.
+_QUEUE_EVENTS_BASE_URL = "http://127.0.0.1:8789"
+_PR_EVENTS_BASE_URL = "http://127.0.0.1:8788"
+
+# Marker inserted into CLAUDE.md to detect already-onboarded repos.
+_CLAUDE_MD_MARKER = "<!-- cw-onboarding -->"
+
+
+def register_mcp_servers(workspace_path: Path, client_name: str) -> None:
+    """Merge cw-queue-events and cw-pr-events into ``<workspace>/.mcp.json``.
+
+    Existing entries are preserved (skip-if-present semantics per key).
+    Absent file is treated as ``{}``. Writes are atomic.
+    """
+    mcp_path = workspace_path / ".mcp.json"
+
+    existing: dict[str, Any] = {}
+    if mcp_path.exists():
+        try:
+            existing = json.loads(mcp_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            existing = {}
+
+    servers: dict[str, Any] = existing.setdefault("mcpServers", {})
+
+    if "cw-queue-events" not in servers:
+        servers["cw-queue-events"] = {
+            "command": "cw",
+            "args": ["queue-channel", "proxy", "--client-id", client_name],
+            "env": {"CW_QUEUE_EVENTS_BASE_URL": _QUEUE_EVENTS_BASE_URL},
+        }
+
+    if "cw-pr-events" not in servers:
+        servers["cw-pr-events"] = {
+            "command": "cw",
+            "args": ["pr-channel", "proxy", "--client-id", client_name],
+            "env": {"CW_PR_EVENTS_BASE_URL": _PR_EVENTS_BASE_URL},
+        }
+
+    atomic_write_text(mcp_path, json.dumps(existing, indent=2) + "\n")
+
+
+def install_cw_allowlist() -> None:
+    """Merge ``Bash(cw:*)`` into ``~/.claude/settings.json`` allow list.
+
+    Skip-if-present. Unparseable JSON → emit manual instruction, return early
+    (no raise, no write).
+    """
+    path = _CLAUDE_SETTINGS_PATH
+
+    raw = ""
+    if path.exists():
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError:
+            raw = ""
+
+    data: dict[str, Any] = {}
+    if raw.strip():
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            click.echo(
+                "cw init: could not parse ~/.claude/settings.json — "
+                'add "Bash(cw:*)" to permissions.allow manually.'
+            )
+            return
+
+    permissions: dict[str, Any] = data.setdefault("permissions", {})
+    allow: list[Any] = permissions.setdefault("allow", [])
+
+    entry = "Bash(cw:*)"
+    if entry not in allow:
+        allow.append(entry)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(path, json.dumps(data, indent=2) + "\n")
+
+
+def install_sessionstart_hook(workspace_path: Path) -> None:
+    """Add the ``cw orchestrate status`` SessionStart hook to the workspace settings.
+
+    Target: ``<workspace>/.claude/settings.json`` (NOT ``.local.json``).
+    Duplicate-detection traverses hooks.SessionStart entries; skip-if-present.
+    Creates ``<workspace>/.claude/`` if absent.
+    """
+    claude_dir = workspace_path / ".claude"
+    settings_path = claude_dir / "settings.json"
+
+    claude_dir.mkdir(parents=True, exist_ok=True)
+
+    data: dict[str, Any] = {}
+    if settings_path.exists():
+        try:
+            raw = settings_path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (json.JSONDecodeError, OSError):
+            data = {}
+
+    target_command = "cw orchestrate status --json || true"
+
+    # Duplicate detection: traverse hooks.SessionStart[*].hooks[*].command
+    hooks_root: dict[str, Any] = data.get("hooks", {})
+    for item in hooks_root.get("SessionStart", []):
+        for hook in item.get("hooks", []):
+            if hook.get("command") == target_command:
+                return  # already present
+
+    # Build or extend the hooks structure.
+    hooks_section: dict[str, Any] = data.setdefault("hooks", {})
+    session_start: list[Any] = hooks_section.setdefault("SessionStart", [])
+    session_start.append(
+        {
+            "matcher": "",
+            "hooks": [{"type": "command", "command": target_command}],
+        }
+    )
+
+    atomic_write_text(settings_path, json.dumps(data, indent=2) + "\n")
+
+
+def install_claude_md_snippet(workspace_path: Path) -> None:
+    """Append a cw-onboarding snippet to ``<workspace>/CLAUDE.md``.
+
+    Runs ``cw schema list`` first; if it fails (cw schema not available),
+    emits a warning and returns. Idempotent via the ``<!-- cw-onboarding -->``
+    marker.
+    """
+    result = subprocess.run(
+        ["cw", "schema", "list"],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        click.echo("cw init: cw schema list unavailable — skipping CLAUDE.md snippet.")
+        return
+
+    claude_md = workspace_path / "CLAUDE.md"
+
+    existing_text = ""
+    if claude_md.exists():
+        try:
+            existing_text = claude_md.read_text(encoding="utf-8")
+        except OSError:
+            existing_text = ""
+
+    if _CLAUDE_MD_MARKER in existing_text:
+        return  # already onboarded
+
+    snippet = (
+        "\n"
+        f"{_CLAUDE_MD_MARKER}\n"
+        "## cw Agent Integration\n"
+        "\n"
+        "This workspace is managed by `cw`. Background sessions receive tasks\n"
+        "via the MCP channels wired in `.mcp.json`.\n"
+        "\n"
+        "- Queue events: `cw-queue-events` MCP server (port 8789)\n"
+        "- PR events: `cw-pr-events` MCP server (port 8788)\n"
+        "- Dispatch status: `cw orchestrate status` (SessionStart hook)\n"
+    )
+
+    try:
+        with claude_md.open("a", encoding="utf-8") as fh:
+            fh.write(snippet)
+    except OSError as exc:
+        click.echo(f"cw init: could not write CLAUDE.md snippet: {exc}")

--- a/src/cw/onboarding.py
+++ b/src/cw/onboarding.py
@@ -90,7 +90,7 @@ def install_cw_allowlist() -> None:
         except json.JSONDecodeError:
             click.echo(
                 "cw init: could not parse ~/.claude/settings.json — "
-                'add "Bash(cw:*)" to permissions.allow manually.'
+                f'add "{CW_ALLOWLIST_ENTRY}" to permissions.allow manually.'
             )
             return
 

--- a/src/cw/onboarding.py
+++ b/src/cw/onboarding.py
@@ -20,7 +20,11 @@ from cw.atomic import atomic_write_text
 _CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 
 # Base URLs for the two MCP proxy channels.
+# Why: mirrors _DEFAULT_BASE_URL in cw_queue_events_channel.py — update
+# together if port changes.
 _QUEUE_EVENTS_BASE_URL = "http://127.0.0.1:8789"
+# Why: mirrors _DEFAULT_BASE_URL in cw_pr_events_channel.py — update
+# together if port changes.
 _PR_EVENTS_BASE_URL = "http://127.0.0.1:8788"
 
 # Marker inserted into CLAUDE.md to detect already-onboarded repos.
@@ -61,6 +65,9 @@ def register_mcp_servers(workspace_path: Path, client_name: str) -> None:
     atomic_write_text(mcp_path, json.dumps(existing, indent=2) + "\n")
 
 
+CW_ALLOWLIST_ENTRY = "Bash(cw:*)"
+
+
 def install_cw_allowlist() -> None:
     """Merge ``Bash(cw:*)`` into ``~/.claude/settings.json`` allow list.
 
@@ -90,12 +97,15 @@ def install_cw_allowlist() -> None:
     permissions: dict[str, Any] = data.setdefault("permissions", {})
     allow: list[Any] = permissions.setdefault("allow", [])
 
-    entry = "Bash(cw:*)"
+    entry = CW_ALLOWLIST_ENTRY
     if entry not in allow:
         allow.append(entry)
 
     path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write_text(path, json.dumps(data, indent=2) + "\n")
+
+
+_SESSIONSTART_COMMAND = "cw orchestrate status --json || true"
 
 
 def install_sessionstart_hook(workspace_path: Path) -> None:
@@ -116,20 +126,23 @@ def install_sessionstart_hook(workspace_path: Path) -> None:
             raw = settings_path.read_text(encoding="utf-8")
             data = json.loads(raw)
         except (json.JSONDecodeError, OSError):
+            click.echo(
+                f"cw init: could not parse {settings_path} — "
+                "resetting to empty settings to add SessionStart hook."
+            )
             data = {}
 
-    target_command = "cw orchestrate status --json || true"
+    target_command = _SESSIONSTART_COMMAND
 
     # Duplicate detection: traverse hooks.SessionStart[*].hooks[*].command
-    hooks_root: dict[str, Any] = data.get("hooks", {})
-    for item in hooks_root.get("SessionStart", []):
+    hooks: dict[str, Any] = data.setdefault("hooks", {})
+    for item in hooks.get("SessionStart", []):
         for hook in item.get("hooks", []):
             if hook.get("command") == target_command:
                 return  # already present
 
     # Build or extend the hooks structure.
-    hooks_section: dict[str, Any] = data.setdefault("hooks", {})
-    session_start: list[Any] = hooks_section.setdefault("SessionStart", [])
+    session_start: list[Any] = hooks.setdefault("SessionStart", [])
     session_start.append(
         {
             "matcher": "",
@@ -168,6 +181,8 @@ def install_claude_md_snippet(workspace_path: Path) -> None:
     if _CLAUDE_MD_MARKER in existing_text:
         return  # already onboarded
 
+    _queue_port = _QUEUE_EVENTS_BASE_URL.rsplit(":", 1)[-1]
+    _pr_port = _PR_EVENTS_BASE_URL.rsplit(":", 1)[-1]
     snippet = (
         "\n"
         f"{_CLAUDE_MD_MARKER}\n"
@@ -176,13 +191,12 @@ def install_claude_md_snippet(workspace_path: Path) -> None:
         "This workspace is managed by `cw`. Background sessions receive tasks\n"
         "via the MCP channels wired in `.mcp.json`.\n"
         "\n"
-        "- Queue events: `cw-queue-events` MCP server (port 8789)\n"
-        "- PR events: `cw-pr-events` MCP server (port 8788)\n"
+        f"- Queue events: `cw-queue-events` MCP server (port {_queue_port})\n"
+        f"- PR events: `cw-pr-events` MCP server (port {_pr_port})\n"
         "- Dispatch status: `cw orchestrate status` (SessionStart hook)\n"
     )
 
     try:
-        with claude_md.open("a", encoding="utf-8") as fh:
-            fh.write(snippet)
+        atomic_write_text(claude_md, existing_text + snippet)
     except OSError as exc:
         click.echo(f"cw init: could not write CLAUDE.md snippet: {exc}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3321,7 +3321,7 @@ class TestInitCli:
         runner = CliRunner()
         result = runner.invoke(
             main,
-            ["init", "my-repo", "--path", str(repo)],
+            ["init", "my-repo", "--path", str(repo), "--no-onboarding"],
         )
         assert result.exit_code == 0, result.output
         assert "Added client 'my-repo'" in result.output
@@ -3346,6 +3346,7 @@ class TestInitCli:
                 "develop",
                 "--purposes",
                 "impl,idea",
+                "--no-onboarding",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -3365,7 +3366,7 @@ class TestInitCli:
         runner = CliRunner()
         result = runner.invoke(
             main,
-            ["init"],
+            ["init", "--no-onboarding"],
             input=f"my-repo\n{repo}\nmain\n",
         )
         assert result.exit_code == 0, result.output
@@ -3445,10 +3446,11 @@ class TestInitCli:
 
         # Pre-register the client so --onboard-only can find it.
         runner = CliRunner()
-        runner.invoke(
+        result = runner.invoke(
             main,
             ["init", "my-repo", "--path", str(repo), "--no-onboarding"],
         )
+        assert result.exit_code == 0, f"Setup failed: {result.output}"
 
         with (
             patch("cw.cli.register_mcp_servers") as mock_mcp,
@@ -3497,6 +3499,63 @@ class TestInitCli:
 
         assert result.exit_code != 0
         assert "Name is required" in result.output
+
+    def test_init_no_onboarding_and_onboard_only_conflict(
+        self,
+        tmp_config_dir: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """--no-onboarding and --onboard-only together exit nonzero with error."""
+        repo = make_git_repo("my-repo")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "init",
+                "my-repo",
+                "--path",
+                str(repo),
+                "--no-onboarding",
+                "--onboard-only",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+    def test_init_calls_onboarding_with_correct_workspace(
+        self,
+        tmp_config_dir: Path,
+        make_git_repo: Callable[[str], Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Default cw init calls all four onboarding functions with correct args."""
+        from unittest.mock import MagicMock
+
+        repo = make_git_repo("my-repo")
+
+        mock_mcp = MagicMock()
+        mock_allow = MagicMock()
+        mock_hook = MagicMock()
+        mock_md = MagicMock()
+
+        monkeypatch.setattr("cw.cli.register_mcp_servers", mock_mcp)
+        monkeypatch.setattr("cw.cli.install_cw_allowlist", mock_allow)
+        monkeypatch.setattr("cw.cli.install_sessionstart_hook", mock_hook)
+        monkeypatch.setattr("cw.cli.install_claude_md_snippet", mock_md)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["init", "my-repo", "--path", str(repo)],
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_mcp.assert_called_once_with(repo, "my-repo")
+        mock_allow.assert_called_once()
+        mock_hook.assert_called_once_with(repo)
+        mock_md.assert_called_once_with(repo)
 
 
 class TestQueueNextCli:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3408,6 +3408,96 @@ class TestInitCli:
         assert result.exit_code != 0
         assert "already exists" in result.output
 
+    def test_init_no_onboarding(
+        self,
+        tmp_config_dir: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """--no-onboarding skips all four onboarding functions."""
+        repo = make_git_repo("my-repo")
+
+        with (
+            patch("cw.cli.register_mcp_servers") as mock_mcp,
+            patch("cw.cli.install_cw_allowlist") as mock_allow,
+            patch("cw.cli.install_sessionstart_hook") as mock_hook,
+            patch("cw.cli.install_claude_md_snippet") as mock_md,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["init", "my-repo", "--path", str(repo), "--no-onboarding"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Added client 'my-repo'" in result.output
+        mock_mcp.assert_not_called()
+        mock_allow.assert_not_called()
+        mock_hook.assert_not_called()
+        mock_md.assert_not_called()
+
+    def test_init_onboard_only(
+        self,
+        tmp_config_dir: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """--onboard-only calls onboarding functions and skips init_client."""
+        repo = make_git_repo("my-repo")
+
+        # Pre-register the client so --onboard-only can find it.
+        runner = CliRunner()
+        runner.invoke(
+            main,
+            ["init", "my-repo", "--path", str(repo), "--no-onboarding"],
+        )
+
+        with (
+            patch("cw.cli.register_mcp_servers") as mock_mcp,
+            patch("cw.cli.install_cw_allowlist") as mock_allow,
+            patch("cw.cli.install_sessionstart_hook") as mock_hook,
+            patch("cw.cli.install_claude_md_snippet") as mock_md,
+            patch("cw.cli.init_client") as mock_init,
+        ):
+            result = runner.invoke(
+                main,
+                ["init", "my-repo", "--onboard-only"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Onboarding complete" in result.output
+        mock_init.assert_not_called()
+        mock_mcp.assert_called_once()
+        mock_allow.assert_called_once()
+        mock_hook.assert_called_once()
+        mock_md.assert_called_once()
+
+    def test_init_onboard_only_missing_client(
+        self,
+        tmp_config_dir: Path,
+    ) -> None:
+        """--onboard-only with nonexistent client name exits nonzero with error."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["init", "no-such-client", "--onboard-only"],
+        )
+
+        assert result.exit_code != 0
+        assert "no-such-client" in result.output
+
+    def test_init_onboard_only_missing_name(
+        self,
+        tmp_config_dir: Path,
+    ) -> None:
+        """--onboard-only without a name exits nonzero with error."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["init", "--onboard-only"],
+        )
+
+        assert result.exit_code != 0
+        assert "Name is required" in result.output
+
 
 class TestQueueNextCli:
     def test_next_empty_queue(self, tmp_config_dir: Path) -> None:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from cw.onboarding import (
     _CLAUDE_MD_MARKER,
     _SESSIONSTART_COMMAND,
+    CW_ALLOWLIST_ENTRY,
     install_claude_md_snippet,
     install_cw_allowlist,
     install_sessionstart_hook,
@@ -115,7 +116,7 @@ class TestInstallCwAllowlist:
         install_cw_allowlist()
 
         data = json.loads(settings.read_text())
-        assert "Bash(cw:*)" in data["permissions"]["allow"]
+        assert CW_ALLOWLIST_ENTRY in data["permissions"]["allow"]
 
     def test_idempotent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         settings = tmp_path / "settings.json"
@@ -125,7 +126,7 @@ class TestInstallCwAllowlist:
         install_cw_allowlist()
 
         data = json.loads(settings.read_text())
-        assert data["permissions"]["allow"].count("Bash(cw:*)") == 1
+        assert data["permissions"]["allow"].count(CW_ALLOWLIST_ENTRY) == 1
 
     def test_absent_file_creates_it(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -137,7 +138,7 @@ class TestInstallCwAllowlist:
 
         assert settings.exists()
         data = json.loads(settings.read_text())
-        assert "Bash(cw:*)" in data["permissions"]["allow"]
+        assert CW_ALLOWLIST_ENTRY in data["permissions"]["allow"]
 
     def test_unparseable_json_echoes_manual_instruction_no_write(
         self,
@@ -168,7 +169,7 @@ class TestInstallCwAllowlist:
 
         data = json.loads(settings.read_text())
         allow = data["permissions"]["allow"]
-        assert "Bash(cw:*)" in allow
+        assert CW_ALLOWLIST_ENTRY in allow
         assert "Bash(git:*)" in allow
         assert "Bash(gh:*)" in allow
 

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -32,8 +32,9 @@ class TestRegisterMcpServers:
         workspace = tmp_path / "repo"
         workspace.mkdir()
 
-        register_mcp_servers(workspace, "my-client")
+        changed = register_mcp_servers(workspace, "my-client")
 
+        assert changed is True
         mcp_path = workspace / ".mcp.json"
         assert mcp_path.exists()
         data = json.loads(mcp_path.read_text())
@@ -65,8 +66,9 @@ class TestRegisterMcpServers:
         first_content = mcp_path.read_text()
 
         # Second call must not change anything.
-        register_mcp_servers(workspace, "other-client")
+        changed = register_mcp_servers(workspace, "other-client")
 
+        assert changed is False
         second_content = mcp_path.read_text()
         # Keys were not overwritten; client-id still points to first call's value.
         assert first_content == second_content
@@ -100,6 +102,26 @@ class TestRegisterMcpServers:
 
         assert (workspace / ".mcp.json").exists()
 
+    def test_unparseable_mcp_json_refuses_with_manual_instruction(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Corrupt .mcp.json must not be overwritten; manual instruction emitted."""
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        mcp_path = workspace / ".mcp.json"
+        corrupt = "{not valid json{{{"
+        mcp_path.write_text(corrupt)
+
+        changed = register_mcp_servers(workspace, "my-client")
+
+        assert changed is False
+        # File left untouched.
+        assert mcp_path.read_text() == corrupt
+        captured = capsys.readouterr()
+        assert "manually" in captured.out
+
 
 # ---------------------------------------------------------------------------
 # install_cw_allowlist
@@ -113,8 +135,9 @@ class TestInstallCwAllowlist:
         settings = tmp_path / "settings.json"
         monkeypatch.setattr("cw.onboarding._CLAUDE_SETTINGS_PATH", settings)
 
-        install_cw_allowlist()
+        changed = install_cw_allowlist()
 
+        assert changed is True
         data = json.loads(settings.read_text())
         assert CW_ALLOWLIST_ENTRY in data["permissions"]["allow"]
 
@@ -123,8 +146,9 @@ class TestInstallCwAllowlist:
         monkeypatch.setattr("cw.onboarding._CLAUDE_SETTINGS_PATH", settings)
 
         install_cw_allowlist()
-        install_cw_allowlist()
+        changed = install_cw_allowlist()
 
+        assert changed is False
         data = json.loads(settings.read_text())
         assert data["permissions"]["allow"].count(CW_ALLOWLIST_ENTRY) == 1
 
@@ -257,11 +281,13 @@ class TestInstallSessionstartHook:
 
 
 class TestInstallClaudeMdSnippet:
-    def test_cw_schema_fails_skips_with_warning(
+    def test_cw_schema_fails_writes_snippet_without_schema_lines(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
+        """Schema probe fails: snippet written, schema lines omitted, no warning."""
         workspace = tmp_path / "repo"
         workspace.mkdir()
+        claude_md = workspace / ".claude" / "CLAUDE.md"
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
@@ -270,16 +296,49 @@ class TestInstallClaudeMdSnippet:
                 stdout=b"",
                 stderr=b"",
             )
-            install_claude_md_snippet(workspace)
+            changed = install_claude_md_snippet(workspace)
 
+        assert changed is True
+        assert claude_md.exists()
+        text = claude_md.read_text()
+        assert _CLAUDE_MD_MARKER in text
+        assert "cw Agent Integration" in text
+        # Schema lines must NOT be present when probe failed.
+        assert "cw schema" not in text
+        # No warning emitted.
         captured = capsys.readouterr()
-        assert "unavailable" in captured.out
-        assert not (workspace / "CLAUDE.md").exists()
+        assert captured.out == ""
+
+    def test_cw_schema_succeeds_writes_snippet_with_schema_lines(
+        self, tmp_path: Path
+    ) -> None:
+        """When cw schema list succeeds, snippet includes schema lines."""
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        claude_md = workspace / ".claude" / "CLAUDE.md"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["cw", "schema", "list"],
+                returncode=0,
+                stdout=b"",
+                stderr=b"",
+            )
+            changed = install_claude_md_snippet(workspace)
+
+        assert changed is True
+        assert claude_md.exists()
+        text = claude_md.read_text()
+        assert _CLAUDE_MD_MARKER in text
+        assert "cw schema" in text
+        assert "--json" in text
 
     def test_idempotent_marker_already_present(self, tmp_path: Path) -> None:
         workspace = tmp_path / "repo"
         workspace.mkdir()
-        claude_md = workspace / "CLAUDE.md"
+        claude_dir = workspace / ".claude"
+        claude_dir.mkdir()
+        claude_md = claude_dir / "CLAUDE.md"
         claude_md.write_text(f"# Existing\n\n{_CLAUDE_MD_MARKER}\nAlready here.\n")
 
         with patch("subprocess.run") as mock_run:
@@ -289,15 +348,18 @@ class TestInstallClaudeMdSnippet:
                 stdout=b"",
                 stderr=b"",
             )
-            install_claude_md_snippet(workspace)
+            changed = install_claude_md_snippet(workspace)
 
+        assert changed is False
         # Content must be unchanged.
         assert claude_md.read_text().count(_CLAUDE_MD_MARKER) == 1
 
     def test_appends_marker_when_absent(self, tmp_path: Path) -> None:
         workspace = tmp_path / "repo"
         workspace.mkdir()
-        claude_md = workspace / "CLAUDE.md"
+        claude_dir = workspace / ".claude"
+        claude_dir.mkdir()
+        claude_md = claude_dir / "CLAUDE.md"
         claude_md.write_text("# My Project\n\nExisting content.\n")
 
         with patch("subprocess.run") as mock_run:
@@ -326,32 +388,25 @@ class TestInstallClaudeMdSnippet:
             )
             install_claude_md_snippet(workspace)
 
-        claude_md = workspace / "CLAUDE.md"
+        claude_md = workspace / ".claude" / "CLAUDE.md"
         assert claude_md.exists()
         assert _CLAUDE_MD_MARKER in claude_md.read_text()
 
-    def test_cw_schema_fails_content_unchanged(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """When cw schema list fails, pre-existing CLAUDE.md must not be modified."""
+    def test_creates_claude_dir_when_absent(self, tmp_path: Path) -> None:
         workspace = tmp_path / "repo"
         workspace.mkdir()
-        claude_md = workspace / "CLAUDE.md"
-        original_content = "# Existing project\n\nSome content.\n"
-        claude_md.write_text(original_content)
+        assert not (workspace / ".claude").exists()
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=["cw", "schema", "list"],
-                returncode=1,
+                returncode=0,
                 stdout=b"",
                 stderr=b"",
             )
             install_claude_md_snippet(workspace)
 
-        assert claude_md.read_text() == original_content
-        captured = capsys.readouterr()
-        assert "unavailable" in captured.out
+        assert (workspace / ".claude" / "CLAUDE.md").exists()
 
 
 class TestInstallSessionstartHookExtra:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,331 @@
+"""Tests for cw.onboarding — agent-onboarding helpers."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from cw.onboarding import (
+    _CLAUDE_MD_MARKER,
+    install_claude_md_snippet,
+    install_cw_allowlist,
+    install_sessionstart_hook,
+    register_mcp_servers,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+# ---------------------------------------------------------------------------
+# register_mcp_servers
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterMcpServers:
+    def test_happy_path_creates_mcp_json(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+
+        register_mcp_servers(workspace, "my-client")
+
+        mcp_path = workspace / ".mcp.json"
+        assert mcp_path.exists()
+        data = json.loads(mcp_path.read_text())
+        servers = data["mcpServers"]
+        assert "cw-queue-events" in servers
+        assert "cw-pr-events" in servers
+
+        q = servers["cw-queue-events"]
+        assert q["command"] == "cw"
+        assert "--client-id" in q["args"]
+        assert "my-client" in q["args"]
+        assert "CW_QUEUE_EVENTS_BASE_URL" in q["env"]
+
+        p = servers["cw-pr-events"]
+        assert p["command"] == "cw"
+        assert "--client-id" in p["args"]
+        assert "my-client" in p["args"]
+        assert "CW_PR_EVENTS_BASE_URL" in p["env"]
+
+    def test_idempotent_skip_if_present(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+
+        # First call writes the entries.
+        register_mcp_servers(workspace, "my-client")
+
+        # Manually check initial content.
+        mcp_path = workspace / ".mcp.json"
+        first_content = mcp_path.read_text()
+
+        # Second call must not change anything.
+        register_mcp_servers(workspace, "other-client")
+
+        second_content = mcp_path.read_text()
+        # Keys were not overwritten; client-id still points to first call's value.
+        assert first_content == second_content
+
+    def test_merges_into_existing_mcp_json(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        mcp_path = workspace / ".mcp.json"
+        existing = {
+            "mcpServers": {
+                "other-server": {"command": "other", "args": [], "env": {}},
+            }
+        }
+        mcp_path.write_text(json.dumps(existing))
+
+        register_mcp_servers(workspace, "my-client")
+
+        data = json.loads(mcp_path.read_text())
+        assert "other-server" in data["mcpServers"]
+        assert "cw-queue-events" in data["mcpServers"]
+        assert "cw-pr-events" in data["mcpServers"]
+
+    def test_absent_dir_still_creates_file(self, tmp_path: Path) -> None:
+        # workspace itself doesn't need to exist for .mcp.json; but the parent
+        # dir is created by register_mcp_servers when needed.  Here the
+        # workspace dir exists (mkdir), so .mcp.json is created inside it.
+        workspace = tmp_path / "deep" / "repo"
+        workspace.mkdir(parents=True)
+
+        register_mcp_servers(workspace, "x")
+
+        assert (workspace / ".mcp.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# install_cw_allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestInstallCwAllowlist:
+    def test_happy_path_adds_entry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = tmp_path / "settings.json"
+        monkeypatch.setattr("cw.onboarding._CLAUDE_SETTINGS_PATH", settings)
+
+        install_cw_allowlist()
+
+        data = json.loads(settings.read_text())
+        assert "Bash(cw:*)" in data["permissions"]["allow"]
+
+    def test_idempotent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        settings = tmp_path / "settings.json"
+        monkeypatch.setattr("cw.onboarding._CLAUDE_SETTINGS_PATH", settings)
+
+        install_cw_allowlist()
+        install_cw_allowlist()
+
+        data = json.loads(settings.read_text())
+        assert data["permissions"]["allow"].count("Bash(cw:*)") == 1
+
+    def test_absent_file_creates_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = tmp_path / "subdir" / "settings.json"
+        monkeypatch.setattr("cw.onboarding._CLAUDE_SETTINGS_PATH", settings)
+
+        install_cw_allowlist()
+
+        assert settings.exists()
+        data = json.loads(settings.read_text())
+        assert "Bash(cw:*)" in data["permissions"]["allow"]
+
+    def test_unparseable_json_echoes_manual_instruction_no_write(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        settings = tmp_path / "settings.json"
+        settings.write_text("not-valid-json{{{")
+        monkeypatch.setattr("cw.onboarding._CLAUDE_SETTINGS_PATH", settings)
+
+        install_cw_allowlist()
+
+        # File must be unchanged (no write on parse failure).
+        assert settings.read_text() == "not-valid-json{{{"
+        captured = capsys.readouterr()
+        assert "manually" in captured.out
+
+    def test_merges_into_existing_allow_list(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = tmp_path / "settings.json"
+        existing = {"permissions": {"allow": ["Bash(git:*)", "Bash(gh:*)"]}}
+        settings.write_text(json.dumps(existing))
+        monkeypatch.setattr("cw.onboarding._CLAUDE_SETTINGS_PATH", settings)
+
+        install_cw_allowlist()
+
+        data = json.loads(settings.read_text())
+        allow = data["permissions"]["allow"]
+        assert "Bash(cw:*)" in allow
+        assert "Bash(git:*)" in allow
+        assert "Bash(gh:*)" in allow
+
+
+# ---------------------------------------------------------------------------
+# install_sessionstart_hook
+# ---------------------------------------------------------------------------
+
+
+class TestInstallSessionstartHook:
+    _COMMAND = "cw orchestrate status --json || true"
+
+    def test_happy_path_writes_hook(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+
+        install_sessionstart_hook(workspace)
+
+        settings_path = workspace / ".claude" / "settings.json"
+        assert settings_path.exists()
+        data = json.loads(settings_path.read_text())
+        session_start = data["hooks"]["SessionStart"]
+        commands = [
+            h["command"] for item in session_start for h in item.get("hooks", [])
+        ]
+        assert self._COMMAND in commands
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+
+        install_sessionstart_hook(workspace)
+        install_sessionstart_hook(workspace)
+
+        settings_path = workspace / ".claude" / "settings.json"
+        data = json.loads(settings_path.read_text())
+        commands = [
+            h["command"]
+            for item in data["hooks"]["SessionStart"]
+            for h in item.get("hooks", [])
+        ]
+        assert commands.count(self._COMMAND) == 1
+
+    def test_existing_different_hooks_preserved(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        claude_dir = workspace / ".claude"
+        claude_dir.mkdir()
+        settings_path = claude_dir / "settings.json"
+        existing = {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "",
+                        "hooks": [{"type": "command", "command": "echo hello"}],
+                    }
+                ]
+            }
+        }
+        settings_path.write_text(json.dumps(existing))
+
+        install_sessionstart_hook(workspace)
+
+        data = json.loads(settings_path.read_text())
+        commands = [
+            h["command"]
+            for item in data["hooks"]["SessionStart"]
+            for h in item.get("hooks", [])
+        ]
+        assert "echo hello" in commands
+        assert self._COMMAND in commands
+
+    def test_absent_dir_created(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        # .claude/ does NOT exist yet
+        assert not (workspace / ".claude").exists()
+
+        install_sessionstart_hook(workspace)
+
+        assert (workspace / ".claude" / "settings.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# install_claude_md_snippet
+# ---------------------------------------------------------------------------
+
+
+class TestInstallClaudeMdSnippet:
+    def test_cw_schema_fails_skips_with_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["cw", "schema", "list"],
+                returncode=1,
+                stdout=b"",
+                stderr=b"",
+            )
+            install_claude_md_snippet(workspace)
+
+        captured = capsys.readouterr()
+        assert "unavailable" in captured.out
+        assert not (workspace / "CLAUDE.md").exists()
+
+    def test_idempotent_marker_already_present(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        claude_md = workspace / "CLAUDE.md"
+        claude_md.write_text(f"# Existing\n\n{_CLAUDE_MD_MARKER}\nAlready here.\n")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["cw", "schema", "list"],
+                returncode=0,
+                stdout=b"",
+                stderr=b"",
+            )
+            install_claude_md_snippet(workspace)
+
+        # Content must be unchanged.
+        assert claude_md.read_text().count(_CLAUDE_MD_MARKER) == 1
+
+    def test_appends_marker_when_absent(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        claude_md = workspace / "CLAUDE.md"
+        claude_md.write_text("# My Project\n\nExisting content.\n")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["cw", "schema", "list"],
+                returncode=0,
+                stdout=b"",
+                stderr=b"",
+            )
+            install_claude_md_snippet(workspace)
+
+        text = claude_md.read_text()
+        assert _CLAUDE_MD_MARKER in text
+        assert "cw Agent Integration" in text
+
+    def test_creates_claude_md_when_absent(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["cw", "schema", "list"],
+                returncode=0,
+                stdout=b"",
+                stderr=b"",
+            )
+            install_claude_md_snippet(workspace)
+
+        claude_md = workspace / "CLAUDE.md"
+        assert claude_md.exists()
+        assert _CLAUDE_MD_MARKER in claude_md.read_text()

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 from cw.onboarding import (
     _CLAUDE_MD_MARKER,
+    _SESSIONSTART_COMMAND,
     install_claude_md_snippet,
     install_cw_allowlist,
     install_sessionstart_hook,
@@ -178,8 +179,6 @@ class TestInstallCwAllowlist:
 
 
 class TestInstallSessionstartHook:
-    _COMMAND = "cw orchestrate status --json || true"
-
     def test_happy_path_writes_hook(self, tmp_path: Path) -> None:
         workspace = tmp_path / "repo"
         workspace.mkdir()
@@ -193,7 +192,7 @@ class TestInstallSessionstartHook:
         commands = [
             h["command"] for item in session_start for h in item.get("hooks", [])
         ]
-        assert self._COMMAND in commands
+        assert _SESSIONSTART_COMMAND in commands
 
     def test_idempotent(self, tmp_path: Path) -> None:
         workspace = tmp_path / "repo"
@@ -209,7 +208,7 @@ class TestInstallSessionstartHook:
             for item in data["hooks"]["SessionStart"]
             for h in item.get("hooks", [])
         ]
-        assert commands.count(self._COMMAND) == 1
+        assert commands.count(_SESSIONSTART_COMMAND) == 1
 
     def test_existing_different_hooks_preserved(self, tmp_path: Path) -> None:
         workspace = tmp_path / "repo"
@@ -238,7 +237,7 @@ class TestInstallSessionstartHook:
             for h in item.get("hooks", [])
         ]
         assert "echo hello" in commands
-        assert self._COMMAND in commands
+        assert _SESSIONSTART_COMMAND in commands
 
     def test_absent_dir_created(self, tmp_path: Path) -> None:
         workspace = tmp_path / "repo"
@@ -329,3 +328,58 @@ class TestInstallClaudeMdSnippet:
         claude_md = workspace / "CLAUDE.md"
         assert claude_md.exists()
         assert _CLAUDE_MD_MARKER in claude_md.read_text()
+
+    def test_cw_schema_fails_content_unchanged(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When cw schema list fails, pre-existing CLAUDE.md must not be modified."""
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        claude_md = workspace / "CLAUDE.md"
+        original_content = "# Existing project\n\nSome content.\n"
+        claude_md.write_text(original_content)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["cw", "schema", "list"],
+                returncode=1,
+                stdout=b"",
+                stderr=b"",
+            )
+            install_claude_md_snippet(workspace)
+
+        assert claude_md.read_text() == original_content
+        captured = capsys.readouterr()
+        assert "unavailable" in captured.out
+
+
+class TestInstallSessionstartHookExtra:
+    def test_corrupt_settings_file_warns_and_writes(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Unparseable settings.json emits a warning, resets to empty, writes hook."""
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        claude_dir = workspace / ".claude"
+        claude_dir.mkdir()
+        settings_path = claude_dir / "settings.json"
+        settings_path.write_text("{invalid json{{")
+
+        # Must not raise
+        install_sessionstart_hook(workspace)
+
+        # Warning was emitted
+        captured = capsys.readouterr()
+        assert "could not parse" in captured.out
+
+        # Valid settings.json was written with the hook
+        assert settings_path.exists()
+        data = json.loads(settings_path.read_text())
+        commands = [
+            h["command"]
+            for item in data["hooks"]["SessionStart"]
+            for h in item.get("hooks", [])
+        ]
+        assert _SESSIONSTART_COMMAND in commands


### PR DESCRIPTION
Closes #509.

Extends `cw init` (plus `--onboard-only` / `--no-onboarding`) so fresh agent sessions are tool-aware with zero hand-wiring:

- **`.mcp.json`** (project-scoped, `mcpServers` format): registers both channel proxies with the cw client name as `--client-id`; merge-by-key skip-if-present, atomic write; corrupt existing file → refuse + manual instruction.
- **Permission allowlist**: merges `Bash(cw:*)` into `~/.claude/settings.json` `permissions.allow` (set semantics, never wholesale overwrite; unparseable → refuse).
- **SessionStart hook** (project `.claude/settings.json`): `cw orchestrate status --json || true`, duplicate-checked; interim until `cw brief`.
- **`.claude/CLAUDE.md` snippet** behind an idempotency marker; `cw schema`/`--json` lines degrade silently when the subcommand probe fails.
- All steps idempotent (re-run echoes "already configured"); docs in INSTALL.md + CONFIG_REFERENCE.md; `.example` placeholders updated.

Implements the binding spec in the issue's Pre-flight Resolutions comment. Gates: ruff, format, mypy --strict, pre-commit, pytest (1832 passed, 95.95% total cov), diff-cover 93% patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)