### PR TITLE
feat(dev-queue): auto-fast-forward local main when behind origin (#312)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -1686,11 +1686,9 @@ def dev_queue_status(client: str | None) -> None:
     help="Suppress per-tick operator output (for cron/scripted use).",
 )
 @click.option(
-    "--no-auto-ff",
+    "--auto-ff/--no-auto-ff",
     "auto_ff",
-    is_flag=True,
     default=True,
-    flag_value=False,
     help="Disable automatic fast-forward of local main (legacy block-only behavior).",
 )
 @handle_errors

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -1685,6 +1685,14 @@ def dev_queue_status(client: str | None) -> None:
     default=False,
     help="Suppress per-tick operator output (for cron/scripted use).",
 )
+@click.option(
+    "--no-auto-ff",
+    "auto_ff",
+    is_flag=True,
+    default=True,
+    flag_value=False,
+    help="Disable automatic fast-forward of local main (legacy block-only behavior).",
+)
 @handle_errors
 def dev_queue_run(
     max_parallel: int | None,
@@ -1692,6 +1700,7 @@ def dev_queue_run(
     use_plan: bool,
     parent: str | None,
     quiet: bool,
+    auto_ff: bool,
 ) -> None:
     """Run the dispatch loop, spawning sessions for pending tickets."""
     run_dispatch_loop(
@@ -1700,6 +1709,7 @@ def dev_queue_run(
         use_plan=use_plan,
         parent=parent,
         emit=None if quiet else click.echo,
+        auto_ff=auto_ff,
     )
 
 
@@ -2063,7 +2073,7 @@ def dev_queue_refresh_all() -> None:
     had_error = False
     for client in clients.values():
         try:
-            before, after = fast_forward_main(client)
+            before, after = fast_forward_main(client, ignore_untracked=True)
             if before == after:
                 click.echo(f"{client.name}: already up to date ({before[:8]})")
             else:

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -313,8 +313,12 @@ def dispatch_tick(
                         behind_count,
                     )
                     stale = False
-                except (WorktreeError, MissingWorkspaceError):
-                    pass
+                except (WorktreeError, MissingWorkspaceError) as exc:
+                    _log.warning(
+                        "auto-ff: fast-forward failed for %s: %s",
+                        client.name,
+                        exc,
+                    )
                 # Why: no git-level lock — concurrent dispatch loops are safe;
                 # git pull --ff-only is idempotent when already current.
 

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -26,7 +26,12 @@ from cw.config import (
 )
 from cw.dev_queue import dev_queue_lock, load_dev_queue, load_plan, save_dev_queue
 from cw.events import advance_cursor, read_events, record_event
-from cw.exceptions import StaleWorktreeError, UsageLimitError, WorktreeError
+from cw.exceptions import (
+    MissingWorkspaceError,
+    StaleWorktreeError,
+    UsageLimitError,
+    WorktreeError,
+)
 from cw.models import (
     DispatchSkipReason,
     OrchestratorEventType,
@@ -43,8 +48,10 @@ from cw.reconcile import (
 )
 from cw.spawn import spawn_create_impl
 from cw.worktree import (
+    check_main_ff_safety,
     check_not_main_checkout,
     create_worktree,
+    fast_forward_main,
     is_main_behind_origin,
     remove_worktree,
     worktree_has_unsaved_work,
@@ -139,6 +146,7 @@ def dispatch_tick(
     emit: Callable[[str], None] | None = None,
     warned_stale: set[tuple[str, str]] | None = None,
     usage_limited_until: datetime | None = None,
+    auto_ff: bool = True,
 ) -> DispatchTickResult:
     """Run one dispatch tick.
 
@@ -168,6 +176,12 @@ def dispatch_tick(
             caller (:func:`run_dispatch_loop`) when a
             :class:`~cw.exceptions.UsageLimitError` is detected.
             Single-tick (``--once``) mode does not set back-off.
+        auto_ff: When True (default), attempt to fast-forward local main
+            automatically before emitting TICKET_NEEDS_SYNC. Only fires
+            when ``check_main_ff_safety`` returns ``"behind"``; other
+            states (``"ahead"``, ``"diverged"``, ``"detached"``) still
+            fall through to the stale-block path. Pass ``False`` to
+            restore legacy block-only behavior.
 
     Returns:
         :class:`DispatchTickResult` with ``spawned`` count and
@@ -245,7 +259,7 @@ def dispatch_tick(
         # On any error, log and proceed so a transient network issue never
         # blocks the whole loop.
         try:
-            stale, _local_sha, _origin_sha, _behind = is_main_behind_origin(client)
+            stale, local_sha, origin_sha, behind_count = is_main_behind_origin(client)
         except Exception:  # noqa: BLE001
             # Defense-in-depth: _fetch_default_branch now handles
             # FileNotFoundError/PermissionError internally; this catches
@@ -282,6 +296,27 @@ def dispatch_tick(
             for t in queue_snapshot.tasks
             if t.client == client.name and t.status == QueueItemStatus.PENDING
         )
+
+        if stale and auto_ff:
+            ff_safety = check_main_ff_safety(client)
+            if ff_safety == "behind":
+                try:
+                    fast_forward_main(client, ignore_untracked=True)
+                    # Why: double-fetch accepted — is_main_behind_origin fetches
+                    # and git pull --ff-only fetches again. Acceptable for a
+                    # single-user tool.
+                    _log.info(
+                        "auto-ff: %s/main: %s..%s (%d commits)",
+                        client.name,
+                        local_sha[:8],
+                        origin_sha[:8],
+                        behind_count,
+                    )
+                    stale = False
+                except (WorktreeError, MissingWorkspaceError):
+                    pass
+                # Why: no git-level lock — concurrent dispatch loops are safe;
+                # git pull --ff-only is idempotent when already current.
 
         if stale:
             stale_tasks = [
@@ -723,6 +758,7 @@ def run_dispatch_loop(
     parent: str | None = None,
     native_daemon: NativeDaemonClient | None = None,
     emit: Callable[[str], None] | None = None,
+    auto_ff: bool = True,
 ) -> None:
     """Run the dispatch loop, optionally overriding per-client concurrency caps.
 
@@ -742,6 +778,10 @@ def run_dispatch_loop(
             When None, all human-readable output is suppressed (quiet
             mode for cron/scripted use).  Typically ``click.echo`` in
             CLI context.
+        auto_ff: Passed through to each ``dispatch_tick`` call.  When
+            True (default), stale-but-behind repos are fast-forwarded
+            automatically. Pass False to restore legacy block-only
+            behavior (``--no-auto-ff`` CLI flag).
     """
     config = load_orchestrator_config()
 
@@ -773,6 +813,7 @@ def run_dispatch_loop(
             emit=emit,
             warned_stale=warned_stale,
             usage_limited_until=usage_limited_until,
+            auto_ff=auto_ff,
         )
 
         if result.usage_limit_detected and not once:

--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -27,6 +27,8 @@ _WORKTREE_NAME_CAP = 64
 _HASH_BASE_SEGMENTS = (".cw", "wt")
 # Git porcelain v1 format: "XY path" — 2-char status prefix + 1 space = 3 chars.
 _GIT_PORCELAIN_PATH_OFFSET = 3
+# XY field value for untracked files in porcelain v1.
+_GIT_PORCELAIN_UNTRACKED = "??"
 # 8 hex chars = 32 bits. For a single-user tool with a handful of
 # clients the collision probability is negligible; raising this value
 # pushes the hashed base closer to _WORKTREE_NAME_CAP and reduces
@@ -602,7 +604,9 @@ def fast_forward_main(
         # Why: dispatch auto-ff may run against a workspace with untracked runtime
         # artifacts (.claude/scheduled_tasks.lock etc.); git pull --ff-only is
         # safe with untracked files because ff-only never rewrites the working tree.
-        status_lines = [line for line in status_lines if line[:2] != "??"]
+        status_lines = [
+            line for line in status_lines if line[:2] != _GIT_PORCELAIN_UNTRACKED
+        ]
     if status_lines:
         msg = (
             f"Refusing to fast-forward {client.name}: working tree is dirty "

--- a/src/cw/worktree.py
+++ b/src/cw/worktree.py
@@ -8,7 +8,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from cw.exceptions import MissingWorkspaceError, StaleWorktreeError, WorktreeError
 
@@ -506,7 +506,65 @@ def is_main_behind_origin(
     return (behind_count > 0, local_sha, origin_sha, behind_count)
 
 
-def fast_forward_main(client: ClientConfig) -> tuple[str, str]:
+def check_main_ff_safety(
+    client: ClientConfig,
+) -> Literal["equal", "behind", "ahead", "diverged", "detached"]:
+    """Classify local main's relationship to origin for dispatch auto-ff.
+
+    Returns one of:
+      "behind"   — local main is strictly behind origin; fast-forward is safe
+      "equal"    — local main matches origin; no action needed
+      "ahead"    — local main has unpushed commits; operator action required
+      "diverged" — local main has both new commits and is behind; needs reconciliation
+      "detached" — HEAD is detached; fast-forward would be unsafe
+
+    Operative outcomes from the dispatch path (when stale=True is already
+    established): "behind" triggers auto-ff; "diverged" and "detached" fall
+    through to TICKET_NEEDS_SYNC + warn. "equal" and "ahead" exist for
+    defensive completeness but are not reachable from the stale=True path.
+    """
+    git_dir = _git_dir(client)
+    default_branch = client.default_branch
+
+    # Detached HEAD check — symbolic-ref exits non-zero when detached.
+    # Prior art: _checked_out_branch() at line 148; fast_forward_main() below.
+    sym = _run_git("symbolic-ref", "--short", "HEAD", cwd=git_dir, check=False)
+    if sym.returncode != 0:
+        return "detached"
+
+    # Two merge-base --is-ancestor calls for directional classification.
+    main_behind = _run_git(
+        "merge-base",
+        "--is-ancestor",
+        default_branch,
+        f"origin/{default_branch}",
+        cwd=git_dir,
+        check=False,
+    )
+    origin_behind = _run_git(
+        "merge-base",
+        "--is-ancestor",
+        f"origin/{default_branch}",
+        default_branch,
+        cwd=git_dir,
+        check=False,
+    )
+    # returncode 0 means the first arg is a reachable ancestor of the second.
+    is_main_ancestor = main_behind.returncode == 0  # main ≤ origin → behind
+    is_origin_ancestor = origin_behind.returncode == 0  # origin ≤ main → ahead
+
+    if is_main_ancestor and is_origin_ancestor:
+        return "equal"
+    if is_main_ancestor:
+        return "behind"
+    if is_origin_ancestor:
+        return "ahead"
+    return "diverged"
+
+
+def fast_forward_main(
+    client: ClientConfig, *, ignore_untracked: bool = False
+) -> tuple[str, str]:
     """Fast-forward the client's local default branch to origin.
 
     Runs ``git pull --ff-only origin <default_branch>`` in the client's git
@@ -537,9 +595,15 @@ def fast_forward_main(client: ClientConfig) -> tuple[str, str]:
         )
         raise WorktreeError(msg)
 
-    # Guard 2: ensure the working tree is clean.
-    status_out = _run_git("status", "--porcelain", cwd=git_dir).stdout.strip()
-    if status_out:
+    # Guard 2: ensure the working tree is clean (or only has untracked files).
+    status_out = _run_git("status", "--porcelain", cwd=git_dir).stdout
+    status_lines = status_out.splitlines()
+    if ignore_untracked:
+        # Why: dispatch auto-ff may run against a workspace with untracked runtime
+        # artifacts (.claude/scheduled_tasks.lock etc.); git pull --ff-only is
+        # safe with untracked files because ff-only never rewrites the working tree.
+        status_lines = [line for line in status_lines if line[:2] != "??"]
+    if status_lines:
         msg = (
             f"Refusing to fast-forward {client.name}: working tree is dirty "
             f"(git status --porcelain reported changes). "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4895,6 +4895,62 @@ class TestDevQueueRunQuiet:
             f"Expected callable emit but got: {captured_emit[0]!r}"
         )
 
+    def test_auto_ff_on_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bare invocation passes auto_ff=True to run_dispatch_loop."""
+        from cw import cli as cli_module
+        from cw.cli import main
+
+        captured_auto_ff: list[bool] = []
+
+        def _fake_loop(
+            *,
+            max_parallel: object = None,
+            once: bool = False,
+            use_plan: bool = False,
+            parent: object = None,
+            native_daemon: object = None,
+            emit: object = None,
+            auto_ff: bool = True,
+        ) -> None:
+            captured_auto_ff.append(auto_ff)
+
+        monkeypatch.setattr(cli_module, "run_dispatch_loop", _fake_loop)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["dev-queue", "run", "--once"])
+        assert result.exit_code == 0, result.output
+        assert captured_auto_ff == [True], (
+            f"Expected auto_ff=True by default but got: {captured_auto_ff!r}"
+        )
+
+    def test_no_auto_ff_flag_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--no-auto-ff passes auto_ff=False to run_dispatch_loop."""
+        from cw import cli as cli_module
+        from cw.cli import main
+
+        captured_auto_ff: list[bool] = []
+
+        def _fake_loop(
+            *,
+            max_parallel: object = None,
+            once: bool = False,
+            use_plan: bool = False,
+            parent: object = None,
+            native_daemon: object = None,
+            emit: object = None,
+            auto_ff: bool = True,
+        ) -> None:
+            captured_auto_ff.append(auto_ff)
+
+        monkeypatch.setattr(cli_module, "run_dispatch_loop", _fake_loop)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["dev-queue", "run", "--once", "--no-auto-ff"])
+        assert result.exit_code == 0, result.output
+        assert captured_auto_ff == [False], (
+            f"Expected auto_ff=False with --no-auto-ff but got: {captured_auto_ff!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests: _format_status_human

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4061,7 +4061,7 @@ class TestDevQueueRefreshAll:
 
         called_clients: list[str] = []
 
-        def _mock_ff(client: object) -> tuple[str, str]:
+        def _mock_ff(client: object, **_kwargs: object) -> tuple[str, str]:
             from cw.models import ClientConfig
 
             assert isinstance(client, ClientConfig)
@@ -4091,7 +4091,7 @@ class TestDevQueueRefreshAll:
 
         monkeypatch.setattr(
             "cw.cli.fast_forward_main",
-            lambda _c: (
+            lambda _c, **_kw: (
                 "abc123def456abc123def456abc123def456abc1",
                 "abc123def456abc123def456abc123def456abc1",
             ),
@@ -4115,7 +4115,7 @@ class TestDevQueueRefreshAll:
 
         monkeypatch.setattr(
             "cw.cli.fast_forward_main",
-            lambda _c: (
+            lambda _c, **_kw: (
                 "oldsha1oldsha1oldsha1oldsha1oldsha1oldsh",
                 "newsha2newsha2newsha2newsha2newsha2newsh",
             ),
@@ -4147,7 +4147,7 @@ class TestDevQueueRefreshAll:
 
         called_clients: list[str] = []
 
-        def _mock_ff(client: object) -> tuple[str, str]:
+        def _mock_ff(client: object, **_kwargs: object) -> tuple[str, str]:
             from cw.models import ClientConfig
 
             assert isinstance(client, ClientConfig)
@@ -4181,7 +4181,7 @@ class TestDevQueueRefreshAll:
 
         monkeypatch.setattr(
             "cw.cli.fast_forward_main",
-            lambda _c: ("aaa", "bbb"),
+            lambda _c, **_kw: ("aaa", "bbb"),
         )
 
         runner = CliRunner()
@@ -4215,7 +4215,7 @@ class TestDevQueueRefreshAll:
 
         called_clients: list[str] = []
 
-        def _mock_ff(client: object) -> tuple[str, str]:
+        def _mock_ff(client: object, **_kwargs: object) -> tuple[str, str]:
             from cw.models import ClientConfig
 
             assert isinstance(client, ClientConfig)
@@ -4245,7 +4245,7 @@ class TestDevQueueRefreshAll:
         ws = tmp_path / "nonexistent"
         self._write_clients_yaml(tmp_config_dir, [("client-a", str(ws))])
 
-        def _mock_ff(client: object) -> tuple[str, str]:
+        def _mock_ff(client: object, **_kwargs: object) -> tuple[str, str]:
             msg = "workspace missing for client-a"
             raise MissingWorkspaceError(msg)
 
@@ -4278,7 +4278,7 @@ class TestDevQueueRefreshAll:
             ],
         )
 
-        def _mock_ff(client: object) -> tuple[str, str]:
+        def _mock_ff(client: object, **_kwargs: object) -> tuple[str, str]:
             from cw.models import ClientConfig
 
             assert isinstance(client, ClientConfig)
@@ -4853,6 +4853,7 @@ class TestDevQueueRunQuiet:
             parent: object = None,
             native_daemon: object = None,
             emit: object = None,
+            auto_ff: bool = True,
         ) -> None:
             captured_emit.append(emit)
 
@@ -4880,6 +4881,7 @@ class TestDevQueueRunQuiet:
             parent: object = None,
             native_daemon: object = None,
             emit: object = None,
+            auto_ff: bool = True,
         ) -> None:
             captured_emit.append(emit)
 

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -2854,7 +2854,10 @@ class TestFreshnessGateAutoFF:
         simple_config: OrchestratorConfig,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """safety='behind' + successful ff → TICKET_NEEDS_SYNC NOT emitted, task claimed."""
+        """safety='behind' + successful ff → task claimed.
+
+        TICKET_NEEDS_SYNC must NOT be emitted; spawned=1.
+        """
         _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
         task = TicketTask(ticket_id="CW-100", client="test-client")
         add_ticket(task)
@@ -2882,7 +2885,8 @@ class TestFreshnessGateAutoFF:
             consumer="test-auto-ff-behind",
             event_types=[OrchestratorEventType.TICKET_NEEDS_SYNC],
         )
-        assert len(events) == 0, "TICKET_NEEDS_SYNC must NOT be emitted after successful ff"
+        # TICKET_NEEDS_SYNC must NOT be emitted after a successful auto-ff.
+        assert len(events) == 0
 
     def test_auto_ff_ahead_skips_with_ticket_needs_sync(
         self,
@@ -2985,7 +2989,10 @@ class TestFreshnessGateAutoFF:
         simple_config: OrchestratorConfig,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """safety='behind' but fast_forward_main raises WorktreeError → TICKET_NEEDS_SYNC."""
+        """safety='behind' but fast_forward_main raises WorktreeError.
+
+        Exception must be swallowed; TICKET_NEEDS_SYNC emitted as fallback.
+        """
         _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
         task = TicketTask(ticket_id="CW-104", client="test-client")
         add_ticket(task)
@@ -3006,7 +3013,7 @@ class TestFreshnessGateAutoFF:
         monkeypatch.setattr("cw.dispatch.fast_forward_main", _boom)
 
         daemon = FakeNativeDaemonClient()
-        # Must NOT raise — exception must be swallowed and fall through to TICKET_NEEDS_SYNC
+        # Exception must be swallowed; falls through to TICKET_NEEDS_SYNC.
         result = dispatch_tick(simple_config, native_daemon=daemon)
 
         assert result.spawned == 0
@@ -3045,7 +3052,8 @@ class TestFreshnessGateAutoFF:
         result = dispatch_tick(simple_config, auto_ff=False, native_daemon=daemon)
 
         assert result.spawned == 0
-        assert not check_called[0], "check_main_ff_safety must NOT be called when auto_ff=False"
+        # check_main_ff_safety must NOT be called when auto_ff=False.
+        assert not check_called[0]
         events = read_events(
             consumer="test-auto-ff-disabled",
             event_types=[OrchestratorEventType.TICKET_NEEDS_SYNC],

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -2837,3 +2837,217 @@ class TestConfigReloadedEachTick:
             for record in caplog.records
             if record.levelno == logging.WARNING
         )
+
+
+# ---------------------------------------------------------------------------
+# TestFreshnessGateAutoFF
+# ---------------------------------------------------------------------------
+
+
+class TestFreshnessGateAutoFF:
+    """Auto-ff tests: stale+behind triggers fast-forward; other states block."""
+
+    def test_auto_ff_behind_succeeds_claims_ticket(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """safety='behind' + successful ff → TICKET_NEEDS_SYNC NOT emitted, task claimed."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        task = TicketTask(ticket_id="CW-100", client="test-client")
+        add_ticket(task)
+
+        monkeypatch.setattr(
+            "cw.dispatch.is_main_behind_origin",
+            lambda _client: (True, "abc12345" * 5, "def67890" * 5, 3),
+        )
+        monkeypatch.setattr(
+            "cw.dispatch.check_main_ff_safety",
+            lambda _client: "behind",
+        )
+        monkeypatch.setattr(
+            "cw.dispatch.fast_forward_main",
+            lambda _client, **_kwargs: ("abc12345" * 5, "def67890" * 5),
+        )
+
+        daemon = FakeNativeDaemonClient()
+        result = dispatch_tick(simple_config, native_daemon=daemon)
+
+        # ff succeeded → stale cleared → task should be spawned
+        assert result.spawned == 1
+
+        events = read_events(
+            consumer="test-auto-ff-behind",
+            event_types=[OrchestratorEventType.TICKET_NEEDS_SYNC],
+        )
+        assert len(events) == 0, "TICKET_NEEDS_SYNC must NOT be emitted after successful ff"
+
+    def test_auto_ff_ahead_skips_with_ticket_needs_sync(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """safety='ahead' → TICKET_NEEDS_SYNC emitted, claim blocked."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        task = TicketTask(ticket_id="CW-101", client="test-client")
+        add_ticket(task)
+
+        monkeypatch.setattr(
+            "cw.dispatch.is_main_behind_origin",
+            lambda _client: (True, "aaa", "bbb", 1),
+        )
+        monkeypatch.setattr(
+            "cw.dispatch.check_main_ff_safety",
+            lambda _client: "ahead",
+        )
+
+        daemon = FakeNativeDaemonClient()
+        result = dispatch_tick(simple_config, native_daemon=daemon)
+
+        assert result.spawned == 0
+        events = read_events(
+            consumer="test-auto-ff-ahead",
+            event_types=[OrchestratorEventType.TICKET_NEEDS_SYNC],
+        )
+        assert len(events) == 1
+        assert events[0].payload["ticket_id"] == "CW-101"
+
+    def test_auto_ff_diverged_skips(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """safety='diverged' → TICKET_NEEDS_SYNC emitted, claim blocked."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        task = TicketTask(ticket_id="CW-102", client="test-client")
+        add_ticket(task)
+
+        monkeypatch.setattr(
+            "cw.dispatch.is_main_behind_origin",
+            lambda _client: (True, "aaa", "bbb", 2),
+        )
+        monkeypatch.setattr(
+            "cw.dispatch.check_main_ff_safety",
+            lambda _client: "diverged",
+        )
+
+        daemon = FakeNativeDaemonClient()
+        result = dispatch_tick(simple_config, native_daemon=daemon)
+
+        assert result.spawned == 0
+        events = read_events(
+            consumer="test-auto-ff-diverged",
+            event_types=[OrchestratorEventType.TICKET_NEEDS_SYNC],
+        )
+        assert len(events) == 1
+
+    def test_auto_ff_detached_skips(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """safety='detached' → TICKET_NEEDS_SYNC emitted, claim blocked."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        task = TicketTask(ticket_id="CW-103", client="test-client")
+        add_ticket(task)
+
+        monkeypatch.setattr(
+            "cw.dispatch.is_main_behind_origin",
+            lambda _client: (True, "aaa", "bbb", 1),
+        )
+        monkeypatch.setattr(
+            "cw.dispatch.check_main_ff_safety",
+            lambda _client: "detached",
+        )
+
+        daemon = FakeNativeDaemonClient()
+        result = dispatch_tick(simple_config, native_daemon=daemon)
+
+        assert result.spawned == 0
+        events = read_events(
+            consumer="test-auto-ff-detached",
+            event_types=[OrchestratorEventType.TICKET_NEEDS_SYNC],
+        )
+        assert len(events) == 1
+
+    def test_auto_ff_ff_raises_falls_through_to_ticket_needs_sync(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """safety='behind' but fast_forward_main raises WorktreeError → TICKET_NEEDS_SYNC."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        task = TicketTask(ticket_id="CW-104", client="test-client")
+        add_ticket(task)
+
+        monkeypatch.setattr(
+            "cw.dispatch.is_main_behind_origin",
+            lambda _client: (True, "aaa", "bbb", 2),
+        )
+        monkeypatch.setattr(
+            "cw.dispatch.check_main_ff_safety",
+            lambda _client: "behind",
+        )
+
+        def _boom(_client: object, **_kwargs: object) -> tuple[str, str]:
+            msg = "git pull failed"
+            raise WorktreeError(msg)
+
+        monkeypatch.setattr("cw.dispatch.fast_forward_main", _boom)
+
+        daemon = FakeNativeDaemonClient()
+        # Must NOT raise — exception must be swallowed and fall through to TICKET_NEEDS_SYNC
+        result = dispatch_tick(simple_config, native_daemon=daemon)
+
+        assert result.spawned == 0
+        events = read_events(
+            consumer="test-auto-ff-raises",
+            event_types=[OrchestratorEventType.TICKET_NEEDS_SYNC],
+        )
+        assert len(events) == 1
+
+    def test_auto_ff_false_keeps_ticket_needs_sync(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """auto_ff=False preserves legacy block-only behavior even when 'behind'."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        task = TicketTask(ticket_id="CW-105", client="test-client")
+        add_ticket(task)
+
+        monkeypatch.setattr(
+            "cw.dispatch.is_main_behind_origin",
+            lambda _client: (True, "aaa", "bbb", 3),
+        )
+        # check_main_ff_safety must NOT be called; if it is called that's a bug
+        check_called = [False]
+
+        def _check_boom(_client: object) -> str:
+            check_called[0] = True
+            return "behind"
+
+        monkeypatch.setattr("cw.dispatch.check_main_ff_safety", _check_boom)
+
+        daemon = FakeNativeDaemonClient()
+        result = dispatch_tick(simple_config, auto_ff=False, native_daemon=daemon)
+
+        assert result.spawned == 0
+        assert not check_called[0], "check_main_ff_safety must NOT be called when auto_ff=False"
+        events = read_events(
+            consumer="test-auto-ff-disabled",
+            event_types=[OrchestratorEventType.TICKET_NEEDS_SYNC],
+        )
+        assert len(events) == 1

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -16,6 +16,7 @@ from cw.models import ClientConfig
 from cw.worktree import (
     _fetch_default_branch,
     _git_dir,
+    check_main_ff_safety,
     check_not_main_checkout,
     create_worktree,
     fast_forward_main,
@@ -1292,6 +1293,219 @@ class TestFastForwardMain:
         assert before == old_sha
         assert after == new_sha
         assert pull_called[0], "pull MUST be called for clean on-branch checkout"
+
+    def test_untracked_only_with_ignore_untracked_proceeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ignore_untracked=True: untracked-only status does not block ff."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        client = ClientConfig(
+            name="test-client",
+            workspace_path=ws,
+            default_branch="main",
+        )
+        old_sha = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        new_sha = "ffffffffffffffffffffffffffffffffffffffff"
+        pull_called = [False]
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock()
+            result.stderr = ""
+            if "symbolic-ref" in args:
+                result.stdout = "main\n"
+            elif "status" in args and "--porcelain" in args:
+                result.stdout = "?? artifact.lock\n"  # untracked only
+            elif "pull" in args:
+                pull_called[0] = True
+                result.stdout = ""
+            elif "rev-parse" in args:
+                result.stdout = (old_sha if not pull_called[0] else new_sha) + "\n"
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+
+        before, after = fast_forward_main(client, ignore_untracked=True)
+        assert before == old_sha
+        assert after == new_sha
+        assert pull_called[0], "pull MUST be called when only untracked files present"
+
+    def test_untracked_only_without_ignore_untracked_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without ignore_untracked, untracked files still block ff (default=False)."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        client = ClientConfig(
+            name="test-client",
+            workspace_path=ws,
+            default_branch="main",
+        )
+        pull_called = [False]
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            if "pull" in args:
+                pull_called[0] = True
+            result = MagicMock()
+            result.stderr = ""
+            if "symbolic-ref" in args:
+                result.stdout = "main\n"
+            elif "status" in args and "--porcelain" in args:
+                result.stdout = "?? artifact.lock\n"  # untracked only
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+
+        with pytest.raises(WorktreeError, match="dirty"):
+            fast_forward_main(client)
+
+        assert not pull_called[0], "pull must NOT be called when ignore_untracked=False"
+
+    def test_mixed_dirty_with_ignore_untracked_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ignore_untracked=True + modified file still blocks ff."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        client = ClientConfig(
+            name="test-client",
+            workspace_path=ws,
+            default_branch="main",
+        )
+        pull_called = [False]
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            if "pull" in args:
+                pull_called[0] = True
+            result = MagicMock()
+            result.stderr = ""
+            if "symbolic-ref" in args:
+                result.stdout = "main\n"
+            elif "status" in args and "--porcelain" in args:
+                # untracked + modified — modified must still block
+                result.stdout = "?? artifact.lock\n M src/cw/foo.py\n"
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("cw.worktree._run_git", mock_run)
+
+        with pytest.raises(WorktreeError, match="dirty"):
+            fast_forward_main(client, ignore_untracked=True)
+
+        assert not pull_called[0], "pull must NOT be called when modified files present"
+
+
+class TestCheckMainFfSafety:
+    """Tests for check_main_ff_safety — classifies local/origin divergence."""
+
+    @staticmethod
+    def _make_client(tmp_path: Path) -> ClientConfig:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        return ClientConfig(
+            name="test-client",
+            workspace_path=ws,
+            default_branch="main",
+        )
+
+    @staticmethod
+    def _make_mock(
+        *,
+        detached: bool = False,
+        main_is_ancestor: bool = False,
+        origin_is_ancestor: bool = False,
+    ) -> object:
+        """Build a _run_git mock for check_main_ff_safety calls.
+
+        symbolic-ref exits non-zero when detached.
+        merge-base --is-ancestor: returncode 0 = true, 1 = false.
+        """
+
+        def mock_run(*args: str, cwd: object, check: bool = True) -> MagicMock:
+            result = MagicMock()
+            result.stderr = ""
+            result.stdout = ""
+            if "symbolic-ref" in args:
+                if detached:
+                    result.returncode = 1
+                    result.stdout = ""
+                    # simulate check=False path: do NOT raise
+                else:
+                    result.returncode = 0
+                    result.stdout = "main\n"
+            elif "merge-base" in args and "--is-ancestor" in args:
+                # Determine which call: main→origin or origin→main
+                # args: ("merge-base", "--is-ancestor", X, Y)
+                subject = args[2] if len(args) > 2 else ""
+                if subject == "main":
+                    # main is ancestor of origin/main?
+                    result.returncode = 0 if main_is_ancestor else 1
+                else:
+                    # origin/main is ancestor of main?
+                    result.returncode = 0 if origin_is_ancestor else 1
+            return result
+
+        return mock_run
+
+    def test_detached_head_returns_detached(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Detached HEAD → 'detached'."""
+        client = self._make_client(tmp_path)
+        monkeypatch.setattr(
+            "cw.worktree._run_git",
+            self._make_mock(detached=True),
+        )
+        assert check_main_ff_safety(client) == "detached"
+
+    def test_behind_returns_behind(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """main is ancestor of origin/main only → 'behind'."""
+        client = self._make_client(tmp_path)
+        monkeypatch.setattr(
+            "cw.worktree._run_git",
+            self._make_mock(main_is_ancestor=True, origin_is_ancestor=False),
+        )
+        assert check_main_ff_safety(client) == "behind"
+
+    def test_ahead_returns_ahead(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """origin/main is ancestor of main only → 'ahead'."""
+        client = self._make_client(tmp_path)
+        monkeypatch.setattr(
+            "cw.worktree._run_git",
+            self._make_mock(main_is_ancestor=False, origin_is_ancestor=True),
+        )
+        assert check_main_ff_safety(client) == "ahead"
+
+    def test_equal_returns_equal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both are mutual ancestors (equal SHAs) → 'equal'."""
+        client = self._make_client(tmp_path)
+        monkeypatch.setattr(
+            "cw.worktree._run_git",
+            self._make_mock(main_is_ancestor=True, origin_is_ancestor=True),
+        )
+        assert check_main_ff_safety(client) == "equal"
+
+    def test_diverged_returns_diverged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Neither is ancestor of the other → 'diverged'."""
+        client = self._make_client(tmp_path)
+        monkeypatch.setattr(
+            "cw.worktree._run_git",
+            self._make_mock(main_is_ancestor=False, origin_is_ancestor=False),
+        )
+        assert check_main_ff_safety(client) == "diverged"
 
 
 class TestFetchDefaultBranch:


### PR DESCRIPTION
## Summary

- Dispatch loop now auto-fast-forwards local `main` when it is strictly behind `origin/main` instead of silently blocking ticket dispatch with `TICKET_NEEDS_SYNC`
- New `check_main_ff_safety()` classifies local/origin relationship (behind/ahead/diverged/detached) before attempting the ff — only `"behind"` triggers the fast-forward; diverged/ahead/detached still fall through to TICKET_NEEDS_SYNC with a warning
- `fast_forward_main()` extended with `ignore_untracked=True` so runtime artifacts (`.lock` files, etc.) don't block the ff in dispatch context
- `--no-auto-ff` flag added to `cw dev-queue run` to restore legacy block-only behavior

## Test plan

- [ ] `check_main_ff_safety` unit tests: all 5 states (behind/ahead/diverged/equal/detached)
- [ ] `fast_forward_main(ignore_untracked=True)` tests: untracked-only proceeds, modified+untracked still blocks
- [ ] `TestFreshnessGateAutoFF`: 6 dispatch-level cases (behind→success, ahead→block, diverged→block, detached→block, ff-raises→block, auto_ff=False→legacy)
- [ ] CLI tests: `--no-auto-ff` passes `auto_ff=False`, bare invocation passes `auto_ff=True`

Closes #312

🤖 Generated with [Claude Code](https://claude.ai/claude-code)