### PR TITLE
feat(dispatch): two-tier lane-aware scheduler — RFC 0004 Phase 2 (#558)

### DIFF
--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -74,8 +74,9 @@ CLIENTS_LOCK = CONFIG_DIR / ".clients.yaml.lock"
 
 _DEFAULT_ORCHESTRATOR_YAML = """\
 tick_interval_seconds: 30
-default_max_parallel: 2
-per_client_max_parallel: {}
+default_ceiling: 2
+per_client_ceiling: {}
+# max_parallel_clients: null  # uncomment to cap how many clients dispatch per tick
 linear_prefix_map: {}
 reap_policy: signal_only  # default: signal only; set to auto to restore self-healing
 """

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from cw.models import (
+        ClientConfig,
         DevQueueStore,
         OrchestratorConfig,
         OrchestratorEvent,
@@ -139,6 +140,35 @@ def _claim_next_pending(
             save_dev_queue(store)
             return task
     return None
+
+
+def _lane_stats_for_client(
+    client: ClientConfig, queue_snapshot: DevQueueStore
+) -> dict[str, dict[str, int]]:
+    """Per-lane ``{claimed: 0, running, pending}`` counts for event payloads.
+
+    Why task-based running: RUNNING/BLOCKED_ON_USER tasks carry ``lane``;
+    sessions do not (``Session.lane`` is #560). BLOCKED_ON_USER occupies its
+    lane slot per ADR-0006, so it counts as running here.
+    """
+    stats: dict[str, dict[str, int]] = {}
+    for lane_cfg in client.effective_lanes:
+        running = sum(
+            1
+            for t in queue_snapshot.tasks
+            if t.client == client.name
+            and t.lane == lane_cfg.name
+            and t.status in (QueueItemStatus.RUNNING, QueueItemStatus.BLOCKED_ON_USER)
+        )
+        pending = sum(
+            1
+            for t in queue_snapshot.tasks
+            if t.client == client.name
+            and t.lane == lane_cfg.name
+            and t.status == QueueItemStatus.PENDING
+        )
+        stats[lane_cfg.name] = {"claimed": 0, "running": running, "pending": pending}
+    return stats
 
 
 def dispatch_tick(
@@ -240,29 +270,8 @@ def dispatch_tick(
                 for t in queue_snapshot.tasks
                 if t.client == client.name and t.status == QueueItemStatus.PENDING
             )
-            # Compute per-lane breakdown for the event payload (claimed=0 for all).
-            backoff_lane_stats: dict[str, dict[str, int]] = {}
-            for lane_cfg in client.effective_lanes:
-                lane_running = sum(
-                    1
-                    for t in queue_snapshot.tasks
-                    if t.client == client.name
-                    and t.lane == lane_cfg.name
-                    and t.status
-                    in (QueueItemStatus.RUNNING, QueueItemStatus.BLOCKED_ON_USER)
-                )
-                lane_pending = sum(
-                    1
-                    for t in queue_snapshot.tasks
-                    if t.client == client.name
-                    and t.lane == lane_cfg.name
-                    and t.status == QueueItemStatus.PENDING
-                )
-                backoff_lane_stats[lane_cfg.name] = {
-                    "claimed": 0,
-                    "running": lane_running,
-                    "pending": lane_pending,
-                }
+            # Per-lane breakdown for the event payload (claimed=0 for all).
+            backoff_lane_stats = _lane_stats_for_client(client, queue_snapshot)
             record_event(
                 OrchestratorEventType.DISPATCH_TICK,
                 {
@@ -385,10 +394,14 @@ def dispatch_tick(
                     "running": running_count,
                     "cap": cap,
                     "skip_reason": DispatchSkipReason.FRESHNESS_GATE,
+                    "lanes": _lane_stats_for_client(client, queue_snapshot),
                 },
             )
             continue
 
+        # Why: incremented only past the freshness gate — a stale/skipped
+        # client does not consume Tier-1 quota, so max_parallel_clients=N
+        # always grants N *dispatchable* clients per tick.
         dispatched_client_count += 1
         priority_ids = plan_order_by_client.get(client.name)
         client_spawned = 0
@@ -399,9 +412,9 @@ def dispatch_tick(
         # Build per-lane running count from tasks→sessions join.
         # Tasks in RUNNING or BLOCKED_ON_USER with an active session_id count
         # toward their lane's cap (ADR-0006: BLOCKED_ON_USER occupies the slot).
+        # Reuses the queue_snapshot taken above — nothing between the two
+        # points mutates the queue (auto-ff is git-only).
         running_by_lane: dict[str, int] = {}
-        with dev_queue_lock():
-            queue_snapshot = load_dev_queue()
         for qt in queue_snapshot.tasks:
             if qt.client != client.name:
                 continue

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -91,13 +91,14 @@ class DispatchTickResult:
 def _claim_next_pending(
     client_name: str,
     *,
+    lane: str,
     priority_ticket_ids: list[str] | None = None,
 ) -> TicketTask | None:
-    """Atomically claim the next PENDING task for a client.
+    """Atomically claim the next PENDING task for a client in a specific lane.
 
     Acquires the dev-queue file lock, loads the queue, marks the first
-    PENDING task for *client_name* as RUNNING, saves, and returns it.
-    Returns None if no pending task exists for the client.
+    PENDING task for *client_name* in *lane* as RUNNING, saves, and returns it.
+    Returns None if no pending task exists for the client in the lane.
 
     If *priority_ticket_ids* is provided, prefer claiming PENDING tasks in
     that order (only those whose ticket_id appears in the list).  Tasks not
@@ -114,6 +115,7 @@ def _claim_next_pending(
                     if (
                         task.client == client_name
                         and task.ticket_id == ticket_id
+                        and task.lane == lane
                         and task.status == QueueItemStatus.PENDING
                     ):
                         task.status = QueueItemStatus.RUNNING
@@ -124,7 +126,9 @@ def _claim_next_pending(
             [
                 t
                 for t in store.tasks
-                if t.client == client_name and t.status == QueueItemStatus.PENDING
+                if t.client == client_name
+                and t.lane == lane
+                and t.status == QueueItemStatus.PENDING
             ],
             key=lambda t: (-t.priority, t.created_at),
         )
@@ -228,9 +232,7 @@ def dispatch_tick(
                 and s.origin == SessionOrigin.DAEMON
                 and s.status in (SessionStatus.ACTIVE, SessionStatus.IDLE)
             )
-            cap = config.per_client_max_parallel.get(
-                client.name, config.default_max_parallel
-            )
+            cap = config.per_client_ceiling.get(client.name, config.default_ceiling)
             with dev_queue_lock():
                 queue_snapshot = load_dev_queue()
             pending_count = sum(
@@ -238,6 +240,29 @@ def dispatch_tick(
                 for t in queue_snapshot.tasks
                 if t.client == client.name and t.status == QueueItemStatus.PENDING
             )
+            # Compute per-lane breakdown for the event payload (claimed=0 for all).
+            backoff_lane_stats: dict[str, dict[str, int]] = {}
+            for lane_cfg in client.effective_lanes:
+                lane_running = sum(
+                    1
+                    for t in queue_snapshot.tasks
+                    if t.client == client.name
+                    and t.lane == lane_cfg.name
+                    and t.status
+                    in (QueueItemStatus.RUNNING, QueueItemStatus.BLOCKED_ON_USER)
+                )
+                lane_pending = sum(
+                    1
+                    for t in queue_snapshot.tasks
+                    if t.client == client.name
+                    and t.lane == lane_cfg.name
+                    and t.status == QueueItemStatus.PENDING
+                )
+                backoff_lane_stats[lane_cfg.name] = {
+                    "claimed": 0,
+                    "running": lane_running,
+                    "pending": lane_pending,
+                }
             record_event(
                 OrchestratorEventType.DISPATCH_TICK,
                 {
@@ -247,11 +272,20 @@ def dispatch_tick(
                     "running": running_count,
                     "cap": cap,
                     "skip_reason": DispatchSkipReason.USAGE_LIMITED,
+                    "lanes": backoff_lane_stats,
                 },
             )
         return DispatchTickResult(spawned=0, usage_limit_detected=False)
 
+    # Tier-1: optionally cap how many clients are eligible per tick.
+    # max_parallel_clients=None preserves the original behaviour (all clients).
+    dispatched_client_count = 0
     for client in clients.values():
+        if (
+            config.max_parallel_clients is not None
+            and dispatched_client_count >= config.max_parallel_clients
+        ):
+            break
         # --- Freshness gate ---
         # Check whether the client's local default branch is behind origin
         # before claiming any ticket.  Stale repos cause sessions to exit
@@ -282,9 +316,12 @@ def dispatch_tick(
             and s.status in (SessionStatus.ACTIVE, SessionStatus.IDLE)
         )
 
-        cap = config.per_client_max_parallel.get(
-            client.name, config.default_max_parallel
+        # Tier-2 ceiling: per-client slot budget across all lanes.
+        client_ceiling = config.per_client_ceiling.get(
+            client.name, config.default_ceiling
         )
+        # Keep legacy cap alias for freshness-gate and back-off event payloads.
+        cap = client_ceiling
 
         # Pre-claim pending count for dispatch.tick payload. Single lock
         # acquisition — reused for stale_tasks when stale=True (avoids a
@@ -352,192 +389,267 @@ def dispatch_tick(
             )
             continue
 
+        dispatched_client_count += 1
         priority_ids = plan_order_by_client.get(client.name)
         client_spawned = 0
-        cap_full = running_count >= cap
+        cap_full = running_count >= client_ceiling
         spawn_error = False
         usage_limit_detected = False
-        while running_count < cap:
-            task: TicketTask | None = _claim_next_pending(
-                client.name,
-                priority_ticket_ids=priority_ids,
-            )
-            if task is None:
+
+        # Build per-lane running count from tasks→sessions join.
+        # Tasks in RUNNING or BLOCKED_ON_USER with an active session_id count
+        # toward their lane's cap (ADR-0006: BLOCKED_ON_USER occupies the slot).
+        running_by_lane: dict[str, int] = {}
+        with dev_queue_lock():
+            queue_snapshot = load_dev_queue()
+        for qt in queue_snapshot.tasks:
+            if qt.client != client.name:
+                continue
+            if qt.status not in (
+                QueueItemStatus.RUNNING,
+                QueueItemStatus.BLOCKED_ON_USER,
+            ):
+                continue
+            lane_key = qt.lane
+            running_by_lane[lane_key] = running_by_lane.get(lane_key, 0) + 1
+
+        # Resolve effective lanes. For clients with no declared lanes, use the
+        # synthesized default lane but override its max_parallel with the client
+        # ceiling so backward-compat behaviour is preserved.
+        effective_lanes = client.effective_lanes
+        if not client.lanes:
+            effective_lanes = [
+                effective_lanes[0].model_copy(update={"max_parallel": client_ceiling})
+            ]
+
+        # Tier-1 client slot budget: use the session-based running_count (not
+        # the task-based total_running) so pre-existing DAEMON sessions without
+        # a corresponding task still occupy slots (backward compat). The per-
+        # lane running_by_lane counts govern per-lane grants within this budget.
+        available_client_slots = client_ceiling - running_count
+        lane_stats: dict[str, dict[str, int]] = {}
+
+        for lane_cfg in effective_lanes:
+            if available_client_slots <= 0:
                 break
+            if lane_cfg.paused:
+                continue
+            running_in_lane = running_by_lane.get(lane_cfg.name, 0)
+            pending_in_lane = sum(
+                1
+                for t in queue_snapshot.tasks
+                if t.client == client.name
+                and t.lane == lane_cfg.name
+                and t.status == QueueItemStatus.PENDING
+            )
+            grant = min(
+                lane_cfg.max_parallel - running_in_lane,
+                pending_in_lane,
+                available_client_slots,
+            )
+            lane_claimed = 0
+            for _ in range(max(0, grant)):
+                task: TicketTask | None = _claim_next_pending(
+                    client.name,
+                    lane=lane_cfg.name,
+                    priority_ticket_ids=priority_ids,
+                )
+                if task is None:
+                    break
 
-            try:
-                branch = f"{AUTO_DEV_LABEL_PREFIX}{task.ticket_id}"
-                # Create a real git worktree (idempotent — returns existing
-                # path if already created). Replaces a previous bug where
-                # dispatch made an empty directory and relied on
-                # ``claude -w`` to turn it into a worktree, which never
-                # worked because that flag takes a name rather than a path.
                 try:
-                    worktree_path = create_worktree(client, branch)
-                except StaleWorktreeError:
-                    # A stale worktree (wrong branch / not a worktree) refused
-                    # reuse (#404). No session exists yet, so reconcile's
-                    # TIMED_OUT cleanup will never fire for it — without
-                    # removing it here the task reverts to PENDING and re-hits
-                    # the same stale tree every tick (an infinite spin). Force-
-                    # remove it (best-effort) so the next claim rebuilds fresh,
-                    # then re-raise into the handler below to revert to PENDING.
-                    # Caught narrowly as StaleWorktreeError (not WorktreeError)
-                    # so the main-checkout guard never triggers a removal.
-                    #
-                    # Dirty-check guard (#425): if the stale tree contains
-                    # unsaved work, skip the removal and park the task as
-                    # BLOCKED_ON_USER instead of PENDING so the operator can
-                    # inspect. The outer except handler will not overwrite
-                    # BLOCKED_ON_USER (it checks status == RUNNING before
-                    # reverting).
-                    if worktree_has_unsaved_work(client, branch):
-                        _log.warning(
-                            "dispatch: stale worktree %s/%s has unsaved work"
-                            " — leaving for operator inspection; parking as"
-                            " BLOCKED_ON_USER",
-                            client.name,
-                            branch,
-                        )
-                        with dev_queue_lock():
-                            store = load_dev_queue()
-                            for stored_task in store.tasks:
-                                if (
-                                    stored_task.ticket_id == task.ticket_id
-                                    and stored_task.client == client.name
-                                    and stored_task.status == QueueItemStatus.RUNNING
-                                ):
-                                    stored_task.status = QueueItemStatus.BLOCKED_ON_USER
-                                    stored_task.session_id = None
-                                    break
-                            save_dev_queue(store)
-                    else:
-                        with contextlib.suppress(WorktreeError, OSError):
-                            remove_worktree(client, branch, force=True)
-                    raise
+                    branch = f"{AUTO_DEV_LABEL_PREFIX}{task.ticket_id}"
+                    # Create a real git worktree (idempotent — returns existing
+                    # path if already created). Replaces a previous bug where
+                    # dispatch made an empty directory and relied on
+                    # ``claude -w`` to turn it into a worktree, which never
+                    # worked because that flag takes a name rather than a path.
+                    try:
+                        worktree_path = create_worktree(client, branch)
+                    except StaleWorktreeError:
+                        # A stale worktree (wrong branch / not a worktree) refused
+                        # reuse (#404). No session exists yet, so reconcile's
+                        # TIMED_OUT cleanup will never fire for it — without
+                        # removing it here the task reverts to PENDING and re-hits
+                        # the same stale tree every tick (an infinite spin). Force-
+                        # remove it (best-effort) so the next claim rebuilds fresh,
+                        # then re-raise into the handler below to revert to PENDING.
+                        # Caught narrowly as StaleWorktreeError (not WorktreeError)
+                        # so the main-checkout guard never triggers a removal.
+                        #
+                        # Dirty-check guard (#425): if the stale tree contains
+                        # unsaved work, skip the removal and park the task as
+                        # BLOCKED_ON_USER instead of PENDING so the operator can
+                        # inspect. The outer except handler will not overwrite
+                        # BLOCKED_ON_USER (it checks status == RUNNING before
+                        # reverting).
+                        if worktree_has_unsaved_work(client, branch):
+                            _log.warning(
+                                "dispatch: stale worktree %s/%s has unsaved work"
+                                " — leaving for operator inspection; parking as"
+                                " BLOCKED_ON_USER",
+                                client.name,
+                                branch,
+                            )
+                            with dev_queue_lock():
+                                store = load_dev_queue()
+                                for stored_task in store.tasks:
+                                    if (
+                                        stored_task.ticket_id == task.ticket_id
+                                        and stored_task.client == client.name
+                                        and stored_task.status
+                                        == QueueItemStatus.RUNNING
+                                    ):
+                                        stored_task.status = (
+                                            QueueItemStatus.BLOCKED_ON_USER
+                                        )
+                                        stored_task.session_id = None
+                                        break
+                                save_dev_queue(store)
+                        else:
+                            with contextlib.suppress(WorktreeError, OSError):
+                                remove_worktree(client, branch, force=True)
+                        raise
 
-                # Guard against the #300 regression: if create_worktree
-                # returns the main checkout path (degenerate path-computation
-                # or symlink indirection), refuse the spawn.  create_worktree
-                # normally catches this itself, but a mocked or buggy
-                # implementation could still return the same path.
-                check_not_main_checkout(worktree_path, client)
+                    # Guard against the #300 regression: if create_worktree
+                    # returns the main checkout path (degenerate path-computation
+                    # or symlink indirection), refuse the spawn.  create_worktree
+                    # normally catches this itself, but a mocked or buggy
+                    # implementation could still return the same path.
+                    check_not_main_checkout(worktree_path, client)
 
-                label = branch
-                session_id = spawn_create_impl(
-                    client=client,
-                    worktree=worktree_path,
-                    prompt=f"/auto-dev {task.ticket_id} --headless",
-                    label=label,
-                    native_daemon=resolved_native_daemon,
-                    parent=parent,
-                    ticket_id=task.ticket_id,
-                    headless=True,
-                    task=task,
-                    wall_clock_budget_seconds=resolve_headless_budget(
-                        task, None, config
-                    ),
-                )
-
-                # Stamp session_id on the queued task so the completion
-                # consumer can match SESSION_COMPLETED events to the
-                # correct (current) session and reject stale events from
-                # prior crashed sessions for the same ticket. See GitHub
-                # issue #97.
-                with dev_queue_lock():
-                    store = load_dev_queue()
-                    for stored_task in store.tasks:
-                        if (
-                            stored_task.ticket_id == task.ticket_id
-                            and stored_task.client == client.name
-                            and stored_task.status == QueueItemStatus.RUNNING
-                        ):
-                            stored_task.session_id = session_id
-                            break
-                    save_dev_queue(store)
-
-                record_event(
-                    OrchestratorEventType.SESSION_SPAWNED,
-                    {
-                        "ticket_id": task.ticket_id,
-                        "client": client.name,
-                        "session_id": session_id,
-                    },
-                )
-
-                if emit is not None:
-                    emit(
-                        f"SPAWN {client.name}/{task.ticket_id}"
-                        f" session={session_id}"
-                        f" worktree={worktree_path}"
+                    label = branch
+                    session_id = spawn_create_impl(
+                        client=client,
+                        worktree=worktree_path,
+                        prompt=f"/auto-dev {task.ticket_id} --headless",
+                        label=label,
+                        native_daemon=resolved_native_daemon,
+                        parent=parent,
+                        ticket_id=task.ticket_id,
+                        headless=True,
+                        task=task,
+                        wall_clock_budget_seconds=resolve_headless_budget(
+                            task, None, config
+                        ),
                     )
 
-                running_count += 1
-                spawned += 1
-                client_spawned += 1
-            except UsageLimitError:
-                # Narrow catch for fleet-wide usage limits. Raised by
-                # spawn_create_impl → NativeDaemonClient.spawn_bg when the
-                # claude output matches USAGE_LIMIT_RE. The task was claimed
-                # to RUNNING but no session_id was assigned (spawn failed);
-                # revert it explicitly to PENDING below, then break so no
-                # further slots are tried this tick.
-                usage_limit_detected = True
-                any_usage_limit_detected = True
-                _log.warning(
-                    "dispatch_tick: usage limit detected for %s/%s; setting back-off",
-                    client.name,
-                    task.ticket_id,
-                )
-                # Revert the claimed task back to PENDING — spawn never succeeded.
-                with dev_queue_lock():
-                    store = load_dev_queue()
-                    for stored_task in store.tasks:
-                        if (
-                            stored_task.ticket_id == task.ticket_id
-                            and stored_task.client == client.name
-                            and stored_task.status == QueueItemStatus.RUNNING
-                        ):
-                            stored_task.status = QueueItemStatus.PENDING
-                            stored_task.session_id = None
-                            break
-                    save_dev_queue(store)
-                break  # do not retry other slots this tick
-            except Exception:  # noqa: BLE001
-                # Sanctioned broad-catch per PYTHON-PATTERNS.md:316-331.
-                # Paired tests: TestDispatchTickSpawnErrors in
-                # tests/test_dispatch.py:1097+ (asserts the loop survives
-                # spawn failures and the task is reverted to PENDING).
-                #
-                # Catch broad like the reconcile guard above: a backend
-                # outage (tmux pane exhaustion, transient daemon failure,
-                # OSError from the adapter) must NOT kill the loop. The
-                # task was just claimed RUNNING by _claim_next_pending; it
-                # would otherwise be left in a half-state (status=RUNNING,
-                # session_id=None) requiring manual repair. Revert to
-                # PENDING + clear session_id so the next tick (or
-                # reconcile) can retry. Break to skip this client's
-                # remaining slots this tick — re-trying the same failing
-                # backend immediately would just spin. See GitHub issue
-                # #149.
-                spawn_error = True
-                _log.exception(
-                    "dispatch_tick: spawn failed for %s/%s; reverting task to PENDING",
-                    client.name,
-                    task.ticket_id,
-                )
-                with dev_queue_lock():
-                    store = load_dev_queue()
-                    for stored_task in store.tasks:
-                        if (
-                            stored_task.ticket_id == task.ticket_id
-                            and stored_task.client == client.name
-                            and stored_task.status == QueueItemStatus.RUNNING
-                        ):
-                            stored_task.status = QueueItemStatus.PENDING
-                            stored_task.session_id = None
-                            break
-                    save_dev_queue(store)
+                    # Stamp session_id on the queued task so the completion
+                    # consumer can match SESSION_COMPLETED events to the
+                    # correct (current) session and reject stale events from
+                    # prior crashed sessions for the same ticket. See GitHub
+                    # issue #97.
+                    with dev_queue_lock():
+                        store = load_dev_queue()
+                        for stored_task in store.tasks:
+                            if (
+                                stored_task.ticket_id == task.ticket_id
+                                and stored_task.client == client.name
+                                and stored_task.status == QueueItemStatus.RUNNING
+                            ):
+                                stored_task.session_id = session_id
+                                break
+                        save_dev_queue(store)
+
+                    record_event(
+                        OrchestratorEventType.SESSION_SPAWNED,
+                        {
+                            "ticket_id": task.ticket_id,
+                            "client": client.name,
+                            "session_id": session_id,
+                            "lane": task.lane,
+                        },
+                    )
+
+                    if emit is not None:
+                        emit(
+                            f"SPAWN {client.name}/{task.ticket_id}"
+                            f" session={session_id}"
+                            f" worktree={worktree_path}"
+                        )
+
+                    running_count += 1
+                    spawned += 1
+                    client_spawned += 1
+                    lane_claimed += 1
+                    available_client_slots -= 1
+                except UsageLimitError:
+                    # Narrow catch for fleet-wide usage limits. Raised by
+                    # spawn_create_impl → NativeDaemonClient.spawn_bg when the
+                    # claude output matches USAGE_LIMIT_RE. The task was claimed
+                    # to RUNNING but no session_id was assigned (spawn failed);
+                    # revert it explicitly to PENDING below, then break so no
+                    # further slots are tried this tick.
+                    usage_limit_detected = True
+                    any_usage_limit_detected = True
+                    _log.warning(
+                        "dispatch_tick: usage limit detected for"
+                        " %s/%s; setting back-off",
+                        client.name,
+                        task.ticket_id,
+                    )
+                    # Revert the claimed task back to PENDING — spawn never succeeded.
+                    with dev_queue_lock():
+                        store = load_dev_queue()
+                        for stored_task in store.tasks:
+                            if (
+                                stored_task.ticket_id == task.ticket_id
+                                and stored_task.client == client.name
+                                and stored_task.status == QueueItemStatus.RUNNING
+                            ):
+                                stored_task.status = QueueItemStatus.PENDING
+                                stored_task.session_id = None
+                                break
+                        save_dev_queue(store)
+                    break  # do not retry other slots this tick
+                except Exception:  # noqa: BLE001
+                    # Sanctioned broad-catch per PYTHON-PATTERNS.md:316-331.
+                    # Paired tests: TestDispatchTickSpawnErrors in
+                    # tests/test_dispatch.py:1097+ (asserts the loop survives
+                    # spawn failures and the task is reverted to PENDING).
+                    #
+                    # Catch broad like the reconcile guard above: a backend
+                    # outage (tmux pane exhaustion, transient daemon failure,
+                    # OSError from the adapter) must NOT kill the loop. The
+                    # task was just claimed RUNNING by _claim_next_pending; it
+                    # would otherwise be left in a half-state (status=RUNNING,
+                    # session_id=None) requiring manual repair. Revert to
+                    # PENDING + clear session_id so the next tick (or
+                    # reconcile) can retry. Break to skip this client's
+                    # remaining slots this tick — re-trying the same failing
+                    # backend immediately would just spin. See GitHub issue
+                    # #149.
+                    spawn_error = True
+                    _log.exception(
+                        "dispatch_tick: spawn failed for %s/%s;"
+                        " reverting task to PENDING",
+                        client.name,
+                        task.ticket_id,
+                    )
+                    with dev_queue_lock():
+                        store = load_dev_queue()
+                        for stored_task in store.tasks:
+                            if (
+                                stored_task.ticket_id == task.ticket_id
+                                and stored_task.client == client.name
+                                and stored_task.status == QueueItemStatus.RUNNING
+                            ):
+                                stored_task.status = QueueItemStatus.PENDING
+                                stored_task.session_id = None
+                                break
+                        save_dev_queue(store)
+                    break
+
+                if usage_limit_detected or spawn_error:
+                    break
+
+            lane_stats[lane_cfg.name] = {
+                "claimed": lane_claimed,
+                "running": running_in_lane,
+                "pending": pending_in_lane,
+            }
+
+            if usage_limit_detected or spawn_error:
                 break
 
         if emit is not None:
@@ -570,6 +682,7 @@ def dispatch_tick(
                 "running": running_count,
                 "cap": cap,
                 "skip_reason": skip_reason,
+                "lanes": lane_stats,
             },
         )
 
@@ -802,9 +915,7 @@ def run_dispatch_loop(
             if max_parallel is not None:
                 clients = load_clients()
                 overridden = dict.fromkeys(clients, max_parallel)
-                config = config.model_copy(
-                    update={"per_client_max_parallel": overridden}
-                )
+                config = config.model_copy(update={"per_client_ceiling": overridden})
         except (yaml.YAMLError, pydantic.ValidationError):
             _log.warning("dispatch: config reload failed; using last-good config")
 

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -343,6 +344,46 @@ class OrchestratorConfig(BaseModel):
     # sessions to BLOCKED_ON_USER for operator review; ``auto`` restores the
     # pre-#554 self-healing behavior. See ADR-0006 invariant 4 and GitHub #554.
     reap_policy: ReapPolicy = ReapPolicy.SIGNAL_ONLY
+    # RFC 0004 Phase 2 — two-knob scheduler (#558)
+    # Tier-1: limit how many clients are eligible per tick.
+    # None = no limit (today's behavior preserved).
+    max_parallel_clients: int | None = None
+    # Tier-2: per-client ceiling across all lanes. Takes precedence over the
+    # legacy per_client_max_parallel / default_max_parallel fields; those are
+    # migrated on load via _migrate_legacy_ceiling_fields and kept as deprecated
+    # aliases for one release.
+    per_client_ceiling: dict[str, int] = Field(default_factory=dict)
+    default_ceiling: int = 1
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_ceiling_fields(cls, data: object) -> object:
+        """Lift legacy per_client_max_parallel / default_max_parallel into new fields.
+
+        The new per_client_ceiling / default_ceiling fields take precedence when
+        both are present. Legacy fields are kept as deprecated aliases and still
+        populate OrchestratorConfig for one release — callers using the legacy
+        field name directly will see the same value via the new field.
+        """
+        if not isinstance(data, dict):
+            return data
+        has_new_ceiling = "per_client_ceiling" in data or "default_ceiling" in data
+        legacy_per_client = data.get("per_client_max_parallel")
+        legacy_default = data.get("default_max_parallel")
+        if not has_new_ceiling:
+            if isinstance(legacy_per_client, dict) and legacy_per_client:
+                data.setdefault("per_client_ceiling", dict(legacy_per_client))
+                logging.getLogger(__name__).warning(
+                    "OrchestratorConfig: per_client_max_parallel is deprecated; "
+                    "use per_client_ceiling instead"
+                )
+            if isinstance(legacy_default, int):
+                data.setdefault("default_ceiling", legacy_default)
+                logging.getLogger(__name__).warning(
+                    "OrchestratorConfig: default_max_parallel is deprecated; "
+                    "use default_ceiling instead"
+                )
+        return data
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -2550,6 +2550,9 @@ class TestDispatchTickEvents:
         assert p["skip_reason"] == DispatchSkipReason.FRESHNESS_GATE
         assert p["claimed"] == 0
         assert p["pending"] == 2  # both tasks were pending pre-claim
+        # Payload shape is consistent across all emit sites (#558 PM review):
+        # the freshness-gate event carries the per-lane breakdown too.
+        assert p["lanes"] == {"default": {"claimed": 0, "running": 0, "pending": 2}}
 
     def test_skip_reason_spawn_error_on_spawn_failure(
         self,
@@ -3187,6 +3190,59 @@ class TestTier1ClientSelection:
 
         # Both clients dispatched
         assert result.spawned == 2
+
+    def test_stale_client_does_not_consume_tier1_quota(
+        self,
+        tmp_dispatch_dirs: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A freshness-gate-skipped client does not consume Tier-1 quota."""
+        ws_a = make_git_repo("workspace/client-a3")
+        ws_b = make_git_repo("workspace/client-b3")
+        client_a = ClientConfig(
+            name="client-a3",
+            workspace_path=ws_a,
+            default_branch="main",
+            worktree_base=tmp_path / "worktrees-a3",
+        )
+        client_b = ClientConfig(
+            name="client-b3",
+            workspace_path=ws_b,
+            default_branch="main",
+            worktree_base=tmp_path / "worktrees-b3",
+        )
+
+        config_dir = tmp_dispatch_dirs / ".config" / "cw"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "clients.yaml").write_text(
+            "clients:\n"
+            f"  client-a3:\n"
+            f"    workspace_path: {client_a.workspace_path}\n"
+            f"    default_branch: main\n"
+            f"    worktree_base: {client_a.worktree_base}\n"
+            f"  client-b3:\n"
+            f"    workspace_path: {client_b.workspace_path}\n"
+            f"    default_branch: main\n"
+            f"    worktree_base: {client_b.worktree_base}\n"
+        )
+
+        add_ticket(TicketTask(ticket_id="T-A3", client="client-a3"))
+        add_ticket(TicketTask(ticket_id="T-B3", client="client-b3"))
+
+        # client-a3 is stale (skipped by the freshness gate); client-b3 fresh.
+        monkeypatch.setattr(
+            "cw.dispatch.is_main_behind_origin",
+            lambda client: (client.name == "client-a3", "aaa", "bbb", 1),
+        )
+
+        config = OrchestratorConfig(max_parallel_clients=1, default_ceiling=1)
+        daemon = FakeNativeDaemonClient()
+        result = dispatch_tick(config, native_daemon=daemon, auto_ff=False)
+
+        # The stale client did not consume the single Tier-1 slot.
+        assert result.spawned == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -17,7 +17,7 @@ from cw.config import (
     orchestrator_config_file,
     save_state,
 )
-from cw.dev_queue import add_ticket, load_dev_queue, save_dev_queue, save_plan
+from cw.dev_queue import add_ticket, dev_queue_lock, load_dev_queue, save_dev_queue, save_plan
 from cw.dispatch import (
     DispatchTickResult,
     _accumulate_task_cost,
@@ -31,9 +31,11 @@ from cw.exceptions import StaleWorktreeError, WorktreeError
 from cw.models import (
     ClientConfig,
     CwState,
+    DEFAULT_LANE,
     DevQueueStore,
     DispatchPlan,
     DispatchSkipReason,
+    LaneConfig,
     OrchestratorConfig,
     OrchestratorEventType,
     QueueItemStatus,
@@ -117,6 +119,13 @@ def _make_clients_yaml(tmp_path: Path, client: ClientConfig) -> None:
     ]
     if client.worktree_base is not None:
         lines.append(f"    worktree_base: {client.worktree_base}\n")
+    if client.lanes:
+        lines.append("    lanes:\n")
+        for lane in client.lanes:
+            lines.append(f"      - name: {lane.name}\n")
+            lines.append(f"        max_parallel: {lane.max_parallel}\n")
+            if lane.priority != 0:
+                lines.append(f"        priority: {lane.priority}\n")
     clients_file.write_text("".join(lines))
 
 
@@ -3071,3 +3080,321 @@ class TestFreshnessGateAutoFF:
             event_types=[OrchestratorEventType.TICKET_NEEDS_SYNC],
         )
         assert len(events) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestTier1ClientSelection — max_parallel_clients (#558)
+# ---------------------------------------------------------------------------
+
+
+class TestTier1ClientSelection:
+    """Tier-1: max_parallel_clients limits how many clients are dispatched per tick."""
+
+    def test_max_parallel_clients_limits_eligible_clients(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+    ) -> None:
+        """With max_parallel_clients=1 and two clients, only one client is dispatched."""
+        client_a = ClientConfig(
+            name="client-a",
+            workspace_path=tmp_dispatch_dirs / "workspace" / "client-a",
+        )
+        client_b = ClientConfig(
+            name="client-b",
+            workspace_path=tmp_dispatch_dirs / "workspace" / "client-b",
+        )
+        client_a.workspace_path.mkdir(parents=True, exist_ok=True)
+        client_b.workspace_path.mkdir(parents=True, exist_ok=True)
+
+        config_dir = tmp_dispatch_dirs / ".config" / "cw"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "clients.yaml").write_text(
+            "clients:\n"
+            f"  client-a:\n"
+            f"    workspace_path: {client_a.workspace_path}\n"
+            f"    default_branch: main\n"
+            f"  client-b:\n"
+            f"    workspace_path: {client_b.workspace_path}\n"
+            f"    default_branch: main\n"
+        )
+
+        add_ticket(TicketTask(ticket_id="T-A1", client="client-a"))
+        add_ticket(TicketTask(ticket_id="T-B1", client="client-b"))
+
+        config = OrchestratorConfig(max_parallel_clients=1, default_ceiling=1)
+        daemon = FakeNativeDaemonClient()
+        result = dispatch_tick(config, native_daemon=daemon)
+
+        # Only 1 client dispatched (whichever iteration visits first)
+        assert result.spawned == 1
+
+    def test_max_parallel_clients_none_dispatches_all(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+    ) -> None:
+        """With max_parallel_clients=None (default), all eligible clients are dispatched."""
+        client_a = ClientConfig(
+            name="client-a",
+            workspace_path=tmp_dispatch_dirs / "workspace" / "client-a",
+        )
+        client_b = ClientConfig(
+            name="client-b",
+            workspace_path=tmp_dispatch_dirs / "workspace" / "client-b",
+        )
+        client_a.workspace_path.mkdir(parents=True, exist_ok=True)
+        client_b.workspace_path.mkdir(parents=True, exist_ok=True)
+
+        config_dir = tmp_dispatch_dirs / ".config" / "cw"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "clients.yaml").write_text(
+            "clients:\n"
+            f"  client-a:\n"
+            f"    workspace_path: {client_a.workspace_path}\n"
+            f"    default_branch: main\n"
+            f"  client-b:\n"
+            f"    workspace_path: {client_b.workspace_path}\n"
+            f"    default_branch: main\n"
+        )
+
+        add_ticket(TicketTask(ticket_id="T-A1", client="client-a"))
+        add_ticket(TicketTask(ticket_id="T-B1", client="client-b"))
+
+        config = OrchestratorConfig(max_parallel_clients=None, default_ceiling=1)
+        daemon = FakeNativeDaemonClient()
+        result = dispatch_tick(config, native_daemon=daemon)
+
+        # Both clients dispatched
+        assert result.spawned == 2
+
+
+# ---------------------------------------------------------------------------
+# TestTier2LaneAllocation — per-lane grants (#558)
+# ---------------------------------------------------------------------------
+
+
+class TestTier2LaneAllocation:
+    """Tier-2: per-lane grant formula allocates slots across lanes correctly."""
+
+    def test_multi_lane_grants_respected_independently(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+    ) -> None:
+        """Two lanes each with max_parallel=1; two tasks in different lanes → 2 spawned."""
+        lanes = [LaneConfig(name="impl", max_parallel=1), LaneConfig(name="idea", max_parallel=1)]
+        client = ClientConfig(
+            name="test-client",
+            workspace_path=sample_client_config.workspace_path,
+            default_branch="main",
+            lanes=lanes,
+        )
+        _make_clients_yaml(tmp_dispatch_dirs, client)
+
+        add_ticket(TicketTask(ticket_id="IMPL-1", client="test-client", lane="impl"))
+        add_ticket(TicketTask(ticket_id="IDEA-1", client="test-client", lane="idea"))
+
+        config = OrchestratorConfig(default_ceiling=2)
+        daemon = FakeNativeDaemonClient()
+        result = dispatch_tick(config, native_daemon=daemon)
+
+        assert result.spawned == 2
+
+    def test_saturated_lane_does_not_block_other_lanes(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+    ) -> None:
+        """Lane 'impl' is at capacity; lane 'idea' still spawns."""
+        lanes = [LaneConfig(name="impl", max_parallel=1), LaneConfig(name="idea", max_parallel=1)]
+        client = ClientConfig(
+            name="test-client",
+            workspace_path=sample_client_config.workspace_path,
+            default_branch="main",
+            lanes=lanes,
+        )
+        _make_clients_yaml(tmp_dispatch_dirs, client)
+
+        # Seed an active session for the 'impl' lane task
+        impl_task = TicketTask(ticket_id="IMPL-RUNNING", client="test-client", lane="impl")
+        impl_task.status = QueueItemStatus.RUNNING
+        impl_task.session_id = "sess-impl-1"
+        with dev_queue_lock():
+            store = load_dev_queue()
+            store.tasks.append(impl_task)
+            save_dev_queue(store)
+
+        sess = Session(
+            id="sess-impl-1",
+            name="test-client/auto-dev/IMPL-RUNNING",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+            workspace_path=sample_client_config.workspace_path,
+        )
+        save_state(CwState(sessions=[sess]))
+
+        # Pending task in the 'idea' lane
+        add_ticket(TicketTask(ticket_id="IDEA-1", client="test-client", lane="idea"))
+        # Pending task in 'impl' lane — should NOT be claimed (lane full)
+        add_ticket(TicketTask(ticket_id="IMPL-2", client="test-client", lane="impl"))
+
+        config = OrchestratorConfig(default_ceiling=2)
+        daemon = FakeNativeDaemonClient()
+        result = dispatch_tick(config, native_daemon=daemon)
+
+        # Only idea-lane task spawned; impl lane is saturated
+        assert result.spawned == 1
+        store = load_dev_queue()
+        running = [t for t in store.tasks if t.status == QueueItemStatus.RUNNING and t.session_id != "sess-impl-1"]
+        assert len(running) == 1
+        assert running[0].ticket_id == "IDEA-1"
+
+    def test_lane_filtered_claim_order(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+    ) -> None:
+        """_claim_next_pending with lane filter only claims tasks in that lane."""
+        lanes = [LaneConfig(name="impl", max_parallel=1), LaneConfig(name="idea", max_parallel=1)]
+        client = ClientConfig(
+            name="test-client",
+            workspace_path=sample_client_config.workspace_path,
+            default_branch="main",
+            lanes=lanes,
+        )
+        _make_clients_yaml(tmp_dispatch_dirs, client)
+
+        # Higher-priority task in wrong lane
+        add_ticket(TicketTask(ticket_id="IMPL-HIGH", client="test-client", lane="impl", priority=10))
+        add_ticket(TicketTask(ticket_id="IDEA-LOW", client="test-client", lane="idea", priority=0))
+
+        config = OrchestratorConfig(default_ceiling=2)
+        daemon = FakeNativeDaemonClient()
+        result = dispatch_tick(config, native_daemon=daemon)
+
+        # Both lanes each get one spawn
+        assert result.spawned == 2
+        store = load_dev_queue()
+        running = store.running()
+        running_ids = {t.ticket_id for t in running}
+        assert "IMPL-HIGH" in running_ids
+        assert "IDEA-LOW" in running_ids
+
+
+# ---------------------------------------------------------------------------
+# TestLaneCapCountingWithBlockedOnUser (#558)
+# ---------------------------------------------------------------------------
+
+
+class TestLaneCapCountingWithBlockedOnUser:
+    """BLOCKED_ON_USER task session_id still occupies the lane slot (ADR-0006)."""
+
+    def test_blocked_on_user_session_counts_toward_lane_cap(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+    ) -> None:
+        """A BLOCKED_ON_USER task with active session occupies lane; no over-spawn."""
+        lanes = [LaneConfig(name="impl", max_parallel=1)]
+        client = ClientConfig(
+            name="test-client",
+            workspace_path=sample_client_config.workspace_path,
+            default_branch="main",
+            lanes=lanes,
+        )
+        _make_clients_yaml(tmp_dispatch_dirs, client)
+
+        # A BLOCKED_ON_USER task with a live session_id
+        blocked_task = TicketTask(
+            ticket_id="IMPL-BLOCKED",
+            client="test-client",
+            lane="impl",
+        )
+        blocked_task.status = QueueItemStatus.BLOCKED_ON_USER
+        blocked_task.session_id = "sess-blocked-1"
+        with dev_queue_lock():
+            store = load_dev_queue()
+            store.tasks.append(blocked_task)
+            save_dev_queue(store)
+
+        sess = Session(
+            id="sess-blocked-1",
+            name="test-client/auto-dev/IMPL-BLOCKED",
+            client="test-client",
+            purpose=SessionPurpose.IMPL,
+            origin=SessionOrigin.DAEMON,
+            status=SessionStatus.ACTIVE,
+            workspace_path=sample_client_config.workspace_path,
+        )
+        save_state(CwState(sessions=[sess]))
+
+        # Another pending task in the same lane
+        add_ticket(TicketTask(ticket_id="IMPL-NEW", client="test-client", lane="impl"))
+
+        config = OrchestratorConfig(default_ceiling=1)
+        daemon = FakeNativeDaemonClient()
+        result = dispatch_tick(config, native_daemon=daemon)
+
+        # Lane is full (BLOCKED_ON_USER counts) — should NOT spawn
+        assert result.spawned == 0
+
+
+# ---------------------------------------------------------------------------
+# TestSingleLaneBackwardCompat (#558)
+# ---------------------------------------------------------------------------
+
+
+class TestSingleLaneBackwardCompat:
+    """No-lanes client uses synthesized default lane; behavior byte-identical to pre-#558."""
+
+    def test_no_lanes_config_dispatches_same_as_before(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """A client with no lanes: config dispatches exactly as before (1 task, 1 session)."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        add_ticket(TicketTask(ticket_id="COMPAT-1", client="test-client"))
+
+        daemon = FakeNativeDaemonClient()
+        result = dispatch_tick(simple_config, native_daemon=daemon)
+
+        assert result.spawned == 1
+        store = load_dev_queue()
+        running = store.running()
+        assert len(running) == 1
+        assert running[0].ticket_id == "COMPAT-1"
+
+        # Verify DISPATCH_TICK event has lanes field
+        events = read_events(
+            consumer="test-compat",
+            event_types=[OrchestratorEventType.DISPATCH_TICK],
+        )
+        assert len(events) == 1
+        p = events[0].payload
+        assert p["claimed"] == 1
+        assert "lanes" in p
+        assert DEFAULT_LANE in p["lanes"]
+        assert p["lanes"][DEFAULT_LANE]["claimed"] == 1
+
+    def test_no_lanes_second_tick_respects_cap(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """No-lanes client: second tick with cap=1 and running session does not over-spawn."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        add_ticket(TicketTask(ticket_id="COMPAT-A", client="test-client"))
+        add_ticket(TicketTask(ticket_id="COMPAT-B", client="test-client"))
+
+        daemon = FakeNativeDaemonClient()
+        dispatch_tick(simple_config, native_daemon=daemon)
+        # After first tick: 1 RUNNING, 1 PENDING
+        result2 = dispatch_tick(simple_config, native_daemon=daemon)
+        # Cap=1, running=1 → no spawn on second tick
+        assert result2.spawned == 0

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -17,7 +17,13 @@ from cw.config import (
     orchestrator_config_file,
     save_state,
 )
-from cw.dev_queue import add_ticket, dev_queue_lock, load_dev_queue, save_dev_queue, save_plan
+from cw.dev_queue import (
+    add_ticket,
+    dev_queue_lock,
+    load_dev_queue,
+    save_dev_queue,
+    save_plan,
+)
 from cw.dispatch import (
     DispatchTickResult,
     _accumulate_task_cost,
@@ -29,9 +35,9 @@ from cw.dispatch import (
 from cw.events import read_events, record_event
 from cw.exceptions import StaleWorktreeError, WorktreeError
 from cw.models import (
+    DEFAULT_LANE,
     ClientConfig,
     CwState,
-    DEFAULT_LANE,
     DevQueueStore,
     DispatchPlan,
     DispatchSkipReason,
@@ -3093,19 +3099,24 @@ class TestTier1ClientSelection:
     def test_max_parallel_clients_limits_eligible_clients(
         self,
         tmp_dispatch_dirs: Path,
-        sample_client_config: ClientConfig,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
     ) -> None:
-        """With max_parallel_clients=1 and two clients, only one client is dispatched."""
+        """With max_parallel_clients=1 and two clients, only one is dispatched."""
+        ws_a = make_git_repo("workspace/client-a")
+        ws_b = make_git_repo("workspace/client-b")
         client_a = ClientConfig(
             name="client-a",
-            workspace_path=tmp_dispatch_dirs / "workspace" / "client-a",
+            workspace_path=ws_a,
+            default_branch="main",
+            worktree_base=tmp_path / "worktrees-a",
         )
         client_b = ClientConfig(
             name="client-b",
-            workspace_path=tmp_dispatch_dirs / "workspace" / "client-b",
+            workspace_path=ws_b,
+            default_branch="main",
+            worktree_base=tmp_path / "worktrees-b",
         )
-        client_a.workspace_path.mkdir(parents=True, exist_ok=True)
-        client_b.workspace_path.mkdir(parents=True, exist_ok=True)
 
         config_dir = tmp_dispatch_dirs / ".config" / "cw"
         config_dir.mkdir(parents=True, exist_ok=True)
@@ -3114,9 +3125,11 @@ class TestTier1ClientSelection:
             f"  client-a:\n"
             f"    workspace_path: {client_a.workspace_path}\n"
             f"    default_branch: main\n"
+            f"    worktree_base: {client_a.worktree_base}\n"
             f"  client-b:\n"
             f"    workspace_path: {client_b.workspace_path}\n"
             f"    default_branch: main\n"
+            f"    worktree_base: {client_b.worktree_base}\n"
         )
 
         add_ticket(TicketTask(ticket_id="T-A1", client="client-a"))
@@ -3132,34 +3145,41 @@ class TestTier1ClientSelection:
     def test_max_parallel_clients_none_dispatches_all(
         self,
         tmp_dispatch_dirs: Path,
-        sample_client_config: ClientConfig,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
     ) -> None:
-        """With max_parallel_clients=None (default), all eligible clients are dispatched."""
+        """With max_parallel_clients=None (default), all eligible clients dispatched."""
+        ws_a = make_git_repo("workspace/client-a2")
+        ws_b = make_git_repo("workspace/client-b2")
         client_a = ClientConfig(
-            name="client-a",
-            workspace_path=tmp_dispatch_dirs / "workspace" / "client-a",
+            name="client-a2",
+            workspace_path=ws_a,
+            default_branch="main",
+            worktree_base=tmp_path / "worktrees-a2",
         )
         client_b = ClientConfig(
-            name="client-b",
-            workspace_path=tmp_dispatch_dirs / "workspace" / "client-b",
+            name="client-b2",
+            workspace_path=ws_b,
+            default_branch="main",
+            worktree_base=tmp_path / "worktrees-b2",
         )
-        client_a.workspace_path.mkdir(parents=True, exist_ok=True)
-        client_b.workspace_path.mkdir(parents=True, exist_ok=True)
 
         config_dir = tmp_dispatch_dirs / ".config" / "cw"
         config_dir.mkdir(parents=True, exist_ok=True)
         (config_dir / "clients.yaml").write_text(
             "clients:\n"
-            f"  client-a:\n"
+            f"  client-a2:\n"
             f"    workspace_path: {client_a.workspace_path}\n"
             f"    default_branch: main\n"
-            f"  client-b:\n"
+            f"    worktree_base: {client_a.worktree_base}\n"
+            f"  client-b2:\n"
             f"    workspace_path: {client_b.workspace_path}\n"
             f"    default_branch: main\n"
+            f"    worktree_base: {client_b.worktree_base}\n"
         )
 
-        add_ticket(TicketTask(ticket_id="T-A1", client="client-a"))
-        add_ticket(TicketTask(ticket_id="T-B1", client="client-b"))
+        add_ticket(TicketTask(ticket_id="T-A2", client="client-a2"))
+        add_ticket(TicketTask(ticket_id="T-B2", client="client-b2"))
 
         config = OrchestratorConfig(max_parallel_clients=None, default_ceiling=1)
         daemon = FakeNativeDaemonClient()
@@ -3182,8 +3202,11 @@ class TestTier2LaneAllocation:
         tmp_dispatch_dirs: Path,
         sample_client_config: ClientConfig,
     ) -> None:
-        """Two lanes each with max_parallel=1; two tasks in different lanes → 2 spawned."""
-        lanes = [LaneConfig(name="impl", max_parallel=1), LaneConfig(name="idea", max_parallel=1)]
+        """Two lanes max_parallel=1 each; two tasks in different lanes → 2 spawned."""
+        lanes = [
+            LaneConfig(name="impl", max_parallel=1),
+            LaneConfig(name="idea", max_parallel=1),
+        ]
         client = ClientConfig(
             name="test-client",
             workspace_path=sample_client_config.workspace_path,
@@ -3207,7 +3230,10 @@ class TestTier2LaneAllocation:
         sample_client_config: ClientConfig,
     ) -> None:
         """Lane 'impl' is at capacity; lane 'idea' still spawns."""
-        lanes = [LaneConfig(name="impl", max_parallel=1), LaneConfig(name="idea", max_parallel=1)]
+        lanes = [
+            LaneConfig(name="impl", max_parallel=1),
+            LaneConfig(name="idea", max_parallel=1),
+        ]
         client = ClientConfig(
             name="test-client",
             workspace_path=sample_client_config.workspace_path,
@@ -3217,7 +3243,9 @@ class TestTier2LaneAllocation:
         _make_clients_yaml(tmp_dispatch_dirs, client)
 
         # Seed an active session for the 'impl' lane task
-        impl_task = TicketTask(ticket_id="IMPL-RUNNING", client="test-client", lane="impl")
+        impl_task = TicketTask(
+            ticket_id="IMPL-RUNNING", client="test-client", lane="impl"
+        )
         impl_task.status = QueueItemStatus.RUNNING
         impl_task.session_id = "sess-impl-1"
         with dev_queue_lock():
@@ -3248,7 +3276,11 @@ class TestTier2LaneAllocation:
         # Only idea-lane task spawned; impl lane is saturated
         assert result.spawned == 1
         store = load_dev_queue()
-        running = [t for t in store.tasks if t.status == QueueItemStatus.RUNNING and t.session_id != "sess-impl-1"]
+        running = [
+            t
+            for t in store.tasks
+            if t.status == QueueItemStatus.RUNNING and t.session_id != "sess-impl-1"
+        ]
         assert len(running) == 1
         assert running[0].ticket_id == "IDEA-1"
 
@@ -3258,7 +3290,10 @@ class TestTier2LaneAllocation:
         sample_client_config: ClientConfig,
     ) -> None:
         """_claim_next_pending with lane filter only claims tasks in that lane."""
-        lanes = [LaneConfig(name="impl", max_parallel=1), LaneConfig(name="idea", max_parallel=1)]
+        lanes = [
+            LaneConfig(name="impl", max_parallel=1),
+            LaneConfig(name="idea", max_parallel=1),
+        ]
         client = ClientConfig(
             name="test-client",
             workspace_path=sample_client_config.workspace_path,
@@ -3268,8 +3303,22 @@ class TestTier2LaneAllocation:
         _make_clients_yaml(tmp_dispatch_dirs, client)
 
         # Higher-priority task in wrong lane
-        add_ticket(TicketTask(ticket_id="IMPL-HIGH", client="test-client", lane="impl", priority=10))
-        add_ticket(TicketTask(ticket_id="IDEA-LOW", client="test-client", lane="idea", priority=0))
+        add_ticket(
+            TicketTask(
+                ticket_id="IMPL-HIGH",
+                client="test-client",
+                lane="impl",
+                priority=10,
+            )
+        )
+        add_ticket(
+            TicketTask(
+                ticket_id="IDEA-LOW",
+                client="test-client",
+                lane="idea",
+                priority=0,
+            )
+        )
 
         config = OrchestratorConfig(default_ceiling=2)
         daemon = FakeNativeDaemonClient()
@@ -3348,7 +3397,7 @@ class TestLaneCapCountingWithBlockedOnUser:
 
 
 class TestSingleLaneBackwardCompat:
-    """No-lanes client uses synthesized default lane; behavior byte-identical to pre-#558."""
+    """No-lanes client: synthesized default lane; byte-identical to pre-#558."""
 
     def test_no_lanes_config_dispatches_same_as_before(
         self,
@@ -3356,7 +3405,7 @@ class TestSingleLaneBackwardCompat:
         sample_client_config: ClientConfig,
         simple_config: OrchestratorConfig,
     ) -> None:
-        """A client with no lanes: config dispatches exactly as before (1 task, 1 session)."""
+        """A client with no lanes: dispatches exactly as before (1 task, 1 session)."""
         _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
         add_ticket(TicketTask(ticket_id="COMPAT-1", client="test-client"))
 
@@ -3387,7 +3436,7 @@ class TestSingleLaneBackwardCompat:
         sample_client_config: ClientConfig,
         simple_config: OrchestratorConfig,
     ) -> None:
-        """No-lanes client: second tick with cap=1 and running session does not over-spawn."""
+        """No-lanes client: second tick, cap=1, running session → does not overspawn."""
         _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
         add_ticket(TicketTask(ticket_id="COMPAT-A", client="test-client"))
         add_ticket(TicketTask(ticket_id="COMPAT-B", client="test-client"))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -699,10 +699,8 @@ class TestOrchestratorConfigCeilingMigration:
     def test_legacy_per_client_max_parallel_lifted(self) -> None:
         """Legacy per_client_max_parallel is migrated into per_client_ceiling."""
         config = OrchestratorConfig(
-            **{
-                "per_client_max_parallel": {"my-client": 3},
-                "default_max_parallel": 2,
-            }
+            per_client_max_parallel={"my-client": 3},
+            default_max_parallel=2,
         )
         assert config.per_client_ceiling == {"my-client": 3}
         assert config.default_ceiling == 2
@@ -710,12 +708,10 @@ class TestOrchestratorConfigCeilingMigration:
     def test_new_fields_win_over_legacy(self) -> None:
         """When both new and legacy fields are present, new fields win."""
         config = OrchestratorConfig(
-            **{
-                "per_client_ceiling": {"my-client": 5},
-                "default_ceiling": 4,
-                "per_client_max_parallel": {"my-client": 3},
-                "default_max_parallel": 2,
-            }
+            per_client_ceiling={"my-client": 5},
+            default_ceiling=4,
+            per_client_max_parallel={"my-client": 3},
+            default_max_parallel=2,
         )
         assert config.per_client_ceiling == {"my-client": 5}
         assert config.default_ceiling == 4

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -690,3 +690,38 @@ class TestClientConfigEffectiveLanes:
         assert len(lanes) == 2
         assert lanes[0].name == "fast"
         assert lanes[1].name == "slow"
+
+
+class TestOrchestratorConfigCeilingMigration:
+    """Migration of legacy per_client_max_parallel / default_max_parallel into
+    per_client_ceiling / default_ceiling fields (#558)."""
+
+    def test_legacy_per_client_max_parallel_lifted(self) -> None:
+        """Legacy per_client_max_parallel is migrated into per_client_ceiling."""
+        config = OrchestratorConfig(
+            **{
+                "per_client_max_parallel": {"my-client": 3},
+                "default_max_parallel": 2,
+            }
+        )
+        assert config.per_client_ceiling == {"my-client": 3}
+        assert config.default_ceiling == 2
+
+    def test_new_fields_win_over_legacy(self) -> None:
+        """When both new and legacy fields are present, new fields win."""
+        config = OrchestratorConfig(
+            **{
+                "per_client_ceiling": {"my-client": 5},
+                "default_ceiling": 4,
+                "per_client_max_parallel": {"my-client": 3},
+                "default_max_parallel": 2,
+            }
+        )
+        assert config.per_client_ceiling == {"my-client": 5}
+        assert config.default_ceiling == 4
+
+    def test_absent_legacy_keys_use_defaults(self) -> None:
+        """Without legacy keys, new fields default to empty dict and 1."""
+        config = OrchestratorConfig()
+        assert config.per_client_ceiling == {}
+        assert config.default_ceiling == 1


### PR DESCRIPTION
Closes #558. RFC 0004 Phase 2, per the Pre-flight Resolutions on the ticket.

- **Tier-1**: `max_parallel_clients` (default None = today's all-clients behavior) caps how many clients dispatch per tick; freshness-gate-skipped clients don't consume quota (`# Why:` documented + tested).
- **Tier-2**: per-lane grants within the client ceiling — `grant = min(lane.max_parallel − running[lane], pending[lane], available)`, claims lane-filtered through the existing priority/FIFO order. Non-destructive: only claims, never rebalances running work.
- **Lane occupancy** via the tasks→sessions join: `RUNNING` and `BLOCKED_ON_USER` tasks with a live session both count toward their lane (ADR-0006 — a signal_only-distressed session keeps its slot; no over-spawn). `Session.lane` stays deferred to #560.
- **Knobs**: `per_client_ceiling` + `default_ceiling` + `max_parallel_clients` on `OrchestratorConfig`, with a before-validator lifting legacy `per_client_max_parallel`/`default_max_parallel` (deprecated alias, one release). Default YAML template uses the new keys. Override store is #559.
- **Backward compat**: no-lanes clients resolve to the synthesized default lane at the client ceiling — behavior byte-identical (regression-tested).
- **Events**: `SESSION_SPAWNED` + all three `DISPATCH_TICK` emit sites carry `lane`/`lanes` (the PM reviewer's MISSING_BEHAVIOR on the freshness-gate emit is fixed; lane stats deduplicated into `_lane_stats_for_client`).

Worker sentinel: `review_pending_approval` (0 MUST_FIX; PM escalated the payload-shape gap). Operator applied the 4 review fixes (lanes field, snapshot reuse, default-YAML keys, Tier-1 quota comment+test) and re-ran the full gate suite: 1951 passed, 96.03% total / 97% diff coverage, mypy --strict, ruff, pre-commit all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)