### PR TITLE
[RFC 0004 Phase 3/4] Lane-aware status/dashboard grouping + consumer audit (#561)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -63,6 +63,7 @@ from cw.doctor import (
 from cw.events import advance_cursor, read_events, record_event
 from cw.exceptions import CwError, MissingWorkspaceError, WorktreeError
 from cw.models import (
+    DEFAULT_LANE,
     ClientConfig,
     CompletionReason,
     OrchestratorEventType,
@@ -1609,6 +1610,32 @@ def dev_queue_clear(client: str, status_filter: str | None) -> None:
     click.echo(f"Cleared {count} dev-queue task(s) for {client}.")
 
 
+def _emit_dev_queue_lane_breakdown(tasks: list[TicketTask]) -> None:
+    """Print indented lane lines for tasks when multi-lane or non-default lanes used.
+
+    Groups tasks by lane and emits one line per lane showing pending, running,
+    and blocked counts.  Skipped when all tasks share the single default lane.
+    """
+    # Collect lanes that are either non-default OR appear alongside other lanes
+    lanes_seen: set[str] = {t.lane for t in tasks}
+    if len(lanes_seen) <= 1 and lanes_seen == {DEFAULT_LANE}:
+        return
+    by_lane: dict[str, list[TicketTask]] = {}
+    for task in tasks:
+        by_lane.setdefault(task.lane, []).append(task)
+    for lane_name in sorted(by_lane):
+        lane_tasks = by_lane[lane_name]
+        pending = sum(1 for t in lane_tasks if t.status == QueueItemStatus.PENDING)
+        running = sum(1 for t in lane_tasks if t.status == QueueItemStatus.RUNNING)
+        blocked = sum(
+            1 for t in lane_tasks if t.status == QueueItemStatus.BLOCKED_ON_USER
+        )
+        click.echo(
+            f"    lane {lane_name}:"
+            f" pending={pending} running={running} blocked={blocked}"
+        )
+
+
 @dev_queue.command(name="status")
 @click.option("--client", "-c", default=None, help="Filter by client.")
 @handle_errors
@@ -1663,6 +1690,7 @@ def dev_queue_status(client: str | None) -> None:
                     f"  running={tick.running}/{tick.cap}"
                     f"  skip={tick.skip_reason}"
                 )
+                _emit_dev_queue_lane_breakdown(by_client[client_name])
 
 
 @dev_queue.command(name="run")
@@ -2118,6 +2146,15 @@ def orchestrate() -> None:
     """Orchestrator pipeline: status snapshot and PR retirement."""
 
 
+def _should_show_lane_breakdown(lanes: dict[str, dict[str, int]]) -> bool:
+    """Return True when lane breakdown adds information beyond the top-level totals."""
+    if not lanes:
+        return False
+    if len(lanes) > 1:
+        return True
+    return next(iter(lanes)) != DEFAULT_LANE
+
+
 def _format_status_human(status: OrchestratorStatus) -> str:
     """Render an OrchestratorStatus as a human-readable string."""
     ts = status.generated_at.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -2138,6 +2175,13 @@ def _format_status_human(status: OrchestratorStatus) -> str:
                 f"  skip={tick.skip_reason}"
                 f"  at={tick.tick_at.strftime('%Y-%m-%dT%H:%M:%SZ')}"
             )
+            if _should_show_lane_breakdown(tick.lanes):
+                for lane_name, stats in sorted(tick.lanes.items()):
+                    lines.append(
+                        f"    {lane_name}: claimed={stats.get('claimed', 0)}"
+                        f" running={stats.get('running', 0)}"
+                        f" pending={stats.get('pending', 0)}"
+                    )
     else:
         lines.append("  (no dispatch ticks recorded)")
 

