### PR TITLE
feat(status): surface ci_status + mergeable in MonitoredPR and status output

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -2131,11 +2131,13 @@ def _format_status_human(status: OrchestratorStatus) -> str:
         lines.append(line)
 
     lines.extend(("", f"Monitored PRs:     {len(status.monitored_prs)}"))
-    lines.extend(
-        f"  - {pr.repo}#{pr.pr_number}  role={pr.role}  status={pr.status}"
-        f"  unresolved={pr.unresolved_threads}"
-        for pr in status.monitored_prs
-    )
+    for pr in status.monitored_prs:
+        ci = pr.ci_status if pr.ci_status is not None else "(none)"
+        mg = str(pr.mergeable) if pr.mergeable is not None else "(none)"
+        lines.append(
+            f"  - {pr.repo}#{pr.pr_number}  role={pr.role}  status={pr.status}"
+            f"  unresolved={pr.unresolved_threads}  ci={ci}  mergeable={mg}"
+        )
 
     lines.extend(("", f"Recent events:     {len(status.recent_events)}"))
     lines.extend(

--- a/src/cw/orchestrate.py
+++ b/src/cw/orchestrate.py
@@ -334,6 +334,8 @@ class MonitoredPR(BaseModel):
     role: str
     status: str
     unresolved_threads: int
+    ci_status: str | None = None  # GH check rollup: pending, success, failure, error, action_required, expected, stale
+    mergeable: bool | None = None
 
 
 class SessionSummary(BaseModel):
@@ -524,6 +526,8 @@ def _load_monitored_prs() -> list[MonitoredPR]:
                     role=str(pr_data.get("role", "author")),
                     status=str(pr_data.get("status", "watching")),
                     unresolved_threads=_count_unresolved(thread_status),
+                    ci_status=pr_data.get("ci_status"),
+                    mergeable=pr_data.get("mergeable"),
                 )
             )
     return monitored

--- a/src/cw/orchestrate.py
+++ b/src/cw/orchestrate.py
@@ -334,7 +334,8 @@ class MonitoredPR(BaseModel):
     role: str
     status: str
     unresolved_threads: int
-    ci_status: str | None = None  # GH check rollup: pending, success, failure, error, action_required, expected, stale
+    # GH check rollup: pending, success, failure, error, action_required, stale
+    ci_status: str | None = None
     mergeable: bool | None = None
 
 

