### PR TITLE
feat(config): single state lock — mutate_state() + protect reap_reason stamps (#387)

### DIFF
--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -177,7 +177,14 @@ def sessions_lock() -> Iterator[None]:
 
 
 def mutate_state(fn: Callable[[CwState], None]) -> CwState:
-    """Load state, apply fn in place under sessions_lock, save and return."""
+    """Load state, apply fn in place under sessions_lock, save and return.
+
+    Not reentrant: ``sessions_lock`` is a per-open-fd ``flock``, so calling
+    this while the caller already holds ``sessions_lock`` self-deadlocks.
+    Code running inside a ``with sessions_lock():`` block (e.g. anything
+    called from ``reconcile._reconcile_locked``) must mutate the loaded
+    state and ``save_state`` directly instead.
+    """
     with sessions_lock():
         state = load_state()
         fn(state)

--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -33,7 +33,7 @@ from cw.models import (
 from cw.native_daemon import SHORT_SESSION_ID_RE
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
 logger = logging.getLogger(__name__)
 
@@ -174,6 +174,15 @@ def sessions_lock() -> Iterator[None]:
     finally:
         fcntl.flock(fd, fcntl.LOCK_UN)
         fd.close()
+
+
+def mutate_state(fn: Callable[[CwState], None]) -> CwState:
+    """Load state, apply fn in place under sessions_lock, save and return."""
+    with sessions_lock():
+        state = load_state()
+        fn(state)
+        save_state(state)
+        return state
 
 
 @contextlib.contextmanager

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -46,6 +46,7 @@ from cw.config import (
     get_client,
     load_orchestrator_config,
     load_state,
+    mutate_state,
     save_state,
     sessions_lock,
 )
@@ -1481,7 +1482,10 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
     # was not yet reverted (e.g. signal_stop crashed after setting status but
     # before touching the queue, or a headless session completed without
     # the dispatch consumer processing it). TIMED_OUT/COMPLETED sessions are
-    # already terminal so no state mutation is needed — queue revert only.
+    # already terminal; the only state mutation for these sessions is the
+    # reap_reason stamp performed above via mutate_state() in
+    # revert_timed_out_tasks / revert_completed_silent_tasks.
+    # This block handles queue revert only.
     timed_out_ticket_ids = revert_timed_out_tasks()
     completed_silent_ticket_ids = revert_completed_silent_tasks()
     all_reverted = list(
@@ -1967,13 +1971,14 @@ def revert_timed_out_tasks() -> list[str]:
         for t in store.tasks
         if t.status == QueueItemStatus.RUNNING and t.session_id in session_ids
     }
-    state_changed = False
-    for s in target_sessions:
-        if s.reap_reason is None and s.id in backstop_session_ids:
-            s.reap_reason = ReapReason.COMPLETED_BACKSTOP
-            state_changed = True
-    if state_changed:
-        save_state(state)
+    if backstop_session_ids:
+
+        def _stamp(state: CwState) -> None:
+            for s in state.sessions:
+                if s.id in backstop_session_ids and s.reap_reason is None:
+                    s.reap_reason = ReapReason.COMPLETED_BACKSTOP
+
+        mutate_state(_stamp)
     # Compute dirtiness BEFORE acquiring dev_queue_lock (see TOCTOU note in
     # _revert_running_tasks_for_sessions docstring).
     dirty_session_ids = _build_dirty_session_ids_and_notify(target_sessions)
@@ -2019,13 +2024,14 @@ def revert_completed_silent_tasks() -> list[str]:
         for t in store.tasks
         if t.status == QueueItemStatus.RUNNING and t.session_id in session_ids
     }
-    state_changed = False
-    for s in target_sessions:
-        if s.reap_reason is None and s.id in backstop_session_ids:
-            s.reap_reason = ReapReason.COMPLETED_BACKSTOP
-            state_changed = True
-    if state_changed:
-        save_state(state)
+    if backstop_session_ids:
+
+        def _stamp(state: CwState) -> None:
+            for s in state.sessions:
+                if s.id in backstop_session_ids and s.reap_reason is None:
+                    s.reap_reason = ReapReason.COMPLETED_BACKSTOP
+
+        mutate_state(_stamp)
     # Compute dirtiness BEFORE acquiring dev_queue_lock (see TOCTOU note in
     # _revert_running_tasks_for_sessions docstring).
     dirty_session_ids = _build_dirty_session_ids_and_notify(target_sessions)

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -19,7 +19,8 @@ daemon hiccup would otherwise irreversibly mark every session as CRASHED.
 Lock note: ``reconcile`` acquires ``sessions_lock`` (config.py) across its
 entire load_state → mutate → save_state sequence.  The helpers called from
 within the lock (``revert_stalled_headless_sessions``,
-``flag_silently_idle_daemon_sessions``) save_state directly without
+``flag_silently_idle_daemon_sessions``, ``revert_timed_out_tasks``,
+``revert_completed_silent_tasks``) save_state directly without
 re-acquiring; callers of those helpers must hold the lock themselves if
 called outside ``reconcile``.
 """
@@ -46,7 +47,6 @@ from cw.config import (
     get_client,
     load_orchestrator_config,
     load_state,
-    mutate_state,
     save_state,
     sessions_lock,
 )
@@ -1483,9 +1483,9 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
     # before touching the queue, or a headless session completed without
     # the dispatch consumer processing it). TIMED_OUT/COMPLETED sessions are
     # already terminal; the only state mutation for these sessions is the
-    # reap_reason stamp performed above via mutate_state() in
-    # revert_timed_out_tasks / revert_completed_silent_tasks.
-    # This block handles queue revert only.
+    # reap_reason stamp inside revert_timed_out_tasks /
+    # revert_completed_silent_tasks (in-place + save_state, serialized by
+    # the sessions_lock this function runs under).
     timed_out_ticket_ids = revert_timed_out_tasks()
     completed_silent_ticket_ids = revert_completed_silent_tasks()
     all_reverted = list(
@@ -1940,6 +1940,9 @@ def revert_timed_out_tasks() -> list[str]:
     ``signal_stop`` crashed after writing TIMED_OUT status but before
     reverting the dev-queue task. Returns the list of ticket IDs reverted.
 
+    Caller must hold ``sessions_lock`` (all call sites are inside
+    ``_reconcile_locked``); the reap_reason stamp below relies on it.
+
     Sessions with dirty worktrees are routed to BLOCKED_ON_USER instead of
     PENDING, and a SESSION_NEEDS_ATTENTION event is emitted for operator
     inspection (GitHub issue #421).
@@ -1971,14 +1974,16 @@ def revert_timed_out_tasks() -> list[str]:
         for t in store.tasks
         if t.status == QueueItemStatus.RUNNING and t.session_id in session_ids
     }
-    if backstop_session_ids:
-
-        def _stamp(state: CwState) -> None:
-            for s in state.sessions:
-                if s.id in backstop_session_ids and s.reap_reason is None:
-                    s.reap_reason = ReapReason.COMPLETED_BACKSTOP
-
-        mutate_state(_stamp)
+    # Why: stamp in place + save_state, NOT mutate_state — the caller
+    # already holds sessions_lock, and the lock is a per-open-fd flock,
+    # so re-acquiring it here self-deadlocks (#387 gate hang).
+    state_changed = False
+    for s in target_sessions:
+        if s.reap_reason is None and s.id in backstop_session_ids:
+            s.reap_reason = ReapReason.COMPLETED_BACKSTOP
+            state_changed = True
+    if state_changed:
+        save_state(state)
     # Compute dirtiness BEFORE acquiring dev_queue_lock (see TOCTOU note in
     # _revert_running_tasks_for_sessions docstring).
     dirty_session_ids = _build_dirty_session_ids_and_notify(target_sessions)
@@ -1992,6 +1997,9 @@ def revert_completed_silent_tasks() -> list[str]:
     without reverting their dev-queue task (e.g. the session wrote COMPLETED
     status but the dispatch consumer had not yet processed it). Returns the
     list of ticket IDs reverted.
+
+    Caller must hold ``sessions_lock`` (all call sites are inside
+    ``_reconcile_locked``); the reap_reason stamp below relies on it.
 
     Sessions with dirty worktrees are routed to BLOCKED_ON_USER instead of
     PENDING, and a SESSION_NEEDS_ATTENTION event is emitted for operator
@@ -2024,14 +2032,16 @@ def revert_completed_silent_tasks() -> list[str]:
         for t in store.tasks
         if t.status == QueueItemStatus.RUNNING and t.session_id in session_ids
     }
-    if backstop_session_ids:
-
-        def _stamp(state: CwState) -> None:
-            for s in state.sessions:
-                if s.id in backstop_session_ids and s.reap_reason is None:
-                    s.reap_reason = ReapReason.COMPLETED_BACKSTOP
-
-        mutate_state(_stamp)
+    # Why: stamp in place + save_state, NOT mutate_state — the caller
+    # already holds sessions_lock, and the lock is a per-open-fd flock,
+    # so re-acquiring it here self-deadlocks (#387 gate hang).
+    state_changed = False
+    for s in target_sessions:
+        if s.reap_reason is None and s.id in backstop_session_ids:
+            s.reap_reason = ReapReason.COMPLETED_BACKSTOP
+            state_changed = True
+    if state_changed:
+        save_state(state)
     # Compute dirtiness BEFORE acquiring dev_queue_lock (see TOCTOU note in
     # _revert_running_tasks_for_sessions docstring).
     dirty_session_ids = _build_dirty_session_ids_and_notify(target_sessions)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ from cw.config import (
     load_clients,
     load_state,
     migrate_cw_state,
+    mutate_state,
     save_state,
     show_config,
 )
@@ -979,3 +980,77 @@ class TestOrchestratorConfigUsageLimitBackoff:
 
         config = OrchestratorConfig(usage_limit_backoff_seconds=7200)
         assert config.usage_limit_backoff_seconds == 7200
+
+
+class TestMutateState:
+    """Tests for mutate_state() — load-mutate-save under sessions_lock."""
+
+    def _make_session(self, sid: str) -> "Session":
+        from datetime import UTC, datetime
+        from pathlib import Path as P
+
+        return Session(
+            id=sid,
+            name=f"client-a/{sid}",
+            client="client-a",
+            purpose=SessionPurpose.IMPL,
+            workspace_path=P("/tmp/ws"),
+            started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+    def test_mutate_state_applies_callback_and_persists(
+        self, tmp_config_dir: "Path"
+    ) -> None:
+        """Callback mutation is reflected in reloaded state from disk."""
+        s1 = self._make_session("ms-sess-1")
+        save_state(CwState(sessions=[s1]))
+
+        s2 = self._make_session("ms-sess-2")
+
+        def _append(state: CwState) -> None:
+            state.sessions.append(s2)
+
+        mutate_state(_append)
+
+        reloaded = load_state()
+        ids = {s.id for s in reloaded.sessions}
+        assert "ms-sess-1" in ids
+        assert "ms-sess-2" in ids
+
+    def test_mutate_state_releases_lock_on_exception(
+        self, tmp_config_dir: "Path"
+    ) -> None:
+        """Lock is released even when the callback raises; subsequent call succeeds."""
+        save_state(CwState())
+
+        def _raises(state: CwState) -> None:
+            raise ValueError("intentional error")
+
+        with pytest.raises(ValueError, match="intentional error"):
+            mutate_state(_raises)
+
+        # A second call must succeed — no deadlock from an unreleased lock.
+        s = self._make_session("ms-after-exc")
+
+        def _append(state: CwState) -> None:
+            state.sessions.append(s)
+
+        mutate_state(_append)
+
+        reloaded = load_state()
+        assert any(sess.id == "ms-after-exc" for sess in reloaded.sessions)
+
+    def test_mutate_state_returns_mutated_state(
+        self, tmp_config_dir: "Path"
+    ) -> None:
+        """Return value is the post-mutation CwState, not the pre-mutation one."""
+        save_state(CwState())
+        s = self._make_session("ms-return-1")
+
+        def _append(state: CwState) -> None:
+            state.sessions.append(s)
+
+        result = mutate_state(_append)
+
+        assert isinstance(result, CwState)
+        assert any(sess.id == "ms-return-1" for sess in result.sessions)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -985,21 +985,21 @@ class TestOrchestratorConfigUsageLimitBackoff:
 class TestMutateState:
     """Tests for mutate_state() — load-mutate-save under sessions_lock."""
 
-    def _make_session(self, sid: str) -> "Session":
+    def _make_session(self, sid: str) -> Session:
         from datetime import UTC, datetime
-        from pathlib import Path as P
+        from pathlib import Path
 
         return Session(
             id=sid,
             name=f"client-a/{sid}",
             client="client-a",
             purpose=SessionPurpose.IMPL,
-            workspace_path=P("/tmp/ws"),
+            workspace_path=Path("/tmp/ws"),
             started_at=datetime(2026, 1, 1, tzinfo=UTC),
         )
 
     def test_mutate_state_applies_callback_and_persists(
-        self, tmp_config_dir: "Path"
+        self, tmp_config_dir: Path
     ) -> None:
         """Callback mutation is reflected in reloaded state from disk."""
         s1 = self._make_session("ms-sess-1")
@@ -1018,13 +1018,14 @@ class TestMutateState:
         assert "ms-sess-2" in ids
 
     def test_mutate_state_releases_lock_on_exception(
-        self, tmp_config_dir: "Path"
+        self, tmp_config_dir: Path
     ) -> None:
         """Lock is released even when the callback raises; subsequent call succeeds."""
         save_state(CwState())
 
         def _raises(state: CwState) -> None:
-            raise ValueError("intentional error")
+            msg = "intentional error"
+            raise ValueError(msg)
 
         with pytest.raises(ValueError, match="intentional error"):
             mutate_state(_raises)
@@ -1040,9 +1041,7 @@ class TestMutateState:
         reloaded = load_state()
         assert any(sess.id == "ms-after-exc" for sess in reloaded.sessions)
 
-    def test_mutate_state_returns_mutated_state(
-        self, tmp_config_dir: "Path"
-    ) -> None:
+    def test_mutate_state_returns_mutated_state(self, tmp_config_dir: Path) -> None:
         """Return value is the post-mutation CwState, not the pre-mutation one."""
         save_state(CwState())
         s = self._make_session("ms-return-1")

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -14,7 +14,7 @@ import freezegun
 import pytest
 
 from cw._util import claude_project_dir
-from cw.config import load_state, save_state
+from cw.config import load_state, mutate_state, save_state
 from cw.dev_queue import load_dev_queue, save_dev_queue
 from cw.events import read_events
 from cw.exceptions import WorktreeError
@@ -8442,3 +8442,72 @@ def test_reap_reason_not_stamped_when_task_already_completed_completed_silent(
     s = next(s for s in reloaded.sessions if s.id == "backstop-c-noop-1")
     # Task was not RUNNING so no revert happened — reap_reason must stay None.
     assert s.reap_reason is None
+
+
+def test_revert_timed_out_tasks_stamp_survives_concurrent_mutate_state(
+    tmp_config_dir: Path,
+) -> None:
+    """Both mutations survive when revert_timed_out_tasks() races a concurrent
+    mutate_state() write.  Neither call should clobber the other's changes
+    because both go through mutate_state() under sessions_lock."""
+    import concurrent.futures
+
+    sess = Session(
+        id="conc-to-1",
+        name="client-a/auto-dev/CONC-TO-1",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.TIMED_OUT,
+        workspace_path=Path("/tmp/ws"),
+        started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        completed_at=datetime(2026, 1, 1, 1, tzinfo=UTC),
+        completed_reason=CompletionReason.TIMED_OUT,
+    )
+    bystander = Session(
+        id="conc-bystander",
+        name="client-a/bystander",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.USER,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        started_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    save_state(CwState(sessions=[sess, bystander]))
+    save_dev_queue(
+        DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="CONC-TO-1",
+                    client="client-a",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="conc-to-1",
+                )
+            ]
+        )
+    )
+
+    def _competing_write() -> None:
+        def _mark(state: CwState) -> None:
+            for s in state.sessions:
+                if s.id == "conc-bystander":
+                    s.surface_ref = "concurrent-write"
+
+        mutate_state(_mark)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(_competing_write)
+        revert_timed_out_tasks()
+    # Re-raise any exception from the thread (future.result() does this).
+    future.result()
+
+    reloaded = load_state()
+
+    # revert_timed_out_tasks must have stamped the TIMED_OUT session.
+    stamped = next(s for s in reloaded.sessions if s.id == "conc-to-1")
+    assert stamped.reap_reason == ReapReason.COMPLETED_BACKSTOP
+
+    # The concurrent write must also have survived.
+    bystander_after = next(s for s in reloaded.sessions if s.id == "conc-bystander")
+    assert bystander_after.surface_ref == "concurrent-write"

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -14,7 +14,7 @@ import freezegun
 import pytest
 
 from cw._util import claude_project_dir
-from cw.config import load_state, mutate_state, save_state
+from cw.config import load_state, save_state, sessions_lock
 from cw.dev_queue import load_dev_queue, save_dev_queue
 from cw.events import read_events
 from cw.exceptions import WorktreeError
@@ -8444,17 +8444,17 @@ def test_reap_reason_not_stamped_when_task_already_completed_completed_silent(
     assert s.reap_reason is None
 
 
-def test_revert_timed_out_tasks_stamp_survives_concurrent_mutate_state(
+def test_revert_timed_out_tasks_completes_while_holding_sessions_lock(
     tmp_config_dir: Path,
 ) -> None:
-    """Both mutations survive when revert_timed_out_tasks() races a concurrent
-    mutate_state() write.  Neither call should clobber the other's changes
-    because both go through mutate_state() under sessions_lock."""
-    import concurrent.futures
-
+    """Regression for the #387 self-deadlock: production calls
+    revert_timed_out_tasks() from _reconcile_locked, i.e. while already
+    holding sessions_lock. The reap_reason stamp must save in place rather
+    than re-acquire the lock (flock is per-open-fd, so re-acquiring
+    self-deadlocks)."""
     sess = Session(
-        id="conc-to-1",
-        name="client-a/auto-dev/CONC-TO-1",
+        id="lockheld-to-1",
+        name="client-a/auto-dev/LOCKHELD-1",
         client="client-a",
         purpose=SessionPurpose.IMPL,
         origin=SessionOrigin.DAEMON,
@@ -8464,50 +8464,24 @@ def test_revert_timed_out_tasks_stamp_survives_concurrent_mutate_state(
         completed_at=datetime(2026, 1, 1, 1, tzinfo=UTC),
         completed_reason=CompletionReason.TIMED_OUT,
     )
-    bystander = Session(
-        id="conc-bystander",
-        name="client-a/bystander",
-        client="client-a",
-        purpose=SessionPurpose.IMPL,
-        origin=SessionOrigin.USER,
-        status=SessionStatus.ACTIVE,
-        workspace_path=Path("/tmp/ws"),
-        started_at=datetime(2026, 1, 1, tzinfo=UTC),
-    )
-    save_state(CwState(sessions=[sess, bystander]))
+    save_state(CwState(sessions=[sess]))
     save_dev_queue(
         DevQueueStore(
             tasks=[
                 TicketTask(
-                    ticket_id="CONC-TO-1",
+                    ticket_id="LOCKHELD-1",
                     client="client-a",
                     status=QueueItemStatus.RUNNING,
-                    session_id="conc-to-1",
+                    session_id="lockheld-to-1",
                 )
             ]
         )
     )
 
-    def _competing_write() -> None:
-        def _mark(state: CwState) -> None:
-            for s in state.sessions:
-                if s.id == "conc-bystander":
-                    s.surface_ref = "concurrent-write"
+    with sessions_lock():
+        reverted = revert_timed_out_tasks()
 
-        mutate_state(_mark)
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-        future = pool.submit(_competing_write)
-        revert_timed_out_tasks()
-    # Re-raise any exception from the thread (future.result() does this).
-    future.result()
-
+    assert reverted == ["LOCKHELD-1"]
     reloaded = load_state()
-
-    # revert_timed_out_tasks must have stamped the TIMED_OUT session.
-    stamped = next(s for s in reloaded.sessions if s.id == "conc-to-1")
+    stamped = next(s for s in reloaded.sessions if s.id == "lockheld-to-1")
     assert stamped.reap_reason == ReapReason.COMPLETED_BACKSTOP
-
-    # The concurrent write must also have survived.
-    bystander_after = next(s for s in reloaded.sessions if s.id == "conc-bystander")
-    assert bystander_after.surface_ref == "concurrent-write"


### PR DESCRIPTION
Closes #387.

Implements the narrowed scope from the Pre-flight Resolutions (ADR-0005 follow-through):

- **`mutate_state()` helper** in `config.py` — load → apply callback in place → save, all under the existing `sessions_lock()`; returns the mutated `CwState`. Documented as non-reentrant. This is the single write path future call-site migrations (#388) converge on.
- **`reap_reason` stamps** in `revert_timed_out_tasks` / `revert_completed_silent_tasks` stamp in place + `save_state` under the caller's lock, with the contract ("caller must hold `sessions_lock`") documented in both docstrings and the module Lock note.
- **Comment fix** at the reconcile sweep call site — the old comment claimed "no state mutation is needed"; the stamp is a mutation.
- **Tests**: `mutate_state` unit tests (callback applied + persisted, exception releases lock, return value), stamp-only-when-reverting tests, and a lock-held regression test.

**Deadlock found and fixed during gating** (7726cf2): the pre-flight premise that the two stamps were "genuinely unprotected" was wrong — both revert functions only run inside `_reconcile_locked()`, which already holds `sessions_lock`. Wrapping the stamp in `mutate_state()` re-acquired the flock on a second fd and self-deadlocked the full test suite (this is what hung the original auto-dev worker's gate run). The stamp now writes in place under the caller's lock; `test_revert_timed_out_tasks_completes_while_holding_sessions_lock` pins the contract.

Gates: ruff ✓, ruff format ✓, mypy --strict ✓, pre-commit ✓, pytest 1809 passed ✓, coverage 96.01% total / 100% diff ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)