### PR TITLE
feat(reconcile): split detect (pure) / act (gated-ready) phases (#552)

### DIFF
--- a/docs/adr/0006-reaping-is-gated-by-an-authority.md
+++ b/docs/adr/0006-reaping-is-gated-by-an-authority.md
@@ -1,0 +1,130 @@
+# Reaping is gated by an authority, not automatic
+
+**Status:** Proposed
+**Driven by:** #542 (session reaped mid-wait → task PENDING, wait rides to
+124 instead of ATTENTION), #402 (isolation breach), #438 (`doctor --reap`
+unguarded write); operator distrust of automatic reaping (milestone 1.1).
+**Builds on:** [ADR-0005](0005-single-state-lock.md) (single state lock —
+closes the *lost-write* race; this ADR closes the *unwanted-action* class),
+[RFC 0004](../rfcs/0004-work-lanes-queue-redesign.md) (lanes + first-class
+orchestration sessions — supplies the reap *authority*).
+**Amends:** RFC 0004 §"Reconciler interaction" (which states "no change to
+the revert path"). This ADR changes that default; see Reconciliation below.
+**Implemented by:** #552 (detect/act split), #554 (`reap_policy` gate),
+#555 (`SESSION_REAP_PROPOSED` + authorization), #556 (doc inversion).
+
+## Decision
+
+`reconcile()` is split into a **detect** phase (classify phantoms,
+budget-exceeded, silently-idle) and an **act** phase (revert `TicketTask`
+RUNNING→PENDING, stop the daemon surface, force-remove the worktree). The
+act phase is **gated by a `reap_policy`** that defaults to `signal_only`:
+detection emits a distress event and routes the owning task to
+`BLOCKED_ON_USER`, but performs no destructive mutation until an
+**authority** authorizes it. Per RFC 0004, that authority is the **lane's
+long-lived orchestration session** (`SessionPurpose.ORCHESTRATE`); absent
+one, an explicit operator command. Automatic reaping becomes opt-in
+(`reap_policy: auto`), not the default.
+
+This is the complement to ADR-0005, not an overlap. ADR-0005 makes
+concurrent writes *not clobber each other* (S1). This ADR governs whether
+a *correct, serialized* write should fire at all. A session can be reaped
+losslessly (ADR-0005) and still be reaped *wrongly* — that is the gap #542
+and #402 sit in.
+
+## Invariant
+
+1. The detect phase MUST NOT mutate session *status*, the dev queue, the
+   daemon roster, or worktrees. Detect classifies and returns candidates
+   (with evidence); it performs no writes. (Observation bookkeeping per
+   #545 and `claude_session_id` backfill stay in detect.) The
+   `BLOCKED_ON_USER` routing of a distressed task is an act-phase write —
+   the non-destructive one permitted under `signal_only`.
+2. Every act-phase mutation runs only when `reap_policy` authorizes it for
+   that session's lane, OR via explicit operator command
+   (`cw doctor --reap <session>` / `cw reconcile --apply`). All such
+   mutations go through ADR-0005's single serialized write path: code not
+   holding `sessions_lock` calls `mutate_state()`; code already inside the
+   reconcile lock window mutates in place and `save_state`s under the held
+   lock (`mutate_state` is non-reentrant — per-open-fd flock; see the
+   #387/#563 deadlock). Either way, this ADR introduces no second write
+   path.
+3. The detect phase MUST classify (and, once #555 lands, emit
+   `SESSION_REAP_PROPOSED` carrying `lane` per RFC 0004,
+   `proposed_action`, `reason`, evidence) for every would-be reap BEFORE
+   any act. A reap with no preceding proposal is a bug.
+4. `signal_only` is the default. Absent/unknown config → `signal_only`
+   (fail-safe: never auto-destroy on a malformed config).
+5. `reap_policy` resolves per lane (lane `LaneConfig` override → global
+   default → `signal_only`), reusing RFC 0004's lane-config layering.
+   Until lanes land (RFC 0004 waves), it is a single global field.
+6. The ADR-0005 transient-outage guard and spawn-grace stay in detect.
+
+## What this means for callers
+
+- **`dispatch_tick`** calls detect every tick (unchanged cadence) and acts
+  only on lanes whose `reap_policy` is `auto`. Under `signal_only` a
+  distressed session keeps its slot until an authority resolves it —
+  callers MUST count `BLOCKED_ON_USER`/`REAP_PROPOSED` sessions as
+  occupying capacity (so RFC 0004's Tier-2 allocator does not over-spawn
+  into a stalled lane) and MUST NOT read a below-cap lane as a stuck
+  dispatcher.
+- **The lane's ORCHESTRATE session** (RFC 0004) consumes
+  `SESSION_REAP_PROPOSED` from the event bus and authorizes or salvages
+  per lane. Authorizing a reap in lane X never reaps a session in lane Y.
+- **`cw status`/`list`/`start`** trigger detection only; never reap under
+  the default policy. They surface `REAP_PROPOSED` distinctly.
+- **#542 specifically:** a sentinel-aware `wait` must observe
+  `REAP_PROPOSED`/`BLOCKED_ON_USER` and resolve to ATTENTION rather than
+  riding the wall-clock to 124 — the gated path makes that state
+  observable instead of a silent task→PENDING flip.
+
+## What this means for producers
+
+- `reconcile.py` is the sole producer of `SESSION_REAP_PROPOSED`; the three
+  sweeps feed one detect→propose path and one policy-gated act path, so a
+  future fourth sweep inherits the gate.
+- The dirty-worktree guard (#404/#425) is the in-tree prototype: it already
+  refuses-to-remove, routes to `BLOCKED_ON_USER`, and emits
+  `needs_attention`. This ADR generalizes that branch to be the default
+  for *all* destructive paths.
+
+## Reconciliation with RFC 0004
+
+RFC 0004 §"Reconciler interaction" assumed the revert path is unchanged
+("RUNNING→PENDING reverts preserve lane … no change"). That holds for the
+*lane-preservation* mechanics, but this ADR changes *when* the revert
+fires: under `signal_only` it does not fire automatically. RFC 0004 should
+absorb a per-lane `reap_policy: signal_only | auto` field on `LaneConfig`
+and note that the Tier-2 allocator treats a `signal_only`-blocked session
+as occupying a slot. Tracked as the RFC-0004 amendment in the 1.1
+reconciliation plan.
+
+## Consequences
+
+- Under the default, a genuinely-dead session no longer self-heals; its
+  slot stays occupied until an authority acts. Unattended `auto` lanes
+  (overnight debt) opt back into self-healing per lane.
+- The destructive surface becomes auditable in one gated choke point —
+  every force-remove and queue revert is enumerable, closing the #402/#438
+  class where a reap fired from an unexpected path.
+- Reap regression tests bifurcate: detect-phase asserts classification +
+  no mutation; act-phase asserts mutation only under `auto` or explicit
+  authorization.
+
+## Alternatives considered
+
+- **Rely on ADR-0005 alone.** Rejected. The state lock stops *lost* writes
+  but not *unwanted* ones — #542 is a correctly-serialized reap that
+  shouldn't have happened. Locking does not address authority.
+- **More liveness heuristics** (#340/#384/#543/#544/#545). Each is a better
+  guess at *when to auto-act*; the operator distrust is structural — the
+  decision belongs to the lane authority, not a heuristic.
+- **Remove reaping entirely.** Rejected. `auto` lanes want self-healing;
+  this is policy, not a global switch.
+
+## Referenced by
+
+- ADR-0005, RFC 0004
+- #542, #402, #438
+- #552, #554, #555, #556

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -33,6 +33,7 @@ import logging
 import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -1262,6 +1263,42 @@ def reconcile() -> ReconcileReport:
 
 
 _SalvageCandidate = tuple[str, str | None, str, str, bool]
+
+
+class ProposedAction(StrEnum):
+    """Action the act dispatcher will take for a classified session. See GitHub #552, ADR-0006."""
+
+    REVERT_TASK = "revert_task"
+    CRASH_COMPLETE = "crash_complete"
+    SALVAGE_COMPLETION = "salvage_completion"
+    PARK_BLOCKED_ON_USER = "park_blocked_on_user"
+    SALVAGE_GIT = "salvage_git"
+    SKIP_PARKED = "skip_parked"
+    INCREMENT_COUNTER = "increment_counter"
+    RECOVER_COUNTER = "recover_counter"
+
+
+@dataclass(frozen=True)
+class ReapCandidate:
+    """Classification result from detect phase. Consumed by act dispatcher. See GitHub #552, ADR-0006."""
+
+    session_id: str
+    proposed_action: ProposedAction
+    ticket_id: str | None = None
+    worktree_dirty: bool = False
+    salvage_result: AutoDevResult | None = None
+    salvage_csid: str | None = None
+    usage_limit_detected: bool = False
+    elapsed_seconds: float = 0.0
+    reap_reason: ReapReason | None = None
+    branch: str | None = None
+    worktree_path_str: str | None = None
+    post_review_clean: bool = False
+    paused_status: str | None = None
+    new_observation_count: int = 0
+    # For phantom sweep: carry client + worktree_path for SESSION_PHANTOM_REVERTED payload
+    client: str | None = None
+    worktree_path: Path | None = None
 
 
 def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -1454,6 +1454,187 @@ class ReapCandidate:
     worktree_path: Path | None = None
 
 
+
+def _detect_phantom_candidates(
+    state: CwState,
+    phantom_set: set[str],
+    *,
+    now: datetime,
+) -> list[ReapCandidate]:
+    """Pure classification phase for phantom sessions.
+
+    Returns a list of ReapCandidate objects. Makes zero writes.
+    The worktree_dirty check for DAEMON sessions is performed here
+    so the act phase does not need to repeat it. See GitHub #552, ADR-0006.
+    """
+    candidates: list[ReapCandidate] = []
+    for session in state.sessions:
+        if session.id not in phantom_set:
+            continue
+        ticket_id = ticket_id_for_session(session.name)
+        # Try sentinel salvage before declaring crashed (DAEMON only).
+        salvage = (
+            _salvage_terminal_result(session)
+            if session.origin is SessionOrigin.DAEMON
+            else None
+        )
+        if salvage is not None:
+            result, claude_session_id = salvage
+            candidates.append(
+                ReapCandidate(
+                    session_id=session.id,
+                    proposed_action=ProposedAction.SALVAGE_COMPLETION,
+                    ticket_id=ticket_id,
+                    salvage_result=result,
+                    salvage_csid=claude_session_id,
+                    client=session.client,
+                    worktree_path=session.worktree_path,
+                )
+            )
+            continue
+        # Dirty-check for DAEMON sessions only; USER sessions have no worktree.
+        worktree_dirty = (
+            _worktree_dirty_by_path(session.client, session.worktree_path)
+            if session.origin is SessionOrigin.DAEMON
+            else False
+        )
+        candidates.append(
+            ReapCandidate(
+                session_id=session.id,
+                proposed_action=ProposedAction.CRASH_COMPLETE,
+                ticket_id=ticket_id,
+                worktree_dirty=worktree_dirty,
+                client=session.client,
+                worktree_path=session.worktree_path,
+            )
+        )
+    return candidates
+
+
+def _act_on_phantom_candidates(
+    state: CwState,
+    candidates: list[ReapCandidate],
+    *,
+    now: datetime,
+) -> tuple[list[str], list[str], bool, list[str], dict[str, AutoDevResult]]:
+    """Act phase for phantom sessions: apply all mutations.
+
+    Returns (ticket_ids_to_revert, phantom_names, usage_limited,
+             salvaged_ticket_ids, salvaged_result_by_ticket).
+    ticket_ids_to_revert contains only PENDING-routed tickets (not dirty/blocked).
+    """
+    if not candidates:
+        return [], [], False, [], {}
+
+    session_by_id = {s.id: s for s in state.sessions}
+
+    crash_candidates = [c for c in candidates if c.proposed_action == ProposedAction.CRASH_COMPLETE]
+    salvage_candidates = [c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_COMPLETION]
+
+    phantom_names: list[str] = []
+    # ticket_ids to revert (only PENDING-routed, excludes dirty/BLOCKED_ON_USER)
+    ticket_ids_to_revert: list[str] = []
+    salvaged_ticket_ids: list[str] = []
+    salvaged_result_by_ticket: dict[str, AutoDevResult] = {}
+    pending_events: list[dict[str, object]] = []
+
+    for candidate in salvage_candidates:
+        session = session_by_id[candidate.session_id]
+        assert candidate.salvage_result is not None
+        assert candidate.salvage_csid is not None
+        _apply_salvaged_completion(session, candidate.salvage_result, candidate.salvage_csid, now=now)
+        phantom_names.append(session.name)
+        if candidate.ticket_id:
+            salvaged_ticket_ids.append(candidate.ticket_id)
+            salvaged_result_by_ticket[candidate.ticket_id] = candidate.salvage_result
+        salvaged_payload: dict[str, object] = {
+            "session_id": session.id,
+            "session_name": session.name,
+            "client": session.client,
+            "crashed": False,
+            "salvaged": True,
+            "status": candidate.salvage_result.status,
+        }
+        if candidate.ticket_id:
+            salvaged_payload["ticket_id"] = candidate.ticket_id
+        pending_events.append(salvaged_payload)
+
+    for candidate in crash_candidates:
+        session = session_by_id[candidate.session_id]
+        session.status = SessionStatus.COMPLETED
+        session.completed_reason = CompletionReason.CRASHED
+        session.completed_at = now
+        session.reap_reason = ReapReason.PHANTOM_SURFACE
+        phantom_names.append(session.name)
+        crash_payload: dict[str, object] = {
+            "session_id": session.id,
+            "session_name": session.name,
+            "client": session.client,
+            "crashed": True,
+        }
+        if candidate.ticket_id:
+            crash_payload["ticket_id"] = candidate.ticket_id
+        pending_events.append(crash_payload)
+
+    save_state(state)
+
+    for payload in pending_events:
+        record_event(OrchestratorEventType.SESSION_COMPLETED, payload)
+
+    # Emit SESSION_PHANTOM_REVERTED for DAEMON-origin CRASH_COMPLETE candidates.
+    dirty_ticket_ids: set[str] = set()
+    for candidate in crash_candidates:
+        if candidate.ticket_id and session_by_id[candidate.session_id].origin is SessionOrigin.DAEMON:
+            wt_path_str: str | None = str(candidate.worktree_path) if candidate.worktree_path else None
+            if candidate.worktree_dirty:
+                dirty_ticket_ids.add(candidate.ticket_id)
+            queue_status = "blocked_on_user" if candidate.worktree_dirty else "pending"
+            record_event(
+                OrchestratorEventType.SESSION_PHANTOM_REVERTED,
+                {
+                    "session_id": candidate.session_id,
+                    "ticket_id": candidate.ticket_id,
+                    "client": candidate.client,
+                    "worktree_dirty": candidate.worktree_dirty,
+                    "worktree_path": wt_path_str,
+                    "queue_status": queue_status,
+                },
+                correlation_id=candidate.ticket_id,
+            )
+
+    # Queue mutations.
+    daemon_ticket_ids_to_revert = [
+        c.ticket_id
+        for c in crash_candidates
+        if c.ticket_id and session_by_id[c.session_id].origin is SessionOrigin.DAEMON
+    ]
+    revert_set = set(daemon_ticket_ids_to_revert)
+    salvaged_set = set(salvaged_ticket_ids)
+    if revert_set or salvaged_set:
+        with dev_queue_lock():
+            store = load_dev_queue()
+            changed = False
+            for task in store.tasks:
+                if task.status != QueueItemStatus.RUNNING:
+                    continue
+                if task.ticket_id in revert_set:
+                    if task.ticket_id in dirty_ticket_ids:
+                        task.status = QueueItemStatus.BLOCKED_ON_USER
+                    else:
+                        task.status = QueueItemStatus.PENDING
+                        ticket_ids_to_revert.append(task.ticket_id)
+                    task.session_id = None
+                    changed = True
+                elif task.ticket_id in salvaged_set:
+                    salvaged_result = salvaged_result_by_ticket[task.ticket_id]
+                    task.status = _queue_status_for_salvaged(salvaged_result)
+                    changed = True
+            if changed:
+                save_dev_queue(store)
+
+    return ticket_ids_to_revert, phantom_names, False, salvaged_ticket_ids, salvaged_result_by_ticket
+
+
 def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
     """Body of reconcile(), called while sessions_lock is held.
 
@@ -1546,127 +1727,14 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
         ), salvage_git_candidates
 
     phantom_set = set(drift.phantom_session_ids)
-    ticket_ids_to_revert: list[str] = []
-    salvaged_ticket_ids: list[str] = []
-    salvaged_result_by_ticket: dict[str, AutoDevResult] = {}
-    pending_events: list[dict[str, object]] = []
-    phantom_names: list[str] = []
-    # Accumulate data for session.phantom_reverted events (DAEMON-origin only).
-    # Emitted after save_state but before dev_queue_lock — see operator resolution
-    # in issue #459 for lock-ordering rationale.
-    # (session_id, ticket_id, client, worktree_path)
-    phantom_reverted_data: list[tuple[str, str, str, Path | None]] = []
-    for session in state.sessions:
-        if session.id not in phantom_set:
-            continue
-        ticket_id = ticket_id_for_session(session.name)
-        # Recover a terminal-success sentinel before declaring the phantom
-        # crashed, so already-shipped work is not re-dispatched (#372).
-        salvage = (
-            _salvage_terminal_result(session)
-            if session.origin is SessionOrigin.DAEMON
-            else None
-        )
-        if salvage is not None:
-            result, claude_session_id = salvage
-            _apply_salvaged_completion(session, result, claude_session_id, now=now)
-            phantom_names.append(session.name)
-            if ticket_id:
-                salvaged_ticket_ids.append(ticket_id)
-                salvaged_result_by_ticket[ticket_id] = result
-            salvaged_payload: dict[str, object] = {
-                "session_id": session.id,
-                "session_name": session.name,
-                "client": session.client,
-                "crashed": False,
-                "salvaged": True,
-                "status": result.status,
-            }
-            if ticket_id:
-                salvaged_payload["ticket_id"] = ticket_id
-            pending_events.append(salvaged_payload)
-            continue
-        session.status = SessionStatus.COMPLETED
-        session.completed_reason = CompletionReason.CRASHED
-        session.completed_at = now
-        session.reap_reason = ReapReason.PHANTOM_SURFACE
-        phantom_names.append(session.name)
-        if ticket_id and session.origin is SessionOrigin.DAEMON:
-            ticket_ids_to_revert.append(ticket_id)
-            phantom_reverted_data.append(
-                (session.id, ticket_id, session.client, session.worktree_path)
-            )
-        payload: dict[str, object] = {
-            "session_id": session.id,
-            "session_name": session.name,
-            "client": session.client,
-            "crashed": True,
-        }
-        if ticket_id:
-            payload["ticket_id"] = ticket_id
-        pending_events.append(payload)
-
-    save_state(state)
-    for payload in pending_events:
-        record_event(OrchestratorEventType.SESSION_COMPLETED, payload)
-
-    # Why: dirty-check runs under sessions_lock before the queue mutation, but
-    # the orphaned claude --bg process may still be alive and could write to the
-    # worktree between this check and the BLOCKED_ON_USER routing below (TOCTOU).
-    # The accepted tradeoff is block > clobber — narrow the window, accept the race.
-    dirty_ticket_ids: set[str] = set()
-    for sess_id, rev_ticket_id, rev_client, rev_wt_path in phantom_reverted_data:
-        wt_dirty = _worktree_dirty_by_path(rev_client, rev_wt_path)
-        wt_path_str: str | None = str(rev_wt_path) if rev_wt_path else None
-        if wt_dirty:
-            dirty_ticket_ids.add(rev_ticket_id)
-        queue_status = "blocked_on_user" if wt_dirty else "pending"
-        record_event(
-            OrchestratorEventType.SESSION_PHANTOM_REVERTED,
-            {
-                "session_id": sess_id,
-                "ticket_id": rev_ticket_id,
-                "client": rev_client,
-                "worktree_dirty": wt_dirty,
-                "worktree_path": wt_path_str,
-                "queue_status": queue_status,
-            },
-            correlation_id=rev_ticket_id,
-        )
-
-    reverted: list[str] = []
-    if ticket_ids_to_revert or salvaged_ticket_ids:
-        revert_set = set(ticket_ids_to_revert)
-        salvaged_set = set(salvaged_ticket_ids)
-        with dev_queue_lock():
-            store = load_dev_queue()
-            changed = False
-            for task in store.tasks:
-                if task.status != QueueItemStatus.RUNNING:
-                    continue
-                if task.ticket_id in revert_set:
-                    if task.ticket_id in dirty_ticket_ids:
-                        # Dirty worktree: park for operator inspection rather than
-                        # re-dispatching — clobbering in-flight work is data loss.
-                        task.status = QueueItemStatus.BLOCKED_ON_USER
-                    else:
-                        task.status = QueueItemStatus.PENDING
-                        reverted.append(task.ticket_id)
-                    # Drop the stamp from the prior (now-crashed) session so
-                    # the next dispatch_tick can re-stamp with the freshly
-                    # spawned session_id without a window where the task
-                    # carries a stale id. See GitHub issue #97.
-                    task.session_id = None
-                    changed = True
-                elif task.ticket_id in salvaged_set:
-                    # Terminal-success salvage: retire the task instead of
-                    # reverting, so shipped/no_op work is not re-dispatched (#372).
-                    # Paused statuses route to BLOCKED_ON_USER instead (#471).
-                    salvaged_result = salvaged_result_by_ticket[task.ticket_id]
-                    task.status = _queue_status_for_salvaged(salvaged_result)
-                    changed = True
-            if changed:
-                save_dev_queue(store)
+    phantom_candidates = _detect_phantom_candidates(state, phantom_set, now=now)
+    (
+        reverted,
+        phantom_names,
+        _watchdog_usage_limited_phantom,
+        _salvaged_phantom_ticket_ids,
+        _salvaged_phantom_results,
+    ) = _act_on_phantom_candidates(state, phantom_candidates, now=now)
 
     # Sweep for TIMED_OUT and DAEMON-COMPLETED sessions whose owning TicketTask
     # was not yet reverted (e.g. signal_stop crashed after setting status but

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -23,6 +23,8 @@ within the lock (``revert_stalled_headless_sessions``,
 ``revert_completed_silent_tasks``) save_state directly without
 re-acquiring; callers of those helpers must hold the lock themselves if
 called outside ``reconcile``.
+
+See ADR-0006 for the detect/act phase invariant.
 """
 
 from __future__ import annotations
@@ -768,7 +770,6 @@ def _worktree_dirty_by_path(client_name: str, worktree_path: Path | None) -> boo
         return False
 
 
-
 def _detect_stalled_candidates(
     state: CwState,
     *,
@@ -801,7 +802,9 @@ def _detect_stalled_candidates(
                     session_id=session.id,
                     proposed_action=ProposedAction.SKIP_PARKED,
                     ticket_id=ticket_id,
-                    paused_status=str(actual_paused_status) if actual_paused_status else None,
+                    paused_status=str(actual_paused_status)
+                    if actual_paused_status
+                    else None,
                 )
             )
             continue
@@ -854,9 +857,15 @@ def _act_on_stalled_candidates(
         return []
 
     # Separate by action for batch processing.
-    skip_candidates = [c for c in candidates if c.proposed_action == ProposedAction.SKIP_PARKED]
-    salvage_candidates = [c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_COMPLETION]
-    revert_candidates = [c for c in candidates if c.proposed_action == ProposedAction.REVERT_TASK]
+    skip_candidates = [
+        c for c in candidates if c.proposed_action == ProposedAction.SKIP_PARKED
+    ]
+    salvage_candidates = [
+        c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_COMPLETION
+    ]
+    revert_candidates = [
+        c for c in candidates if c.proposed_action == ProposedAction.REVERT_TASK
+    ]
 
     # SKIP_PARKED: emit event only, no state/queue change.
     for candidate in skip_candidates:
@@ -879,9 +888,11 @@ def _act_on_stalled_candidates(
 
     for candidate in salvage_candidates:
         session = session_by_id[candidate.session_id]
-        assert candidate.salvage_result is not None
-        assert candidate.salvage_csid is not None
-        _apply_salvaged_completion(session, candidate.salvage_result, candidate.salvage_csid, now=now)
+        if candidate.salvage_result is None or candidate.salvage_csid is None:
+            continue  # Invariant: SALVAGE_COMPLETION always has salvage_result + csid
+        _apply_salvaged_completion(
+            session, candidate.salvage_result, candidate.salvage_csid, now=now
+        )
 
     for candidate in revert_candidates:
         session = session_by_id[candidate.session_id]
@@ -937,7 +948,8 @@ def _act_on_stalled_candidates(
 
     for candidate in salvage_candidates:
         session = session_by_id[candidate.session_id]
-        assert candidate.salvage_result is not None
+        if candidate.salvage_result is None:
+            continue  # Invariant: SALVAGE_COMPLETION always has salvage_result
         completed_payload: dict[str, object] = {
             "session_id": session.id,
             "session_name": session.name,
@@ -1051,7 +1063,6 @@ def resolve_idle_retry_cap(
     return DEFAULT_IDLE_RETRY_CAP
 
 
-
 def _detect_idle_candidates(
     state: CwState,
     *,
@@ -1084,7 +1095,9 @@ def _detect_idle_candidates(
         if elapsed < budget:
             continue
         # Liveness check: if active, check for recovery of observation counter.
-        if _transcript_recently_active(session, now) or _awaiting_subagent(session, now):
+        if _transcript_recently_active(session, now) or _awaiting_subagent(
+            session, now
+        ):
             if session.idle_observation_count > 0:
                 candidates.append(
                     ReapCandidate(
@@ -1128,7 +1141,9 @@ def _detect_idle_candidates(
             branch = _checked_out_branch(session.worktree_path)
             if branch is not None:
                 post_review_clean = _detect_post_review_clean(session)
-                worktree_dirty = _worktree_dirty_by_path(session.client, session.worktree_path)
+                worktree_dirty = _worktree_dirty_by_path(
+                    session.client, session.worktree_path
+                )
                 candidates.append(
                     ReapCandidate(
                         session_id=session.id,
@@ -1185,13 +1200,26 @@ def _act_on_idle_candidates(
 
     session_by_id = {s.id: s for s in state.sessions}
 
-    counter_candidates = [c for c in candidates if c.proposed_action in (
-        ProposedAction.INCREMENT_COUNTER, ProposedAction.RECOVER_COUNTER
-    )]
-    salvage_candidates = [c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_COMPLETION]
-    revert_candidates = [c for c in candidates if c.proposed_action == ProposedAction.REVERT_TASK]
-    park_candidates = [c for c in candidates if c.proposed_action == ProposedAction.PARK_BLOCKED_ON_USER]
-    salvage_git_candidates_list = [c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_GIT]
+    counter_candidates = [
+        c
+        for c in candidates
+        if c.proposed_action
+        in (ProposedAction.INCREMENT_COUNTER, ProposedAction.RECOVER_COUNTER)
+    ]
+    salvage_candidates = [
+        c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_COMPLETION
+    ]
+    revert_candidates = [
+        c for c in candidates if c.proposed_action == ProposedAction.REVERT_TASK
+    ]
+    park_candidates = [
+        c
+        for c in candidates
+        if c.proposed_action == ProposedAction.PARK_BLOCKED_ON_USER
+    ]
+    salvage_git_candidates_list = [
+        c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_GIT
+    ]
 
     # Counter-only updates: just update the counter and possibly save_state.
     counters_changed = False
@@ -1203,9 +1231,11 @@ def _act_on_idle_candidates(
     # Salvage completions.
     for candidate in salvage_candidates:
         session = session_by_id[candidate.session_id]
-        assert candidate.salvage_result is not None
-        assert candidate.salvage_csid is not None
-        _apply_salvaged_completion(session, candidate.salvage_result, candidate.salvage_csid, now=now)
+        if candidate.salvage_result is None or candidate.salvage_csid is None:
+            continue  # Invariant: SALVAGE_COMPLETION always has salvage_result + csid
+        _apply_salvaged_completion(
+            session, candidate.salvage_result, candidate.salvage_csid, now=now
+        )
 
     # Recover (revert to PENDING for re-dispatch).
     for candidate in revert_candidates:
@@ -1225,7 +1255,12 @@ def _act_on_idle_candidates(
         session.last_result = {"paused_status": _SILENTLY_IDLE_REASON}
         session.reap_reason = ReapReason.RETRY_CAP_PARKED
 
-    has_dispositions = bool(salvage_candidates or revert_candidates or park_candidates or salvage_git_candidates_list)
+    has_dispositions = bool(
+        salvage_candidates
+        or revert_candidates
+        or park_candidates
+        or salvage_git_candidates_list
+    )
 
     if counters_changed or has_dispositions:
         save_state(state)
@@ -1307,7 +1342,8 @@ def _act_on_idle_candidates(
 
     for candidate in salvage_candidates:
         session = session_by_id[candidate.session_id]
-        assert candidate.salvage_result is not None
+        if candidate.salvage_result is None:
+            continue  # Invariant: SALVAGE_COMPLETION always has salvage_result
         completed_payload: dict[str, object] = {
             "session_id": session.id,
             "session_name": session.name,
@@ -1323,7 +1359,13 @@ def _act_on_idle_candidates(
             get_native_daemon_client().stop(session.surface_ref)
 
     salvage_git: list[_SalvageCandidate] = [
-        (c.session_id, c.ticket_id, c.branch or "", c.worktree_path_str or "", c.post_review_clean)
+        (
+            c.session_id,
+            c.ticket_id,
+            c.branch or "",
+            c.worktree_path_str or "",
+            c.post_review_clean,
+        )
         for c in salvage_git_candidates_list
         if c.branch is not None and c.worktree_path_str is not None
     ]
@@ -1419,7 +1461,10 @@ _SalvageCandidate = tuple[str, str | None, str, str, bool]
 
 
 class ProposedAction(StrEnum):
-    """Action the act dispatcher will take for a classified session. See GitHub #552, ADR-0006."""
+    """Action the act dispatcher will take for a classified session.
+
+    See GitHub #552, ADR-0006.
+    """
 
     REVERT_TASK = "revert_task"
     CRASH_COMPLETE = "crash_complete"
@@ -1433,7 +1478,10 @@ class ProposedAction(StrEnum):
 
 @dataclass(frozen=True)
 class ReapCandidate:
-    """Classification result from detect phase. Consumed by act dispatcher. See GitHub #552, ADR-0006."""
+    """Classification result from detect phase. Consumed by act dispatcher.
+
+    See GitHub #552, ADR-0006.
+    """
 
     session_id: str
     proposed_action: ProposedAction
@@ -1449,17 +1497,14 @@ class ReapCandidate:
     post_review_clean: bool = False
     paused_status: str | None = None
     new_observation_count: int = 0
-    # For phantom sweep: carry client + worktree_path for SESSION_PHANTOM_REVERTED payload
+    # Phantom sweep: carry client + worktree_path for SESSION_PHANTOM_REVERTED payload
     client: str | None = None
     worktree_path: Path | None = None
-
 
 
 def _detect_phantom_candidates(
     state: CwState,
     phantom_set: set[str],
-    *,
-    now: datetime,
 ) -> list[ReapCandidate]:
     """Pure classification phase for phantom sessions.
 
@@ -1528,8 +1573,12 @@ def _act_on_phantom_candidates(
 
     session_by_id = {s.id: s for s in state.sessions}
 
-    crash_candidates = [c for c in candidates if c.proposed_action == ProposedAction.CRASH_COMPLETE]
-    salvage_candidates = [c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_COMPLETION]
+    crash_candidates = [
+        c for c in candidates if c.proposed_action == ProposedAction.CRASH_COMPLETE
+    ]
+    salvage_candidates = [
+        c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_COMPLETION
+    ]
 
     phantom_names: list[str] = []
     # ticket_ids to revert (only PENDING-routed, excludes dirty/BLOCKED_ON_USER)
@@ -1540,9 +1589,11 @@ def _act_on_phantom_candidates(
 
     for candidate in salvage_candidates:
         session = session_by_id[candidate.session_id]
-        assert candidate.salvage_result is not None
-        assert candidate.salvage_csid is not None
-        _apply_salvaged_completion(session, candidate.salvage_result, candidate.salvage_csid, now=now)
+        if candidate.salvage_result is None or candidate.salvage_csid is None:
+            continue  # Invariant: SALVAGE_COMPLETION always has salvage_result + csid
+        _apply_salvaged_completion(
+            session, candidate.salvage_result, candidate.salvage_csid, now=now
+        )
         phantom_names.append(session.name)
         if candidate.ticket_id:
             salvaged_ticket_ids.append(candidate.ticket_id)
@@ -1584,8 +1635,13 @@ def _act_on_phantom_candidates(
     # Emit SESSION_PHANTOM_REVERTED for DAEMON-origin CRASH_COMPLETE candidates.
     dirty_ticket_ids: set[str] = set()
     for candidate in crash_candidates:
-        if candidate.ticket_id and session_by_id[candidate.session_id].origin is SessionOrigin.DAEMON:
-            wt_path_str: str | None = str(candidate.worktree_path) if candidate.worktree_path else None
+        if (
+            candidate.ticket_id
+            and session_by_id[candidate.session_id].origin is SessionOrigin.DAEMON
+        ):
+            wt_path_str: str | None = (
+                str(candidate.worktree_path) if candidate.worktree_path else None
+            )
             if candidate.worktree_dirty:
                 dirty_ticket_ids.add(candidate.ticket_id)
             queue_status = "blocked_on_user" if candidate.worktree_dirty else "pending"
@@ -1632,7 +1688,13 @@ def _act_on_phantom_candidates(
             if changed:
                 save_dev_queue(store)
 
-    return ticket_ids_to_revert, phantom_names, False, salvaged_ticket_ids, salvaged_result_by_ticket
+    return (
+        ticket_ids_to_revert,
+        phantom_names,
+        False,
+        salvaged_ticket_ids,
+        salvaged_result_by_ticket,
+    )
 
 
 def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
@@ -1727,7 +1789,7 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
         ), salvage_git_candidates
 
     phantom_set = set(drift.phantom_session_ids)
-    phantom_candidates = _detect_phantom_candidates(state, phantom_set, now=now)
+    phantom_candidates = _detect_phantom_candidates(state, phantom_set)
     (
         reverted,
         phantom_names,

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -1051,6 +1051,286 @@ def resolve_idle_retry_cap(
     return DEFAULT_IDLE_RETRY_CAP
 
 
+
+def _detect_idle_candidates(
+    state: CwState,
+    *,
+    now: datetime,
+    native_live: set[str],
+    config: OrchestratorConfig,
+    task_by_ticket: dict[str, TicketTask],
+) -> list[ReapCandidate]:
+    """Pure classification phase for silently idle DAEMON sessions.
+
+    Returns a list of ReapCandidate objects. Makes zero writes to state,
+    queue, or event bus. The idle_observation_count increment is computed
+    but NOT written; it is carried in new_observation_count on the candidate.
+    See GitHub #552, ADR-0006.
+    """
+    candidates: list[ReapCandidate] = []
+    for session in state.sessions:
+        if session.origin is not SessionOrigin.DAEMON:
+            continue
+        if session.status not in _LIVE_STATUSES:
+            continue
+        if _has_terminal_sentinel(session):
+            continue
+        if session.surface_ref is None or session.surface_ref not in native_live:
+            continue
+        elapsed = (now - session.started_at).total_seconds()
+        ticket_id = ticket_id_for_session(session.name)
+        task = task_by_ticket.get(ticket_id) if ticket_id else None
+        budget = resolve_idle_watchdog_budget(task, config)
+        if elapsed < budget:
+            continue
+        # Liveness check: if active, check for recovery of observation counter.
+        if _transcript_recently_active(session, now) or _awaiting_subagent(session, now):
+            if session.idle_observation_count > 0:
+                candidates.append(
+                    ReapCandidate(
+                        session_id=session.id,
+                        proposed_action=ProposedAction.RECOVER_COUNTER,
+                        ticket_id=ticket_id,
+                        new_observation_count=0,
+                    )
+                )
+            continue
+        # Sentinel salvage: evidence-based completion, not deferred by counter.
+        salvage = _salvage_terminal_result(session)
+        if salvage is not None:
+            result, claude_session_id = salvage
+            candidates.append(
+                ReapCandidate(
+                    session_id=session.id,
+                    proposed_action=ProposedAction.SALVAGE_COMPLETION,
+                    ticket_id=ticket_id,
+                    salvage_result=result,
+                    salvage_csid=claude_session_id,
+                    elapsed_seconds=elapsed,
+                )
+            )
+            continue
+        # Confirm-before-reap: accumulate consecutive failed observations.
+        new_count = session.idle_observation_count + 1
+        if new_count < config.idle_confirm_observations:
+            candidates.append(
+                ReapCandidate(
+                    session_id=session.id,
+                    proposed_action=ProposedAction.INCREMENT_COUNTER,
+                    ticket_id=ticket_id,
+                    new_observation_count=new_count,
+                )
+            )
+            continue
+        # Threshold reached: classify final disposition.
+        # Git-state salvage path.
+        if session.worktree_path is not None:
+            branch = _checked_out_branch(session.worktree_path)
+            if branch is not None:
+                post_review_clean = _detect_post_review_clean(session)
+                worktree_dirty = _worktree_dirty_by_path(session.client, session.worktree_path)
+                candidates.append(
+                    ReapCandidate(
+                        session_id=session.id,
+                        proposed_action=ProposedAction.SALVAGE_GIT,
+                        ticket_id=ticket_id,
+                        branch=branch,
+                        worktree_path_str=str(session.worktree_path),
+                        post_review_clean=post_review_clean,
+                        worktree_dirty=worktree_dirty,
+                        new_observation_count=new_count,
+                    )
+                )
+                continue
+        cap = resolve_idle_retry_cap(task, config)
+        worktree_dirty = _worktree_dirty_by_path(session.client, session.worktree_path)
+        if task is not None and task.attempts < cap:
+            candidates.append(
+                ReapCandidate(
+                    session_id=session.id,
+                    proposed_action=ProposedAction.REVERT_TASK,
+                    ticket_id=ticket_id,
+                    elapsed_seconds=elapsed,
+                    worktree_dirty=worktree_dirty,
+                    new_observation_count=new_count,
+                )
+            )
+        else:
+            candidates.append(
+                ReapCandidate(
+                    session_id=session.id,
+                    proposed_action=ProposedAction.PARK_BLOCKED_ON_USER,
+                    ticket_id=ticket_id,
+                    worktree_dirty=worktree_dirty,
+                    new_observation_count=new_count,
+                )
+            )
+    return candidates
+
+
+def _act_on_idle_candidates(
+    state: CwState,
+    candidates: list[ReapCandidate],
+    *,
+    now: datetime,
+) -> tuple[list[str], list[_SalvageCandidate]]:
+    """Act phase for silently idle sessions: apply all mutations.
+
+    Consumes ReapCandidate objects from _detect_idle_candidates.
+    Returns (blocked_ticket_ids, salvage_git_candidates) matching
+    flag_silently_idle_daemon_sessions's return type.
+    """
+    if not candidates:
+        return [], []
+
+    session_by_id = {s.id: s for s in state.sessions}
+
+    counter_candidates = [c for c in candidates if c.proposed_action in (
+        ProposedAction.INCREMENT_COUNTER, ProposedAction.RECOVER_COUNTER
+    )]
+    salvage_candidates = [c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_COMPLETION]
+    revert_candidates = [c for c in candidates if c.proposed_action == ProposedAction.REVERT_TASK]
+    park_candidates = [c for c in candidates if c.proposed_action == ProposedAction.PARK_BLOCKED_ON_USER]
+    salvage_git_candidates_list = [c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_GIT]
+
+    # Counter-only updates: just update the counter and possibly save_state.
+    counters_changed = False
+    for candidate in counter_candidates:
+        session = session_by_id[candidate.session_id]
+        session.idle_observation_count = candidate.new_observation_count
+        counters_changed = True
+
+    # Salvage completions.
+    for candidate in salvage_candidates:
+        session = session_by_id[candidate.session_id]
+        assert candidate.salvage_result is not None
+        assert candidate.salvage_csid is not None
+        _apply_salvaged_completion(session, candidate.salvage_result, candidate.salvage_csid, now=now)
+
+    # Recover (revert to PENDING for re-dispatch).
+    for candidate in revert_candidates:
+        session = session_by_id[candidate.session_id]
+        session.status = SessionStatus.TIMED_OUT
+        session.completed_at = now
+        session.completed_reason = CompletionReason.TIMED_OUT
+        session.reap_reason = (
+            ReapReason.USAGE_LIMIT_CUTOFF
+            if _detect_usage_limit(session)
+            else ReapReason.IDLE_STALL
+        )
+
+    # Park: flag-only (preserves #348 — no daemon stop, session stays ACTIVE).
+    for candidate in park_candidates:
+        session = session_by_id[candidate.session_id]
+        session.last_result = {"paused_status": _SILENTLY_IDLE_REASON}
+        session.reap_reason = ReapReason.RETRY_CAP_PARKED
+
+    has_dispositions = bool(salvage_candidates or revert_candidates or park_candidates or salvage_git_candidates_list)
+
+    if counters_changed or has_dispositions:
+        save_state(state)
+
+    if not has_dispositions:
+        return [], []
+
+    recovered_ids = {c.ticket_id for c in revert_candidates if c.ticket_id}
+    parked_ids = {c.ticket_id for c in park_candidates if c.ticket_id}
+    salvaged_ticket_ids_set = {c.ticket_id for c in salvage_candidates if c.ticket_id}
+    salvaged_result_by_ticket = {
+        c.ticket_id: c.salvage_result
+        for c in salvage_candidates
+        if c.ticket_id and c.salvage_result
+    }
+    blocked: list[str] = []
+    if recovered_ids or parked_ids or salvaged_ticket_ids_set:
+        with dev_queue_lock():
+            store = load_dev_queue()
+            changed = False
+            for task in store.tasks:
+                if task.status != QueueItemStatus.RUNNING:
+                    continue
+                if task.ticket_id in recovered_ids:
+                    task.status = QueueItemStatus.PENDING
+                    task.session_id = None
+                    changed = True
+                elif task.ticket_id in parked_ids:
+                    task.status = QueueItemStatus.BLOCKED_ON_USER
+                    blocked.append(task.ticket_id)
+                    changed = True
+                elif task.ticket_id in salvaged_ticket_ids_set:
+                    result = salvaged_result_by_ticket[task.ticket_id]
+                    task.status = _queue_status_for_salvaged(result)
+                    changed = True
+            if changed:
+                save_dev_queue(store)
+
+    for candidate in revert_candidates:
+        session = session_by_id[candidate.session_id]
+        if session.surface_ref is not None:
+            get_native_daemon_client().stop(session.surface_ref)
+        _cleanup_timed_out_worktree(session, candidate.ticket_id)
+        cause = (
+            _CAUSE_USAGE_LIMIT
+            if session.reap_reason is ReapReason.USAGE_LIMIT_CUTOFF
+            else _CAUSE_IDLE_STALL
+        )
+        record_event(
+            OrchestratorEventType.SESSION_TIMED_OUT,
+            {
+                "session_id": session.id,
+                "session_name": session.name,
+                "client": session.client,
+                "ticket_id": candidate.ticket_id,
+                "claude_session_id": session.claude_session_id,
+                "elapsed_seconds": candidate.elapsed_seconds,
+                "cause": cause,
+                "last_assistant_message_excerpt": "",
+            },
+        )
+
+    for candidate in park_candidates:
+        session = session_by_id[candidate.session_id]
+        record_event(
+            OrchestratorEventType.SESSION_NEEDS_ATTENTION,
+            {
+                "session_id": session.id,
+                "session_name": session.name,
+                "client": session.client,
+                "ticket_id": candidate.ticket_id,
+                "claude_session_id": session.claude_session_id,
+                "paused_status": _SILENTLY_IDLE_REASON,
+                "breadcrumbs": "",
+                "crashed": False,
+            },
+        )
+        fire_push_notification(session.name, session.client)
+
+    for candidate in salvage_candidates:
+        session = session_by_id[candidate.session_id]
+        assert candidate.salvage_result is not None
+        completed_payload: dict[str, object] = {
+            "session_id": session.id,
+            "session_name": session.name,
+            "client": session.client,
+            "ticket_id": candidate.ticket_id,
+            "claude_session_id": session.claude_session_id,
+            "crashed": False,
+            "salvaged": True,
+            "status": candidate.salvage_result.status,
+        }
+        record_event(OrchestratorEventType.SESSION_COMPLETED, completed_payload)
+        if session.surface_ref is not None:
+            get_native_daemon_client().stop(session.surface_ref)
+
+    salvage_git: list[_SalvageCandidate] = [
+        (c.session_id, c.ticket_id, c.branch or "", c.worktree_path_str or "", c.post_review_clean)
+        for c in salvage_git_candidates_list
+        if c.branch is not None and c.worktree_path_str is not None
+    ]
+
+    return blocked, salvage_git
+
+
 def flag_silently_idle_daemon_sessions(
     state: CwState,
     *,
@@ -1083,210 +1363,14 @@ def flag_silently_idle_daemon_sessions(
     """
     if task_by_ticket is None:
         task_by_ticket = {t.ticket_id: t for t in load_dev_queue().tasks}
-
-    recover: list[tuple[Session, str | None]] = []
-    park: list[tuple[Session, str | None]] = []
-    salvaged: list[tuple[Session, str | None, AutoDevResult]] = []
-    # Git-state salvage candidates collected under the lock (no git/gh subprocesses).
-    # Tuple: (session_id, ticket_id, branch, worktree_path_str, post_review_clean)
-    salvage_git: list[_SalvageCandidate] = []
-    counters_changed = False
-    for session in state.sessions:
-        if session.origin is not SessionOrigin.DAEMON:
-            continue
-        if session.status not in _LIVE_STATUSES:
-            continue
-        if _has_terminal_sentinel(session):
-            continue
-        # Only target sessions whose daemon surface is still live — phantom
-        # sessions (dead surface) are handled by the crashed-phantom sweep.
-        if session.surface_ref is None or session.surface_ref not in native_live:
-            continue
-        elapsed = (now - session.started_at).total_seconds()
-        ticket_id = ticket_id_for_session(session.name)
-        task = task_by_ticket.get(ticket_id) if ticket_id else None
-        budget = resolve_idle_watchdog_budget(task, config)
-        if elapsed < budget:
-            continue
-        # Liveness check: skip workers that are still making progress. A recent
-        # transcript write (#340) OR an in-flight subagent (#384 — parent
-        # transcript goes quiet while a subagent runs) both count as alive.
-        if _transcript_recently_active(session, now) or _awaiting_subagent(
-            session, now
-        ):
-            # Recovery: reset the confirmation counter so subsequent idleness
-            # starts a fresh count. (#545)
-            if session.idle_observation_count > 0:
-                session.idle_observation_count = 0
-                counters_changed = True
-            continue
-        # Before parking or recovering, try to find a terminal-success sentinel
-        # the worker emitted while waiting on CI (e.g. shipped-then-wait_for_ci).
-        # If found, the session is dispositioned by that sentinel immediately —
-        # sentinel salvage is evidence-based completion, not deferred by the
-        # confirm-before-reap counter. (#398)
-        salvage = _salvage_terminal_result(session)
-        if salvage is not None:
-            result, claude_session_id = salvage
-            _apply_salvaged_completion(session, result, claude_session_id, now=now)
-            salvaged.append((session, ticket_id, result))
-            continue
-        # Confirm-before-reap (#545): accumulate consecutive failed observations
-        # before dispositioning. Git-salvage and park/recover are both deferred
-        # until the threshold is reached — git-salvaging a quiet-but-healthy
-        # worker would PR half-done work.
-        session.idle_observation_count += 1
-        counters_changed = True
-        if session.idle_observation_count < config.idle_confirm_observations:
-            continue
-        # Git-state salvage: check under lock using only event bus reads (no
-        # git/gh subprocess). Branch and worktree are needed by the post-lock
-        # salvage_committed_no_pr_sessions pass.
-        if session.worktree_path is not None:
-            branch = _checked_out_branch(session.worktree_path)
-            if branch is not None:
-                post_review_clean = _detect_post_review_clean(session)
-                salvage_git.append(
-                    (
-                        session.id,
-                        ticket_id,
-                        branch,
-                        str(session.worktree_path),
-                        post_review_clean,
-                    )
-                )
-                continue
-        cap = resolve_idle_retry_cap(task, config)
-        if task is not None and task.attempts < cap:
-            recover.append((session, ticket_id))
-        else:
-            park.append((session, ticket_id))
-
-    if (
-        not recover
-        and not park
-        and not salvaged
-        and not salvage_git
-        and not counters_changed
-    ):
-        return [], []
-
-    # Counter-only tick: persist the updated observation counts so a process
-    # restart between ticks does not replay the same observation as fresh, then
-    # return with no disposition events. (#545)
-    if not recover and not park and not salvaged and not salvage_git:
-        save_state(state)
-        return [], []
-
-    # Auto-recover: retire the session and revert its task for re-dispatch.
-    # Compute usage-limit cause before save_state so reap_reason persists.
-    for session, _ in recover:
-        session.status = SessionStatus.TIMED_OUT
-        session.completed_at = now
-        session.completed_reason = CompletionReason.TIMED_OUT
-        session.reap_reason = (
-            ReapReason.USAGE_LIMIT_CUTOFF
-            if _detect_usage_limit(session)
-            else ReapReason.IDLE_STALL
-        )
-    # Park: flag-only (preserves #348 — no daemon stop, session stays ACTIVE).
-    for session, _ in park:
-        session.last_result = {"paused_status": _SILENTLY_IDLE_REASON}
-        session.reap_reason = ReapReason.RETRY_CAP_PARKED
-
-    # Write session to disk BEFORE queue mutation so a crash between the two
-    # leaves state set on disk — watchdog skips on subsequent ticks. (#324, #348)
-    save_state(state)
-
-    recovered_ids = {tid for _, tid in recover if tid}
-    parked_ids = {tid for _, tid in park if tid}
-    salvaged_ticket_ids = {tid for _, tid, _ in salvaged if tid}
-    salvaged_result_by_ticket = {tid: result for _, tid, result in salvaged if tid}
-    blocked: list[str] = []
-    if recovered_ids or parked_ids or salvaged_ticket_ids:
-        with dev_queue_lock():
-            store = load_dev_queue()
-            changed = False
-            for task in store.tasks:
-                if task.status != QueueItemStatus.RUNNING:
-                    continue
-                if task.ticket_id in recovered_ids:
-                    task.status = QueueItemStatus.PENDING
-                    task.session_id = None
-                    changed = True
-                elif task.ticket_id in parked_ids:
-                    task.status = QueueItemStatus.BLOCKED_ON_USER
-                    blocked.append(task.ticket_id)
-                    changed = True
-                elif task.ticket_id in salvaged_ticket_ids:
-                    result = salvaged_result_by_ticket[task.ticket_id]
-                    task.status = _queue_status_for_salvaged(result)
-                    changed = True
-            if changed:
-                save_dev_queue(store)
-
-    # Recovery: stop the dead surface + emit a distinguishable timeout event.
-    # Payload mirrors the wall-clock timeout path; cause distinguishes the source.
-    # reap_reason was set (and persisted) in the mutation loop above, so we
-    # read it back rather than re-running _detect_usage_limit here.
-    for session, ticket_id in recover:
-        if session.surface_ref is not None:
-            get_native_daemon_client().stop(session.surface_ref)
-        # Stale-worktree cleanup: this task was reverted to PENDING above for
-        # re-dispatch, so the retry must start from a fresh worktree (#404).
-        _cleanup_timed_out_worktree(session, ticket_id)
-        cause = (
-            _CAUSE_USAGE_LIMIT
-            if session.reap_reason is ReapReason.USAGE_LIMIT_CUTOFF
-            else _CAUSE_IDLE_STALL
-        )
-        record_event(
-            OrchestratorEventType.SESSION_TIMED_OUT,
-            {
-                "session_id": session.id,
-                "session_name": session.name,
-                "client": session.client,
-                "ticket_id": ticket_id,
-                "claude_session_id": session.claude_session_id,
-                "elapsed_seconds": (now - session.started_at).total_seconds(),
-                "cause": cause,
-                "last_assistant_message_excerpt": "",
-            },
-        )
-
-    # Park: needs-attention for operator disposition (unchanged from #348).
-    for session, ticket_id in park:
-        record_event(
-            OrchestratorEventType.SESSION_NEEDS_ATTENTION,
-            {
-                "session_id": session.id,
-                "session_name": session.name,
-                "client": session.client,
-                "ticket_id": ticket_id,
-                "claude_session_id": session.claude_session_id,
-                "paused_status": _SILENTLY_IDLE_REASON,
-                "breadcrumbs": "",
-                "crashed": False,
-            },
-        )
-        fire_push_notification(session.name, session.client)
-
-    for session, ticket_id, result in salvaged:
-        completed_payload: dict[str, object] = {
-            "session_id": session.id,
-            "session_name": session.name,
-            "client": session.client,
-            "ticket_id": ticket_id,
-            "claude_session_id": session.claude_session_id,
-            "crashed": False,
-            "salvaged": True,
-            "status": result.status,
-        }
-        record_event(OrchestratorEventType.SESSION_COMPLETED, completed_payload)
-        if session.surface_ref is not None:
-            get_native_daemon_client().stop(session.surface_ref)
-
-    return blocked, salvage_git
+    candidates = _detect_idle_candidates(
+        state,
+        now=now,
+        native_live=native_live,
+        config=config,
+        task_by_ticket=task_by_ticket,
+    )
+    return _act_on_idle_candidates(state, candidates, now=now)
 
 
 def reconcile() -> ReconcileReport:

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -1168,6 +1168,7 @@ def _detect_idle_candidates(
                     elapsed_seconds=elapsed,
                     worktree_dirty=worktree_dirty,
                     new_observation_count=new_count,
+                    usage_limit_detected=_detect_usage_limit(session),
                 )
             )
         else:
@@ -1204,7 +1205,13 @@ def _act_on_idle_candidates(
         c
         for c in candidates
         if c.proposed_action
-        in (ProposedAction.INCREMENT_COUNTER, ProposedAction.RECOVER_COUNTER)
+        in (
+            ProposedAction.INCREMENT_COUNTER,
+            ProposedAction.RECOVER_COUNTER,
+            # SALVAGE_GIT reaches the threshold — persist new_observation_count so
+            # a process restart between ticks does not replay the observation as fresh.
+            ProposedAction.SALVAGE_GIT,
+        )
     ]
     salvage_candidates = [
         c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_COMPLETION
@@ -1245,7 +1252,7 @@ def _act_on_idle_candidates(
         session.completed_reason = CompletionReason.TIMED_OUT
         session.reap_reason = (
             ReapReason.USAGE_LIMIT_CUTOFF
-            if _detect_usage_limit(session)
+            if candidate.usage_limit_detected
             else ReapReason.IDLE_STALL
         )
 
@@ -1362,8 +1369,8 @@ def _act_on_idle_candidates(
         (
             c.session_id,
             c.ticket_id,
-            c.branch or "",
-            c.worktree_path_str or "",
+            c.branch,
+            c.worktree_path_str,
             c.post_review_clean,
         )
         for c in salvage_git_candidates_list
@@ -1538,6 +1545,11 @@ def _detect_phantom_candidates(
             )
             continue
         # Dirty-check for DAEMON sessions only; USER sessions have no worktree.
+        # Why: this check runs inside sessions_lock before the queue mutation, but
+        # the orphaned claude --bg process may still be alive and could write to the
+        # worktree between here and the BLOCKED_ON_USER routing in
+        # _act_on_phantom_candidates (TOCTOU). Accepted tradeoff: block > clobber —
+        # narrow the window, accept the race. See _act_on_phantom_candidates.
         worktree_dirty = (
             _worktree_dirty_by_path(session.client, session.worktree_path)
             if session.origin is SessionOrigin.DAEMON

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -768,6 +768,193 @@ def _worktree_dirty_by_path(client_name: str, worktree_path: Path | None) -> boo
         return False
 
 
+
+def _detect_stalled_candidates(
+    state: CwState,
+    *,
+    now: datetime,
+    config: OrchestratorConfig,
+    task_by_ticket: dict[str, TicketTask],
+) -> list[ReapCandidate]:
+    """Pure classification phase for stalled headless DAEMON sessions.
+
+    Returns a list of ReapCandidate objects. Makes zero writes to state,
+    queue, or event bus. See GitHub #552, ADR-0006.
+    """
+    candidates: list[ReapCandidate] = []
+    for session in state.sessions:
+        if session.status not in _LIVE_STATUSES:
+            continue
+        if session.origin is not SessionOrigin.DAEMON:
+            continue
+        if not _is_headless(session):
+            continue
+        # Park-marker check: sessions already parked by the idle watchdog.
+        # Detect returns SKIP_PARKED candidate; act emits the skip event.
+        if isinstance(session.last_result, dict) and session.last_result.get(
+            "paused_status"
+        ) in (_SILENTLY_IDLE_REASON, _NEEDS_SALVAGE_REASON):
+            actual_paused_status = session.last_result.get("paused_status")
+            ticket_id = ticket_id_for_session(session.name)
+            candidates.append(
+                ReapCandidate(
+                    session_id=session.id,
+                    proposed_action=ProposedAction.SKIP_PARKED,
+                    ticket_id=ticket_id,
+                    paused_status=str(actual_paused_status) if actual_paused_status else None,
+                )
+            )
+            continue
+        ticket_id = ticket_id_for_session(session.name)
+        task = task_by_ticket.get(ticket_id) if ticket_id else None
+        budget = resolve_headless_budget(task, session, config)
+        elapsed = (now - session.started_at).total_seconds()
+        if elapsed < budget:
+            continue
+        # Try terminal-sentinel salvage before declaring timeout.
+        salvage = _salvage_terminal_result(session)
+        if salvage is not None:
+            result, claude_session_id = salvage
+            candidates.append(
+                ReapCandidate(
+                    session_id=session.id,
+                    proposed_action=ProposedAction.SALVAGE_COMPLETION,
+                    ticket_id=ticket_id,
+                    salvage_result=result,
+                    salvage_csid=claude_session_id,
+                    elapsed_seconds=elapsed,
+                )
+            )
+            continue
+        candidates.append(
+            ReapCandidate(
+                session_id=session.id,
+                proposed_action=ProposedAction.REVERT_TASK,
+                ticket_id=ticket_id,
+                elapsed_seconds=elapsed,
+                reap_reason=ReapReason.WALL_CLOCK_BUDGET,
+            )
+        )
+    return candidates
+
+
+def _act_on_stalled_candidates(
+    state: CwState,
+    candidates: list[ReapCandidate],
+    *,
+    now: datetime,
+) -> list[str]:
+    """Act phase for stalled headless sessions: apply all mutations.
+
+    Consumes ReapCandidate objects from _detect_stalled_candidates.
+    Mirrors the side-effect logic in revert_stalled_headless_sessions.
+    Returns the list of ticket IDs reverted to PENDING.
+    """
+    if not candidates:
+        return []
+
+    # Separate by action for batch processing.
+    skip_candidates = [c for c in candidates if c.proposed_action == ProposedAction.SKIP_PARKED]
+    salvage_candidates = [c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_COMPLETION]
+    revert_candidates = [c for c in candidates if c.proposed_action == ProposedAction.REVERT_TASK]
+
+    # SKIP_PARKED: emit event only, no state/queue change.
+    for candidate in skip_candidates:
+        record_event(
+            OrchestratorEventType.SESSION_SALVAGE_SKIPPED,
+            {
+                "session_id": candidate.session_id,
+                "ticket_id": candidate.ticket_id,
+                "reason": _SALVAGE_SKIP_REASON,
+                "paused_status": candidate.paused_status,
+            },
+            correlation_id=candidate.ticket_id,
+        )
+
+    if not salvage_candidates and not revert_candidates:
+        return []
+
+    # Apply state mutations for salvage and revert.
+    session_by_id = {s.id: s for s in state.sessions}
+
+    for candidate in salvage_candidates:
+        session = session_by_id[candidate.session_id]
+        assert candidate.salvage_result is not None
+        assert candidate.salvage_csid is not None
+        _apply_salvaged_completion(session, candidate.salvage_result, candidate.salvage_csid, now=now)
+
+    for candidate in revert_candidates:
+        session = session_by_id[candidate.session_id]
+        session.status = SessionStatus.TIMED_OUT
+        session.completed_at = now
+        session.completed_reason = CompletionReason.TIMED_OUT
+        session.reap_reason = ReapReason.WALL_CLOCK_BUDGET
+
+    save_state(state)
+
+    timed_out_ticket_ids = {c.ticket_id for c in revert_candidates if c.ticket_id}
+    salvaged_ticket_ids_set = {c.ticket_id for c in salvage_candidates if c.ticket_id}
+    salvaged_result_by_ticket = {
+        c.ticket_id: c.salvage_result
+        for c in salvage_candidates
+        if c.ticket_id and c.salvage_result
+    }
+    reverted: list[str] = []
+    if timed_out_ticket_ids or salvaged_ticket_ids_set:
+        with dev_queue_lock():
+            store = load_dev_queue()
+            changed = False
+            for task in store.tasks:
+                if task.status != QueueItemStatus.RUNNING:
+                    continue
+                if task.ticket_id in timed_out_ticket_ids:
+                    task.status = QueueItemStatus.PENDING
+                    task.session_id = None
+                    reverted.append(task.ticket_id)
+                    changed = True
+                elif task.ticket_id in salvaged_ticket_ids_set:
+                    result = salvaged_result_by_ticket[task.ticket_id]
+                    task.status = _queue_status_for_salvaged(result)
+                    changed = True
+            if changed:
+                save_dev_queue(store)
+
+    for candidate in revert_candidates:
+        session = session_by_id[candidate.session_id]
+        payload: dict[str, object] = {
+            "session_id": session.id,
+            "session_name": session.name,
+            "client": session.client,
+            "ticket_id": candidate.ticket_id,
+            "claude_session_id": session.claude_session_id,
+            "elapsed_seconds": candidate.elapsed_seconds,
+            "last_assistant_message_excerpt": "",
+        }
+        record_event(OrchestratorEventType.SESSION_TIMED_OUT, payload)
+        if session.surface_ref is not None:
+            get_native_daemon_client().stop(session.surface_ref)
+        _cleanup_timed_out_worktree(session, candidate.ticket_id)
+
+    for candidate in salvage_candidates:
+        session = session_by_id[candidate.session_id]
+        assert candidate.salvage_result is not None
+        completed_payload: dict[str, object] = {
+            "session_id": session.id,
+            "session_name": session.name,
+            "client": session.client,
+            "ticket_id": candidate.ticket_id,
+            "claude_session_id": session.claude_session_id,
+            "crashed": False,
+            "salvaged": True,
+            "status": candidate.salvage_result.status,
+        }
+        record_event(OrchestratorEventType.SESSION_COMPLETED, completed_payload)
+        if session.surface_ref is not None:
+            get_native_daemon_client().stop(session.surface_ref)
+
+    return reverted
+
+
 def revert_stalled_headless_sessions(
     state: CwState,
     *,
@@ -798,130 +985,12 @@ def revert_stalled_headless_sessions(
     Returns the list of ticket IDs whose TicketTask was reverted to PENDING.
     See GitHub issue #185, #265.
     """
-    # Read-only dev-queue load for budget lookups — no lock needed here.
-    # Use the caller-supplied index when available (avoids a second filesystem
-    # read when reconcile() shares one load across the stalled + idle sweeps).
     if task_by_ticket is None:
         task_by_ticket = {t.ticket_id: t for t in load_dev_queue().tasks}
-
-    pending: list[tuple[Session, str | None]] = []
-    salvaged: list[tuple[Session, str | None, AutoDevResult]] = []
-    for session in state.sessions:
-        if session.status not in _LIVE_STATUSES:
-            continue
-        if session.origin is not SessionOrigin.DAEMON:
-            continue
-        if not _is_headless(session):
-            continue
-        # Skip sessions that were parked by flag_silently_idle_daemon_sessions
-        # (#431). Their last_result is {"paused_status": _SILENTLY_IDLE_REASON}
-        # and they are BLOCKED_ON_USER in the queue already; wall-clock revert
-        # would re-dispatch already-parked work.
-        if isinstance(session.last_result, dict) and session.last_result.get(
-            "paused_status"
-        ) in (_SILENTLY_IDLE_REASON, _NEEDS_SALVAGE_REASON):
-            salvage_skip_ticket_id = ticket_id_for_session(session.name)
-            actual_paused_status = session.last_result.get("paused_status")
-            record_event(
-                OrchestratorEventType.SESSION_SALVAGE_SKIPPED,
-                {
-                    "session_id": session.id,
-                    "ticket_id": salvage_skip_ticket_id,
-                    "reason": _SALVAGE_SKIP_REASON,
-                    "paused_status": actual_paused_status,
-                },
-                correlation_id=salvage_skip_ticket_id,
-            )
-            continue
-        ticket_id = ticket_id_for_session(session.name)
-        task = task_by_ticket.get(ticket_id) if ticket_id else None
-        budget = resolve_headless_budget(task, session, config)
-        elapsed = (now - session.started_at).total_seconds()
-        if elapsed < budget:
-            continue
-        # Before declaring a timeout, try to recover a terminal-success
-        # sentinel the worker emitted before stalling (e.g. waiting on CI).
-        # If found, the session is dispositioned by that sentinel and its
-        # ticket is NOT reverted for re-dispatch. See GitHub issue #372.
-        salvage = _salvage_terminal_result(session)
-        if salvage is not None:
-            result, claude_session_id = salvage
-            _apply_salvaged_completion(session, result, claude_session_id, now=now)
-            salvaged.append((session, ticket_id, result))
-            continue
-        session.status = SessionStatus.TIMED_OUT
-        session.completed_at = now
-        session.completed_reason = CompletionReason.TIMED_OUT
-        session.reap_reason = ReapReason.WALL_CLOCK_BUDGET
-        pending.append((session, ticket_id))
-
-    if not pending and not salvaged:
-        return []
-
-    save_state(state)
-
-    timed_out_ticket_ids = {tid for _, tid in pending if tid}
-    salvaged_ticket_ids = {tid for _, tid, _ in salvaged if tid}
-    salvaged_result_by_ticket = {tid: result for _, tid, result in salvaged if tid}
-    reverted: list[str] = []
-    if timed_out_ticket_ids or salvaged_ticket_ids:
-        with dev_queue_lock():
-            store = load_dev_queue()
-            changed = False
-            for task in store.tasks:
-                if task.status != QueueItemStatus.RUNNING:
-                    continue
-                if task.ticket_id in timed_out_ticket_ids:
-                    task.status = QueueItemStatus.PENDING
-                    task.session_id = None
-                    reverted.append(task.ticket_id)
-                    changed = True
-                elif task.ticket_id in salvaged_ticket_ids:
-                    # Terminal-success salvage: retire the task so the
-                    # COMPLETED-silent backstop does not revert it to PENDING
-                    # and re-dispatch already-finished work (#372).
-                    # Paused statuses (ambiguities_pending_resolution,
-                    # premises_pending_verification) route to BLOCKED_ON_USER
-                    # so downstream operators know human input is needed (#471).
-                    result = salvaged_result_by_ticket[task.ticket_id]
-                    task.status = _queue_status_for_salvaged(result)
-                    changed = True
-            if changed:
-                save_dev_queue(store)
-
-    for session, ticket_id in pending:
-        payload: dict[str, object] = {
-            "session_id": session.id,
-            "session_name": session.name,
-            "client": session.client,
-            "ticket_id": ticket_id,
-            "claude_session_id": session.claude_session_id,
-            "elapsed_seconds": (now - session.started_at).total_seconds(),
-            "last_assistant_message_excerpt": "",
-        }
-        record_event(OrchestratorEventType.SESSION_TIMED_OUT, payload)
-        if session.surface_ref is not None:
-            get_native_daemon_client().stop(session.surface_ref)
-        # Stale-worktree cleanup: the task was reverted to PENDING above, so
-        # the retry must not inherit this run's worktree state (#404).
-        _cleanup_timed_out_worktree(session, ticket_id)
-
-    for session, ticket_id, result in salvaged:
-        completed_payload: dict[str, object] = {
-            "session_id": session.id,
-            "session_name": session.name,
-            "client": session.client,
-            "ticket_id": ticket_id,
-            "claude_session_id": session.claude_session_id,
-            "crashed": False,
-            "salvaged": True,
-            "status": result.status,
-        }
-        record_event(OrchestratorEventType.SESSION_COMPLETED, completed_payload)
-        if session.surface_ref is not None:
-            get_native_daemon_client().stop(session.surface_ref)
-
-    return reverted
+    candidates = _detect_stalled_candidates(
+        state, now=now, config=config, task_by_ticket=task_by_ticket
+    )
+    return _act_on_stalled_candidates(state, candidates, now=now)
 
 
 def _has_terminal_sentinel(session: Session) -> bool:

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -9059,8 +9059,9 @@ def test_detect_phantom_candidates_salvage_on_terminal_sentinel(
     worktree = tmp_path / "wt-phantom-salv"
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
     now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+    # surface_ref must match the prefix used by _write_salvage_transcript
     sess = _mk_phantom_daemon_session(
-        "phantom-salv-1", started_at, worktree_path=worktree
+        "phantom-salv-1", started_at, surface_ref="fake-short-id", worktree_path=worktree
     )
     payload = _shipped_salvage_payload()
     payload["ticket_id"] = "phantom-salv-1"

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -8507,7 +8507,7 @@ def test_detect_stalled_candidates_under_budget_returns_empty(
     tmp_path: Path,
 ) -> None:
     """Session with elapsed < budget → no candidate, bytes unchanged."""
-    from cw.reconcile import ProposedAction, ReapCandidate, _detect_stalled_candidates
+    from cw.reconcile import _detect_stalled_candidates
 
     worktree = tmp_path / "wt-under"
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
@@ -8535,7 +8535,7 @@ def test_detect_stalled_candidates_revert_task_candidate(
     tmp_path: Path,
 ) -> None:
     """ACTIVE DAEMON headless session with elapsed > budget → REVERT_TASK candidate."""
-    from cw.reconcile import ProposedAction, ReapCandidate, _detect_stalled_candidates
+    from cw.reconcile import ProposedAction, _detect_stalled_candidates
 
     worktree = tmp_path / "wt-revert"
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
@@ -8724,7 +8724,10 @@ def test_detect_idle_candidates_under_budget_returns_empty(
 def test_detect_idle_candidates_increment_counter_only(
     tmp_config_dir: Path,
 ) -> None:
-    """Session past budget, not recently active, count=0, threshold=2 → INCREMENT_COUNTER."""
+    """Session past budget, not recently active, count=0, threshold=2.
+
+    Expects INCREMENT_COUNTER candidate.
+    """
     from cw.reconcile import ProposedAction, _detect_idle_candidates
 
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
@@ -8752,7 +8755,7 @@ def test_detect_idle_candidates_increment_counter_only(
     assert _state_queue_snapshot() == snap
 
 
-def test_detect_idle_candidates_counter_NOT_written_by_detect(
+def test_detect_idle_candidates_counter_not_written_by_detect(
     tmp_config_dir: Path,
 ) -> None:
     """Explicit purity: after detect, load_state() → idle_observation_count still 0."""
@@ -8782,7 +8785,10 @@ def test_detect_idle_candidates_counter_NOT_written_by_detect(
 def test_detect_idle_candidates_threshold_reached_park(
     tmp_config_dir: Path,
 ) -> None:
-    """idle_observation_count at threshold-1 + task.attempts >= cap → PARK_BLOCKED_ON_USER."""
+    """idle_observation_count at threshold-1, task.attempts >= cap.
+
+    Expects PARK_BLOCKED_ON_USER candidate.
+    """
     from cw.reconcile import ProposedAction, _detect_idle_candidates
 
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
@@ -8876,9 +8882,9 @@ def test_detect_idle_candidates_recover_counter_when_liveness_restored(
 
     # Patch transcript recently active → True
     monkeypatch.setattr(
-        "cw.reconcile._transcript_recently_active", lambda s, n, **kw: True
+        "cw.reconcile._transcript_recently_active", lambda _s, _n, **_kw: True
     )
-    monkeypatch.setattr("cw.reconcile._awaiting_subagent", lambda s, n: False)
+    monkeypatch.setattr("cw.reconcile._awaiting_subagent", lambda _s, _n: False)
 
     candidates = _detect_idle_candidates(
         state,
@@ -8928,10 +8934,10 @@ def test_detect_idle_candidates_salvage_git(
     snap = _state_queue_snapshot()
 
     monkeypatch.setattr(
-        "cw.reconcile._checked_out_branch", lambda p: "auto-dev/idle-sgit-1"
+        "cw.reconcile._checked_out_branch", lambda _p: "auto-dev/idle-sgit-1"
     )
-    monkeypatch.setattr("cw.reconcile._detect_post_review_clean", lambda s: False)
-    monkeypatch.setattr("cw.reconcile._worktree_dirty_by_path", lambda c, p: False)
+    monkeypatch.setattr("cw.reconcile._detect_post_review_clean", lambda _s: False)
+    monkeypatch.setattr("cw.reconcile._worktree_dirty_by_path", lambda _c, _p: False)
 
     candidates = _detect_idle_candidates(
         state,
@@ -8978,7 +8984,7 @@ def test_detect_idle_candidates_worktree_dirty_flag(
     save_dev_queue(DevQueueStore(tasks=[task]))
     snap = _state_queue_snapshot()
 
-    monkeypatch.setattr("cw.reconcile._worktree_dirty_by_path", lambda c, p: True)
+    monkeypatch.setattr("cw.reconcile._worktree_dirty_by_path", lambda _c, _p: True)
 
     candidates = _detect_idle_candidates(
         state,
@@ -9025,7 +9031,6 @@ def test_detect_phantom_candidates_crash_complete(
     from cw.reconcile import ProposedAction, _detect_phantom_candidates
 
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
     sess = _mk_phantom_daemon_session("phantom-crash-1", started_at)
     state = CwState(sessions=[sess])
     save_state(state)
@@ -9035,7 +9040,6 @@ def test_detect_phantom_candidates_crash_complete(
     candidates = _detect_phantom_candidates(
         state,
         phantom_set={sess.id},
-        now=now,
     )
 
     assert len(candidates) == 1
@@ -9058,10 +9062,12 @@ def test_detect_phantom_candidates_salvage_on_terminal_sentinel(
     monkeypatch.setenv("HOME", str(home))
     worktree = tmp_path / "wt-phantom-salv"
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
     # surface_ref must match the prefix used by _write_salvage_transcript
     sess = _mk_phantom_daemon_session(
-        "phantom-salv-1", started_at, surface_ref="fake-short-id", worktree_path=worktree
+        "phantom-salv-1",
+        started_at,
+        surface_ref="fake-short-id",
+        worktree_path=worktree,
     )
     payload = _shipped_salvage_payload()
     payload["ticket_id"] = "phantom-salv-1"
@@ -9074,7 +9080,6 @@ def test_detect_phantom_candidates_salvage_on_terminal_sentinel(
     candidates = _detect_phantom_candidates(
         state,
         phantom_set={sess.id},
-        now=now,
     )
 
     assert len(candidates) == 1
@@ -9089,7 +9094,6 @@ def test_detect_phantom_candidates_user_origin_crash_no_ticket(
     from cw.reconcile import ProposedAction, _detect_phantom_candidates
 
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
     sess = Session(
         id="phantom-user-1",
         name="client-a/impl",  # no auto-dev/ prefix → no ticket_id
@@ -9109,7 +9113,6 @@ def test_detect_phantom_candidates_user_origin_crash_no_ticket(
     candidates = _detect_phantom_candidates(
         state,
         phantom_set={sess.id},
-        now=now,
     )
 
     assert len(candidates) == 1
@@ -9124,11 +9127,10 @@ def test_detect_phantom_candidates_worktree_dirty_on_candidate(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Phantom with dirty worktree → candidate.worktree_dirty == True; bytes unchanged."""
+    """Phantom with dirty worktree → candidate.worktree_dirty True; bytes unchanged."""
     from cw.reconcile import _detect_phantom_candidates
 
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
-    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
     wt = tmp_path / "wt-dirty"
     wt.mkdir()
     sess = _mk_phantom_daemon_session("phantom-dirty-1", started_at, worktree_path=wt)
@@ -9137,12 +9139,11 @@ def test_detect_phantom_candidates_worktree_dirty_on_candidate(
     save_dev_queue(DevQueueStore(tasks=[]))
     snap = _state_queue_snapshot()
 
-    monkeypatch.setattr("cw.reconcile._worktree_dirty_by_path", lambda c, p: True)
+    monkeypatch.setattr("cw.reconcile._worktree_dirty_by_path", lambda _c, _p: True)
 
     candidates = _detect_phantom_candidates(
         state,
         phantom_set={sess.id},
-        now=now,
     )
 
     assert len(candidates) == 1
@@ -9158,7 +9159,7 @@ def test_act_on_stalled_revert_task_updates_state_and_queue(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """REVERT_TASK candidate → session TIMED_OUT, queue PENDING, SESSION_TIMED_OUT emitted."""
+    """REVERT_TASK candidate → TIMED_OUT session, PENDING queue, event emitted."""
     from cw.reconcile import ProposedAction, ReapCandidate, _act_on_stalled_candidates
 
     worktree = tmp_path / "wt-act-revert"
@@ -9167,11 +9168,14 @@ def test_act_on_stalled_revert_task_updates_state_and_queue(
 
     monkeypatch.setattr(
         "cw.reconcile.get_native_daemon_client",
-        lambda: FakeNativeDaemonClient(),
+        FakeNativeDaemonClient,
     )
-    monkeypatch.setattr("cw.reconcile.get_client", lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"))
+    monkeypatch.setattr(
+        "cw.reconcile.get_client",
+        lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+    )
     monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: False)
-    monkeypatch.setattr("cw.reconcile.remove_worktree", lambda *a, **kw: None)
+    monkeypatch.setattr("cw.reconcile.remove_worktree", lambda *_a, **_kw: None)
 
     sess = _mk_headless_daemon_session("act-revert-1", worktree, started_at)
     state = CwState(sessions=[sess])
@@ -9225,7 +9229,7 @@ def test_act_on_stalled_salvage_completion(
 
     monkeypatch.setattr(
         "cw.reconcile.get_native_daemon_client",
-        lambda: FakeNativeDaemonClient(),
+        FakeNativeDaemonClient,
     )
 
     worktree = tmp_path / "wt-act-salv"
@@ -9314,7 +9318,9 @@ def test_act_on_idle_park_routes_blocked_on_user(
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
     now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
 
-    sess = _mk_live_idle_daemon_session("idle-act-park-1", "live-ref", started_at, idle_observation_count=1)
+    sess = _mk_live_idle_daemon_session(
+        "idle-act-park-1", "live-ref", started_at, idle_observation_count=1
+    )
     state = CwState(sessions=[sess])
     save_state(state)
     task = TicketTask(
@@ -9349,7 +9355,9 @@ def test_act_on_idle_increments_observation_counter(
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
     now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
 
-    sess = _mk_live_idle_daemon_session("idle-act-inc-1", "live-ref", started_at, idle_observation_count=0)
+    sess = _mk_live_idle_daemon_session(
+        "idle-act-inc-1", "live-ref", started_at, idle_observation_count=0
+    )
     state = CwState(sessions=[sess])
     save_state(state)
     save_dev_queue(DevQueueStore(tasks=[]))
@@ -9372,7 +9380,7 @@ def test_act_on_idle_increments_observation_counter(
 def test_act_on_phantom_crash_routes_pending(
     tmp_config_dir: Path,
 ) -> None:
-    """CRASH_COMPLETE candidate, worktree_dirty=False → queue PENDING, SESSION_PHANTOM_REVERTED."""
+    """CRASH_COMPLETE (dirty=False) → queue PENDING + SESSION_PHANTOM_REVERTED."""
     from cw.reconcile import ProposedAction, ReapCandidate, _act_on_phantom_candidates
 
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
@@ -9398,7 +9406,7 @@ def test_act_on_phantom_crash_routes_pending(
     )
 
     result = _act_on_phantom_candidates(state, [candidate], now=now)
-    ticket_ids_to_revert, phantom_names, usage_limited, salvaged_ticket_ids, _ = result
+    _, _, _, _, _ = result
 
     store = load_dev_queue()
     t = next(t for t in store.tasks if t.ticket_id == "phantom-act-1")
@@ -9415,7 +9423,7 @@ def test_act_on_phantom_crash_routes_pending(
 def test_act_on_phantom_dirty_routes_blocked(
     tmp_config_dir: Path,
 ) -> None:
-    """CRASH_COMPLETE candidate, worktree_dirty=True → queue BLOCKED_ON_USER, SESSION_PHANTOM_REVERTED."""
+    """CRASH_COMPLETE (dirty=True) → BLOCKED_ON_USER + SESSION_PHANTOM_REVERTED."""
     from cw.reconcile import ProposedAction, ReapCandidate, _act_on_phantom_candidates
 
     started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -8485,3 +8485,969 @@ def test_revert_timed_out_tasks_completes_while_holding_sessions_lock(
     reloaded = load_state()
     stamped = next(s for s in reloaded.sessions if s.id == "lockheld-to-1")
     assert stamped.reap_reason == ReapReason.COMPLETED_BACKSTOP
+
+
+# ---------------------------------------------------------------------------
+# Phase detect/act split tests (GitHub #552)
+# ---------------------------------------------------------------------------
+
+
+def _state_queue_snapshot() -> bytes:
+    """Read state + queue bytes for detect-purity assertions."""
+    from cw.config import dev_queue_file, state_file
+
+    return state_file().read_bytes() + dev_queue_file().read_bytes()
+
+
+# --- _detect_stalled_candidates ---
+
+
+def test_detect_stalled_candidates_under_budget_returns_empty(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """Session with elapsed < budget → no candidate, bytes unchanged."""
+    from cw.reconcile import ProposedAction, ReapCandidate, _detect_stalled_candidates
+
+    worktree = tmp_path / "wt-under"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("under-detect", worktree, started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+    snap = _state_queue_snapshot()
+
+    candidates = _detect_stalled_candidates(
+        state,
+        now=now,
+        config=OrchestratorConfig(),
+        task_by_ticket={},
+    )
+
+    assert candidates == []
+    assert _state_queue_snapshot() == snap
+
+
+def test_detect_stalled_candidates_revert_task_candidate(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """ACTIVE DAEMON headless session with elapsed > budget → REVERT_TASK candidate."""
+    from cw.reconcile import ProposedAction, ReapCandidate, _detect_stalled_candidates
+
+    worktree = tmp_path / "wt-revert"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("revert-detect-1", worktree, started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+    snap = _state_queue_snapshot()
+
+    task = TicketTask(
+        ticket_id="revert-detect-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="revert-detect-1",
+    )
+    candidates = _detect_stalled_candidates(
+        state,
+        now=now,
+        config=OrchestratorConfig(),
+        task_by_ticket={"revert-detect-1": task},
+    )
+
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c.proposed_action == ProposedAction.REVERT_TASK
+    assert c.ticket_id == "revert-detect-1"
+    assert c.reap_reason == ReapReason.WALL_CLOCK_BUDGET
+    # Purity: no writes
+    assert _state_queue_snapshot() == snap
+
+
+def test_detect_stalled_candidates_skip_parked_candidate(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """session.last_result = {"paused_status": "silently_idle"} → SKIP_PARKED."""
+    from cw.reconcile import ProposedAction, _detect_stalled_candidates
+
+    worktree = tmp_path / "wt-skip"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("skip-parked-1", worktree, started_at)
+    sess.last_result = {"paused_status": _SILENTLY_IDLE_REASON}
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+    snap = _state_queue_snapshot()
+
+    candidates = _detect_stalled_candidates(
+        state,
+        now=now,
+        config=OrchestratorConfig(),
+        task_by_ticket={},
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].proposed_action == ProposedAction.SKIP_PARKED
+    assert candidates[0].paused_status == _SILENTLY_IDLE_REASON
+    assert _state_queue_snapshot() == snap
+
+
+def test_detect_stalled_candidates_salvage_completion_candidate(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Session past budget with terminal sentinel → SALVAGE_COMPLETION."""
+    from cw.reconcile import ProposedAction, _detect_stalled_candidates
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    worktree = tmp_path / "wt-salvage"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("salv-detect-1", worktree, started_at)
+    payload = _shipped_salvage_payload()
+    payload["ticket_id"] = "salv-detect-1"
+    _write_salvage_transcript(home, worktree, "csid-uuid", payload)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+    snap = _state_queue_snapshot()
+
+    candidates = _detect_stalled_candidates(
+        state,
+        now=now,
+        config=OrchestratorConfig(),
+        task_by_ticket={},
+    )
+
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c.proposed_action == ProposedAction.SALVAGE_COMPLETION
+    assert c.salvage_result is not None
+    assert _state_queue_snapshot() == snap
+
+
+def test_detect_stalled_candidates_skips_user_origin(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """USER-origin session → not in returned list; bytes unchanged."""
+    from cw.reconcile import _detect_stalled_candidates
+
+    worktree = tmp_path / "wt-user"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("user-origin-1", worktree, started_at)
+    sess.origin = SessionOrigin.USER
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+    snap = _state_queue_snapshot()
+
+    candidates = _detect_stalled_candidates(
+        state,
+        now=now,
+        config=OrchestratorConfig(),
+        task_by_ticket={},
+    )
+
+    assert candidates == []
+    assert _state_queue_snapshot() == snap
+
+
+# --- _detect_idle_candidates ---
+
+
+def _mk_live_idle_daemon_session(
+    sid: str,
+    surface_ref: str,
+    started_at: datetime,
+    idle_observation_count: int = 0,
+    worktree_path: Path | None = None,
+) -> Session:
+    """Build a live DAEMON ACTIVE session suitable for idle watchdog tests."""
+    return Session(
+        id=sid,
+        name=f"client-a/auto-dev/{sid}",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=ClientConfig(
+            name="client-a", workspace_path=Path("/tmp/ws")
+        ).workspace_path,
+        surface_ref=surface_ref,
+        started_at=started_at,
+        idle_observation_count=idle_observation_count,
+        worktree_path=worktree_path,
+    )
+
+
+def test_detect_idle_candidates_under_budget_returns_empty(
+    tmp_config_dir: Path,
+) -> None:
+    """Session elapsed < idle budget → no candidate."""
+    from cw.reconcile import _detect_idle_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 1, 0, tzinfo=UTC)
+    sess = _mk_live_idle_daemon_session("idle-under-1", "live-ref", started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+    snap = _state_queue_snapshot()
+
+    candidates = _detect_idle_candidates(
+        state,
+        now=now,
+        native_live={"live-ref"},
+        config=OrchestratorConfig(),
+        task_by_ticket={},
+    )
+
+    assert candidates == []
+    assert _state_queue_snapshot() == snap
+
+
+def test_detect_idle_candidates_increment_counter_only(
+    tmp_config_dir: Path,
+) -> None:
+    """Session past budget, not recently active, count=0, threshold=2 → INCREMENT_COUNTER."""
+    from cw.reconcile import ProposedAction, _detect_idle_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    config = OrchestratorConfig(idle_confirm_observations=2)
+    sess = _mk_live_idle_daemon_session("idle-inc-1", "live-ref", started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+    snap = _state_queue_snapshot()
+
+    candidates = _detect_idle_candidates(
+        state,
+        now=now,
+        native_live={"live-ref"},
+        config=config,
+        task_by_ticket={},
+    )
+
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c.proposed_action == ProposedAction.INCREMENT_COUNTER
+    assert c.new_observation_count == 1
+    # Purity: bytes unchanged
+    assert _state_queue_snapshot() == snap
+
+
+def test_detect_idle_candidates_counter_NOT_written_by_detect(
+    tmp_config_dir: Path,
+) -> None:
+    """Explicit purity: after detect, load_state() → idle_observation_count still 0."""
+    from cw.reconcile import _detect_idle_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    config = OrchestratorConfig(idle_confirm_observations=2)
+    sess = _mk_live_idle_daemon_session("idle-nowrit-1", "live-ref", started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+
+    _detect_idle_candidates(
+        state,
+        now=now,
+        native_live={"live-ref"},
+        config=config,
+        task_by_ticket={},
+    )
+
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "idle-nowrit-1")
+    assert s.idle_observation_count == 0
+
+
+def test_detect_idle_candidates_threshold_reached_park(
+    tmp_config_dir: Path,
+) -> None:
+    """idle_observation_count at threshold-1 + task.attempts >= cap → PARK_BLOCKED_ON_USER."""
+    from cw.reconcile import ProposedAction, _detect_idle_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    config = OrchestratorConfig(idle_confirm_observations=2)
+    sess = _mk_live_idle_daemon_session(
+        "idle-park-1", "live-ref", started_at, idle_observation_count=1
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    # task.attempts >= cap → park
+    task = TicketTask(
+        ticket_id="idle-park-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="idle-park-1",
+        attempts=99,
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+    snap = _state_queue_snapshot()
+
+    candidates = _detect_idle_candidates(
+        state,
+        now=now,
+        native_live={"live-ref"},
+        config=config,
+        task_by_ticket={"idle-park-1": task},
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].proposed_action == ProposedAction.PARK_BLOCKED_ON_USER
+    assert _state_queue_snapshot() == snap
+
+
+def test_detect_idle_candidates_threshold_reached_recover(
+    tmp_config_dir: Path,
+) -> None:
+    """idle_observation_count at threshold-1 + task.attempts < cap → REVERT_TASK."""
+    from cw.reconcile import ProposedAction, _detect_idle_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    config = OrchestratorConfig(idle_confirm_observations=2)
+    sess = _mk_live_idle_daemon_session(
+        "idle-recover-1", "live-ref", started_at, idle_observation_count=1
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    # task.attempts=0 < cap=2 → recover
+    task = TicketTask(
+        ticket_id="idle-recover-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="idle-recover-1",
+        attempts=0,
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+    snap = _state_queue_snapshot()
+
+    candidates = _detect_idle_candidates(
+        state,
+        now=now,
+        native_live={"live-ref"},
+        config=config,
+        task_by_ticket={"idle-recover-1": task},
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].proposed_action == ProposedAction.REVERT_TASK
+    assert _state_queue_snapshot() == snap
+
+
+def test_detect_idle_candidates_recover_counter_when_liveness_restored(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """idle_observation_count=1 + transcript recently active → RECOVER_COUNTER."""
+    from cw.reconcile import ProposedAction, _detect_idle_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    config = OrchestratorConfig(idle_confirm_observations=2)
+    sess = _mk_live_idle_daemon_session(
+        "idle-recov-cnt-1", "live-ref", started_at, idle_observation_count=1
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+    snap = _state_queue_snapshot()
+
+    # Patch transcript recently active → True
+    monkeypatch.setattr(
+        "cw.reconcile._transcript_recently_active", lambda s, n, **kw: True
+    )
+    monkeypatch.setattr("cw.reconcile._awaiting_subagent", lambda s, n: False)
+
+    candidates = _detect_idle_candidates(
+        state,
+        now=now,
+        native_live={"live-ref"},
+        config=config,
+        task_by_ticket={},
+    )
+
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c.proposed_action == ProposedAction.RECOVER_COUNTER
+    assert c.new_observation_count == 0
+    assert _state_queue_snapshot() == snap
+
+
+def test_detect_idle_candidates_salvage_git(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Session at threshold with worktree_path + branch → SALVAGE_GIT."""
+    from cw.reconcile import ProposedAction, _detect_idle_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    config = OrchestratorConfig(idle_confirm_observations=2)
+    wt_path = tmp_path / "wt-salvage-git"
+    wt_path.mkdir(parents=True)
+    sess = _mk_live_idle_daemon_session(
+        "idle-sgit-1",
+        "live-ref",
+        started_at,
+        idle_observation_count=1,
+        worktree_path=wt_path,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    task = TicketTask(
+        ticket_id="idle-sgit-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="idle-sgit-1",
+        attempts=0,
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+    snap = _state_queue_snapshot()
+
+    monkeypatch.setattr(
+        "cw.reconcile._checked_out_branch", lambda p: "auto-dev/idle-sgit-1"
+    )
+    monkeypatch.setattr("cw.reconcile._detect_post_review_clean", lambda s: False)
+    monkeypatch.setattr("cw.reconcile._worktree_dirty_by_path", lambda c, p: False)
+
+    candidates = _detect_idle_candidates(
+        state,
+        now=now,
+        native_live={"live-ref"},
+        config=config,
+        task_by_ticket={"idle-sgit-1": task},
+    )
+
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c.proposed_action == ProposedAction.SALVAGE_GIT
+    assert c.branch == "auto-dev/idle-sgit-1"
+    assert _state_queue_snapshot() == snap
+
+
+def test_detect_idle_candidates_worktree_dirty_flag(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dirty worktree → candidate.worktree_dirty == True; bytes unchanged."""
+    from cw.reconcile import _detect_idle_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    config = OrchestratorConfig(idle_confirm_observations=2)
+    sess = _mk_live_idle_daemon_session(
+        "idle-dirty-1",
+        "live-ref",
+        started_at,
+        idle_observation_count=1,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    # task.attempts=99 >= cap → PARK path, which checks dirty
+    task = TicketTask(
+        ticket_id="idle-dirty-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="idle-dirty-1",
+        attempts=99,
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+    snap = _state_queue_snapshot()
+
+    monkeypatch.setattr("cw.reconcile._worktree_dirty_by_path", lambda c, p: True)
+
+    candidates = _detect_idle_candidates(
+        state,
+        now=now,
+        native_live={"live-ref"},
+        config=config,
+        task_by_ticket={"idle-dirty-1": task},
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].worktree_dirty is True
+    assert _state_queue_snapshot() == snap
+
+
+# --- _detect_phantom_candidates ---
+
+
+def _mk_phantom_daemon_session(
+    sid: str,
+    started_at: datetime,
+    surface_ref: str = "dead-ref",
+    worktree_path: Path | None = None,
+) -> Session:
+    return Session(
+        id=sid,
+        name=f"client-a/auto-dev/{sid}",
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.DAEMON,
+        status=SessionStatus.ACTIVE,
+        workspace_path=ClientConfig(
+            name="client-a", workspace_path=Path("/tmp/ws")
+        ).workspace_path,
+        surface_ref=surface_ref,
+        started_at=started_at,
+        worktree_path=worktree_path,
+    )
+
+
+def test_detect_phantom_candidates_crash_complete(
+    tmp_config_dir: Path,
+) -> None:
+    """DAEMON session in phantom_set, no sentinel → CRASH_COMPLETE."""
+    from cw.reconcile import ProposedAction, _detect_phantom_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+    sess = _mk_phantom_daemon_session("phantom-crash-1", started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+    snap = _state_queue_snapshot()
+
+    candidates = _detect_phantom_candidates(
+        state,
+        phantom_set={sess.id},
+        now=now,
+    )
+
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c.proposed_action == ProposedAction.CRASH_COMPLETE
+    assert c.ticket_id == "phantom-crash-1"
+    assert _state_queue_snapshot() == snap
+
+
+def test_detect_phantom_candidates_salvage_on_terminal_sentinel(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DAEMON session in phantom_set with terminal sentinel → SALVAGE_COMPLETION."""
+    from cw.reconcile import ProposedAction, _detect_phantom_candidates
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    worktree = tmp_path / "wt-phantom-salv"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+    sess = _mk_phantom_daemon_session(
+        "phantom-salv-1", started_at, worktree_path=worktree
+    )
+    payload = _shipped_salvage_payload()
+    payload["ticket_id"] = "phantom-salv-1"
+    _write_salvage_transcript(home, worktree, "csid-salv", payload)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+    snap = _state_queue_snapshot()
+
+    candidates = _detect_phantom_candidates(
+        state,
+        phantom_set={sess.id},
+        now=now,
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].proposed_action == ProposedAction.SALVAGE_COMPLETION
+    assert _state_queue_snapshot() == snap
+
+
+def test_detect_phantom_candidates_user_origin_crash_no_ticket(
+    tmp_config_dir: Path,
+) -> None:
+    """USER session in phantom_set → CRASH_COMPLETE, ticket_id is None."""
+    from cw.reconcile import ProposedAction, _detect_phantom_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+    sess = Session(
+        id="phantom-user-1",
+        name="client-a/impl",  # no auto-dev/ prefix → no ticket_id
+        client="client-a",
+        purpose=SessionPurpose.IMPL,
+        origin=SessionOrigin.USER,
+        status=SessionStatus.ACTIVE,
+        workspace_path=Path("/tmp/ws"),
+        surface_ref="dead-ref",
+        started_at=started_at,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+    snap = _state_queue_snapshot()
+
+    candidates = _detect_phantom_candidates(
+        state,
+        phantom_set={sess.id},
+        now=now,
+    )
+
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c.proposed_action == ProposedAction.CRASH_COMPLETE
+    assert c.ticket_id is None
+    assert _state_queue_snapshot() == snap
+
+
+def test_detect_phantom_candidates_worktree_dirty_on_candidate(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phantom with dirty worktree → candidate.worktree_dirty == True; bytes unchanged."""
+    from cw.reconcile import _detect_phantom_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+    wt = tmp_path / "wt-dirty"
+    wt.mkdir()
+    sess = _mk_phantom_daemon_session("phantom-dirty-1", started_at, worktree_path=wt)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+    snap = _state_queue_snapshot()
+
+    monkeypatch.setattr("cw.reconcile._worktree_dirty_by_path", lambda c, p: True)
+
+    candidates = _detect_phantom_candidates(
+        state,
+        phantom_set={sess.id},
+        now=now,
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].worktree_dirty is True
+    assert _state_queue_snapshot() == snap
+
+
+# --- Act dispatcher tests ---
+
+
+def test_act_on_stalled_revert_task_updates_state_and_queue(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REVERT_TASK candidate → session TIMED_OUT, queue PENDING, SESSION_TIMED_OUT emitted."""
+    from cw.reconcile import ProposedAction, ReapCandidate, _act_on_stalled_candidates
+
+    worktree = tmp_path / "wt-act-revert"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+    monkeypatch.setattr(
+        "cw.reconcile.get_native_daemon_client",
+        lambda: FakeNativeDaemonClient(),
+    )
+    monkeypatch.setattr("cw.reconcile.get_client", lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"))
+    monkeypatch.setattr("cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: False)
+    monkeypatch.setattr("cw.reconcile.remove_worktree", lambda *a, **kw: None)
+
+    sess = _mk_headless_daemon_session("act-revert-1", worktree, started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    task = TicketTask(
+        ticket_id="act-revert-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="act-revert-1",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    candidate = ReapCandidate(
+        session_id="act-revert-1",
+        proposed_action=ProposedAction.REVERT_TASK,
+        ticket_id="act-revert-1",
+        elapsed_seconds=3700.0,
+        reap_reason=ReapReason.WALL_CLOCK_BUDGET,
+    )
+
+    reverted = _act_on_stalled_candidates(state, [candidate], now=now)
+
+    assert "act-revert-1" in reverted
+    assert sess.status == SessionStatus.TIMED_OUT
+
+    store = load_dev_queue()
+    t = next(t for t in store.tasks if t.ticket_id == "act-revert-1")
+    assert t.status == QueueItemStatus.PENDING
+
+    events = read_events(
+        consumer="test-act-revert-1",
+        event_types=[OrchestratorEventType.SESSION_TIMED_OUT],
+    )
+    assert len(events) == 1
+    # Must NOT emit SESSION_COMPLETED for REVERT_TASK path
+    completed_events = read_events(
+        consumer="test-act-revert-1-completed",
+        event_types=[OrchestratorEventType.SESSION_COMPLETED],
+    )
+    assert len(completed_events) == 0
+
+
+def test_act_on_stalled_salvage_completion(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SALVAGE_COMPLETION candidate → session COMPLETED, queue COMPLETED."""
+    from cw.auto_dev_result import AutoDevResult
+    from cw.reconcile import ProposedAction, ReapCandidate, _act_on_stalled_candidates
+
+    monkeypatch.setattr(
+        "cw.reconcile.get_native_daemon_client",
+        lambda: FakeNativeDaemonClient(),
+    )
+
+    worktree = tmp_path / "wt-act-salv"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("act-salv-1", worktree, started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    task = TicketTask(
+        ticket_id="act-salv-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="act-salv-1",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    result = AutoDevResult.model_validate(_shipped_salvage_payload())
+    candidate = ReapCandidate(
+        session_id="act-salv-1",
+        proposed_action=ProposedAction.SALVAGE_COMPLETION,
+        ticket_id="act-salv-1",
+        salvage_result=result,
+        salvage_csid="csid-act-salv",
+    )
+
+    _act_on_stalled_candidates(state, [candidate], now=now)
+
+    assert sess.status == SessionStatus.COMPLETED
+    store = load_dev_queue()
+    t = next(t for t in store.tasks if t.ticket_id == "act-salv-1")
+    assert t.status == QueueItemStatus.COMPLETED
+
+
+def test_act_on_stalled_skip_parked_emits_event_no_queue_change(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """SKIP_PARKED candidate → SESSION_SALVAGE_SKIPPED emitted; queue unchanged."""
+    from cw.reconcile import ProposedAction, ReapCandidate, _act_on_stalled_candidates
+
+    worktree = tmp_path / "wt-skip-act"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("act-skip-1", worktree, started_at)
+    sess.last_result = {"paused_status": _SILENTLY_IDLE_REASON}
+    state = CwState(sessions=[sess])
+    save_state(state)
+    task = TicketTask(
+        ticket_id="act-skip-1",
+        client="client-a",
+        status=QueueItemStatus.BLOCKED_ON_USER,
+        session_id="act-skip-1",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    candidate = ReapCandidate(
+        session_id="act-skip-1",
+        proposed_action=ProposedAction.SKIP_PARKED,
+        ticket_id="act-skip-1",
+        paused_status=_SILENTLY_IDLE_REASON,
+    )
+
+    _act_on_stalled_candidates(state, [candidate], now=now)
+
+    # Queue must be unchanged
+    store = load_dev_queue()
+    t = next(t for t in store.tasks if t.ticket_id == "act-skip-1")
+    assert t.status == QueueItemStatus.BLOCKED_ON_USER
+
+    events = read_events(
+        consumer="test-act-skip-1",
+        event_types=[OrchestratorEventType.SESSION_SALVAGE_SKIPPED],
+    )
+    assert len(events) == 1
+
+
+def test_act_on_idle_park_routes_blocked_on_user(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """PARK_BLOCKED_ON_USER candidate → queue BLOCKED_ON_USER."""
+    from cw.reconcile import ProposedAction, ReapCandidate, _act_on_idle_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+
+    sess = _mk_live_idle_daemon_session("idle-act-park-1", "live-ref", started_at, idle_observation_count=1)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    task = TicketTask(
+        ticket_id="idle-act-park-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="idle-act-park-1",
+        attempts=99,
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    candidate = ReapCandidate(
+        session_id="idle-act-park-1",
+        proposed_action=ProposedAction.PARK_BLOCKED_ON_USER,
+        ticket_id="idle-act-park-1",
+        new_observation_count=2,
+    )
+
+    _act_on_idle_candidates(state, [candidate], now=now)
+
+    store = load_dev_queue()
+    t = next(t for t in store.tasks if t.ticket_id == "idle-act-park-1")
+    assert t.status == QueueItemStatus.BLOCKED_ON_USER
+
+
+def test_act_on_idle_increments_observation_counter(
+    tmp_config_dir: Path,
+) -> None:
+    """INCREMENT_COUNTER candidate → session.idle_observation_count updated."""
+    from cw.reconcile import ProposedAction, ReapCandidate, _act_on_idle_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+
+    sess = _mk_live_idle_daemon_session("idle-act-inc-1", "live-ref", started_at, idle_observation_count=0)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+
+    candidate = ReapCandidate(
+        session_id="idle-act-inc-1",
+        proposed_action=ProposedAction.INCREMENT_COUNTER,
+        ticket_id="idle-act-inc-1",
+        new_observation_count=2,
+    )
+
+    _act_on_idle_candidates(state, [candidate], now=now)
+
+    # Counter must be written by act
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "idle-act-inc-1")
+    assert s.idle_observation_count == 2
+
+
+def test_act_on_phantom_crash_routes_pending(
+    tmp_config_dir: Path,
+) -> None:
+    """CRASH_COMPLETE candidate, worktree_dirty=False → queue PENDING, SESSION_PHANTOM_REVERTED."""
+    from cw.reconcile import ProposedAction, ReapCandidate, _act_on_phantom_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+    sess = _mk_phantom_daemon_session("phantom-act-1", started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    task = TicketTask(
+        ticket_id="phantom-act-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="phantom-act-1",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    candidate = ReapCandidate(
+        session_id="phantom-act-1",
+        proposed_action=ProposedAction.CRASH_COMPLETE,
+        ticket_id="phantom-act-1",
+        worktree_dirty=False,
+        client="client-a",
+        worktree_path=None,
+    )
+
+    result = _act_on_phantom_candidates(state, [candidate], now=now)
+    ticket_ids_to_revert, phantom_names, usage_limited, salvaged_ticket_ids, _ = result
+
+    store = load_dev_queue()
+    t = next(t for t in store.tasks if t.ticket_id == "phantom-act-1")
+    assert t.status == QueueItemStatus.PENDING
+
+    events = read_events(
+        consumer="test-phantom-act-1",
+        event_types=[OrchestratorEventType.SESSION_PHANTOM_REVERTED],
+    )
+    assert len(events) == 1
+    assert events[0].payload["worktree_dirty"] is False
+
+
+def test_act_on_phantom_dirty_routes_blocked(
+    tmp_config_dir: Path,
+) -> None:
+    """CRASH_COMPLETE candidate, worktree_dirty=True → queue BLOCKED_ON_USER, SESSION_PHANTOM_REVERTED."""
+    from cw.reconcile import ProposedAction, ReapCandidate, _act_on_phantom_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+    sess = _mk_phantom_daemon_session("phantom-act-dirty-1", started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    task = TicketTask(
+        ticket_id="phantom-act-dirty-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="phantom-act-dirty-1",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    candidate = ReapCandidate(
+        session_id="phantom-act-dirty-1",
+        proposed_action=ProposedAction.CRASH_COMPLETE,
+        ticket_id="phantom-act-dirty-1",
+        worktree_dirty=True,
+        client="client-a",
+        worktree_path=None,
+    )
+
+    _act_on_phantom_candidates(state, [candidate], now=now)
+
+    store = load_dev_queue()
+    t = next(t for t in store.tasks if t.ticket_id == "phantom-act-dirty-1")
+    assert t.status == QueueItemStatus.BLOCKED_ON_USER
+
+    events = read_events(
+        consumer="test-phantom-dirty-1",
+        event_types=[OrchestratorEventType.SESSION_PHANTOM_REVERTED],
+    )
+    assert len(events) == 1
+    assert events[0].payload["worktree_dirty"] is True

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -9460,3 +9460,326 @@ def test_act_on_phantom_dirty_routes_blocked(
     )
     assert len(events) == 1
     assert events[0].payload["worktree_dirty"] is True
+
+
+# ---------------------------------------------------------------------------
+# Additional act-phase tests addressing coverage gaps (GitHub #552 fix cycle 1)
+# ---------------------------------------------------------------------------
+
+
+def test_act_on_stalled_salvage_completion_emits_session_completed(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SALVAGE_COMPLETION → SESSION_COMPLETED event emitted with salvaged=True."""
+    from cw.auto_dev_result import AutoDevResult
+    from cw.reconcile import ProposedAction, ReapCandidate, _act_on_stalled_candidates
+
+    monkeypatch.setattr(
+        "cw.reconcile.get_native_daemon_client",
+        FakeNativeDaemonClient,
+    )
+
+    worktree = tmp_path / "wt-salv-evt"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("act-salv-evt-1", worktree, started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+
+    payload = _shipped_salvage_payload()
+    payload["ticket_id"] = "act-salv-evt-1"
+    result = AutoDevResult.model_validate(payload)
+    candidate = ReapCandidate(
+        session_id="act-salv-evt-1",
+        proposed_action=ProposedAction.SALVAGE_COMPLETION,
+        ticket_id="act-salv-evt-1",
+        salvage_result=result,
+        salvage_csid="csid-salv-evt",
+    )
+
+    _act_on_stalled_candidates(state, [candidate], now=now)
+
+    events = read_events(
+        consumer="test-act-salv-evt-1",
+        event_types=[OrchestratorEventType.SESSION_COMPLETED],
+    )
+    assert len(events) == 1
+    assert events[0].payload["salvaged"] is True
+    assert events[0].payload["crashed"] is False
+
+
+def test_act_on_idle_park_emits_needs_attention_and_sets_reap_reason(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """PARK_BLOCKED_ON_USER → SESSION_NEEDS_ATTENTION emitted + reap_reason set."""
+    from cw.reconcile import ProposedAction, ReapCandidate, _act_on_idle_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+
+    sess = _mk_live_idle_daemon_session(
+        "idle-park-evt-1", "live-ref", started_at, idle_observation_count=1
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    task = TicketTask(
+        ticket_id="idle-park-evt-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="idle-park-evt-1",
+        attempts=99,
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    candidate = ReapCandidate(
+        session_id="idle-park-evt-1",
+        proposed_action=ProposedAction.PARK_BLOCKED_ON_USER,
+        ticket_id="idle-park-evt-1",
+        new_observation_count=2,
+    )
+
+    _act_on_idle_candidates(state, [candidate], now=now)
+
+    assert sess.reap_reason == ReapReason.RETRY_CAP_PARKED
+
+    events = read_events(
+        consumer="test-idle-park-evt-1",
+        event_types=[OrchestratorEventType.SESSION_NEEDS_ATTENTION],
+    )
+    assert len(events) == 1
+    assert events[0].payload["paused_status"] == _SILENTLY_IDLE_REASON
+
+
+def test_act_on_idle_revert_task_routes_pending_emits_timed_out(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REVERT_TASK → queue PENDING + SESSION_TIMED_OUT + daemon stopped."""
+    from cw.reconcile import ProposedAction, ReapCandidate, _act_on_idle_candidates
+
+    monkeypatch.setattr(
+        "cw.reconcile.get_native_daemon_client",
+        FakeNativeDaemonClient,
+    )
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+
+    sess = _mk_live_idle_daemon_session(
+        "idle-revert-evt-1", "live-ref", started_at, idle_observation_count=3
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    task = TicketTask(
+        ticket_id="idle-revert-evt-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="idle-revert-evt-1",
+        attempts=1,
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    candidate = ReapCandidate(
+        session_id="idle-revert-evt-1",
+        proposed_action=ProposedAction.REVERT_TASK,
+        ticket_id="idle-revert-evt-1",
+        elapsed_seconds=1500.0,
+        new_observation_count=4,
+        usage_limit_detected=False,
+    )
+
+    _act_on_idle_candidates(state, [candidate], now=now)
+
+    assert sess.status == SessionStatus.TIMED_OUT
+    assert sess.reap_reason == ReapReason.IDLE_STALL
+
+    store = load_dev_queue()
+    t = next(t for t in store.tasks if t.ticket_id == "idle-revert-evt-1")
+    assert t.status == QueueItemStatus.PENDING
+
+    events = read_events(
+        consumer="test-idle-revert-evt-1",
+        event_types=[OrchestratorEventType.SESSION_TIMED_OUT],
+    )
+    assert len(events) == 1
+    assert events[0].payload["cause"] == "idle_stall_recovered"
+
+
+def test_act_on_idle_revert_task_usage_limit_detected_sets_cause(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REVERT_TASK with usage_limit_detected=True → cause=usage_limit_cutoff."""
+    from cw.reconcile import ProposedAction, ReapCandidate, _act_on_idle_candidates
+
+    monkeypatch.setattr(
+        "cw.reconcile.get_native_daemon_client",
+        FakeNativeDaemonClient,
+    )
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+
+    sess = _mk_live_idle_daemon_session(
+        "idle-revert-usage-1", "live-ref", started_at, idle_observation_count=3
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+
+    candidate = ReapCandidate(
+        session_id="idle-revert-usage-1",
+        proposed_action=ProposedAction.REVERT_TASK,
+        ticket_id="idle-revert-usage-1",
+        elapsed_seconds=1500.0,
+        new_observation_count=4,
+        usage_limit_detected=True,
+    )
+
+    _act_on_idle_candidates(state, [candidate], now=now)
+
+    assert sess.reap_reason == ReapReason.USAGE_LIMIT_CUTOFF
+
+    events = read_events(
+        consumer="test-idle-revert-usage-1",
+        event_types=[OrchestratorEventType.SESSION_TIMED_OUT],
+    )
+    assert len(events) == 1
+    assert events[0].payload["cause"] == "usage_limit_cutoff"
+
+
+def test_act_on_phantom_salvage_completion_routes_queue_and_emits_event(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SALVAGE_COMPLETION phantom → session COMPLETED, queue COMPLETED, event."""
+    from cw.auto_dev_result import AutoDevResult
+    from cw.reconcile import ProposedAction, ReapCandidate, _act_on_phantom_candidates
+
+    monkeypatch.setattr(
+        "cw.reconcile.get_native_daemon_client",
+        FakeNativeDaemonClient,
+    )
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 0, 0, tzinfo=UTC)
+
+    sess = _mk_phantom_daemon_session("phantom-salv-act-1", started_at)
+    state = CwState(sessions=[sess])
+    save_state(state)
+    task = TicketTask(
+        ticket_id="phantom-salv-act-1",
+        client="client-a",
+        status=QueueItemStatus.RUNNING,
+        session_id="phantom-salv-act-1",
+    )
+    save_dev_queue(DevQueueStore(tasks=[task]))
+
+    payload = _shipped_salvage_payload()
+    payload["ticket_id"] = "phantom-salv-act-1"
+    result = AutoDevResult.model_validate(payload)
+    candidate = ReapCandidate(
+        session_id="phantom-salv-act-1",
+        proposed_action=ProposedAction.SALVAGE_COMPLETION,
+        ticket_id="phantom-salv-act-1",
+        salvage_result=result,
+        salvage_csid="csid-phantom-salv",
+        client="client-a",
+        worktree_path=None,
+    )
+
+    _, _, _, salvaged_ids, _ = _act_on_phantom_candidates(state, [candidate], now=now)
+
+    assert sess.status == SessionStatus.COMPLETED
+    assert "phantom-salv-act-1" in salvaged_ids
+
+    store = load_dev_queue()
+    t = next(t for t in store.tasks if t.ticket_id == "phantom-salv-act-1")
+    assert t.status == QueueItemStatus.COMPLETED
+
+    events = read_events(
+        consumer="test-phantom-salv-act-1",
+        event_types=[OrchestratorEventType.SESSION_COMPLETED],
+    )
+    assert len(events) == 1
+    assert events[0].payload["salvaged"] is True
+    assert events[0].payload["crashed"] is False
+
+
+def test_detect_stalled_needs_salvage_reason_skip_parked(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """session.last_result with _NEEDS_SALVAGE_REASON → SKIP_PARKED candidate."""
+    from cw.reconcile import ProposedAction, _detect_stalled_candidates
+
+    worktree = tmp_path / "wt-needs-salvage"
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+    sess = _mk_headless_daemon_session("needs-salvage-1", worktree, started_at)
+    sess.last_result = {"paused_status": _NEEDS_SALVAGE_REASON}
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+    snap = _state_queue_snapshot()
+
+    candidates = _detect_stalled_candidates(
+        state,
+        now=now,
+        config=OrchestratorConfig(),
+        task_by_ticket={},
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].proposed_action == ProposedAction.SKIP_PARKED
+    assert candidates[0].paused_status == _NEEDS_SALVAGE_REASON
+    assert _state_queue_snapshot() == snap
+
+
+def test_act_on_idle_salvage_git_persists_observation_counter(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """SALVAGE_GIT candidate → idle_observation_count persisted to disk."""
+    from cw.reconcile import ProposedAction, ReapCandidate, _act_on_idle_candidates
+
+    started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+    wt = tmp_path / "wt-git-salv"
+
+    sess = _mk_live_idle_daemon_session(
+        "idle-salv-git-ctr-1",
+        "live-ref",
+        started_at,
+        idle_observation_count=2,
+        worktree_path=wt,
+    )
+    state = CwState(sessions=[sess])
+    save_state(state)
+    save_dev_queue(DevQueueStore(tasks=[]))
+
+    candidate = ReapCandidate(
+        session_id="idle-salv-git-ctr-1",
+        proposed_action=ProposedAction.SALVAGE_GIT,
+        ticket_id="idle-salv-git-ctr-1",
+        branch="auto-dev/idle-salv-git-ctr-1",
+        worktree_path_str=str(wt),
+        post_review_clean=False,
+        new_observation_count=3,
+    )
+
+    _act_on_idle_candidates(state, [candidate], now=now)
+
+    # Counter must be written to disk by act — process restart resilience.
+    reloaded = load_state()
+    s = next(s for s in reloaded.sessions if s.id == "idle-salv-git-ctr-1")
+    assert s.idle_observation_count == 3


### PR DESCRIPTION
Closes #552. Wave 1 / reap-gating thread, per ADR-0006 (`docs/adr/0006-reaping-is-gated-by-an-authority.md`) and the Pre-flight Resolutions on the ticket.

- Detect phase: pure classification returning typed `ReapCandidate`s (`ProposedAction` enum, `worktree_dirty` flag via the existing pure predicates) — zero writes; purity pinned by unit tests.
- Act phase: single `_act_on_*` dispatcher path is the only caller of the mutation helpers; runs in-lock with in-place `save_state` per ADR-0006 invariant 2 (no `mutate_state` under the held lock — #563 lesson).
- `reconcile()` keeps its public contract (detect → act in sequence); existing integration tests pass unchanged. No `reap_policy`, no events, no dispatch.py — those are #554/#555.

Worker sentinel: `review_pending_approval` — 4 MUST_FIX found and resolved in one fix cycle; gates all green (pytest 96.01% total / 97% diff, mypy --strict, ruff, pre-commit, integration). Operator reviewed and approved.

Remaining SHOULD_FIX (non-blocking, deliberately deferred): the triplicated queue-mutation loop across the three act functions will be deduplicated by #554 when it inserts the `reap_policy` gate at the dispatcher (same lines); function-length/definition-order/magic-string nits ride along there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)