### PR TITLE
feat(reconcile): per-lane reap_policy resolution (#560)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -291,13 +291,14 @@ must not be auto-retried; the operator must manually clear or close it.
 ### `session.reap_proposed`
 
 **Emitter:** `_emit_reap_proposed` in `cw.reconcile`
-**Payload v1:**
+**Payload v2:**
 ```json
 {
   "session_id": "<str>",
   "session_name": "<str>",
   "client": "<str>",
   "ticket_id": "<str | null>",
+  "lane": "<str>",
   "proposed_action": "revert_task | crash_complete | park_blocked_on_user",
   "reason": "<ReapReason value | null>",
   "evidence": {
@@ -320,8 +321,8 @@ preventing duplicate events across ticks for the same session.
 
 `correlation_id` is the `ticket_id` when resolvable, else the `session_id`.
 
-**Deferral:** No `lane` field in v1 — RFC 0004 scope deferred to a
-follow-up issue.
+`lane` is the owning task's lane name, or `"default"` for candidates not
+associated with a task (phantom sessions without a matching queue entry).
 
 **Consumer note:** This event is written to the orchestrator event inbox
 (`events/inbox.jsonl`) as a state-snapshot delta. It does NOT appear in the

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -311,7 +311,7 @@ class LaneConfig(BaseModel):
     priority: int = 0
     paused: bool = False
     description: str = ""
-    reap_policy: ReapPolicy = ReapPolicy.SIGNAL_ONLY
+    reap_policy: ReapPolicy | None = None
 
     @field_validator("name")
     @classmethod

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -62,6 +62,7 @@ from cw.auto_dev_result import (
 )
 from cw.config import (
     get_client,
+    load_effective_clients,
     load_orchestrator_config,
     load_state,
     save_state,
@@ -76,6 +77,8 @@ from cw.gh import (
     pr_is_merged_for_ticket,
 )
 from cw.models import (
+    DEFAULT_LANE,
+    ClientConfig,
     CompletionReason,
     OrchestratorConfig,
     OrchestratorEventType,
@@ -812,6 +815,8 @@ def _detect_stalled_candidates(
         ) in (_SILENTLY_IDLE_REASON, _NEEDS_SALVAGE_REASON):
             actual_paused_status = session.last_result.get("paused_status")
             ticket_id = ticket_id_for_session(session.name)
+            # Stamp lane for SKIP_PARKED too so act phase has a consistent candidate.
+            skip_task = task_by_ticket.get(ticket_id) if ticket_id else None
             candidates.append(
                 ReapCandidate(
                     session_id=session.id,
@@ -820,6 +825,8 @@ def _detect_stalled_candidates(
                     paused_status=str(actual_paused_status)
                     if actual_paused_status
                     else None,
+                    lane=skip_task.lane if skip_task else DEFAULT_LANE,
+                    client=session.client,
                 )
             )
             continue
@@ -841,6 +848,8 @@ def _detect_stalled_candidates(
                     salvage_result=result,
                     salvage_csid=claude_session_id,
                     elapsed_seconds=elapsed,
+                    lane=task.lane if task else DEFAULT_LANE,
+                    client=session.client,
                 )
             )
             continue
@@ -851,6 +860,8 @@ def _detect_stalled_candidates(
                 ticket_id=ticket_id,
                 elapsed_seconds=elapsed,
                 reap_reason=ReapReason.WALL_CLOCK_BUDGET,
+                lane=task.lane if task else DEFAULT_LANE,
+                client=session.client,
             )
         )
     return candidates
@@ -907,24 +918,32 @@ def _act_on_stalled_candidates(
     Under ``ReapPolicy.SIGNAL_ONLY`` (default), REVERT_TASK candidates are
     routed to BLOCKED_ON_USER instead of triggering stop/remove.  Non-REVERT
     candidates (SALVAGE_*, SKIP_PARKED) are unaffected and pass through.
+    Per-lane resolution: each REVERT_TASK candidate's effective policy is
+    resolved individually via resolve_reap_policy (GitHub #560).
     """
     if not candidates:
         return []
 
     effective_config = config if config is not None else OrchestratorConfig()
-    if effective_config.reap_policy is ReapPolicy.SIGNAL_ONLY:
-        signal_mutations = {
-            c.ticket_id: QueueItemStatus.BLOCKED_ON_USER
-            for c in candidates
-            if c.ticket_id and c.proposed_action == ProposedAction.REVERT_TASK
-        }
+    clients = load_effective_clients()
+    # Route each REVERT_TASK candidate individually based on its lane's policy.
+    signal_mutations: dict[str, QueueItemStatus] = {}
+    auto_candidates: list[ReapCandidate] = []
+    for c in candidates:
+        if c.proposed_action == ProposedAction.REVERT_TASK:
+            policy = resolve_reap_policy(c, clients, effective_config)
+            if policy is ReapPolicy.SIGNAL_ONLY:
+                if c.ticket_id:
+                    signal_mutations[c.ticket_id] = QueueItemStatus.BLOCKED_ON_USER
+            else:
+                auto_candidates.append(c)
+        else:
+            auto_candidates.append(c)
+    if signal_mutations:
         _apply_queue_mutations(signal_mutations, clear_session_id=set())
-        # Fall through: non-REVERT candidates (SALVAGE_*, SKIP_PARKED) still processed.
-        candidates = [
-            c for c in candidates if c.proposed_action != ProposedAction.REVERT_TASK
-        ]
-        if not candidates:
-            return []
+    candidates = auto_candidates
+    if not candidates:
+        return []
 
     # Separate by action for batch processing.
     skip_candidates = [
@@ -1175,6 +1194,8 @@ def _detect_idle_candidates(
                         proposed_action=ProposedAction.RECOVER_COUNTER,
                         ticket_id=ticket_id,
                         new_observation_count=0,
+                        lane=task.lane if task else DEFAULT_LANE,
+                        client=session.client,
                     )
                 )
             continue
@@ -1190,6 +1211,8 @@ def _detect_idle_candidates(
                     salvage_result=result,
                     salvage_csid=claude_session_id,
                     elapsed_seconds=elapsed,
+                    lane=task.lane if task else DEFAULT_LANE,
+                    client=session.client,
                 )
             )
             continue
@@ -1202,6 +1225,8 @@ def _detect_idle_candidates(
                     proposed_action=ProposedAction.INCREMENT_COUNTER,
                     ticket_id=ticket_id,
                     new_observation_count=new_count,
+                    lane=task.lane if task else DEFAULT_LANE,
+                    client=session.client,
                 )
             )
             continue
@@ -1224,6 +1249,8 @@ def _detect_idle_candidates(
                         post_review_clean=post_review_clean,
                         worktree_dirty=worktree_dirty,
                         new_observation_count=new_count,
+                        lane=task.lane if task else DEFAULT_LANE,
+                        client=session.client,
                     )
                 )
                 continue
@@ -1239,6 +1266,8 @@ def _detect_idle_candidates(
                     worktree_dirty=worktree_dirty,
                     new_observation_count=new_count,
                     usage_limit_detected=_detect_usage_limit(session),
+                    lane=task.lane if task else DEFAULT_LANE,
+                    client=session.client,
                 )
             )
         else:
@@ -1249,6 +1278,8 @@ def _detect_idle_candidates(
                     ticket_id=ticket_id,
                     worktree_dirty=worktree_dirty,
                     new_observation_count=new_count,
+                    lane=task.lane if task else DEFAULT_LANE,
+                    client=session.client,
                 )
             )
     return candidates
@@ -1271,24 +1302,32 @@ def _act_on_idle_candidates(
     routed to BLOCKED_ON_USER instead of triggering stop/remove.  Non-REVERT
     candidates (SALVAGE_*, INCREMENT_COUNTER, RECOVER_COUNTER,
     PARK_BLOCKED_ON_USER) are unaffected and pass through.
+    Per-lane resolution: each REVERT_TASK candidate's effective policy is
+    resolved individually via resolve_reap_policy (GitHub #560).
     """
     if not candidates:
         return [], []
 
     effective_config = config if config is not None else OrchestratorConfig()
-    if effective_config.reap_policy is ReapPolicy.SIGNAL_ONLY:
-        signal_mutations = {
-            c.ticket_id: QueueItemStatus.BLOCKED_ON_USER
-            for c in candidates
-            if c.ticket_id and c.proposed_action == ProposedAction.REVERT_TASK
-        }
+    clients = load_effective_clients()
+    # Route each REVERT_TASK candidate individually based on its lane's policy.
+    signal_mutations: dict[str, QueueItemStatus] = {}
+    auto_candidates: list[ReapCandidate] = []
+    for c in candidates:
+        if c.proposed_action == ProposedAction.REVERT_TASK:
+            policy = resolve_reap_policy(c, clients, effective_config)
+            if policy is ReapPolicy.SIGNAL_ONLY:
+                if c.ticket_id:
+                    signal_mutations[c.ticket_id] = QueueItemStatus.BLOCKED_ON_USER
+            else:
+                auto_candidates.append(c)
+        else:
+            auto_candidates.append(c)
+    if signal_mutations:
         _apply_queue_mutations(signal_mutations, clear_session_id=set())
-        # Fall through to process non-REVERT candidates (counters, park, salvage).
-        candidates = [
-            c for c in candidates if c.proposed_action != ProposedAction.REVERT_TASK
-        ]
-        if not candidates:
-            return [], []
+    candidates = auto_candidates
+    if not candidates:
+        return [], []
 
     session_by_id = {s.id: s for s in state.sessions}
 
@@ -1595,26 +1634,64 @@ class ReapCandidate:
     post_review_clean: bool = False
     paused_status: str | None = None
     new_observation_count: int = 0
-    # Phantom sweep: carry client + worktree_path for SESSION_PHANTOM_REVERTED payload
+    # Lane the owning task is assigned to; stamped from task.lane in detect phase.
+    # Candidates without an owning task carry DEFAULT_LANE. Used by
+    # resolve_reap_policy to select per-lane reap_policy over the global default.
+    lane: str = DEFAULT_LANE
+    # Phantom sweep: carry client + worktree_path for SESSION_PHANTOM_REVERTED payload.
+    # Also stamped in stalled/idle detect from session.client so resolve_reap_policy
+    # can look up the lane config for this candidate.
     client: str | None = None
     worktree_path: Path | None = None
+
+
+def resolve_reap_policy(
+    candidate: ReapCandidate,
+    clients: dict[str, ClientConfig],
+    global_cfg: OrchestratorConfig,
+) -> ReapPolicy:
+    """Resolve the effective reap_policy for a candidate.
+
+    Precedence (highest to lowest):
+      1. Lane-level LaneConfig.reap_policy in the candidate's client config.
+      2. Global OrchestratorConfig.reap_policy.
+      3. ReapPolicy.SIGNAL_ONLY fail-safe (built into OrchestratorConfig default).
+
+    A candidate whose client is absent from *clients* or whose lane name is not
+    declared in that client's lanes falls through to the global config. This
+    keeps behaviour identical to the pre-#560 flat read for any candidate that
+    predates lane stamping.
+    """
+    client_cfg = clients.get(candidate.client) if candidate.client else None
+    if client_cfg is not None:
+        for lane_cfg in client_cfg.effective_lanes:
+            if lane_cfg.name == candidate.lane and lane_cfg.reap_policy is not None:
+                return lane_cfg.reap_policy
+    return global_cfg.reap_policy
 
 
 def _detect_phantom_candidates(
     state: CwState,
     phantom_set: set[str],
+    task_by_ticket: dict[str, TicketTask] | None = None,
 ) -> list[ReapCandidate]:
     """Pure classification phase for phantom sessions.
 
     Returns a list of ReapCandidate objects. Makes zero writes.
     The worktree_dirty check for DAEMON sessions is performed here
     so the act phase does not need to repeat it. See GitHub #552, ADR-0006.
+
+    task_by_ticket is used to stamp candidate.lane from the owning task's lane
+    (GitHub #560). When None or the ticket has no task, lane defaults to DEFAULT_LANE.
     """
+    _task_by_ticket = task_by_ticket or {}
     candidates: list[ReapCandidate] = []
     for session in state.sessions:
         if session.id not in phantom_set:
             continue
         ticket_id = ticket_id_for_session(session.name)
+        task = _task_by_ticket.get(ticket_id) if ticket_id else None
+        lane = task.lane if task else DEFAULT_LANE
         # Try sentinel salvage before declaring crashed (DAEMON only).
         salvage = (
             _salvage_terminal_result(session)
@@ -1630,6 +1707,7 @@ def _detect_phantom_candidates(
                     ticket_id=ticket_id,
                     salvage_result=result,
                     salvage_csid=claude_session_id,
+                    lane=lane,
                     client=session.client,
                     worktree_path=session.worktree_path,
                 )
@@ -1652,6 +1730,7 @@ def _detect_phantom_candidates(
                 proposed_action=ProposedAction.CRASH_COMPLETE,
                 ticket_id=ticket_id,
                 worktree_dirty=worktree_dirty,
+                lane=lane,
                 client=session.client,
                 worktree_path=session.worktree_path,
             )
@@ -1677,34 +1756,33 @@ def _act_on_phantom_candidates(
     stop/remove.  Dirty-worktree CRASH_COMPLETE already routes to
     BLOCKED_ON_USER in both policies — the gate only affects clean phantoms.
     SALVAGE_COMPLETION candidates pass through unaffected.
+    Per-lane resolution: each clean CRASH_COMPLETE candidate's effective policy
+    is resolved individually via resolve_reap_policy (GitHub #560).
     """
     if not candidates:
         return [], [], False, [], {}
 
     effective_config = config if config is not None else OrchestratorConfig()
-    if effective_config.reap_policy is ReapPolicy.SIGNAL_ONLY:
-        # Signal-only for CRASH_COMPLETE candidates where worktree is NOT dirty.
-        # Dirty phantoms already route to BLOCKED_ON_USER in both policies, so
-        # exclude them here to avoid double-processing.
-        signal_mutations = {
-            c.ticket_id: QueueItemStatus.BLOCKED_ON_USER
-            for c in candidates
-            if (
-                c.ticket_id
-                and c.proposed_action == ProposedAction.CRASH_COMPLETE
-                and not c.worktree_dirty
-            )
-        }
+    clients = load_effective_clients()
+    # Route each clean CRASH_COMPLETE candidate individually based on its lane's policy.
+    # Dirty phantoms always go to BLOCKED_ON_USER regardless of policy.
+    signal_mutations: dict[str, QueueItemStatus] = {}
+    auto_candidates: list[ReapCandidate] = []
+    for c in candidates:
+        if c.proposed_action == ProposedAction.CRASH_COMPLETE and not c.worktree_dirty:
+            policy = resolve_reap_policy(c, clients, effective_config)
+            if policy is ReapPolicy.SIGNAL_ONLY:
+                if c.ticket_id:
+                    signal_mutations[c.ticket_id] = QueueItemStatus.BLOCKED_ON_USER
+            else:
+                auto_candidates.append(c)
+        else:
+            auto_candidates.append(c)
+    if signal_mutations:
         _apply_queue_mutations(signal_mutations, clear_session_id=set())
-        # Keep only SALVAGE_COMPLETION and dirty-CRASH_COMPLETE candidates.
-        candidates = [
-            c
-            for c in candidates
-            if c.proposed_action == ProposedAction.SALVAGE_COMPLETION
-            or (c.proposed_action == ProposedAction.CRASH_COMPLETE and c.worktree_dirty)
-        ]
-        if not candidates:
-            return [], [], False, [], {}
+    candidates = auto_candidates
+    if not candidates:
+        return [], [], False, [], {}
 
     session_by_id = {s.id: s for s in state.sessions}
 
@@ -1893,6 +1971,7 @@ def _emit_reap_proposed(
             "session_name": session.name,
             "client": session.client,
             "ticket_id": candidate.ticket_id,
+            "lane": candidate.lane,
             "proposed_action": candidate.proposed_action.value,
             "reason": candidate.reap_reason.value if candidate.reap_reason else None,
             "evidence": {
@@ -2017,7 +2096,9 @@ def _reconcile_locked() -> tuple[ReconcileReport, list[_SalvageCandidate]]:
         ), salvage_git_candidates
 
     phantom_set = set(drift.phantom_session_ids)
-    phantom_candidates = _detect_phantom_candidates(state, phantom_set)
+    phantom_candidates = _detect_phantom_candidates(
+        state, phantom_set, task_by_ticket=shared_task_by_ticket
+    )
     _emit_reap_proposed(state, phantom_candidates, native_live=native_live, now=now)
     (
         reverted,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -647,11 +647,11 @@ class TestLaneConfig:
         assert lane.priority == 0
         assert lane.paused is False
         assert lane.description == ""
-        assert lane.reap_policy == ReapPolicy.SIGNAL_ONLY
+        assert lane.reap_policy is None
 
     def test_reap_policy_uses_enum(self) -> None:
-        """reap_policy is a ReapPolicy instance, not raw str."""
-        lane = LaneConfig(name="fast")
+        """reap_policy is a ReapPolicy instance when explicitly set."""
+        lane = LaneConfig(name="fast", reap_policy=ReapPolicy.SIGNAL_ONLY)
         assert isinstance(lane.reap_policy, ReapPolicy)
         assert lane.reap_policy == ReapPolicy.SIGNAL_ONLY
 

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -10561,3 +10561,657 @@ class TestEmitReapProposed:
         _emit_reap_proposed(state, [], native_live=set(), now=now)
 
         assert _state_queue_snapshot() == snap
+
+
+# ---------------------------------------------------------------------------
+# Per-lane reap_policy tests (GitHub #560)
+# ---------------------------------------------------------------------------
+
+
+def _client_with_lane(
+    client_name: str,
+    lane_name: str,
+    lane_policy: ReapPolicy,
+    *,
+    workspace_path: Path | None = None,
+) -> ClientConfig:
+    """Build a ClientConfig with one lane carrying a specific reap_policy."""
+    from cw.models import LaneConfig
+
+    return ClientConfig(
+        name=client_name,
+        workspace_path=workspace_path or Path("/tmp/ws"),
+        lanes=[LaneConfig(name=lane_name, reap_policy=lane_policy)],
+    )
+
+
+class TestResolveReapPolicy:
+    """resolve_reap_policy respects lane → global → SIGNAL_ONLY precedence."""
+
+    def test_lane_policy_beats_global(self) -> None:
+        """Lane AUTO overrides global SIGNAL_ONLY."""
+        from cw.reconcile import ProposedAction, ReapCandidate, resolve_reap_policy
+
+        clients = {
+            "client-a": _client_with_lane("client-a", "fast", ReapPolicy.AUTO),
+        }
+        cfg = OrchestratorConfig(reap_policy=ReapPolicy.SIGNAL_ONLY)
+        candidate = ReapCandidate(
+            session_id="s1",
+            proposed_action=ProposedAction.REVERT_TASK,
+            ticket_id="t1",
+            lane="fast",
+            client="client-a",
+        )
+        assert resolve_reap_policy(candidate, clients, cfg) is ReapPolicy.AUTO
+
+    def test_global_used_when_lane_not_in_client(self) -> None:
+        """Lane name absent from client's lanes → falls back to global."""
+        from cw.reconcile import ProposedAction, ReapCandidate, resolve_reap_policy
+
+        clients = {
+            "client-a": _client_with_lane("client-a", "slow", ReapPolicy.SIGNAL_ONLY),
+        }
+        cfg = OrchestratorConfig(reap_policy=ReapPolicy.AUTO)
+        candidate = ReapCandidate(
+            session_id="s2",
+            proposed_action=ProposedAction.REVERT_TASK,
+            ticket_id="t2",
+            lane="fast",  # not in client's lanes
+            client="client-a",
+        )
+        assert resolve_reap_policy(candidate, clients, cfg) is ReapPolicy.AUTO
+
+    def test_global_used_when_client_not_in_dict(self) -> None:
+        """Unknown client → falls back to global."""
+        from cw.reconcile import ProposedAction, ReapCandidate, resolve_reap_policy
+
+        clients: dict[str, ClientConfig] = {}
+        cfg = OrchestratorConfig(reap_policy=ReapPolicy.AUTO)
+        candidate = ReapCandidate(
+            session_id="s3",
+            proposed_action=ProposedAction.REVERT_TASK,
+            ticket_id="t3",
+            lane="fast",
+            client="unknown-client",
+        )
+        assert resolve_reap_policy(candidate, clients, cfg) is ReapPolicy.AUTO
+
+    def test_signal_only_failsafe_when_no_client(self) -> None:
+        """candidate.client=None + global defaults → SIGNAL_ONLY."""
+        from cw.reconcile import ProposedAction, ReapCandidate, resolve_reap_policy
+
+        clients: dict[str, ClientConfig] = {}
+        cfg = OrchestratorConfig()  # default: SIGNAL_ONLY
+        candidate = ReapCandidate(
+            session_id="s4",
+            proposed_action=ProposedAction.REVERT_TASK,
+            ticket_id="t4",
+        )
+        assert resolve_reap_policy(candidate, clients, cfg) is ReapPolicy.SIGNAL_ONLY
+
+    def test_default_lane_resolves_via_global(self) -> None:
+        """DEFAULT_LANE not in custom lanes → global policy used."""
+        from cw.models import DEFAULT_LANE
+        from cw.reconcile import ProposedAction, ReapCandidate, resolve_reap_policy
+
+        lane_cfg = _client_with_lane("client-a", "custom-lane", ReapPolicy.SIGNAL_ONLY)
+        clients = {"client-a": lane_cfg}
+        cfg = OrchestratorConfig(reap_policy=ReapPolicy.AUTO)
+        candidate = ReapCandidate(
+            session_id="s5",
+            proposed_action=ProposedAction.REVERT_TASK,
+            ticket_id="t5",
+            lane=DEFAULT_LANE,
+            client="client-a",
+        )
+        # "default" lane not in client's declared lanes → global AUTO
+        assert resolve_reap_policy(candidate, clients, cfg) is ReapPolicy.AUTO
+
+
+class TestActOnStalledCandidatesPerLane:
+    """Per-lane reap_policy overrides global for stalled candidates."""
+
+    def test_lane_auto_global_signal_acts(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lane AUTO + global SIGNAL_ONLY: REVERT_TASK candidate routed to PENDING."""
+        from cw.reconcile import (
+            ProposedAction,
+            ReapCandidate,
+            _act_on_stalled_candidates,
+        )
+
+        worktree = tmp_path / "wt-lane-auto-stalled"
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+        daemon = FakeNativeDaemonClient()
+        monkeypatch.setattr("cw.reconcile.get_native_daemon_client", lambda: daemon)
+        monkeypatch.setattr(
+            "cw.reconcile.get_client",
+            lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+        )
+        monkeypatch.setattr(
+            "cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: False
+        )
+        monkeypatch.setattr("cw.reconcile.remove_worktree", lambda *_a, **_kw: None)
+        _fast_client = _client_with_lane(
+            "client-a", "fast", ReapPolicy.AUTO, workspace_path=tmp_path / "ws"
+        )
+        monkeypatch.setattr(
+            "cw.reconcile.load_effective_clients",
+            lambda: {"client-a": _fast_client},
+        )
+
+        sess = _mk_headless_daemon_session("lane-auto-stall-1", worktree, started_at)
+        state = CwState(sessions=[sess])
+        save_state(state)
+        task = TicketTask(
+            ticket_id="lane-auto-stall-1",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="lane-auto-stall-1",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        candidate = ReapCandidate(
+            session_id="lane-auto-stall-1",
+            proposed_action=ProposedAction.REVERT_TASK,
+            ticket_id="lane-auto-stall-1",
+            elapsed_seconds=3700.0,
+            lane="fast",
+            client="client-a",
+        )
+
+        # Global is SIGNAL_ONLY but lane is AUTO → should ACT (reverts to PENDING)
+        reverted = _act_on_stalled_candidates(
+            state, [candidate], now=now, config=OrchestratorConfig()
+        )
+
+        assert "lane-auto-stall-1" in reverted
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "lane-auto-stall-1")
+        assert t.status == QueueItemStatus.PENDING
+
+    def test_lane_signal_global_auto_signals(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lane SIGNAL_ONLY + global AUTO: REVERT_TASK candidate → BLOCKED_ON_USER."""
+        from cw.reconcile import (
+            ProposedAction,
+            ReapCandidate,
+            _act_on_stalled_candidates,
+        )
+
+        worktree = tmp_path / "wt-lane-sig-stalled"
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+        daemon = FakeNativeDaemonClient()
+        monkeypatch.setattr("cw.reconcile.get_native_daemon_client", lambda: daemon)
+        _slow_client = _client_with_lane(
+            "client-a", "slow", ReapPolicy.SIGNAL_ONLY, workspace_path=tmp_path / "ws"
+        )
+        monkeypatch.setattr(
+            "cw.reconcile.load_effective_clients",
+            lambda: {"client-a": _slow_client},
+        )
+
+        sess = _mk_headless_daemon_session("lane-sig-stall-1", worktree, started_at)
+        state = CwState(sessions=[sess])
+        save_state(state)
+        task = TicketTask(
+            ticket_id="lane-sig-stall-1",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="lane-sig-stall-1",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        candidate = ReapCandidate(
+            session_id="lane-sig-stall-1",
+            proposed_action=ProposedAction.REVERT_TASK,
+            ticket_id="lane-sig-stall-1",
+            elapsed_seconds=3700.0,
+            lane="slow",
+            client="client-a",
+        )
+
+        # Global is AUTO but lane is SIGNAL_ONLY → routes to BLOCKED_ON_USER
+        reverted = _act_on_stalled_candidates(
+            state, [candidate], now=now, config=_auto_config()
+        )
+
+        assert reverted == []
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "lane-sig-stall-1")
+        assert t.status == QueueItemStatus.BLOCKED_ON_USER
+
+
+class TestActOnIdleCandidatesPerLane:
+    """Per-lane reap_policy overrides global for idle candidates."""
+
+    def test_lane_auto_global_signal_idle_acts(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lane AUTO + global SIGNAL_ONLY: idle REVERT_TASK → PENDING."""
+        from cw.reconcile import (
+            ProposedAction,
+            ReapCandidate,
+            _act_on_idle_candidates,
+        )
+
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+
+        daemon = FakeNativeDaemonClient()
+        monkeypatch.setattr("cw.reconcile.get_native_daemon_client", lambda: daemon)
+        monkeypatch.setattr(
+            "cw.reconcile.get_client",
+            lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+        )
+        monkeypatch.setattr(
+            "cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: False
+        )
+        monkeypatch.setattr("cw.reconcile.remove_worktree", lambda *_a, **_kw: None)
+        _fast_client_idle = _client_with_lane(
+            "client-a", "fast", ReapPolicy.AUTO, workspace_path=tmp_path / "ws"
+        )
+        monkeypatch.setattr(
+            "cw.reconcile.load_effective_clients",
+            lambda: {"client-a": _fast_client_idle},
+        )
+
+        sess = _mk_live_idle_daemon_session(
+            "lane-auto-idle-1", "live-ref", started_at, idle_observation_count=2
+        )
+        state = CwState(sessions=[sess])
+        save_state(state)
+        task = TicketTask(
+            ticket_id="lane-auto-idle-1",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="lane-auto-idle-1",
+            attempts=1,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        candidate = ReapCandidate(
+            session_id="lane-auto-idle-1",
+            proposed_action=ProposedAction.REVERT_TASK,
+            ticket_id="lane-auto-idle-1",
+            elapsed_seconds=1000.0,
+            new_observation_count=2,
+            lane="fast",
+            client="client-a",
+        )
+
+        blocked, _salvage = _act_on_idle_candidates(
+            state, [candidate], now=now, config=OrchestratorConfig()
+        )
+
+        assert blocked == []
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "lane-auto-idle-1")
+        assert t.status == QueueItemStatus.PENDING
+
+    def test_lane_signal_global_auto_idle_signals(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lane SIGNAL_ONLY + global AUTO: idle REVERT_TASK → BLOCKED_ON_USER."""
+        from cw.reconcile import (
+            ProposedAction,
+            ReapCandidate,
+            _act_on_idle_candidates,
+        )
+
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+
+        daemon = FakeNativeDaemonClient()
+        monkeypatch.setattr("cw.reconcile.get_native_daemon_client", lambda: daemon)
+        _slow_client_idle = _client_with_lane(
+            "client-a", "slow", ReapPolicy.SIGNAL_ONLY, workspace_path=tmp_path / "ws"
+        )
+        monkeypatch.setattr(
+            "cw.reconcile.load_effective_clients",
+            lambda: {"client-a": _slow_client_idle},
+        )
+
+        sess = _mk_live_idle_daemon_session(
+            "lane-sig-idle-1", "live-ref", started_at, idle_observation_count=2
+        )
+        state = CwState(sessions=[sess])
+        save_state(state)
+        task = TicketTask(
+            ticket_id="lane-sig-idle-1",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="lane-sig-idle-1",
+            attempts=1,
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        candidate = ReapCandidate(
+            session_id="lane-sig-idle-1",
+            proposed_action=ProposedAction.REVERT_TASK,
+            ticket_id="lane-sig-idle-1",
+            elapsed_seconds=1000.0,
+            new_observation_count=2,
+            lane="slow",
+            client="client-a",
+        )
+
+        blocked, _salvage = _act_on_idle_candidates(
+            state, [candidate], now=now, config=_auto_config()
+        )
+
+        assert blocked == []
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "lane-sig-idle-1")
+        assert t.status == QueueItemStatus.BLOCKED_ON_USER
+
+
+class TestActOnPhantomCandidatesPerLane:
+    """Per-lane reap_policy overrides global for phantom candidates."""
+
+    def test_lane_auto_global_signal_phantom_reverts(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lane AUTO + global SIGNAL_ONLY: clean CRASH_COMPLETE → PENDING."""
+        from cw.reconcile import (
+            ProposedAction,
+            ReapCandidate,
+            _act_on_phantom_candidates,
+        )
+
+        monkeypatch.setattr(
+            "cw.reconcile.get_native_daemon_client", FakeNativeDaemonClient
+        )
+        _fast_ph_client = _client_with_lane(
+            "client-a", "fast", ReapPolicy.AUTO, workspace_path=tmp_path / "ws"
+        )
+        monkeypatch.setattr(
+            "cw.reconcile.load_effective_clients",
+            lambda: {"client-a": _fast_ph_client},
+        )
+
+        now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+
+        sess = _mk_session("lane-auto-ph-1", "gone-ref")
+        sess.origin = SessionOrigin.DAEMON
+        sess.name = "client-a/auto-dev/lane-auto-ph-1"
+        state = CwState(sessions=[sess])
+        save_state(state)
+        task = TicketTask(
+            ticket_id="lane-auto-ph-1",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="lane-auto-ph-1",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        candidate = ReapCandidate(
+            session_id="lane-auto-ph-1",
+            proposed_action=ProposedAction.CRASH_COMPLETE,
+            ticket_id="lane-auto-ph-1",
+            worktree_dirty=False,
+            client="client-a",
+            lane="fast",
+        )
+
+        reverted, _names, _usage, _salvaged, _results = _act_on_phantom_candidates(
+            state, [candidate], now=now, config=OrchestratorConfig()
+        )
+
+        assert "lane-auto-ph-1" in reverted
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "lane-auto-ph-1")
+        assert t.status == QueueItemStatus.PENDING
+
+    def test_lane_signal_global_auto_phantom_blocked(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lane SIGNAL_ONLY + global AUTO: clean CRASH_COMPLETE → BLOCKED_ON_USER."""
+        from cw.reconcile import (
+            ProposedAction,
+            ReapCandidate,
+            _act_on_phantom_candidates,
+        )
+
+        monkeypatch.setattr(
+            "cw.reconcile.get_native_daemon_client", FakeNativeDaemonClient
+        )
+        _slow_ph_client = _client_with_lane(
+            "client-a", "slow", ReapPolicy.SIGNAL_ONLY, workspace_path=tmp_path / "ws"
+        )
+        monkeypatch.setattr(
+            "cw.reconcile.load_effective_clients",
+            lambda: {"client-a": _slow_ph_client},
+        )
+
+        now = datetime(2026, 1, 1, 0, 20, 0, tzinfo=UTC)
+
+        sess = _mk_session("lane-sig-ph-1", "gone-ref")
+        sess.origin = SessionOrigin.DAEMON
+        sess.name = "client-a/auto-dev/lane-sig-ph-1"
+        state = CwState(sessions=[sess])
+        save_state(state)
+        task = TicketTask(
+            ticket_id="lane-sig-ph-1",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="lane-sig-ph-1",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task]))
+
+        candidate = ReapCandidate(
+            session_id="lane-sig-ph-1",
+            proposed_action=ProposedAction.CRASH_COMPLETE,
+            ticket_id="lane-sig-ph-1",
+            worktree_dirty=False,
+            client="client-a",
+            lane="slow",
+        )
+
+        reverted, _names, _usage, _salvaged, _results = _act_on_phantom_candidates(
+            state, [candidate], now=now, config=_auto_config()
+        )
+
+        assert "lane-sig-ph-1" not in reverted
+        store = load_dev_queue()
+        t = next(t for t in store.tasks if t.ticket_id == "lane-sig-ph-1")
+        assert t.status == QueueItemStatus.BLOCKED_ON_USER
+
+
+class TestMixedLanePolicySingleTick:
+    """Single reconcile tick with two candidates on different lane policies."""
+
+    def test_mixed_policy_stalled_one_acts_one_signals(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lane A (auto) acts while lane B (signal_only) routes BLOCKED_ON_USER."""
+        from cw.reconcile import (
+            ProposedAction,
+            ReapCandidate,
+            _act_on_stalled_candidates,
+        )
+
+        worktree_a = tmp_path / "wt-mixed-a"
+        worktree_b = tmp_path / "wt-mixed-b"
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+        daemon = FakeNativeDaemonClient()
+        monkeypatch.setattr("cw.reconcile.get_native_daemon_client", lambda: daemon)
+        monkeypatch.setattr(
+            "cw.reconcile.get_client",
+            lambda name: ClientConfig(name=name, workspace_path=tmp_path / "ws"),
+        )
+        monkeypatch.setattr(
+            "cw.reconcile.worktree_has_unsaved_work", lambda _c, _b: False
+        )
+        monkeypatch.setattr("cw.reconcile.remove_worktree", lambda *_a, **_kw: None)
+
+        from cw.models import LaneConfig
+
+        client = ClientConfig(
+            name="client-a",
+            workspace_path=tmp_path / "ws",
+            lanes=[
+                LaneConfig(name="fast", reap_policy=ReapPolicy.AUTO),
+                LaneConfig(name="slow", reap_policy=ReapPolicy.SIGNAL_ONLY),
+            ],
+        )
+        monkeypatch.setattr(
+            "cw.reconcile.load_effective_clients",
+            lambda: {"client-a": client},
+        )
+
+        sess_a = _mk_headless_daemon_session("mixed-auto-1", worktree_a, started_at)
+        sess_b = _mk_headless_daemon_session("mixed-sig-1", worktree_b, started_at)
+        state = CwState(sessions=[sess_a, sess_b])
+        save_state(state)
+        task_a = TicketTask(
+            ticket_id="mixed-auto-1",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="mixed-auto-1",
+        )
+        task_b = TicketTask(
+            ticket_id="mixed-sig-1",
+            client="client-a",
+            status=QueueItemStatus.RUNNING,
+            session_id="mixed-sig-1",
+        )
+        save_dev_queue(DevQueueStore(tasks=[task_a, task_b]))
+
+        candidate_a = ReapCandidate(
+            session_id="mixed-auto-1",
+            proposed_action=ProposedAction.REVERT_TASK,
+            ticket_id="mixed-auto-1",
+            elapsed_seconds=3700.0,
+            lane="fast",
+            client="client-a",
+        )
+        candidate_b = ReapCandidate(
+            session_id="mixed-sig-1",
+            proposed_action=ProposedAction.REVERT_TASK,
+            ticket_id="mixed-sig-1",
+            elapsed_seconds=3700.0,
+            lane="slow",
+            client="client-a",
+        )
+
+        # Global is SIGNAL_ONLY; lane A is AUTO, lane B is SIGNAL_ONLY
+        reverted = _act_on_stalled_candidates(
+            state,
+            [candidate_a, candidate_b],
+            now=now,
+            config=OrchestratorConfig(),
+        )
+
+        # Lane A (fast/AUTO): reverted to PENDING
+        assert "mixed-auto-1" in reverted
+        # Lane B (slow/SIGNAL_ONLY): routes to BLOCKED_ON_USER
+        assert "mixed-sig-1" not in reverted
+
+        store = load_dev_queue()
+        t_a = next(t for t in store.tasks if t.ticket_id == "mixed-auto-1")
+        t_b = next(t for t in store.tasks if t.ticket_id == "mixed-sig-1")
+        assert t_a.status == QueueItemStatus.PENDING
+        assert t_b.status == QueueItemStatus.BLOCKED_ON_USER
+
+
+class TestReapProposedPayloadLane:
+    """SESSION_REAP_PROPOSED payload includes lane field (GitHub #560)."""
+
+    def test_reap_proposed_payload_includes_lane(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Candidate with lane='fast' → payload has lane='fast'."""
+        from cw.reconcile import ProposedAction, ReapCandidate, _emit_reap_proposed
+
+        worktree = tmp_path / "wt-lane-payload"
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+        sess = _mk_headless_daemon_session("lane-payload-1", worktree, started_at)
+        state = CwState(sessions=[sess])
+        save_state(state)
+        save_dev_queue(DevQueueStore(tasks=[]))
+
+        candidate = ReapCandidate(
+            session_id="lane-payload-1",
+            proposed_action=ProposedAction.REVERT_TASK,
+            ticket_id="lane-payload-1",
+            elapsed_seconds=3700.0,
+            lane="fast",
+        )
+
+        _emit_reap_proposed(state, [candidate], native_live=set(), now=now)
+
+        events = read_events()
+        reap_events = [
+            e for e in events if e.type == OrchestratorEventType.SESSION_REAP_PROPOSED
+        ]
+        assert len(reap_events) == 1
+        assert reap_events[0].payload["lane"] == "fast"
+
+    def test_reap_proposed_default_lane_in_payload(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Candidate with default lane → payload has lane='default'."""
+        from cw.models import DEFAULT_LANE
+        from cw.reconcile import ProposedAction, ReapCandidate, _emit_reap_proposed
+
+        worktree = tmp_path / "wt-default-lane-payload"
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 1, 1, 0, tzinfo=UTC)
+
+        sess = _mk_headless_daemon_session("default-lane-1", worktree, started_at)
+        state = CwState(sessions=[sess])
+        save_state(state)
+        save_dev_queue(DevQueueStore(tasks=[]))
+
+        candidate = ReapCandidate(
+            session_id="default-lane-1",
+            proposed_action=ProposedAction.REVERT_TASK,
+            ticket_id="default-lane-1",
+            elapsed_seconds=3700.0,
+        )
+
+        _emit_reap_proposed(state, [candidate], native_live=set(), now=now)
+
+        events = read_events()
+        reap_events = [
+            e for e in events if e.type == OrchestratorEventType.SESSION_REAP_PROPOSED
+        ]
+        assert len(reap_events) == 1
+        assert reap_events[0].payload["lane"] == DEFAULT_LANE


### PR DESCRIPTION
## Summary

- Adds `LaneConfig.reap_policy: ReapPolicy | None = None` — `None` means inherit from global config (fail-safe; only explicit lane overrides take precedence over `OrchestratorConfig.reap_policy`)
- Adds `resolve_reap_policy(candidate, clients, global_cfg) -> ReapPolicy` — lane-level policy wins if explicitly set, else falls through to the global orchestrator config
- `ReapCandidate` gains `lane: str` and `client: str | None` fields; all three detect functions stamp them from the owning task / session
- All three act dispatchers (`_act_on_stalled_candidates`, `_act_on_idle_candidates`, `_act_on_phantom_candidates`) now route each candidate individually rather than applying a flat global policy
- `_emit_reap_proposed` payload gains `"lane"` field — satisfies ADR-0006 invariant 3
- `docs/events.md` `session.reap_proposed` bumped to v2 with lane field documented

## Design notes

`LaneConfig.reap_policy` defaults to `None` (not `SIGNAL_ONLY`) so that lanes without an explicit override inherit from the global config. This preserves backward compatibility: existing deployments with no lane-level `reap_policy` continue to behave exactly as before. Only a lane that explicitly sets `reap_policy: auto` in `clients.yaml` gets per-lane auto-reaping.

The two SHOULD_FIX items from code review are tracked as follow-ups:
- Thread `load_effective_clients()` from `_reconcile_locked` (currently called once per act dispatcher)
- Add fail-safe coercion validator on `LaneConfig.reap_policy` (mirrors `OrchestratorConfig._coerce_reap_policy`)

## Test plan

- [ ] `TestResolveReapPolicy` — 5 unit tests for `resolve_reap_policy` precedence
- [ ] `TestActOnStalledCandidatesPerLane` — lane-auto/global-signal + lane-signal/global-auto
- [ ] `TestActOnIdleCandidatesPerLane` — same for idle candidates
- [ ] `TestActOnPhantomCandidatesPerLane` — same for phantom candidates
- [ ] `TestMixedLanePolicySingleTick` — two candidates with different lane policies in one tick
- [ ] `TestReapProposedPayloadLane` — `"lane"` field in payload; default lane in payload
- [ ] Pre-existing phantom/stall/idle tests continue to pass (backward-compatible)
- [ ] All quality gates: ruff ✓ mypy --strict ✓ pytest 2022 passed ✓ patch coverage 100% ✓

Closes #560

🤖 Generated with [Claude Code](https://claude.ai/claude-code)