### PR TITLE
feat(dev_queue): add lanes field — RFC 0004 Phase 1

### DIFF
--- a/config/CONFIG_REFERENCE.md
+++ b/config/CONFIG_REFERENCE.md
@@ -49,6 +49,7 @@ State is stored at `~/.local/share/cw/` (or `$XDG_DATA_HOME/cw/`).
 | `worker_model` | string \| null | `null` | Pin the model for DAEMON-origin worker spawns (auto-dev). Forwarded as `--model <id>` to `claude --bg` from both initial spawn and DAEMON-origin resume. USER-origin sessions (interactive `cw start` / `cw resume`) always inherit the operator's logged-in default model. Opaque string — no validation. |
 | `repo_path` | path | *none** | Shared repo path (worktree mode) |
 | `branch` | string | *none** | Branch name (worktree mode) |
+| `lanes` | list[LaneConfig] | `[]` | Named dispatch lanes. Phase 1 (data model only); dispatch wiring in #558. Each lane has `name` (required), `max_parallel: int = 1`, `priority: int = 0`, `paused: bool = false`, `description: str = ""`, `reap_policy: str = "signal_only"`. |
 
 \* Either `workspace_path` OR both `repo_path` + `branch` must be set.
 

--- a/src/cw/dev_queue.py
+++ b/src/cw/dev_queue.py
@@ -19,6 +19,7 @@ from cw.config import (
 )
 from cw.exceptions import CwError
 from cw.models import (
+    DEFAULT_LANE,
     DEV_QUEUE_SCHEMA_VERSION,
     DevQueueStore,
     DispatchPlan,
@@ -114,6 +115,12 @@ def _fill_task_cost_default(task_raw: dict[str, Any]) -> None:
         task_raw["total_cost_usd"] = None
 
 
+def _fill_lane_default(task_raw: dict[str, Any]) -> None:
+    """Fill lane introduced in dev-queue schema v3."""
+    if "lane" not in task_raw:
+        task_raw["lane"] = DEFAULT_LANE
+
+
 def migrate_dev_queue(raw: dict[str, Any]) -> dict[str, Any]:
     """Normalise a raw dev_queue.json payload into a currently-valid shape."""
     tasks = raw.get("tasks")
@@ -121,6 +128,7 @@ def migrate_dev_queue(raw: dict[str, Any]) -> dict[str, Any]:
         for task_raw in tasks:
             if isinstance(task_raw, dict):
                 _fill_task_cost_default(task_raw)
+                _fill_lane_default(task_raw)
     raw["schema_version"] = DEV_QUEUE_SCHEMA_VERSION
     return raw
 

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class SessionPurpose(StrEnum):
@@ -75,7 +75,9 @@ class ReapReason(StrEnum):
 # v7: added Session.reap_reason (GitHub #380).
 # v8: added Session.reap_proposed_at (GitHub #555).
 CW_STATE_SCHEMA_VERSION = 8
-DEV_QUEUE_SCHEMA_VERSION = 2
+# v3: added TicketTask.lane (GitHub #557).
+DEV_QUEUE_SCHEMA_VERSION = 3
+DEFAULT_LANE: str = "default"
 
 
 class TaskSpec(BaseModel):
@@ -220,6 +222,9 @@ class TicketTask(BaseModel):
     # AutoDevResult sentinel without rediscovering it at runtime (#314).
     # Always None today; populated by a future dev-queue plan command.
     plan_source: str | None = None
+    # Lane this ticket is assigned to. Defaults to DEFAULT_LANE; set by
+    # orchestrate/dispatch in Phase 2 (#558).
+    lane: str = DEFAULT_LANE
 
 
 class DispatchPlan(BaseModel):
@@ -261,6 +266,29 @@ class ReapPolicy(StrEnum):
 
     SIGNAL_ONLY = "signal_only"
     AUTO = "auto"
+
+
+class LaneConfig(BaseModel):
+    """Configuration for a named dispatch lane.
+
+    Lanes provide a scheduling boundary for TicketTasks.
+    Phase 1 (data model only): no dispatch wiring yet — see #558.
+    """
+
+    name: str
+    max_parallel: int = 1
+    priority: int = 0
+    paused: bool = False
+    description: str = ""
+    reap_policy: ReapPolicy = ReapPolicy.SIGNAL_ONLY
+
+    @field_validator("name")
+    @classmethod
+    def _name_nonempty(cls, v: str) -> str:
+        if not v:
+            msg = "lane name must be non-empty"
+            raise ValueError(msg)
+        return v
 
 
 _USAGE_LIMIT_BACKOFF_SECONDS = 3600
@@ -455,6 +483,14 @@ class ClientConfig(BaseModel):
     worker_model: str | None = None
     auto_background_threshold: int | None = None
     notifications: bool = False
+    lanes: list[LaneConfig] = Field(default_factory=list)
+
+    @property
+    def effective_lanes(self) -> list[LaneConfig]:
+        """Return declared lanes; synthesize a default lane when none are declared."""
+        if self.lanes:
+            return list(self.lanes)
+        return [LaneConfig(name=DEFAULT_LANE)]
 
     @model_validator(mode="after")
     def _validate_path_config(self) -> ClientConfig:

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -13,6 +13,7 @@ from cw.cli import main
 from cw.config import load_orchestrator_config
 from cw.dev_queue import (
     _find_ticket,
+    _lock,
     add_ticket,
     cancel_task_for_session,
     cancel_ticket,
@@ -1136,6 +1137,92 @@ class TestMigrateDevQueue:
         raw: dict[str, object] = {"schema_version": 1}
         migrated = migrate_dev_queue(raw)
         assert migrated["schema_version"] == DEV_QUEUE_SCHEMA_VERSION
+
+    def test_v2_to_v3_fills_lane_default(self) -> None:
+        """migrate_dev_queue fills lane on tasks missing it."""
+        raw: dict[str, object] = {
+            "schema_version": 2,
+            "tasks": [
+                {
+                    "ticket_id": "GEN-10",
+                    "client": "test-client",
+                    "priority": 0,
+                    "status": "pending",
+                    "total_cost_usd": None,
+                }
+            ],
+        }
+        migrated = migrate_dev_queue(raw)
+        assert migrated["tasks"][0]["lane"] == "default"  # type: ignore[index]
+        assert migrated["schema_version"] == DEV_QUEUE_SCHEMA_VERSION
+
+    def test_v3_lane_preserved_idempotently(self) -> None:
+        """Existing lane values survive a second migration pass."""
+        raw: dict[str, object] = {
+            "schema_version": 3,
+            "tasks": [
+                {
+                    "ticket_id": "GEN-11",
+                    "client": "test-client",
+                    "priority": 0,
+                    "status": "pending",
+                    "total_cost_usd": None,
+                    "lane": "custom-lane",
+                }
+            ],
+        }
+        migrated = migrate_dev_queue(raw)
+        assert migrated["tasks"][0]["lane"] == "custom-lane"  # type: ignore[index]
+
+    def test_load_dev_queue_migrates_v2_file_lane(self, tmp_config_dir: Path) -> None:
+        """load_dev_queue applies lane migration when loading a v2 file from disk."""
+        import json
+
+        from cw.config import dev_queue_file
+
+        v2_data = {
+            "schema_version": 2,
+            "tasks": [
+                {
+                    "ticket_id": "GEN-12",
+                    "client": "test-client",
+                    "priority": 0,
+                    "status": "pending",
+                }
+            ],
+        }
+        dev_queue_file().parent.mkdir(parents=True, exist_ok=True)
+        dev_queue_file().write_text(json.dumps(v2_data))
+        store = load_dev_queue()
+        assert store.tasks[0].lane == "default"
+        assert store.schema_version == DEV_QUEUE_SCHEMA_VERSION
+
+    def test_revert_to_pending_preserves_lane(self, tmp_config_dir: Path) -> None:
+        """Lane value is preserved when a RUNNING task is reverted to PENDING."""
+        task = TicketTask(
+            ticket_id="LANE-RT-1",
+            client="test-client",
+            lane="batch",
+            status=QueueItemStatus.RUNNING,
+        )
+        with _lock():
+            store = load_dev_queue()
+            store.tasks.append(task)
+            save_dev_queue(store)
+
+        # Simulate revert: mutate status in place (as _apply_queue_mutations does)
+        with _lock():
+            store = load_dev_queue()
+            for t in store.tasks:
+                if t.ticket_id == "LANE-RT-1":
+                    t.status = QueueItemStatus.PENDING
+            save_dev_queue(store)
+
+        # Reload and verify lane preserved
+        store = load_dev_queue()
+        reverted = next(t for t in store.tasks if t.ticket_id == "LANE-RT-1")
+        assert reverted.lane == "batch"
+        assert reverted.status == QueueItemStatus.PENDING
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -31,6 +31,7 @@ from cw.dev_queue import (
 )
 from cw.exceptions import CwError
 from cw.models import (
+    DEFAULT_LANE,
     DEV_QUEUE_SCHEMA_VERSION,
     DevQueueStore,
     DispatchPlan,
@@ -1153,7 +1154,7 @@ class TestMigrateDevQueue:
             ],
         }
         migrated = migrate_dev_queue(raw)
-        assert migrated["tasks"][0]["lane"] == "default"  # type: ignore[index]
+        assert migrated["tasks"][0]["lane"] == DEFAULT_LANE
         assert migrated["schema_version"] == DEV_QUEUE_SCHEMA_VERSION
 
     def test_v3_lane_preserved_idempotently(self) -> None:
@@ -1172,7 +1173,7 @@ class TestMigrateDevQueue:
             ],
         }
         migrated = migrate_dev_queue(raw)