--- a/src/cw/tui.py
+++ b/src/cw/tui.py
@@ -169,6 +169,7 @@ def _tickets_table(
 
 
 def _prs_table(prs: list[MonitoredPR], *, level: DetailLevel) -> RenderableType:
+    # Why: ci_status/mergeable surfaced in plain-text path only; TUI deferred
     """Render a table of monitored PRs for one client."""
     if not prs:
         return Text("  (no monitored PRs)", style="dim")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5036,6 +5036,53 @@ class TestFormatStatusHuman:
         output = _format_status_human(status)
         assert "role=author" in output
 
+    def test_format_status_human_pr_renders_ci_and_mergeable_populated(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """_format_status_human includes ci_status and mergeable when populated."""
+        from cw.cli import _format_status_human
+        from cw.orchestrate import MonitoredPR, OrchestratorStatus
+
+        pr = MonitoredPR(
+            repo="owner/repo",
+            pr_number=7,
+            role="author",
+            status="watching",
+            unresolved_threads=0,
+            ci_status="success",
+            mergeable=True,
+        )
+        status = OrchestratorStatus(
+            generated_at=datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC),
+            monitored_prs=[pr],
+        )
+        output = _format_status_human(status)
+        assert "ci=success" in output
+        assert "mergeable=True" in output
+
+    def test_format_status_human_pr_ci_none_renders_as_placeholder(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """_format_status_human renders (none) for None ci_status and mergeable."""
+        from cw.cli import _format_status_human
+        from cw.orchestrate import MonitoredPR, OrchestratorStatus
+
+        pr = MonitoredPR(
+            repo="owner/repo",
+            pr_number=8,
+            role="author",
+            status="watching",
+            unresolved_threads=0,
+            # ci_status and mergeable default to None
+        )
+        status = OrchestratorStatus(
+            generated_at=datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC),
+            monitored_prs=[pr],
+        )
+        output = _format_status_human(status)
+        assert "ci=(none)" in output
+        assert "mergeable=(none)" in output
+
 
 class TestDevQueueStatusWithTick:
     def test_dev_queue_status_shows_last_tick(

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -628,7 +628,7 @@ class TestOrchestratorStatus:
     def test_monitored_pr_ci_status_and_mergeable_none_when_absent(
         self, tmp_orchestrate_dirs: Path
     ) -> None:
-        """When ci_status/mergeable absent from monitor file, fields are None (backward compat)."""
+        """When ci_status/mergeable absent from monitor file, fields are None."""
         review_dir = tmp_orchestrate_dirs / "review-monitor"
         _write_monitor_file(review_dir, "owner/repo", 42)  # no new kwargs
         snapshot = orchestrator_status()
@@ -654,7 +654,8 @@ class TestOrchestratorStatus:
     ) -> None:
         """The snapshot round-trips through JSON cleanly."""
         review_dir = tmp_orchestrate_dirs / "review-monitor"
-        _write_monitor_file(review_dir, "owner/repo", 42)  # ci_status/mergeable absent → None
+        # ci_status/mergeable absent → None (backward compat)
+        _write_monitor_file(review_dir, "owner/repo", 42)
         save_state(CwState(sessions=[_make_session("s1", workspace)]))
         snapshot = orchestrator_status()
         as_json = snapshot.model_dump_json()
@@ -666,7 +667,8 @@ class TestOrchestratorStatus:
         assert "monitored_prs" in parsed
         assert len(parsed["monitored_prs"]) == 1
         pr_json = parsed["monitored_prs"][0]
-        assert pr_json["ci_status"] is None  # null guard: must serialize to null, not be excluded
+        # null guard: must serialize to null, not be excluded
+        assert pr_json["ci_status"] is None
         assert pr_json["mergeable"] is None
 
 

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -144,9 +144,11 @@ def _write_monitor_file(
     status: str = "watching",
     role: str = "author",
     thread_status: dict[str, dict[str, bool]] | None = None,
+    ci_status: str | None = None,
+    mergeable: bool | None = None,
 ) -> Path:
     pr_key = f"{repo}#{pr_number}"
-    pr_data = {
+    pr_data: dict[str, object] = {
         "role": role,
         "repo": repo,
         "repo_path": "/tmp/some-repo",
@@ -155,6 +157,10 @@ def _write_monitor_file(
         "thread_status": thread_status or {},
         "delta_findings": [],
     }
+    if ci_status is not None:
+        pr_data["ci_status"] = ci_status
+    if mergeable is not None:
+        pr_data["mergeable"] = mergeable
     payload = {"monitored": {pr_key: pr_data}, "completed": {}}
     filename = repo.replace("/", "--") + ".json"
     path = review_monitor_dir / filename
@@ -605,12 +611,50 @@ class TestOrchestratorStatus:
         assert len(snapshot.monitored_prs) == 1
         assert snapshot.monitored_prs[0].pr_number == 99
 
+    def test_monitored_pr_ci_status_and_mergeable_populated(
+        self, tmp_orchestrate_dirs: Path
+    ) -> None:
+        """ci_status and mergeable are read from the monitor file when present."""
+        review_dir = tmp_orchestrate_dirs / "review-monitor"
+        _write_monitor_file(
+            review_dir, "owner/repo", 42, ci_status="success", mergeable=True
+        )
+        snapshot = orchestrator_status()
+        assert len(snapshot.monitored_prs) == 1
+        pr = snapshot.monitored_prs[0]
+        assert pr.ci_status == "success"
+        assert pr.mergeable is True
+
+    def test_monitored_pr_ci_status_and_mergeable_none_when_absent(
+        self, tmp_orchestrate_dirs: Path
+    ) -> None:
+        """When ci_status/mergeable absent from monitor file, fields are None (backward compat)."""
+        review_dir = tmp_orchestrate_dirs / "review-monitor"
+        _write_monitor_file(review_dir, "owner/repo", 42)  # no new kwargs
+        snapshot = orchestrator_status()
+        pr = snapshot.monitored_prs[0]
+        assert pr.ci_status is None
+        assert pr.mergeable is None
+
+    def test_monitored_pr_mergeable_false_preserved(
+        self, tmp_orchestrate_dirs: Path
+    ) -> None:
+        """mergeable=False is preserved (not coerced to None by or-None patterns)."""
+        review_dir = tmp_orchestrate_dirs / "review-monitor"
+        _write_monitor_file(review_dir, "owner/repo", 42, mergeable=False)
+        snapshot = orchestrator_status()
+        pr = snapshot.monitored_prs[0]
+        assert pr.mergeable is False
+        assert pr.ci_status is None
+
     def test_serialises_to_json(
         self,
         tmp_orchestrate_dirs: Path,
         workspace: Path,
     ) -> None:
         """The snapshot round-trips through JSON cleanly."""
+        review_dir = tmp_orchestrate_dirs / "review-monitor"
+        _write_monitor_file(review_dir, "owner/repo", 42)  # ci_status/mergeable absent → None
         save_state(CwState(sessions=[_make_session("s1", workspace)]))
         snapshot = orchestrator_status()
         as_json = snapshot.model_dump_json()
@@ -619,6 +663,11 @@ class TestOrchestratorStatus:
         assert "generated_at" in parsed
         assert "running_sessions" in parsed
         assert parsed["running_sessions"][0]["id"] == "s1"
+        assert "monitored_prs" in parsed
+        assert len(parsed["monitored_prs"]) == 1
+        pr_json = parsed["monitored_prs"][0]
+        assert pr_json["ci_status"] is None  # null guard: must serialize to null, not be excluded
+        assert pr_json["mergeable"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `ci_status: str | None` and `mergeable: bool | None` to `MonitoredPR` Pydantic model (`orchestrate.py`) with backward-compat `None` defaults
- Update `_load_monitored_prs` to read both fields from the monitor JSON file (absent keys → `None`, no crash)
- Render both fields in `_format_status_human` (`cli.py`) using `(none)` placeholder when `None`
- Add `# Why:` comment to `tui.py._prs_table` noting TUI display is deferred (out of scope for this ticket)

Producer changes (`review_monitor.py`) deferred — this PR is consumer-only per the ticket split.

Closes #476

## Test plan

- [ ] `test_monitored_pr_ci_status_and_mergeable_populated` — fields read when present
- [ ] `test_monitored_pr_ci_status_and_mergeable_none_when_absent` — `None` when keys absent (backward compat)
- [ ] `test_monitored_pr_mergeable_false_preserved` — `False` not coerced to `None`
- [ ] `test_format_status_human_pr_renders_ci_and_mergeable_populated` — rendered in output
- [ ] `test_format_status_human_pr_ci_none_renders_as_placeholder` — `(none)` placeholder shown
- [ ] `test_serialises_to_json` extended — new fields serialize to `null`, not excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)