--- a/src/cw/orchestrate.py
+++ b/src/cw/orchestrate.py
@@ -42,6 +42,7 @@ from cw.dev_queue import load_dev_queue
 from cw.events import advance_cursor, read_events, record_event
 from cw.exceptions import CwError
 from cw.models import (
+    DEFAULT_LANE,
     CompletionReason,
     OrchestratorEvent,
     OrchestratorEventType,
@@ -362,6 +363,7 @@ class TicketSummary(BaseModel):
     status: str
     created_at: datetime
     scope_hint: str | None = None
+    lane: str = DEFAULT_LANE
 
 
 class EventSummary(BaseModel):
@@ -383,6 +385,7 @@ class TickSummary(BaseModel):
     cap: int
     skip_reason: str
     tick_at: datetime
+    lanes: dict[str, dict[str, int]] = Field(default_factory=dict)
 
 
 class OrchestratorStatus(BaseModel):
@@ -409,6 +412,7 @@ def _summarise_ticket(task: TicketTask) -> TicketSummary:
         status=task.status.value,
         created_at=task.created_at,
         scope_hint=task.scope_hint,
+        lane=task.lane,
     )
 
 
@@ -461,6 +465,25 @@ def _summarise_event(event: OrchestratorEvent) -> EventSummary:
     )
 
 
