### PR TITLE
refactor(state): migrate remaining sessions.json writers to mutate_state() (#388)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -1233,6 +1233,8 @@ def signal_stop() -> None:
         # Recovery, not silent wedge.
         return
 
+    # Why not mutate_state: dual-lock (dev_queue_lock nested at the TIMED_OUT path)
+    # and daemon.stop() network call inside the lock window (criteria 1 and 2).
     with sessions_lock():
         state = load_state()
         session = next((s for s in state.sessions if s.id == cw_session_id), None)
@@ -2344,6 +2346,8 @@ def _spawn_close_impl(
     skipped — the multiplexer adapter has been removed. Separated from
     the Click command so tests can inject the daemon client directly.
     """
+    # Why not mutate_state: daemon.stop() network call inside the lock window
+    # (criterion 1: no subprocess/network in lock).
     with sessions_lock():
         state = load_state()
         sess = state.find_by_name_or_id(session_id)
@@ -2479,6 +2483,8 @@ def _spawn_complete_impl(
     Separated from the Click command so tests can inject the daemon client
     directly.
     """
+    # Why not mutate_state: dev_queue_lock nested inside the sessions_lock
+    # window (criterion 2: no dual-lock).
     with sessions_lock():
         state = load_state()
         sess = state.find_by_name_or_id(session_id)

--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -188,8 +188,10 @@ def mutate_state(fn: Callable[[CwState], None]) -> CwState:
     Invariant: every ``save_state`` call outside ``config.py`` is either
     inside a ``with sessions_lock():`` block **or** in a helper whose
     docstring states the caller must hold the lock (the reconcile pattern).
-    Sites excluded from this helper have a ``# Why not mutate_state:``
-    comment explaining the disqualifying condition.
+    Sites in ``cli.py``, ``session.py``, and ``orchestrate.py`` that cannot
+    use this helper carry a ``# Why not mutate_state:`` comment explaining
+    the disqualifying condition (subprocess inside lock, dual-lock, or
+    network call).
     """
     with sessions_lock():
         state = load_state()

--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -184,6 +184,12 @@ def mutate_state(fn: Callable[[CwState], None]) -> CwState:
     Code running inside a ``with sessions_lock():`` block (e.g. anything
     called from ``reconcile._reconcile_locked``) must mutate the loaded
     state and ``save_state`` directly instead.
+
+    Invariant: every ``save_state`` call outside ``config.py`` is either
+    inside a ``with sessions_lock():`` block **or** in a helper whose
+    docstring states the caller must hold the lock (the reconcile pattern).
+    Sites excluded from this helper have a ``# Why not mutate_state:``
+    comment explaining the disqualifying condition.
     """
     with sessions_lock():
         state = load_state()

--- a/src/cw/orchestrate.py
+++ b/src/cw/orchestrate.py
@@ -254,6 +254,8 @@ def retire_merged_prs(
     if not events:
         return []
 
+    # Why not mutate_state: _invoke_review_monitor_complete (subprocess) runs
+    # inside the lock window (criterion 1: no subprocess in lock).
     with sessions_lock():
         state = load_state()
         dispatch_record = load_dispatch_record()

--- a/src/cw/session.py
+++ b/src/cw/session.py
@@ -11,7 +11,7 @@ import click
 if TYPE_CHECKING:
     from pathlib import Path
 
-from cw.config import get_client, load_state, save_state, sessions_lock
+from cw.config import get_client, load_state, mutate_state, save_state, sessions_lock
 from cw.exceptions import CwError
 from cw.history import EventType, HistoryEvent, record_event
 from cw.models import (
@@ -192,10 +192,9 @@ def start_session(
     short_id = daemon.spawn_bg(cwd=session_cwd, prompt=prompt)
     session.surface_ref = short_id
 
-    with sessions_lock():
+    def _append(state: CwState) -> None:
         # Reload under lock to pick up any mutations since the post-reconcile
         # load; append the new session and save atomically.
-        state = load_state()
         if parent_session is not None:
             # Re-resolve parent under lock so the worker_session_ids append
             # lands on the freshest copy.
@@ -204,7 +203,8 @@ def start_session(
                 session.parent_session_id = live_parent.id
                 live_parent.worker_session_ids.append(session.id)
         state.sessions.append(session)
-        save_state(state)
+
+    mutate_state(_append)
     record_event(
         client_name,
         HistoryEvent(
@@ -251,27 +251,24 @@ def background_session(
     auto: bool = False,
 ) -> None:
     """Background a session by triggering /session-done and recording the handoff."""
-    with sessions_lock():
-        state = load_state()
-        session = _resolve_session(state, session_name)
+    captured: list[Session] = []
 
-        if session.status not in (SessionStatus.ACTIVE, SessionStatus.IDLE):
-            msg = (
-                f"Session {session.name} is not active or idle"
-                f" (status: {session.status})"
-            )
+    def _bg(state: CwState) -> None:
+        s = _resolve_session(state, session_name)
+        if s.status not in (SessionStatus.ACTIVE, SessionStatus.IDLE):
+            msg = f"Session {s.name} is not active or idle (status: {s.status})"
             raise CwError(msg)
-
-        click.echo(f"Backgrounding session: {session.name}...")
-
-        if session.status == SessionStatus.ACTIVE:
+        click.echo(f"Backgrounding session: {s.name}...")
+        if s.status == SessionStatus.ACTIVE:
             click.echo("Marking as backgrounded without /session-done injection.")
-
-        session.status = SessionStatus.BACKGROUNDED
-        session.backgrounded_at = datetime.now(UTC)
+        s.status = SessionStatus.BACKGROUNDED
+        s.backgrounded_at = datetime.now(UTC)
         if auto:
-            session.auto_backgrounded = True
-        save_state(state)
+            s.auto_backgrounded = True
+        captured.append(s)
+
+    mutate_state(_bg)
+    session = captured[0]
     record_event(
         session.client,
         HistoryEvent(
@@ -351,13 +348,13 @@ def resume_session(
 
     if surface and _is_native_surface_ref(surface) and surface in live_ids:
         # Happy path: session still alive in daemon — attach directly.
-        with sessions_lock():
-            state = load_state()
-            _live_sess = state.find_by_name_or_id(session_name)
-            if _live_sess is not None:
-                _live_sess.status = SessionStatus.ACTIVE
-                _live_sess.resumed_at = datetime.now(UTC)
-                save_state(state)
+        def _update_live(state: CwState) -> None:
+            live = state.find_by_name_or_id(session_name)
+            if live is not None:
+                live.status = SessionStatus.ACTIVE
+                live.resumed_at = datetime.now(UTC)
+
+        mutate_state(_update_live)
         record_event(
             session.client,
             HistoryEvent(
@@ -395,14 +392,15 @@ def resume_session(
             prompt=full_prompt,
             extra_args=extra_args or None,
         )
-        with sessions_lock():
-            state = load_state()
-            _dead_sess = state.find_by_name_or_id(session_name)
-            if _dead_sess is not None:
-                _dead_sess.surface_ref = new_short_id
-                _dead_sess.status = SessionStatus.ACTIVE
-                _dead_sess.resumed_at = datetime.now(UTC)
-                save_state(state)
+
+        def _update_dead(state: CwState) -> None:
+            dead = state.find_by_name_or_id(session_name)
+            if dead is not None:
+                dead.surface_ref = new_short_id
+                dead.status = SessionStatus.ACTIVE
+                dead.resumed_at = datetime.now(UTC)
+
+        mutate_state(_update_dead)
         record_event(
             session.client,
             HistoryEvent(
@@ -425,6 +423,8 @@ def done_session(
     force: bool = False,
 ) -> None:
     """Mark a session as completed and optionally remove its worktree."""
+    # Why not mutate_state: remove_worktree (git subprocess) runs inside the
+    # lock window on the --cleanup path (criterion 1: no subprocess in lock).
     with sessions_lock():
         state = load_state()
         session = _resolve_session(state, session_name)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -554,6 +554,30 @@ class TestBackgroundSession:
         assert "Warning" in output
         assert "notify" in output.lower()
 
+    def test_auto_flag_persists(
+        self,
+        tmp_config_dir: Path,
+        sample_client: ClientConfig,
+    ) -> None:
+        state = CwState(
+            sessions=[
+                Session(
+                    id="autobg01",
+                    name="test-client/impl",
+                    client="test-client",
+                    purpose=SessionPurpose.IMPL,
+                    status=SessionStatus.ACTIVE,
+                    workspace_path=sample_client.workspace_path,
+                )
+            ]
+        )
+        save_state(state)
+
+        background_session("test-client/impl", auto=True)
+
+        updated = load_state()
+        assert updated.sessions[0].auto_backgrounded is True
+
 
 # ---------------------------------------------------------------------------
 # TestResumeSession
@@ -1346,7 +1370,9 @@ class TestStartSessionParentLinkage:
                 msg = "Simulated disk failure"
                 raise OSError(msg)
 
-        monkeypatch.setattr("cw.session.save_state", failing_save)
+        # mutate_state (in cw.config) calls save_state directly from its own
+        # module; patch the config-level name so the failure is intercepted.
+        monkeypatch.setattr("cw.config.save_state", failing_save)
 
         with pytest.raises(OSError, match="Simulated disk failure"):
             start_session(


### PR DESCRIPTION
## Summary

Converts qualifying `with sessions_lock(): load_state(); …; save_state()` triples in `session.py` to use `mutate_state(fn)` so the choke point is greppable. Adds `# Why not mutate_state:` exclusion comments to all ineligible sites in `cli.py`, `session.py`, and `orchestrate.py`.

**Converted sites (4):**
- `session.py start_session` — pure append, no subprocess or dual-lock
- `session.py background_session` — pure field assignment, no subprocess or dual-lock
- `session.py resume_session` (happy path) — pure status update
- `session.py resume_session` (dead surface path) — pure surface_ref + status update

**Excluded sites with comments:**
- `session.py done_session` — `remove_worktree` subprocess inside lock on `--cleanup` path
- `cli.py signal_stop` — dual-lock (`dev_queue_lock` at TIMED_OUT path) + `daemon.stop()` network call
- `cli.py _spawn_close_impl` — `daemon.stop()` network call inside lock
- `cli.py _spawn_complete_impl` — `dev_queue_lock` nested inside `sessions_lock`
- `orchestrate.py retire_merged_prs` — `_invoke_review_monitor_complete` subprocess inside lock

`doctor.py` has no `save_state` calls (read-only).

**Acceptance criterion satisfied:** every `save_state` call outside `config.py` in the in-scope files (cli.py, session.py, orchestrate.py) is either inside `sessions_lock` with a `# Why not mutate_state:` comment, or the site was converted to `mutate_state`. `reconcile.py`, `dispatch.py`, `spawn.py` are #387 territory and out of scope.

**Test changes:**
- New: `test_auto_flag_persists` — verifies `background_session(auto=True)` persists `auto_backgrounded`
- Fix: `test_crash_mid_write_leaves_state_unchanged` — monkeypatch retargeted to `cw.config.save_state` (the call now goes through `mutate_state` in config.py)

Closes #388

🤖 Generated with [Claude Code](https://claude.ai/claude-code)