### PR TITLE
docs(headless): post-sentinel turn-end hardening + salvage-ship recipe

### DIFF
--- a/.claude/commands/auto-dev.md
+++ b/.claude/commands/auto-dev.md
@@ -1919,6 +1919,14 @@ The Friction/Health checks remain useful for diagnostics and post-mortems, but t
 
 In headless mode, after all pipeline logic completes, emit `stage.entered` (`done`) then emit the sentinel-delimited JSON block as the final lines of stdout. The narrative friction reports remain above (still useful for tmux scrollback / post-mortem); this block is the parsing contract for `cw`.
 
+**The sentinel is the LAST thing you do — end the turn immediately after it.**
+The closing `AUTO_DEV_RESULT>>>` frame must be the final characters of your
+final message: no trailing prose, no "next steps" summary, no further tool
+calls, no background tasks left running (kill or await them BEFORE the
+sentinel). The Stop hook fires only when the turn completes; anything that
+keeps the turn open after the sentinel leaves the session wedged `working`
+and the queue task unrouted (#578 — observed four times in the 1.1 waves).
+
 **Headless only — before emitting the sentinel, emit `stage.entered` (`done`):**
 ```bash
 cw event record stage.entered \

--- a/.claude/skills/cw-followup/SKILL.md
+++ b/.claude/skills/cw-followup/SKILL.md
@@ -188,6 +188,33 @@ followup: #136 → no_op, closed citing PR #154
 followup: #170 → merge_gate_blocked, rebased to origin/main, PR #194 opened
 ```
 
+## Salvage-ship (wedged or dead session, work complete)
+
+The recurring case the sentinel statuses don't cover (#578): the worker
+pushed its branch and emitted a clean sentinel (or finished gates), but the
+session wedged before/at turn-end — task left RUNNING, or watchdog-reverted
+to PENDING, while the work is done. Symptoms: transcript silent >20 min with
+the sentinel (or "gates green") as the last event, session still `working`
+in the daemon roster, no PR.
+
+Recipe (validated 4× in the 1.1 waves — #387, #552, #554, #558):
+
+1. **Verify the work before touching anything**: `git ls-remote origin | grep <ticket>`
+   for the pushed branch; `git log origin/main..origin/<branch> --oneline` for the
+   commit stack; read the sentinel from the transcript for the review verdict +
+   open SHOULD_FIX list.
+2. **Close the session** (`cw spawn close <short-id>`) and **sweep the queue**
+   (`cw dev-queue remove <ticket> -c <client> --all` — the task is stale however
+   it was routed; the PR record becomes the source of truth).
+3. **Disposition the sentinel** as if it had routed normally:
+   `review_pending_approval` with SHOULD_FIX-only → assess the items; ship as-is
+   (note them in the PR body as deferred follow-ups) or apply 1–4 surgical fixes
+   inline in the worker's worktree (`/home/matthew/.cw/wt/<hash>/auto-dev-<n>`),
+   re-run the full gate suite, commit, push to the same branch.
+4. **Open the PR yourself** from the sentinel's branch with auto-merge; the body
+   carries the sentinel's review summary + the salvage note. Never re-dispatch a
+   ticket whose work is already pushed — a fresh worker redoes the hour.
+
 ## Failure modes
 
 - **Cannot resolve session** — print the session ref + sessions.json hint; do not guess. The user may have the wrong session id.


### PR DESCRIPTION
Operational hardening from the 1.1 wave incidents. Refs #578 (does not close it — the turn-end mechanics still need host-side root-causing).

- **auto-dev.md**: the sentinel's closing frame must be the final characters of the worker's final message — no trailing prose, no further tool calls, no live background tasks. The Stop hook (which performs all sentinel-based task routing) only fires when the turn completes; four workers in the 1.1 waves emitted clean sentinels and then wedged `working`, leaving their tasks unrouted.
- **cw-followup skill**: documents the salvage-ship disposition for exactly that wedge (verify pushed work → close session → sweep queue → disposition the sentinel → operator opens the PR), validated four times (#387, #552, #554, #558).

Docs-only; pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)