### PR TITLE
bug(events): inbox cursor-not-found wedge + torn-read + unbounded scan

### DIFF
--- a/src/cw/events.py
+++ b/src/cw/events.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import fcntl
 import json
+import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -15,6 +16,8 @@ from cw.models import OrchestratorEvent, OrchestratorEventType
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def _inbox_path() -> Path:
@@ -101,6 +104,30 @@ def advance_cursor(consumer: str, event_id: str) -> None:
     atomic_write_text(path, json.dumps(data))
 
 
+def _parse_lines(lines: list[str]) -> list[tuple[int, OrchestratorEvent]]:
+    """Parse JSONL lines into (index, event) pairs.
+
+    Tolerates a malformed trailing line (torn write): if the last non-empty
+    line fails JSON parsing, it is skipped with a warning.  Interior corrupt
+    lines re-raise so callers see real corruption.
+    """
+    results: list[tuple[int, OrchestratorEvent]] = []
+    for i, raw_line in enumerate(lines):
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        try:
+            raw = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            if i == len(lines) - 1:
+                # Tolerate malformed trailing line only (torn write)
+                logger.warning("skipping malformed trailing line in inbox: %s", exc)
+                continue
+            raise
+        results.append((i, OrchestratorEvent.model_validate(raw)))
+    return results
+
+
 def read_events(
     consumer: str | None = None,
     *,
@@ -116,6 +143,10 @@ def read_events(
 
     When *since_cursor* is provided (or derived from the consumer cursor),
     only events *after* the referenced event ID are returned.
+
+    At-least-once delivery contract: if a consumer's cursor is not found in the
+    inbox (e.g. due to inbox rotation or compaction), all events are replayed
+    from the beginning. Callers using a named consumer cursor must be idempotent.
 
     Args:
         consumer: Consumer name; used to load a persisted cursor when
@@ -134,19 +165,19 @@ def read_events(
         cursor = _load_cursor(consumer)
 
     inbox = _inbox_path()
-    if not inbox.exists():
+    with _inbox_lock():
+        raw_text = inbox.read_text() if inbox.exists() else ""
+
+    if not raw_text:
         return []
+
+    lines = raw_text.splitlines()
+    parsed = _parse_lines(lines)
 
     events: list[OrchestratorEvent] = []
     past_cursor = cursor is None  # If no cursor, start from beginning
 
-    for raw_line in inbox.read_text().splitlines():
-        stripped = raw_line.strip()
-        if not stripped:
-            continue
-        raw = json.loads(stripped)
-        event = OrchestratorEvent.model_validate(raw)
-
+    for _i, event in parsed:
         # Cursor-based skip: advance past the cursor event, then include from there
         if not past_cursor:
             if event.id == cursor:
@@ -159,6 +190,19 @@ def read_events(
             continue
 
         events.append(event)
+
+    # Cursor-not-found fallback: replay from the beginning
+    if cursor is not None and not past_cursor:
+        logger.warning(
+            "cursor %s not found in inbox; replaying from start", cursor
+        )
+        events = []
+        for _i, event in parsed:
+            if since_ts is not None and event.created_at < since_ts:
+                continue
+            if event_types is not None and event.type not in event_types:
+                continue
+            events.append(event)
 
     if limit is not None:
         events = events[:limit]

--- a/src/cw/events.py
+++ b/src/cw/events.py
@@ -193,9 +193,7 @@ def read_events(
 
     # Cursor-not-found fallback: replay from the beginning
     if cursor is not None and not past_cursor:
-        logger.warning(
-            "cursor %s not found in inbox; replaying from start", cursor
-        )
+        logger.warning("cursor %s not found in inbox; replaying from start", cursor)
         events = []
         for _i, event in parsed:
             if since_ts is not None and event.created_at < since_ts:

--- a/src/cw/events.py
+++ b/src/cw/events.py
@@ -104,14 +104,31 @@ def advance_cursor(consumer: str, event_id: str) -> None:
     atomic_write_text(path, json.dumps(data))
 
 
-def _parse_lines(lines: list[str]) -> list[tuple[int, OrchestratorEvent]]:
-    """Parse JSONL lines into (index, event) pairs.
+def _event_matches(
+    event: OrchestratorEvent,
+    *,
+    since_ts: datetime | None,
+    event_types: list[OrchestratorEventType] | None,
+) -> bool:
+    """Return True if *event* passes the timestamp and type filters."""
+    if since_ts is not None and event.created_at < since_ts:
+        return False
+    return event_types is None or event.type in event_types
+
+
+def _parse_lines(lines: list[str]) -> list[OrchestratorEvent]:
+    """Parse JSONL lines into a list of events.
 
     Tolerates a malformed trailing line (torn write): if the last non-empty
     line fails JSON parsing, it is skipped with a warning.  Interior corrupt
     lines re-raise so callers see real corruption.
     """
-    results: list[tuple[int, OrchestratorEvent]] = []
+    # Precompute last non-empty index so trailing blank lines don't cause the
+    # torn-write check to misfire on an interior corrupt line.
+    last_nonempty_idx = max(
+        (j for j, line in enumerate(lines) if line.strip()), default=-1
+    )
+    results: list[OrchestratorEvent] = []
     for i, raw_line in enumerate(lines):
         stripped = raw_line.strip()
         if not stripped:
@@ -119,12 +136,12 @@ def _parse_lines(lines: list[str]) -> list[tuple[int, OrchestratorEvent]]:
         try:
             raw = json.loads(stripped)
         except json.JSONDecodeError as exc:
-            if i == len(lines) - 1:
+            if i == last_nonempty_idx:
                 # Tolerate malformed trailing line only (torn write)
                 logger.warning("skipping malformed trailing line in inbox: %s", exc)
                 continue
             raise
-        results.append((i, OrchestratorEvent.model_validate(raw)))
+        results.append(OrchestratorEvent.model_validate(raw))
     return results
 
 
@@ -177,30 +194,29 @@ def read_events(
     events: list[OrchestratorEvent] = []
     past_cursor = cursor is None  # If no cursor, start from beginning
 
-    for _i, event in parsed:
+    for event in parsed:
         # Cursor-based skip: advance past the cursor event, then include from there
         if not past_cursor:
             if event.id == cursor:
                 past_cursor = True
             continue
 
-        if since_ts is not None and event.created_at < since_ts:
-            continue
-        if event_types is not None and event.type not in event_types:
+        if not _event_matches(event, since_ts=since_ts, event_types=event_types):
             continue
 
         events.append(event)
 
-    # Cursor-not-found fallback: replay from the beginning
+    # Cursor-not-found fallback: replay from the beginning.
+    # Why: callers are idempotent — orchestrate_retire guards on sess.status ==
+    # COMPLETED, dispatch consumer skips non-RUNNING tasks, and event tail is
+    # display-only — so replaying from the start is safe.
     if cursor is not None and not past_cursor:
         logger.warning("cursor %s not found in inbox; replaying from start", cursor)
-        events = []
-        for _i, event in parsed:
-            if since_ts is not None and event.created_at < since_ts:
-                continue
-            if event_types is not None and event.type not in event_types:
-                continue
-            events.append(event)
+        events = [
+            event
+            for event in parsed
+            if _event_matches(event, since_ts=since_ts, event_types=event_types)
+        ]
 
     if limit is not None:
         events = events[:limit]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -493,6 +493,89 @@ def test_cli_event_tail_type_filter_stage_entered(tmp_events_dir: Path) -> None:
     assert "pr.merged" not in result.output
 
 
+# ---------------------------------------------------------------------------
+# Robustness: cursor-not-found fallback + torn-read guard (issue #393)
+# ---------------------------------------------------------------------------
+
+
+def test_read_events_cursor_not_found_replays_from_start(
+    tmp_events_dir: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """cursor pointing at nonexistent event id replays all events from the start."""
+    import logging
+
+    ev1 = events_record_event(OrchestratorEventType.PR_REGISTERED, {"n": 1})
+    ev2 = events_record_event(OrchestratorEventType.PR_REGISTERED, {"n": 2})
+    ev3 = events_record_event(OrchestratorEventType.PR_REGISTERED, {"n": 3})
+
+    # Persist a cursor pointing at a nonexistent event id
+    nonexistent_id = "deadbeef-0000-1111-2222-333333333333"
+    advance_cursor("stale_consumer", nonexistent_id)
+
+    with caplog.at_level(logging.WARNING, logger="cw.events"):
+        result = read_events(consumer="stale_consumer")
+
+    assert len(result) == 3
+    assert result[0].id == ev1.id
+    assert result[1].id == ev2.id
+    assert result[2].id == ev3.id
+    assert any(nonexistent_id in record.message for record in caplog.records)
+
+
+def test_read_events_torn_final_line_skipped(
+    tmp_events_dir: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Malformed trailing line (torn write) is skipped with a warning."""
+    import logging
+
+    ev1 = events_record_event(OrchestratorEventType.PR_REGISTERED, {"n": 1})
+    ev2 = events_record_event(OrchestratorEventType.PR_MERGED, {"n": 2})
+
+    # Append partial JSON with NO trailing newline (simulate torn write)
+    inbox = tmp_events_dir / "inbox.jsonl"
+    with inbox.open("a") as f:
+        f.write('{"type": "pr.registered", "incomplete"')  # no trailing newline
+
+    with caplog.at_level(logging.WARNING, logger="cw.events"):
+        result = read_events()
+
+    assert len(result) == 2
+    assert result[0].id == ev1.id
+    assert result[1].id == ev2.id
+    assert any("malformed" in record.message for record in caplog.records)
+
+
+def test_read_events_torn_interior_line_raises(tmp_events_dir: Path) -> None:
+    """Interior corrupt line (with trailing newline) raises JSONDecodeError."""
+    events_record_event(OrchestratorEventType.PR_REGISTERED, {"n": 1})
+
+    # Append invalid JSON with trailing newline — interior (not last line)
+    inbox = tmp_events_dir / "inbox.jsonl"
+    with inbox.open("a") as f:
+        f.write('{"type": "bad", "broken"\n')  # trailing newline = interior
+
+    events_record_event(OrchestratorEventType.PR_MERGED, {"n": 3})
+
+    with pytest.raises(json.JSONDecodeError):
+        read_events()
+
+
+def test_read_events_normal_cursor_semantics_unchanged(tmp_events_dir: Path) -> None:
+    """Normal cursor semantics: only events after the cursor are returned."""
+    ev_a = events_record_event(OrchestratorEventType.PR_REGISTERED, {"n": 1})
+    ev_b = events_record_event(OrchestratorEventType.PR_REGISTERED, {"n": 2})
+    ev_c = events_record_event(OrchestratorEventType.PR_REGISTERED, {"n": 3})
+
+    advance_cursor("normal_consumer", ev_b.id)
+    result = read_events(consumer="normal_consumer")
+
+    assert len(result) == 1
+    assert result[0].id == ev_c.id
+    ids = {e.id for e in result}
+    assert ev_a.id not in ids
+    assert ev_b.id not in ids
+
+
 def test_ticket_needs_sync_event_type_serializes(tmp_events_dir: Path) -> None:
     """ticket.needs_sync OrchestratorEvent round-trips through JSON serialisation."""
     event = OrchestratorEvent(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -502,8 +503,6 @@ def test_read_events_cursor_not_found_replays_from_start(
     tmp_events_dir: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """cursor pointing at nonexistent event id replays all events from the start."""
-    import logging
-
     ev1 = events_record_event(OrchestratorEventType.PR_REGISTERED, {"n": 1})
     ev2 = events_record_event(OrchestratorEventType.PR_REGISTERED, {"n": 2})
     ev3 = events_record_event(OrchestratorEventType.PR_REGISTERED, {"n": 3})
@@ -526,8 +525,6 @@ def test_read_events_torn_final_line_skipped(
     tmp_events_dir: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Malformed trailing line (torn write) is skipped with a warning."""
-    import logging
-
     ev1 = events_record_event(OrchestratorEventType.PR_REGISTERED, {"n": 1})
     ev2 = events_record_event(OrchestratorEventType.PR_MERGED, {"n": 2})
 


### PR DESCRIPTION
## Summary

- fix(events): cursor-not-found fallback + torn-read guard in read_events
- test(events): add failing tests for cursor-not-found fallback and torn-read skip
- style(events): ruff format fix
- fix(events): correct last-nonempty-line detection, remove dead index from _parse_lines

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

Closes #393

🤖 Shipped via /prep-pr + project /ship-it