### PR TITLE
feat(reconcile): route emitted-but-unrouted sentinels before idle watchdog fires (#578)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -23,11 +23,6 @@ from cw import __version__
 from cw._util import _iter_assistant_text_blocks, claude_project_dir
 from cw.atomic import atomic_write_text
 from cw.auto_dev_result import (
-    BLOCKER_REASON_NO_RESULT_EMITTED,
-    BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED,
-    BLOCKER_REASON_VALIDATION_FAILED,
-    PAUSED_FOR_USER_INPUT_STATUSES,
-    SALVAGE_TERMINAL_STATUSES,
     AutoDevResult,
     BlockedResult,
     Status,
@@ -120,6 +115,7 @@ from cw.queue import (
     remove_item,
 )
 from cw.reconcile import (
+    _apply_sentinel_to_task,
     _csid_from_transcript,
     _locate_session_transcript,
     reconcile,
@@ -1363,113 +1359,6 @@ def event_tail(
     if consumer is not None and events:
         advance_cursor(consumer, events[-1].id)
         click.echo(f"Cursor advanced to: {events[-1].id}", err=True)
-
-
-# Max dispatch attempts before a validation_failed sentinel caps the task as
-# FAILED rather than reverting to PENDING. See issue #251 Bug B.
-_VALIDATION_FAILED_MAX_ATTEMPTS = 3
-
-# BlockedResult reason codes that are deterministic — the running parser binary
-# will produce the same result on every retry, so there is no point retrying.
-# Route these to FAILED on first occurrence.  See GitHub issue #263.
-_DETERMINISTIC_PARSE_FAILURES: frozenset[str] = frozenset(
-    {BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED}
-)
-
-# BlockedResult reason codes that are transient — the failure condition could
-# resolve on a fresh dispatch (e.g. worker crashed before emitting a sentinel).
-_TRANSIENT_PARSE_FAILURES: frozenset[str] = frozenset(
-    {BLOCKER_REASON_NO_RESULT_EMITTED}
-)
-
-# AutoDevResult statuses that represent terminal outcomes the dev-queue should
-# never auto-retry. Marking these COMPLETED prevents the race described in
-# issue #251 Bug A where revert_completed_silent_tasks reverts a task to
-# PENDING before consume_completed_sessions can process the SESSION_COMPLETED
-# event — causing no_op and similar outcomes to trigger infinite re-dispatch.
-# Also covers ambiguities_pending_resolution and premises_pending_verification
-# (issue #316): these are terminal-pending-user, not retry candidates.
-#
-# Defined in auto_dev_result.py as SALVAGE_TERMINAL_STATUSES; imported here
-# so reconcile.py and cli.py share a single source of truth. See #431.
-_TERMINAL_NO_RETRY_STATUSES: frozenset[str] = SALVAGE_TERMINAL_STATUSES
-
-
-def _apply_sentinel_to_task(
-    ticket_id: str,
-    cw_session_id: str,
-    sentinel: AutoDevResult | BlockedResult,
-) -> None:
-    """Directly update the matching dev-queue task based on the sentinel result.
-
-    Called from signal_stop *before* the session is marked COMPLETED so the
-    task is already in its terminal state when revert_completed_silent_tasks
-    runs. This closes the race window where:
-
-      1. signal_stop marks session COMPLETED (save_state)
-      2. dispatch loop reconcile fires: sees COMPLETED session + RUNNING task
-         → reverts task to PENDING
-      3. consume_completed_sessions reads the SESSION_COMPLETED event but
-         finds task is PENDING (not RUNNING) → skips it
-      4. next tick re-dispatches the ticket (infinite loop for no_op)
-
-    See GitHub issue #251.
-    """
-    with dev_queue_lock():
-        store = load_dev_queue()
-        target: TicketTask | None = None
-        for task in store.tasks:
-            if (
-                task.ticket_id == ticket_id
-                and task.session_id == cw_session_id
-                and task.status == QueueItemStatus.RUNNING
-            ):
-                target = task
-                break
-        if target is None:
-            return
-
-        if isinstance(sentinel, AutoDevResult):
-            if sentinel.status in PAUSED_FOR_USER_INPUT_STATUSES:
-                target.status = QueueItemStatus.BLOCKED_ON_USER
-            elif sentinel.status in _TERMINAL_NO_RETRY_STATUSES:
-                target.status = QueueItemStatus.COMPLETED
-            elif sentinel.status == "blocked":
-                retry = (
-                    sentinel.blocker is not None
-                    and sentinel.blocker.retry_eligible is True
-                )
-                if retry:
-                    target.status = QueueItemStatus.PENDING
-                    target.session_id = None
-                else:
-                    target.status = QueueItemStatus.COMPLETED
-            else:
-                target.status = QueueItemStatus.COMPLETED
-        else:
-            # BlockedResult: sentinel failed to parse or was malformed.
-            if sentinel.blocker.reason in _DETERMINISTIC_PARSE_FAILURES:
-                # Deterministic failure — retrying the same binary won't help.
-                target.status = QueueItemStatus.FAILED
-            elif sentinel.blocker.reason == BLOCKER_REASON_VALIDATION_FAILED:
-                if target.attempts >= _VALIDATION_FAILED_MAX_ATTEMPTS:
-                    target.status = QueueItemStatus.FAILED
-                else:
-                    target.status = QueueItemStatus.PENDING
-                    target.session_id = None
-            elif sentinel.blocker.reason in _TRANSIENT_PARSE_FAILURES:
-                target.status = QueueItemStatus.PENDING
-                target.session_id = None
-            else:
-                # Known codes that intentionally fall here:
-                # BLOCKER_REASON_MULTIPLE_RESULT_BLOCKS,
-                # BLOCKER_REASON_STATUS_UNKNOWN.
-                # Both are terminal (retry won't fix them); COMPLETED avoids
-                # re-burning dispatch cycles.  The else also catches any future
-                # unknown reason code conservatively.
-                target.status = QueueItemStatus.COMPLETED
-
-        save_dev_queue(store)
 
 
 def _parse_sentinel_from_transcript(

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -374,6 +374,11 @@ class OrchestratorConfig(BaseModel):
     # sessions to BLOCKED_ON_USER for operator review; ``auto`` restores the
     # pre-#554 self-healing behavior. See ADR-0006 invariant 4 and GitHub #554.
     reap_policy: ReapPolicy = ReapPolicy.SIGNAL_ONLY
+    # Elapsed seconds before reconcile attempts to route an emitted-but-unrouted
+    # sentinel (signal_stop never fired). Shorter than the idle watchdog budget
+    # because an emitted sentinel is positive evidence the worker completed.
+    # See GitHub #578.
+    sentinel_unrouted_check_seconds: int = 300
     # RFC 0004 Phase 2 — two-knob scheduler (#558)
     # Tier-1: limit how many clients are eligible per tick.
     # None = no limit (today's behavior preserved).

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -55,9 +55,13 @@ from typing import TYPE_CHECKING
 
 from cw._util import claude_project_dir
 from cw.auto_dev_result import (
+    BLOCKER_REASON_NO_RESULT_EMITTED,
+    BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED,
+    BLOCKER_REASON_VALIDATION_FAILED,
     PAUSED_FOR_USER_INPUT_STATUSES,
     SALVAGE_TERMINAL_STATUSES,
     AutoDevResult,
+    BlockedResult,
     parse_stdout,
 )
 from cw.config import (
@@ -415,6 +419,17 @@ def _is_headless(session: Session) -> bool:
 # so reconcile.py and cli.py cannot drift apart. See GitHub issues #372, #431.
 _SALVAGE_TERMINAL_STATUSES: frozenset[str] = SALVAGE_TERMINAL_STATUSES
 
+# Constants for _apply_sentinel_to_task (moved from cli.py; shared by both
+# signal_stop and the ROUTE_EMITTED_SENTINEL reconcile path). See GitHub #578.
+_VALIDATION_FAILED_MAX_ATTEMPTS = 3
+_DETERMINISTIC_PARSE_FAILURES: frozenset[str] = frozenset(
+    {BLOCKER_REASON_SCHEMA_VERSION_UNSUPPORTED}
+)
+_TRANSIENT_PARSE_FAILURES: frozenset[str] = frozenset(
+    {BLOCKER_REASON_NO_RESULT_EMITTED}
+)
+_TERMINAL_NO_RETRY_STATUSES: frozenset[str] = SALVAGE_TERMINAL_STATUSES
+
 
 def _assistant_text_from_transcript(path: Path) -> str:
     """Concatenate the text of every assistant message in a jsonl transcript.
@@ -491,6 +506,93 @@ def _salvage_terminal_result(
     ):
         return result, transcript.stem
     return None
+
+
+def _parse_any_sentinel_from_transcript(
+    session: Session,
+) -> tuple[AutoDevResult | BlockedResult, str] | None:
+    """Parse any sentinel from the transcript, regardless of status.
+
+    Like :func:`_salvage_terminal_result` but applies no status filter — returns
+    the result for any valid parse including PAUSED_FOR_USER_INPUT statuses that
+    :func:`_salvage_terminal_result` would skip.  Returns None only when no
+    sentinel framing is present (BLOCKER_REASON_NO_RESULT_EMITTED).
+
+    Used by the ROUTE_EMITTED_SENTINEL detection path for sessions where the
+    sentinel was emitted but the Stop hook never fired.  See GitHub #578.
+    """
+    transcript = _locate_session_transcript(session)
+    if transcript is None:
+        return None
+    result = parse_stdout(_assistant_text_from_transcript(transcript))
+    if (
+        isinstance(result, BlockedResult)
+        and result.blocker.reason == BLOCKER_REASON_NO_RESULT_EMITTED
+    ):
+        return None
+    return result, transcript.stem
+
+
+def _apply_sentinel_to_task(
+    ticket_id: str,
+    cw_session_id: str,
+    sentinel: AutoDevResult | BlockedResult,
+) -> None:
+    """Update the matching dev-queue task based on the sentinel result.
+
+    Shared by signal_stop (cli.py) and the ROUTE_EMITTED_SENTINEL reconcile
+    path so both use the same sentinel→QueueItemStatus mapping.  Called before
+    marking the session COMPLETED so the task is in its terminal state when
+    revert_completed_silent_tasks runs.  See GitHub issues #251, #578.
+    """
+    with dev_queue_lock():
+        store = load_dev_queue()
+        target: TicketTask | None = None
+        for task in store.tasks:
+            if (
+                task.ticket_id == ticket_id
+                and task.session_id == cw_session_id
+                and task.status == QueueItemStatus.RUNNING
+            ):
+                target = task
+                break
+        if target is None:
+            return
+
+        if isinstance(sentinel, AutoDevResult):
+            if sentinel.status in PAUSED_FOR_USER_INPUT_STATUSES:
+                target.status = QueueItemStatus.BLOCKED_ON_USER
+            elif sentinel.status in _TERMINAL_NO_RETRY_STATUSES:
+                target.status = QueueItemStatus.COMPLETED
+            elif sentinel.status == "blocked":
+                retry = (
+                    sentinel.blocker is not None
+                    and sentinel.blocker.retry_eligible is True
+                )
+                if retry:
+                    target.status = QueueItemStatus.PENDING
+                    target.session_id = None
+                else:
+                    target.status = QueueItemStatus.COMPLETED
+            else:
+                target.status = QueueItemStatus.COMPLETED
+        else:
+            # BlockedResult: sentinel failed to parse or was malformed.
+            if sentinel.blocker.reason in _DETERMINISTIC_PARSE_FAILURES:
+                target.status = QueueItemStatus.FAILED
+            elif sentinel.blocker.reason == BLOCKER_REASON_VALIDATION_FAILED:
+                if target.attempts >= _VALIDATION_FAILED_MAX_ATTEMPTS:
+                    target.status = QueueItemStatus.FAILED
+                else:
+                    target.status = QueueItemStatus.PENDING
+                    target.session_id = None
+            elif sentinel.blocker.reason in _TRANSIENT_PARSE_FAILURES:
+                target.status = QueueItemStatus.PENDING
+                target.session_id = None
+            else:
+                target.status = QueueItemStatus.COMPLETED
+
+        save_dev_queue(store)
 
 
 def _session_project_dir(session: Session) -> Path | None:
@@ -1181,6 +1283,31 @@ def _detect_idle_candidates(
         ticket_id = ticket_id_for_session(session.name)
         task = task_by_ticket.get(ticket_id) if ticket_id else None
         budget = resolve_idle_watchdog_budget(task, config)
+        # ROUTE_EMITTED_SENTINEL: fires before the full idle-budget check.
+        # An emitted sentinel is positive evidence the worker completed; the
+        # 300 s threshold (sentinel_unrouted_check_seconds) is shorter than
+        # the watchdog budget to route the task before a reap fires.
+        # Guard: last_result is None means signal_stop never ran — prevents
+        # double-routing. Exempt from signal_only (constructive, not a reap).
+        # See GitHub #578.
+        unrouted_check = config.sentinel_unrouted_check_seconds
+        if session.last_result is None and elapsed >= unrouted_check:
+            routed = _parse_any_sentinel_from_transcript(session)
+            if routed is not None:
+                _routed_result, _csid = routed
+                candidates.append(
+                    ReapCandidate(
+                        session_id=session.id,
+                        proposed_action=ProposedAction.ROUTE_EMITTED_SENTINEL,
+                        ticket_id=ticket_id,
+                        routed_sentinel=_routed_result,
+                        salvage_csid=_csid,
+                        elapsed_seconds=elapsed,
+                        lane=task.lane if task else DEFAULT_LANE,
+                        client=session.client,
+                    )
+                )
+                continue
         if elapsed < budget:
             continue
         # Liveness check: if active, check for recovery of observation counter.
@@ -1357,6 +1484,28 @@ def _act_on_idle_candidates(
     salvage_git_candidates_list = [
         c for c in candidates if c.proposed_action == ProposedAction.SALVAGE_GIT
     ]
+    routed_sentinel_candidates = [
+        c
+        for c in candidates
+        if c.proposed_action == ProposedAction.ROUTE_EMITTED_SENTINEL
+    ]
+
+    # ROUTE_EMITTED_SENTINEL queue routing: _apply_sentinel_to_task acquires its
+    # own dev_queue_lock so it runs BEFORE the shared lock block below.  Session
+    # state is mutated here; save_state picks it up in the combined flush below.
+    for candidate in routed_sentinel_candidates:
+        if candidate.routed_sentinel is None or candidate.salvage_csid is None:
+            continue
+        if candidate.ticket_id:
+            _apply_sentinel_to_task(
+                candidate.ticket_id, candidate.session_id, candidate.routed_sentinel
+            )
+        session = session_by_id[candidate.session_id]
+        session.status = SessionStatus.COMPLETED
+        session.completed_at = now
+        session.completed_reason = CompletionReason.NORMAL
+        session.last_result = candidate.routed_sentinel.model_dump(mode="json")
+        session.claude_session_id = candidate.salvage_csid
 
     # Counter-only updates: just update the counter and possibly save_state.
     counters_changed = False
@@ -1397,6 +1546,7 @@ def _act_on_idle_candidates(
         or revert_candidates
         or park_candidates
         or salvage_git_candidates_list
+        or routed_sentinel_candidates
     )
 
     if counters_changed or has_dispositions:
@@ -1492,6 +1642,24 @@ def _act_on_idle_candidates(
             "status": candidate.salvage_result.status,
         }
         record_event(OrchestratorEventType.SESSION_COMPLETED, completed_payload)
+        if session.surface_ref is not None:
+            get_native_daemon_client().stop(session.surface_ref)
+
+    for candidate in routed_sentinel_candidates:
+        if candidate.routed_sentinel is None:
+            continue
+        session = session_by_id[candidate.session_id]
+        routed_payload: dict[str, object] = {
+            "session_id": session.id,
+            "session_name": session.name,
+            "client": session.client,
+            "ticket_id": candidate.ticket_id,
+            "claude_session_id": session.claude_session_id,
+            "crashed": False,
+            "salvaged": True,
+            "status": candidate.routed_sentinel.status,
+        }
+        record_event(OrchestratorEventType.SESSION_COMPLETED, routed_payload)
         if session.surface_ref is not None:
             get_native_daemon_client().stop(session.surface_ref)
 
@@ -1611,6 +1779,10 @@ class ProposedAction(StrEnum):
     SKIP_PARKED = "skip_parked"
     INCREMENT_COUNTER = "increment_counter"
     RECOVER_COUNTER = "recover_counter"
+    # Emitted sentinel that signal_stop never routed (turn never completed).
+    # Fires at sentinel_unrouted_check_seconds; exempt from signal_only.
+    # See GitHub #578.
+    ROUTE_EMITTED_SENTINEL = "route_emitted_sentinel"
 
 
 @dataclass(frozen=True)
@@ -1626,6 +1798,8 @@ class ReapCandidate:
     worktree_dirty: bool = False
     salvage_result: AutoDevResult | None = None
     salvage_csid: str | None = None
+    # ROUTE_EMITTED_SENTINEL carries the full parsed result (any status).
+    routed_sentinel: AutoDevResult | BlockedResult | None = None
     usage_limit_detected: bool = False
     elapsed_seconds: float = 0.0
     reap_reason: ReapReason | None = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1820,10 +1820,10 @@ class TestSignalStop:
         """
         import datetime as dt
 
-        from cw.cli import _VALIDATION_FAILED_MAX_ATTEMPTS
         from cw.dev_queue import load_dev_queue, save_dev_queue
         from cw.models import DevQueueStore, QueueItemStatus, TicketTask
         from cw.native_daemon import FakeNativeDaemonClient
+        from cw.reconcile import _VALIDATION_FAILED_MAX_ATTEMPTS
 
         worktree, session = self._setup_headless_session(
             tmp_path, "sess-251-vf-cap", "worktree-251-vf-cap"

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -11215,3 +11215,476 @@ class TestReapProposedPayloadLane:
         ]
         assert len(reap_events) == 1
         assert reap_events[0].payload["lane"] == DEFAULT_LANE
+
+
+# ---------------------------------------------------------------------------
+# GitHub #578 — ROUTE_EMITTED_SENTINEL: reconcile honors emitted-but-unrouted
+# sentinels without waiting for signal_stop
+# ---------------------------------------------------------------------------
+
+
+class TestRouteEmittedSentinel:
+    """flag_silently_idle_daemon_sessions routes a transcript sentinel before
+    the idle watchdog budget fires (GitHub #578)."""
+
+    def test_detect_sentinel_present_routes_before_watchdog(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sentinel present + last_result None + elapsed >= 300 s
+        → ROUTE_EMITTED_SENTINEL, task COMPLETED, session COMPLETED."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        worktree = tmp_path / "wt-578-detect"
+        # 305 s elapsed — past the 300-s check but well under 900-s watchdog.
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 0, 5, 5, tzinfo=UTC)
+        assert (now - started_at).total_seconds() >= 300
+        assert (now - started_at).total_seconds() < IDLE_WATCHDOG_SECONDS
+
+        sess = _mk_headless_daemon_session("578-detect", worktree, started_at)
+        sess.last_result = None
+        _write_salvage_transcript(
+            home, worktree, "claude-578-uuid-1", _shipped_salvage_payload()
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id="578-detect",
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="578-detect",
+                    )
+                ]
+            )
+        )
+
+        mock_daemon = MagicMock()
+        with patch("cw.reconcile.get_native_daemon_client", return_value=mock_daemon):
+            state = load_state()
+            blocked, _salvage = flag_silently_idle_daemon_sessions(
+                state,
+                now=now,
+                native_live={"fake-short-id"},
+                config=_auto_config(),
+            )
+
+        assert blocked == []
+        reloaded = next(s for s in load_state().sessions if s.id == "578-detect")
+        assert reloaded.status == SessionStatus.COMPLETED
+        assert reloaded.completed_reason == CompletionReason.NORMAL
+        assert reloaded.last_result is not None
+        assert reloaded.last_result["status"] == "shipped"
+
+        task = next(t for t in load_dev_queue().tasks if t.ticket_id == "578-detect")
+        assert task.status == QueueItemStatus.COMPLETED
+
+        mock_daemon.stop.assert_called_once_with("fake-short-id")
+
+    def test_detect_elapsed_under_threshold_no_candidate(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """elapsed < sentinel_unrouted_check_seconds → no ROUTE_EMITTED_SENTINEL
+        candidate, sentinel left in transcript for next tick."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        worktree = tmp_path / "wt-578-under"
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 0, 4, 0, tzinfo=UTC)  # 240 s < 300 s threshold
+        assert (now - started_at).total_seconds() < 300
+
+        sess = _mk_headless_daemon_session("578-under", worktree, started_at)
+        sess.last_result = None
+        _write_salvage_transcript(
+            home, worktree, "claude-578-uuid-2", _shipped_salvage_payload()
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id="578-under",
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="578-under",
+                    )
+                ]
+            )
+        )
+
+        state = load_state()
+        blocked, _salvage = flag_silently_idle_daemon_sessions(
+            state,
+            now=now,
+            native_live={"fake-short-id"},
+            config=_auto_config(),
+        )
+
+        assert blocked == []
+        reloaded = next(s for s in load_state().sessions if s.id == "578-under")
+        # Session must NOT be completed — too early for the sentinel check.
+        assert reloaded.status == SessionStatus.ACTIVE
+
+        task = next(t for t in load_dev_queue().tasks if t.ticket_id == "578-under")
+        assert task.status == QueueItemStatus.RUNNING
+
+    def test_detect_last_result_set_skips_double_route(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """session.last_result already set → ROUTE_EMITTED_SENTINEL skipped
+        (signal_stop already ran; prevents double-routing)."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        worktree = tmp_path / "wt-578-dbl"
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 0, 5, 5, tzinfo=UTC)
+
+        sess = _mk_headless_daemon_session("578-dbl", worktree, started_at)
+        # Simulate: signal_stop already ran and stored last_result.
+        sess.last_result = {"status": "shipped"}
+        _write_salvage_transcript(
+            home, worktree, "claude-578-uuid-3", _shipped_salvage_payload()
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id="578-dbl",
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="578-dbl",
+                    )
+                ]
+            )
+        )
+
+        state = load_state()
+        blocked, _salvage = flag_silently_idle_daemon_sessions(
+            state,
+            now=now,
+            native_live={"fake-short-id"},
+            config=_auto_config(),
+        )
+
+        assert blocked == []
+        # Session stays ACTIVE — watchdog budget not yet exhausted, no route.
+        reloaded = next(s for s in load_state().sessions if s.id == "578-dbl")
+        assert reloaded.status == SessionStatus.ACTIVE
+
+        task = next(t for t in load_dev_queue().tasks if t.ticket_id == "578-dbl")
+        assert task.status == QueueItemStatus.RUNNING
+
+    def test_detect_live_session_with_sentinel_routes_not_crash_complete(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Live-roster session + sentinel → ROUTE_EMITTED_SENTINEL, NOT a crash path.
+        Session ends COMPLETED/NORMAL (not TIMED_OUT)."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        worktree = tmp_path / "wt-578-live"
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 0, 5, 5, tzinfo=UTC)
+
+        sess = _mk_headless_daemon_session("578-live", worktree, started_at)
+        sess.last_result = None
+        _write_salvage_transcript(
+            home, worktree, "claude-578-uuid-4", _no_op_salvage_payload()
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id="578-live",
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="578-live",
+                    )
+                ]
+            )
+        )
+
+        mock_daemon = MagicMock()
+        with patch("cw.reconcile.get_native_daemon_client", return_value=mock_daemon):
+            state = load_state()
+            blocked, _salvage = flag_silently_idle_daemon_sessions(
+                state,
+                now=now,
+                native_live={"fake-short-id"},
+                config=_auto_config(),
+            )
+
+        assert blocked == []
+        reloaded = next(s for s in load_state().sessions if s.id == "578-live")
+        assert reloaded.status == SessionStatus.COMPLETED
+        assert reloaded.completed_reason == CompletionReason.NORMAL
+        assert reloaded.last_result is not None
+        assert reloaded.last_result["status"] == "no_op"
+
+        task = next(t for t in load_dev_queue().tasks if t.ticket_id == "578-live")
+        assert task.status == QueueItemStatus.COMPLETED
+
+    def test_act_blocked_retry_eligible_routes_to_pending(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sentinel status=blocked + retry_eligible=True → task reverts to PENDING."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        worktree = tmp_path / "wt-578-retry"
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 0, 5, 5, tzinfo=UTC)
+
+        sess = _mk_headless_daemon_session("578-retry", worktree, started_at)
+        sess.last_result = None
+
+        blocked_retry_payload: dict[str, Any] = {
+            "schema_version": 4,
+            "ticket_id": "578-retry",
+            "status": "blocked",
+            "stage_reached": "stage2_impl",
+            "scope": {
+                "tier": "small",
+                "files": 0,
+                "lines_estimate": 0,
+                "lines_actual": None,
+                "forbidden_touched": False,
+            },
+            "plan_source": "generated",
+            "branch": None,
+            "worktree_path": None,
+            "fork_point_sha": None,
+            "commits": [],
+            "pr": None,
+            "review": {"must_fix_initial": 0, "should_fix": 0, "fix_cycles_used": 0},
+            "health": {
+                "lowest_agent_confidence": "LOW",
+                "any_incomplete_risk": True,
+                "shortcuts": [],
+                "recommendation": "EXIT_FOR_HUMAN_REVIEW",
+                "downgrade_applied": False,
+                "fix_loop_escalated": False,
+            },
+            "friction_highlights": [],
+            "blocker": {
+                "stage": "stage2_impl",
+                "reason": "impl_failed",
+                "retry_eligible": True,
+                "details": "agent timed out",
+                "next_actions": ["redispatch_ticket"],
+            },
+            "next_actions": ["redispatch_ticket"],
+        }
+        _write_salvage_transcript(
+            home, worktree, "claude-578-uuid-5", blocked_retry_payload
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id="578-retry",
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="578-retry",
+                    )
+                ]
+            )
+        )
+
+        mock_daemon = MagicMock()
+        with patch("cw.reconcile.get_native_daemon_client", return_value=mock_daemon):
+            state = load_state()
+            blocked, _salvage = flag_silently_idle_daemon_sessions(
+                state,
+                now=now,
+                native_live={"fake-short-id"},
+                config=_auto_config(),
+            )
+
+        assert blocked == []
+        task = next(t for t in load_dev_queue().tasks if t.ticket_id == "578-retry")
+        assert task.status == QueueItemStatus.PENDING
+        assert task.session_id is None
+
+    def test_act_signal_only_does_not_gate_route_emitted_sentinel(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """signal_only policy does NOT block ROUTE_EMITTED_SENTINEL — routing an
+        emitted sentinel is constructive, not a destructive reap."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        worktree = tmp_path / "wt-578-sigonly"
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 0, 5, 5, tzinfo=UTC)
+
+        sess = _mk_headless_daemon_session("578-sigonly", worktree, started_at)
+        sess.last_result = None
+        _write_salvage_transcript(
+            home, worktree, "claude-578-uuid-6", _shipped_salvage_payload()
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id="578-sigonly",
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="578-sigonly",
+                    )
+                ]
+            )
+        )
+
+        mock_daemon = MagicMock()
+        with patch("cw.reconcile.get_native_daemon_client", return_value=mock_daemon):
+            state = load_state()
+            # signal_only policy — normally gates reaps.
+            blocked, _salvage = flag_silently_idle_daemon_sessions(
+                state,
+                now=now,
+                native_live={"fake-short-id"},
+                config=OrchestratorConfig(reap_policy=ReapPolicy.SIGNAL_ONLY),
+            )
+
+        assert blocked == []
+        reloaded = next(s for s in load_state().sessions if s.id == "578-sigonly")
+        # ROUTE_EMITTED_SENTINEL is exempt from signal_only → session COMPLETED.
+        assert reloaded.status == SessionStatus.COMPLETED
+        task = next(t for t in load_dev_queue().tasks if t.ticket_id == "578-sigonly")
+        assert task.status == QueueItemStatus.COMPLETED
+
+    def test_act_session_completed_event_emitted(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """ROUTE_EMITTED_SENTINEL emits a SESSION_COMPLETED event."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        worktree = tmp_path / "wt-578-event"
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 0, 5, 5, tzinfo=UTC)
+
+        sess = _mk_headless_daemon_session("578-event", worktree, started_at)
+        sess.last_result = None
+        _write_salvage_transcript(
+            home, worktree, "claude-578-uuid-7", _shipped_salvage_payload()
+        )
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id="578-event",
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id="578-event",
+                    )
+                ]
+            )
+        )
+
+        mock_daemon = MagicMock()
+        with patch("cw.reconcile.get_native_daemon_client", return_value=mock_daemon):
+            state = load_state()
+            flag_silently_idle_daemon_sessions(
+                state,
+                now=now,
+                native_live={"fake-short-id"},
+                config=_auto_config(),
+            )
+
+        events = read_events(
+            consumer="test-578-event",
+            event_types=[OrchestratorEventType.SESSION_COMPLETED],
+        )
+        assert len(events) == 1
+        payload = events[0].payload
+        assert payload["session_id"] == "578-event"
+        assert payload["status"] == "shipped"
+        assert payload["salvaged"] is True
+        assert payload["crashed"] is False
+
+    def test_review_pending_approval_sentinel_routes_completed(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Regression: review_pending_approval-shaped sentinel emitted without
+        signal_stop routes task to COMPLETED (PAUSED_FOR_USER_INPUT path),
+        not stuck as RUNNING indefinitely."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        worktree = tmp_path / "wt-578-rpa"
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        now = datetime(2026, 1, 1, 0, 5, 5, tzinfo=UTC)
+
+        ticket_id = "578-rpa"
+        sess = _mk_headless_daemon_session(ticket_id, worktree, started_at)
+        sess.last_result = None
+        payload = _make_terminal_payload("review_pending_approval", ticket_id)
+        _write_salvage_transcript(home, worktree, "claude-578-uuid-8", payload)
+        save_state(CwState(sessions=[sess]))
+        save_dev_queue(
+            DevQueueStore(
+                tasks=[
+                    TicketTask(
+                        ticket_id=ticket_id,
+                        client="client-a",
+                        status=QueueItemStatus.RUNNING,
+                        session_id=ticket_id,
+                    )
+                ]
+            )
+        )
+
+        mock_daemon = MagicMock()
+        with patch("cw.reconcile.get_native_daemon_client", return_value=mock_daemon):
+            state = load_state()
+            blocked, _salvage = flag_silently_idle_daemon_sessions(
+                state,
+                now=now,
+                native_live={"fake-short-id"},
+                config=_auto_config(),
+            )
+
+        assert blocked == []
+        reloaded = next(s for s in load_state().sessions if s.id == ticket_id)
+        assert reloaded.status == SessionStatus.COMPLETED
+        assert reloaded.last_result is not None
+        assert reloaded.last_result["status"] == "review_pending_approval"
+
+        task = next(t for t in load_dev_queue().tasks if t.ticket_id == ticket_id)
+        # review_pending_approval is in SALVAGE_TERMINAL_STATUSES (not retried).
+        assert task.status == QueueItemStatus.COMPLETED


### PR DESCRIPTION
## Summary

- Moves `_apply_sentinel_to_task` (and its supporting constants) from `cli.py` to `reconcile.py` so both `signal_stop` and the new reconcile path share a single implementation
- Adds `ProposedAction.ROUTE_EMITTED_SENTINEL` — fires in `_detect_idle_candidates` at `sentinel_unrouted_check_seconds` (default 300 s, shorter than the 900-s idle watchdog) before the budget check; exempt from `signal_only` policy
- Adds `_parse_any_sentinel_from_transcript` — like `_salvage_terminal_result` but no status filter; returns any valid sentinel except `BLOCKER_REASON_NO_RESULT_EMITTED`
- Adds `OrchestratorConfig.sentinel_unrouted_check_seconds: int = 300`
- Adds `ReapCandidate.routed_sentinel: AutoDevResult | BlockedResult | None` to carry the parsed sentinel through to the act phase
- Guard: `session.last_result is None` prevents double-routing if `signal_stop` already ran

## Test plan

- [x] Detect: sentinel present + `last_result` None + elapsed ≥ 300 s → `ROUTE_EMITTED_SENTINEL`, task `COMPLETED`, session `COMPLETED`
- [x] Detect: elapsed < 300 s → no candidate, session stays `ACTIVE`
- [x] Detect: `last_result` already set → skipped (no double-route)
- [x] Detect: live-roster session with sentinel → `ROUTE_EMITTED_SENTINEL`, `CompletionReason.NORMAL` (not crash path)
- [x] Act: `status=blocked, retry_eligible=True` → task `PENDING`, `session_id` cleared
- [x] Act: `signal_only` policy does not gate `ROUTE_EMITTED_SENTINEL`
- [x] Act: `SESSION_COMPLETED` event emitted with `salvaged=True`
- [x] Regression: `review_pending_approval`-shaped sentinel routes task to `COMPLETED` (not stuck `RUNNING`)

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)