### PR TITLE
docs(reconcile): doc inversion — reaping is gated, not automatic (#556)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ cw list
 - **Keystroke injection**: `cw bg` injects `/session-done` into active Claude sessions. Fragile but zero-coupling to Claude Code internals.
 - **Flat JSON state**: Simple, human-readable. Single-user tool.
 - **Native daemon backend**: Workers are spawned via `claude --bg` and tracked by short hex session id in `~/.claude/daemon/roster.json`. No multiplexer required.
-- **On-demand reconciliation**: `cw status`, `cw list`, `cw start`, and each `dispatch_tick` call `reconcile()` to detect phantoms — sessions in state but no longer in the daemon roster — and reap them (DAEMON-origin tickets revert RUNNING → PENDING for retry). Explicit force via `cw doctor --reap`. No background daemon needed.
+- **On-demand reconciliation**: `cw status`, `cw list`, `cw start`, and each `dispatch_tick` call `reconcile()` to detect phantoms (sessions in state but absent from the daemon roster). By default (`reap_policy: signal_only`, per ADR-0006) detection emits `SESSION_REAP_PROPOSED` and routes the task to `BLOCKED_ON_USER` — no destructive mutation. Destructive act (RUNNING→PENDING revert, daemon stop, worktree removal) requires `reap_policy: auto` for the lane, or an explicit `cw doctor --reap`. No background daemon needed.
 - **File-based locking**: Prevents concurrent state corruption from parallel session operations.
 - **Event history**: Audit trail for session lifecycle transitions.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,7 @@ Core workflow: start → work → background → switch client → resume.
 - ✓ Shared state directory per client: `~/.local/share/cw/clients/<name>/` with session summaries
 - ✓ `cw handoff impl→review` - impl generates a handoff, review auto-resumes with that context on the same branch
 - ✗ Session event hooks: "when impl backgrounds, notify review" — hook script generation works, but no active execution/routing
-- ✓ Health monitoring: phantom-session reconciliation (0.6.2) detects dead/crashed Claude panes via `MultiplexerAdapter.list_surfaces`, reaps them from `sessions.json`, and reverts their dev-queue tickets to PENDING. Runs on `cw status`, `cw list`, `cw start`, every `dispatch_tick`, and on demand via `cw doctor --reap`.
+- ✓ Health monitoring: phantom-session reconciliation detects dead/crashed daemon sessions by comparing `sessions.json` against the live `claude agents` roster. By default (`signal_only`, ADR-0006) detection emits `SESSION_REAP_PROPOSED` without auto-reaping; explicit reap requires `cw doctor --reap` or `reap_policy: auto`. Runs on `cw status`, `cw list`, `cw start`, every `dispatch_tick`.
 - ✓ `cw plan <client>` - show active plan progress across all sessions for a client — parser works, not yet integrated into TUI
 
 ---

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -7,7 +7,8 @@ phases that run under ``sessions_lock`` (see ADR-0005):
 **Detect phase** — pure classification, no state writes.
 Three sweeps (stalled, idle/phantom, post-salvage) each call a
 ``_detect_*`` helper that returns :class:`ReapCandidate` objects.  After
-each sweep ``_emit_reap_proposed`` fires :attr:`OrchestratorEventType.SESSION_REAP_PROPOSED`
+each sweep ``_emit_reap_proposed`` fires
+:attr:`OrchestratorEventType.SESSION_REAP_PROPOSED`
 for every candidate whose :attr:`Session.reap_proposed_at` is ``None``,
 stamping that field to deduplicate across ticks.
 

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -12,9 +12,9 @@ each sweep ``_emit_reap_proposed`` fires
 for every candidate whose :attr:`Session.reap_proposed_at` is ``None``,
 stamping that field to deduplicate across ticks.
 
-# Why: emitting before the act phase keeps the event visible even when the
-# act phase is suppressed by ``signal_only`` policy — consumers (the lane's
-# ORCHESTRATE session or the operator) see the proposal and decide.
+Emitting before the act phase keeps the event visible even when the act
+phase is suppressed by ``signal_only`` — consumers (the lane's ORCHESTRATE
+session or the operator) see the proposal and decide.
 
 **Act phase** — gated by ``reap_policy`` (ADR-0006).
 Under the default ``signal_only`` policy the act phase routes the owning
@@ -23,9 +23,11 @@ mutation (no daemon stop, no worktree removal, no RUNNING→PENDING revert).
 Destructive acts require either ``reap_policy: auto`` on the session's lane
 *or* an explicit operator command (``cw doctor --reap``).
 
-All state mutations inside the act phase go through ``mutate_state()``
-(ADR-0005) so concurrent Stop-hook writes are serialised against the
-reconcile tick.
+Lock note: act-phase helpers call ``save_state()`` directly — not
+``mutate_state()`` (ADR-0005) — because ``_reconcile_locked()`` already
+holds ``sessions_lock`` and re-acquiring the same per-open-fd flock would
+self-deadlock (#387).  Serialisation against concurrent Stop-hook writes
+is enforced by the held lock.
 
 Transient-outage guard: ``reconcile`` skips the act phase entirely when
 ``claude agents --json`` fails or returns an empty roster while

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -1,30 +1,41 @@
 """Reconcile cw session state with the native Claude daemon.
 
 A cw session is "live" if its ``surface_ref`` appears in the roster
-returned by ``claude agents --json``. :func:`compute_drift` checks the
-live set and returns a :class:`ReconcileReport` naming sessions whose
-``surface_ref`` is absent. :func:`reconcile` applies the report.
+returned by ``claude agents --json``.  ``reconcile()`` is split into two
+phases that run under ``sessions_lock`` (see ADR-0005):
 
-The split is deliberate: ``compute_drift`` is pure and testable in
-isolation; ``reconcile`` does the side-effecting work (state mutation,
-event emission, dev-queue revert).
+**Detect phase** — pure classification, no state writes.
+Three sweeps (stalled, idle/phantom, post-salvage) each call a
+``_detect_*`` helper that returns :class:`ReapCandidate` objects.  After
+each sweep ``_emit_reap_proposed`` fires :attr:`OrchestratorEventType.SESSION_REAP_PROPOSED`
+for every candidate whose :attr:`Session.reap_proposed_at` is ``None``,
+stamping that field to deduplicate across ticks.
 
-Transient-outage safety: ``reconcile`` refuses to mutate state when the
-daemon cannot be reached (``_claude_agents_json`` raises
-``CalledProcessError``) or returns an empty roster while the persisted
-state still contains ACTIVE/IDLE sessions with surface refs. A transient
-daemon hiccup would otherwise irreversibly mark every session as CRASHED.
-``compute_drift`` stays pure and does not apply this guard.
+# Why: emitting before the act phase keeps the event visible even when the
+# act phase is suppressed by ``signal_only`` policy — consumers (the lane's
+# ORCHESTRATE session or the operator) see the proposal and decide.
 
-Lock note: ``reconcile`` acquires ``sessions_lock`` (config.py) across its
-entire load_state → mutate → save_state sequence.  The helpers called from
-within the lock (``revert_stalled_headless_sessions``,
-``flag_silently_idle_daemon_sessions``, ``revert_timed_out_tasks``,
-``revert_completed_silent_tasks``) save_state directly without
-re-acquiring; callers of those helpers must hold the lock themselves if
-called outside ``reconcile``.
+**Act phase** — gated by ``reap_policy`` (ADR-0006).
+Under the default ``signal_only`` policy the act phase routes the owning
+:class:`TicketTask` to ``BLOCKED_ON_USER`` but performs no destructive
+mutation (no daemon stop, no worktree removal, no RUNNING→PENDING revert).
+Destructive acts require either ``reap_policy: auto`` on the session's lane
+*or* an explicit operator command (``cw doctor --reap``).
 
-See ADR-0006 for the detect/act phase invariant.
+All state mutations inside the act phase go through ``mutate_state()``
+(ADR-0005) so concurrent Stop-hook writes are serialised against the
+reconcile tick.
+
+Transient-outage guard: ``reconcile`` skips the act phase entirely when
+``claude agents --json`` fails or returns an empty roster while
+ACTIVE/IDLE sessions with surface refs exist — a hiccup must not mass-reap.
+
+``_reconcile_locked()`` runs the above sequence while ``sessions_lock``
+is held; helper functions called from within it (``revert_stalled_*``,
+``flag_silently_idle_*``) ``save_state`` directly without re-acquiring.
+
+See ADR-0005 (single state lock) and ADR-0006 (reaping is gated by an
+authority) for the invariants this module enforces.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- fix(reconcile): correct docstring — act phase uses save_state not mutate_state; prose not comment in docstring
- fix(reconcile): wrap long docstring line for E501
- docs(reconcile): rewrite module docstring for detect/act split + reap_policy gate
- docs(roadmap): update v3 phantom-reconciliation bullet for native daemon + reap gating
- docs(claude-md): rewrite on-demand reconciliation bullet for reap gating

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

Closes #556

🤖 Shipped via /prep-pr + project /ship-it