-        assert migrated["tasks"][0]["lane"] == "custom-lane"  # type: ignore[index]
+        assert migrated["tasks"][0]["lane"] == "custom-lane"
 
     def test_load_dev_queue_migrates_v2_file_lane(self, tmp_config_dir: Path) -> None:
         """load_dev_queue applies lane migration when loading a v2 file from disk."""
@@ -1194,7 +1195,7 @@ class TestMigrateDevQueue:
         dev_queue_file().parent.mkdir(parents=True, exist_ok=True)
         dev_queue_file().write_text(json.dumps(v2_data))
         store = load_dev_queue()
-        assert store.tasks[0].lane == "default"
+        assert store.tasks[0].lane == DEFAULT_LANE
         assert store.schema_version == DEV_QUEUE_SCHEMA_VERSION
 
     def test_revert_to_pending_preserves_lane(self, tmp_config_dir: Path) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -671,9 +671,7 @@ class TestLaneConfig:
 
 
 class TestClientConfigEffectiveLanes:
-    def test_effective_lanes_empty_synthesizes_default(
-        self, tmp_path: object
-    ) -> None:
+    def test_effective_lanes_empty_synthesizes_default(self, tmp_path: object) -> None:
         """ClientConfig with no lanes returns synthesized default lane."""
         config = ClientConfig(name="test", workspace_path=Path("/dev/null"))
         lanes = config.effective_lanes

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,14 +10,17 @@ import pytest
 
 from cw.models import (
     DEFAULT_AUTO_PURPOSES,
+    DEFAULT_LANE,
     ClientConfig,
     CompletionReason,
     CwState,
     DevQueueStore,
+    LaneConfig,
     OrchestratorConfig,
     OrchestratorEvent,
     OrchestratorEventType,
     QueueItemStatus,
+    ReapPolicy,
     Session,
     SessionPurpose,
     SessionStatus,
@@ -634,3 +637,58 @@ class TestCostFields:
         dumped = task.model_dump(mode="json")
         restored = TicketTask.model_validate(dumped)
         assert restored.total_cost_usd == pytest.approx(3.14)
+
+
+class TestLaneConfig:
+    def test_default_fields(self) -> None:
+        """LaneConfig has correct defaults when instantiated with only name."""
+        lane = LaneConfig(name="default")
+        assert lane.max_parallel == 1
+        assert lane.priority == 0
+        assert lane.paused is False
+        assert lane.description == ""
+        assert lane.reap_policy == ReapPolicy.SIGNAL_ONLY
+
+    def test_reap_policy_uses_enum(self) -> None:
+        """reap_policy is a ReapPolicy instance, not raw str."""
+        lane = LaneConfig(name="fast")
+        assert isinstance(lane.reap_policy, ReapPolicy)
+        assert lane.reap_policy == ReapPolicy.SIGNAL_ONLY
+
+    def test_name_required(self) -> None:
+        """LaneConfig without name raises ValidationError."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            LaneConfig()  # type: ignore[call-arg]
+
+    def test_empty_name_raises(self) -> None:
+        """Empty lane name raises ValidationError."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            LaneConfig(name="")
+
+
+class TestClientConfigEffectiveLanes:
+    def test_effective_lanes_empty_synthesizes_default(
+        self, tmp_path: object
+    ) -> None:
+        """ClientConfig with no lanes returns synthesized default lane."""
+        config = ClientConfig(name="test", workspace_path=Path("/dev/null"))
+        lanes = config.effective_lanes
+        assert len(lanes) == 1
+        assert lanes[0].name == DEFAULT_LANE
+
+    def test_effective_lanes_explicit_list_passed_through(
+        self, tmp_path: object
+    ) -> None:
+        """ClientConfig with explicit lanes returns them unchanged."""
+        explicit = [LaneConfig(name="fast"), LaneConfig(name="slow")]
+        config = ClientConfig(
+            name="test", workspace_path=Path("/dev/null"), lanes=explicit
+        )
+        lanes = config.effective_lanes
+        assert len(lanes) == 2
+        assert lanes[0].name == "fast"
+        assert lanes[1].name == "slow"


### PR DESCRIPTION
## Summary

- feat(models): add DEFAULT_LANE, TicketTask.lane, LaneConfig, ClientConfig.lanes (RFC 0004 Phase 1)
- feat(dev_queue): add _fill_lane_default + bump schema v2→v3 (#557)
- test(models): add TestLaneConfig + TestClientConfigEffectiveLanes
- test(dev_queue): add lane migration v2→v3 + round-trip tests
- fix(tests): remove gratuitous type: ignore[index], use DEFAULT_LANE constant
- docs: add lanes field to CONFIG_REFERENCE.md

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

🤖 Shipped via /prep-pr + project /ship-it