+def _extract_lanes(raw: object) -> dict[str, dict[str, int]]:
+    """Safely extract lanes dict from DISPATCH_TICK payload.
+
+    Tolerates pre-#558 events where the key is absent or malformed.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    result: dict[str, dict[str, int]] = {}
+    for lane_name, stats in raw.items():
+        if not isinstance(lane_name, str) or not isinstance(stats, dict):
+            continue
+        result[lane_name] = {
+            k: int(v)
+            for k, v in stats.items()
+            if isinstance(k, str) and isinstance(v, (int, float))
+        }
+    return result
+
+
 def _latest_tick_by_client(
     events: list[OrchestratorEvent],
 ) -> dict[str, TickSummary]:
@@ -482,6 +505,7 @@ def _latest_tick_by_client(
                     cap=int(ev.payload.get("cap", 0)),
                     skip_reason=str(ev.payload.get("skip_reason", "none")),
                     tick_at=ev.created_at,
+                    lanes=_extract_lanes(ev.payload.get("lanes")),
                 )
             except (TypeError, ValueError):
                 continue

--- a/src/cw/tui.py
+++ b/src/cw/tui.py
@@ -31,10 +31,12 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel
 from rich.console import Console, Group
 from rich.live import Live
+from rich.markup import escape as markup_escape
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from cw.models import DEFAULT_LANE
 from cw.orchestrate import (
     EventSummary,
     MonitoredPR,
@@ -161,7 +163,10 @@ def _tickets_table(
         tickets,
         key=lambda t: (-t.priority, t.created_at),
     ):
-        row = [ticket.ticket_id, str(ticket.priority)]
+        ticket_id_display = markup_escape(ticket.ticket_id)
+        if ticket.lane != DEFAULT_LANE:
+            ticket_id_display = markup_escape(f"{ticket.ticket_id} [{ticket.lane}]")
+        row = [ticket_id_display, str(ticket.priority)]
         if level is DetailLevel.VERBOSE:
             row.append(ticket.scope_hint or "—")
         table.add_row(*row)

--- a/src/cw/tui.py
+++ b/src/cw/tui.py
@@ -163,9 +163,12 @@ def _tickets_table(
         tickets,
         key=lambda t: (-t.priority, t.created_at),
     ):
-        ticket_id_display = markup_escape(ticket.ticket_id)
-        if ticket.lane != DEFAULT_LANE:
-            ticket_id_display = markup_escape(f"{ticket.ticket_id} [{ticket.lane}]")
+        raw = (
+            ticket.ticket_id
+            if ticket.lane == DEFAULT_LANE
+            else f"{ticket.ticket_id} [{ticket.lane}]"
+        )
+        ticket_id_display = markup_escape(raw)
         row = [ticket_id_display, str(ticket.priority)]
         if level is DetailLevel.VERBOSE:
             row.append(ticket.scope_hint or "—")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5095,6 +5095,76 @@ class TestFormatStatusHuman:
         assert "ci=(none)" in output
         assert "mergeable=(none)" in output
 
+    def test_format_status_human_multi_lane_shows_indented_lines(self) -> None:
+        """Multi-lane tick renders indented lane lines after the client summary."""
+        from cw.cli import _format_status_human
+        from cw.orchestrate import OrchestratorStatus, TickSummary
+
+        tick = TickSummary(
+            claimed=1,
+            pending=2,
+            running=1,
+            cap=3,
+            skip_reason="none",
+            tick_at=datetime(2026, 6, 12, 0, 0, 0, tzinfo=UTC),
+            lanes={
+                "fast": {"claimed": 1, "running": 1, "pending": 0},
+                "slow": {"claimed": 0, "running": 0, "pending": 2},
+            },
+        )
+        status = OrchestratorStatus(
+            generated_at=datetime(2026, 6, 12, 0, 0, 0, tzinfo=UTC),
+            last_tick_by_client={"lane-client": tick},
+        )
+        output = _format_status_human(status)
+        assert "    fast: claimed=1 running=1 pending=0" in output
+        assert "    slow: claimed=0 running=0 pending=2" in output
+
+    def test_format_status_human_single_default_lane_no_indented_lines(self) -> None:
+        """Single 'default' lane tick does not render indented lane lines."""
+        from cw.cli import _format_status_human
+        from cw.orchestrate import OrchestratorStatus, TickSummary
+
+        tick = TickSummary(
+            claimed=1,
+            pending=0,
+            running=1,
+            cap=2,
+            skip_reason="none",
+            tick_at=datetime(2026, 6, 12, 0, 0, 0, tzinfo=UTC),
+            lanes={"default": {"claimed": 1, "running": 1, "pending": 0}},
+        )
+        status = OrchestratorStatus(
+            generated_at=datetime(2026, 6, 12, 0, 0, 0, tzinfo=UTC),
+            last_tick_by_client={"single-client": tick},
+        )
+        output = _format_status_human(status)
+        # No indented lane breakdown when the only lane is DEFAULT_LANE
+        assert "    default:" not in output
+        assert "    fast:" not in output
+
+    def test_format_status_human_empty_lanes_no_indented_lines(self) -> None:
+        """Empty lanes dict renders no indented lane lines (legacy events)."""
+        from cw.cli import _format_status_human
+        from cw.orchestrate import OrchestratorStatus, TickSummary
+
+        tick = TickSummary(
+            claimed=0,
+            pending=1,
+            running=0,
+            cap=2,
+            skip_reason="none",
+            tick_at=datetime(2026, 6, 12, 0, 0, 0, tzinfo=UTC),
+            lanes={},
+        )
+        status = OrchestratorStatus(
+            generated_at=datetime(2026, 6, 12, 0, 0, 0, tzinfo=UTC),
+            last_tick_by_client={"empty-lanes-client": tick},
+        )
+        output = _format_status_human(status)
+        # No lane breakdown lines at all
+        assert "    " not in output.split("Last dispatch tick")[1].split("\n\n")[0]
+
 
 class TestDevQueueStatusWithTick:
     def test_dev_queue_status_shows_last_tick(
@@ -5132,6 +5202,123 @@ class TestDevQueueStatusWithTick:
         assert "tick-client" in result.output
         assert "claimed=1" in result.output
         assert "skip=cap_full" in result.output
+
+    def test_dev_queue_status_multi_lane_shows_indented_lines(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """Multi-lane tasks produce indented lane breakdown after client summary."""
+        from cw.dev_queue import add_ticket
+        from cw.events import record_event
+        from cw.models import OrchestratorEventType, QueueItemStatus, TicketTask
+
+        add_ticket(
+            TicketTask(
+                ticket_id="GEN-1",
+                client="multi-client",
+                priority=5,
+                status=QueueItemStatus.PENDING,
+                lane="fast",
+            )
+        )
+        add_ticket(
+            TicketTask(
+                ticket_id="GEN-2",
+                client="multi-client",
+                priority=3,
+                status=QueueItemStatus.PENDING,
+                lane="slow",
+            )
+        )
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": "multi-client",
+                "claimed": 0,
+                "pending": 2,
+                "running": 0,
+                "cap": 2,
+                "skip_reason": "none",
+                "lanes": {
+                    "fast": {"claimed": 0, "running": 0, "pending": 1},
+                    "slow": {"claimed": 0, "running": 0, "pending": 1},
+                },
+            },
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["dev-queue", "status"])
+        assert result.exit_code == 0, result.output
+        assert "    lane fast:" in result.output
+        assert "    lane slow:" in result.output
+
+    def test_dev_queue_status_single_default_lane_no_indented_lines(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """Single default-lane tick renders no indented lane lines."""
+        from cw.dev_queue import add_ticket
+        from cw.events import record_event
+        from cw.models import OrchestratorEventType, QueueItemStatus, TicketTask
+
+        add_ticket(
+            TicketTask(
+                ticket_id="GEN-3",
+                client="default-client",
+                priority=5,
+                status=QueueItemStatus.PENDING,
+            )
+        )
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": "default-client",
+                "claimed": 0,
+                "pending": 1,
+                "running": 0,
+                "cap": 2,
+                "skip_reason": "none",
+                "lanes": {"default": {"claimed": 0, "running": 0, "pending": 1}},
+            },
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["dev-queue", "status"])
+        assert result.exit_code == 0, result.output
+        # No indented lane breakdown for single default lane
+        assert "    lane default:" not in result.output
+        assert "    lane fast:" not in result.output
+
+    def test_dev_queue_status_blocked_on_user_shows_in_lane(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """BLOCKED_ON_USER task in non-default lane shows blocked=1 in lane line."""
+        from cw.dev_queue import add_ticket
+        from cw.events import record_event
+        from cw.models import OrchestratorEventType, QueueItemStatus, TicketTask
+
+        add_ticket(
+            TicketTask(
+                ticket_id="GEN-4",
+                client="blocked-client",
+                priority=5,
+                status=QueueItemStatus.BLOCKED_ON_USER,
+                lane="fast",
+            )
+        )
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": "blocked-client",
+                "claimed": 0,
+                "pending": 0,
+                "running": 0,
+                "cap": 2,
+                "skip_reason": "none",
+                "lanes": {"fast": {"claimed": 0, "running": 0, "pending": 0}},
+            },
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["dev-queue", "status"])
+        assert result.exit_code == 0, result.output
+        assert "    lane fast:" in result.output
+        assert "blocked=1" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -30,6 +30,7 @@ from cw.orchestrate import (
     MissingWorkerEntry,
     OrchestratorStatus,
     PRDispatchRecord,
+    TickSummary,
     WorkerEntry,
     clear_completed_pr_sessions,
     orchestrator_parent,
@@ -1364,3 +1365,135 @@ class TestClearCompletedPrSessions:
         """No error when dispatch record is empty."""
         state = CwState(sessions=[])
         clear_completed_pr_sessions(state)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Tests: TickSummary.lanes field + _extract_lanes helper (issue #561)
+# ---------------------------------------------------------------------------
+
+
+class TestTickSummaryLanes:
+    def test_tick_summary_lanes_defaults_empty(self) -> None:
+        """TickSummary without lanes kwarg has lanes == {}."""
+        tick = TickSummary(
+            claimed=0,
+            pending=0,
+            running=0,
+            cap=1,
+            skip_reason="none",
+            tick_at=datetime(2026, 6, 12, 0, 0, 0, tzinfo=UTC),
+        )
+        assert tick.lanes == {}
+
+    def test_tick_summary_lanes_round_trip(self) -> None:
+        """TickSummary with lanes serialises and deserialises with lanes intact."""
+        tick = TickSummary(
+            claimed=0,
+            pending=0,
+            running=0,
+            cap=1,
+            skip_reason="none",
+            tick_at=datetime(2026, 6, 12, 0, 0, 0, tzinfo=UTC),
+            lanes={"fast": {"claimed": 1, "running": 0, "pending": 2}},
+        )
+        parsed = json.loads(tick.model_dump_json())
+        assert parsed["lanes"]["fast"]["claimed"] == 1
+        assert parsed["lanes"]["fast"]["pending"] == 2
+
+    def test_latest_tick_by_client_preserves_lanes(
+        self,
+        tmp_orchestrate_dirs: Path,
+    ) -> None:
+        """DISPATCH_TICK event with lanes key populates TickSummary.lanes."""
+        from cw.events import read_events
+        from cw.orchestrate import _latest_tick_by_client
+
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": "lane-client",
+                "claimed": 1,
+                "pending": 1,
+                "running": 0,
+                "cap": 2,
+                "skip_reason": "none",
+                "lanes": {"fast": {"claimed": 1, "running": 0, "pending": 1}},
+            },
+        )
+        events = read_events()
+        result = _latest_tick_by_client(events)
+        assert "lane-client" in result
+        assert result["lane-client"].lanes == {
+            "fast": {"claimed": 1, "running": 0, "pending": 1}
+        }
+
+    def test_latest_tick_by_client_legacy_event_no_lanes_key(
+        self,
+        tmp_orchestrate_dirs: Path,
+    ) -> None:
+        """DISPATCH_TICK event without lanes key yields TickSummary.lanes == {}."""
+        from cw.events import read_events
+        from cw.orchestrate import _latest_tick_by_client
+
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": "legacy-client",
+                "claimed": 0,
+                "pending": 1,
+                "running": 0,
+                "cap": 2,
+                "skip_reason": "none",
+                # no "lanes" key — pre-#558 format
+            },
+        )
+        events = read_events()
+        result = _latest_tick_by_client(events)
+        assert "legacy-client" in result
+        assert result["legacy-client"].lanes == {}
+
+    def test_orchestrate_status_json_guard(
+        self,
+        tmp_orchestrate_dirs: Path,
+    ) -> None:
+        """orchestrator_status snapshot includes lanes when present in tick event."""
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": "json-client",
+                "claimed": 1,
+                "pending": 0,
+                "running": 1,
+                "cap": 2,
+                "skip_reason": "none",
+                "lanes": {"fast": {"claimed": 1, "running": 1, "pending": 0}},
+            },
+        )
+        snapshot = orchestrator_status()
+        parsed = json.loads(snapshot.model_dump_json())
+        assert "json-client" in parsed["last_tick_by_client"]
+        assert "lanes" in parsed["last_tick_by_client"]["json-client"]
+        fast_lane = parsed["last_tick_by_client"]["json-client"]["lanes"]["fast"]
+        assert fast_lane["claimed"] == 1
+
+    def test_orchestrate_status_json_legacy_lanes_empty(
+        self,
+        tmp_orchestrate_dirs: Path,
+    ) -> None:
+        """orchestrator_status snapshot has lanes == {} for legacy tick events."""
+        record_event(
+            OrchestratorEventType.DISPATCH_TICK,
+            {
+                "client": "legacy-json-client",
+                "claimed": 0,
+                "pending": 2,
+                "running": 0,
+                "cap": 2,
+                "skip_reason": "none",
+                # no lanes key
+            },
+        )
+        snapshot = orchestrator_status()
+        parsed = json.loads(snapshot.model_dump_json())
+        assert "legacy-json-client" in parsed["last_tick_by_client"]
+        assert parsed["last_tick_by_client"]["legacy-json-client"]["lanes"] == {}

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -833,3 +833,91 @@ class TestBuildWatchRows:
         rows = _build_watch_rows(status, frozen_now)
         # Only one row (merged), not two
         assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: lane suffix in _tickets_table + _group_by_client (issue #561)
+# ---------------------------------------------------------------------------
+
+
+class TestTicketsTableLane:
+    def _render_tickets(
+        self,
+        tickets: list[TicketSummary],
+        *,
+        level: DetailLevel = DetailLevel.DEFAULT,
+    ) -> str:
+        """Render _tickets_table to a string for assertion."""
+        from cw.tui import _tickets_table
+
+        buf = StringIO()
+        con = Console(file=buf, width=120, force_terminal=False)
+        con.print(_tickets_table(tickets, level=level))
+        return buf.getvalue()
+
+    def test_tickets_table_non_default_lane_shows_suffix(
+        self, frozen_now: datetime
+    ) -> None:
+        """A ticket in a non-default lane renders with [lane] suffix in ticket cell."""
+        tickets = [
+            TicketSummary(
+                ticket_id="MW-300",
+                client="personal",
+                priority=5,
+                status="pending",
+                created_at=frozen_now,
+                lane="fast",
+            )
+        ]
+        output = self._render_tickets(tickets)
+        assert "[fast]" in output
+
+    def test_tickets_table_default_lane_no_suffix(self, frozen_now: datetime) -> None:
+        """A ticket in the default lane does NOT render [default] suffix."""
+        tickets = [
+            TicketSummary(
+                ticket_id="MW-301",
+                client="personal",
+                priority=5,
+                status="pending",
+                created_at=frozen_now,
+                lane="default",
+            )
+        ]
+        output = self._render_tickets(tickets)
+        assert "[default]" not in output
+
+    def test_group_by_client_stays_client_keyed(self, frozen_now: datetime) -> None:
+        """_group_by_client groups by client regardless of lane (regression pin)."""
+        from cw.tui import _group_by_client
+
+        tickets = [
+            TicketSummary(
+                ticket_id="MW-400",
+                client="client-a",
+                priority=5,
+                status="pending",
+                created_at=frozen_now,
+                lane="fast",
+            ),
+            TicketSummary(
+                ticket_id="MW-401",
+                client="client-a",
+                priority=3,
+                status="pending",
+                created_at=frozen_now,
+                lane="slow",
+            ),
+            TicketSummary(
+                ticket_id="MW-402",
+                client="client-b",
+                priority=5,
+                status="pending",
+                created_at=frozen_now,
+            ),
+        ]
+        clients = _group_by_client([], tickets)
+        assert "client-a" in clients
+        assert "client-b" in clients
+        # client-a appears first (more tickets)
+        assert clients[0] == "client-a"


### PR DESCRIPTION
## Summary

Closes #561

Threads the `lanes` dict from DISPATCH_TICK event payloads through `TickSummary` into both status renderers and the TUI. Core gap: `_latest_tick_by_client` silently dropped the `lanes` key from event payloads (added in #576).

- `TickSummary` gains `lanes: dict[str, dict[str, int]] = Field(default_factory=dict)` — additive, zero breaking change
- `_latest_tick_by_client` now reads `payload.get("lanes", {})` via `_extract_lanes()` — tolerates pre-#558 legacy events
- `cw dev-queue status` shows per-lane breakdown (pending/running/blocked) when client has multi-lane or non-default-lane tasks
- `cw orchestrate status` shows per-lane breakdown (claimed/running/pending) in Last dispatch tick section
- TUI ticket rows gain `[lane]` cell suffix when `lane != DEFAULT_LANE`
- `_group_by_client` stays client-keyed (structural, no change)

## Consumer Audit

- `orchestrate.py:_latest_tick_by_client` ~464-488 — **Fixed** — was silently dropping `lanes` key from DISPATCH_TICK payload
- `doctor.py` ~563-611 — Tolerates new key via `.get()`. No fix needed.
- `cli.py event tail` ~950-1014 — Prints payload as-is. No fix needed.
- `cw_queue_events_server.py` All — Doesn't consume DISPATCH_TICK payload fields. No fix needed.
- `history.py` All — Filesystem-oriented per-client JSONL. Stays client-keyed. No fix needed.
- `dispatch.py` All — Producer of `lanes` key since #576. No fix needed.
- `DevQueueStore.by_client` ~256-257 — Filesystem-oriented. Lane is display sub-dimension only. Stays client-keyed.

## PR Checklist (acceptance criteria)

- [x] `orchestrate.py:_latest_tick_by_client` — **re-pointed** — `TickSummary` now carries `lanes: dict[str,dict[str,int]]`
- [x] `orchestrate.py:TicketSummary` — **additive `lane` field** — display sub-dimension; all grouping logic stays client-keyed
- [x] `cli.py:_format_status_human` — **gains per-lane breakdown** — indented lines only when multi-lane or non-default lane
- [x] `cli.py:dev_queue_status` — **gains per-lane breakdown** — indented lines only when multi-lane or non-default active tasks
- [x] `tui.py:_tickets_table` — **gains `[lane]` cell suffix** — only when `lane != DEFAULT_LANE`
- [x] `tui.py:_group_by_client` — **stays client-keyed** — panel-per-client is structural
- [x] `history.py:by_client` — **stays client-keyed** — filesystem-oriented, not a display grouping
- [x] `DevQueueStore.by_client` — **stays client-keyed** — lane is display sub-dimension only
- [x] All 7 CI gates green; patch coverage ≥90%

## Test plan

- 15 new tests across 3 test files
- `test_orchestrate.py` (6): `TickSummary.lanes` round-trip, `_latest_tick_by_client` preserves lanes, legacy event tolerance, JSON guard tests
- `test_cli.py` (6): `_format_status_human` multi-lane + single-default-lane regression pin, `dev_queue_status` multi-lane + blocked=1 + single-default-lane regression pin
- `test_tui.py` (3): lane suffix, default lane suppression, `_group_by_client` regression pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)