### PR TITLE
fix(dev-queue): wait resolves oldest terminal duplicate task instead of live one

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -51,6 +51,7 @@ from cw.config import (
     show_config,
 )
 from cw.dev_queue import (
+    _find_ticket,
     add_ticket,
     cancel_task_for_session,
     cancel_ticket,
@@ -2344,7 +2345,10 @@ def dev_queue_wait(
     while True:
         # --- Step 1: fast path — task already terminal in the queue ---
         store = load_dev_queue()
-        task = next((t for t in store.tasks if t.ticket_id == ticket_id), None)
+        try:
+            task = _find_ticket(store, ticket_id, resolved)
+        except CwError:
+            task = None
         if task is None:
             # Fallback: delegate to wait_for_terminal so it can surface
             # "not found" errors (CwError) and handle TimeoutError.

--- a/src/cw/dev_queue.py
+++ b/src/cw/dev_queue.py
@@ -367,23 +367,45 @@ def list_tickets(client: str | None = None) -> list[TicketTask]:
 def _find_ticket(store: DevQueueStore, ticket_id: str, client: str) -> TicketTask:
     """Return the TicketTask matching (ticket_id, client) or raise CwError.
 
-    Prefers the most-recent non-terminal (PENDING/RUNNING) record when
-    duplicates exist.
+    Selection priority: PENDING/RUNNING (live, newest created_at) →
+    BLOCKED_ON_USER (newest created_at) → terminal (newest created_at).
+    Re-resolved on every call — callers that poll (e.g. dev_queue_wait)
+    pick up re-enqueued tasks on the next tick automatically.
+
+    Emits a one-time stderr warning when multiple live PENDING/RUNNING tasks
+    exist for the same (ticket_id, client).
     """
-    # Why: add-after-terminal creates duplicate (client, ticket_id) rows
-    # (structurally removed by #507). Returning the oldest terminal record
-    # would cause wait_for_terminal to resolve immediately on a stale status
-    # while a fresh run of the same ticket is currently RUNNING.
+    # Why: add-after-terminal creates duplicate (client, ticket_id) rows.
+    # Returning the oldest terminal record would cause wait to resolve
+    # immediately on a stale status while a fresh RUNNING task is live.
+    import click
+
     matches = [
         t for t in store.tasks if t.ticket_id == ticket_id and t.client == client
     ]
     if not matches:
         msg = f"No dev-queue task found for ticket '{ticket_id}' in client '{client}'."
         raise CwError(msg)
-    active = [t for t in matches if t.status not in _TERMINAL_STATUSES]
-    if active:
-        return active[-1]  # most-recent active record
-    return matches[-1]  # most-recent terminal when no active record exists
+
+    live = [
+        t
+        for t in matches
+        if t.status in {QueueItemStatus.PENDING, QueueItemStatus.RUNNING}
+    ]
+    if live:
+        if len(live) > 1:
+            click.echo(
+                f"Warning: {len(live)} live tasks for ticket '{ticket_id}' "
+                f"in client '{client}'; binding to newest.",
+                err=True,
+            )
+        return max(live, key=lambda t: t.created_at)
+
+    blocked = [t for t in matches if t.status == QueueItemStatus.BLOCKED_ON_USER]
+    if blocked:
+        return max(blocked, key=lambda t: t.created_at)
+
+    return max(matches, key=lambda t: t.created_at)
 
 
 def consume_completed_sessions() -> int:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6367,6 +6367,75 @@ class TestDevQueueWaitSentinelAware:
         assert result.exit_code == _WAIT_EXIT_TIMEOUT
 
 
+# ---------------------------------------------------------------------------
+# TestDevQueueWaitDuplicateResolution (GitHub issue #579)
+# ---------------------------------------------------------------------------
+
+
+class TestDevQueueWaitDuplicateResolution:
+    """Fast-path uses _find_ticket to prefer live task over stale terminal."""
+
+    def test_wait_resolves_live_task_over_cancelled(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CANCELLED + RUNNING for same ticket → wait does not short-circuit on CANCELLED.
+
+        With --timeout 0, a non-terminal task triggers exit 124 (timeout).
+        If the fast-path mistakenly binds to CANCELLED it would exit 1.
+        """
+        from datetime import UTC, datetime, timedelta
+
+        from cw.cli import _WAIT_EXIT_TIMEOUT
+        from cw.dev_queue import save_dev_queue
+        from cw.models import DevQueueStore, QueueItemStatus, TicketTask
+
+        old_ts = datetime(2025, 5, 1, tzinfo=UTC)
+        new_ts = old_ts + timedelta(hours=1)
+
+        store = DevQueueStore(
+            tasks=[
+                TicketTask(
+                    ticket_id="GEN-579C",
+                    client="genhealth",
+                    status=QueueItemStatus.CANCELLED,
+                    created_at=old_ts,
+                ),
+                TicketTask(
+                    ticket_id="GEN-579C",
+                    client="genhealth",
+                    status=QueueItemStatus.RUNNING,
+                    session_id="sess-live",
+                    created_at=new_ts,
+                ),
+            ]
+        )
+        save_dev_queue(store)
+
+        # Prevent consume_completed_sessions from doing real dispatch work
+        monkeypatch.setattr("cw.dev_queue.consume_completed_sessions", lambda: 0)
+        monkeypatch.setattr("cw.cli.time.sleep", lambda _: None)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "dev-queue",
+                "wait",
+                "GEN-579C",
+                "--client",
+                "genhealth",
+                "--timeout",
+                "0",
+            ],
+        )
+        # exit 124 = timeout hit on non-terminal task (RUNNING was found)
+        # exit 1   = CANCELLED was resolved as the fast-path result (the bug)
+        assert result.exit_code == _WAIT_EXIT_TIMEOUT, (
+            f"Expected timeout (124) but got {result.exit_code}.\n"
+            f"Output: {result.output}"
+        )
+
+
 class TestResultValidate:
     def _valid_payload(self) -> dict[str, object]:
         return {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6378,7 +6378,7 @@ class TestDevQueueWaitDuplicateResolution:
     def test_wait_resolves_live_task_over_cancelled(
         self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """CANCELLED + RUNNING for same ticket → wait does not short-circuit on CANCELLED.
+        """CANCELLED + RUNNING for same ticket — fast-path must not short-circuit.
 
         With --timeout 0, a non-terminal task triggers exit 124 (timeout).
         If the fast-path mistakenly binds to CANCELLED it would exit 1.

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -1531,9 +1531,7 @@ class TestFindTicket:
         assert result.status == QueueItemStatus.RUNNING
         assert result.session_id == "sess-579"
 
-    def test_find_completed_only_returns_completed(
-        self, tmp_config_dir: Path
-    ) -> None:
+    def test_find_completed_only_returns_completed(self, tmp_config_dir: Path) -> None:
         """Only a COMPLETED task in queue → returns it (no live tasks)."""
         task = TicketTask(
             ticket_id="GEN-580",
@@ -1577,9 +1575,7 @@ class TestFindTicket:
         assert "Warning" in captured.err
         assert "GEN-581" in captured.err
 
-    def test_find_blocked_on_user_beats_cancelled(
-        self, tmp_config_dir: Path
-    ) -> None:
+    def test_find_blocked_on_user_beats_cancelled(self, tmp_config_dir: Path) -> None:
         """BLOCKED_ON_USER wins over CANCELLED when no live (PENDING/RUNNING) task."""
         from datetime import UTC, datetime, timedelta
 
@@ -1604,9 +1600,7 @@ class TestFindTicket:
         result = _find_ticket(loaded, "GEN-582", "genhealth")
         assert result.status == QueueItemStatus.BLOCKED_ON_USER
 
-    def test_find_explicit_created_at_tiebreak(
-        self, tmp_config_dir: Path
-    ) -> None:
+    def test_find_explicit_created_at_tiebreak(self, tmp_config_dir: Path) -> None:
         """Two RUNNING tasks → max created_at wins regardless of list position."""
         from datetime import UTC, datetime, timedelta
 

--- a/tests/test_dev_queue.py
+++ b/tests/test_dev_queue.py
@@ -1502,6 +1502,137 @@ class TestFindTicket:
         with pytest.raises(TimeoutError):
             wait_for_terminal("GEN-12", "genhealth", timeout=0, poll_interval=0)
 
+    def test_find_cancelled_plus_running_returns_running(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """RUNNING task wins over old CANCELLED task — regression for #579."""
+        from datetime import UTC, datetime, timedelta
+
+        old_ts = datetime(2025, 1, 1, tzinfo=UTC)
+        new_ts = old_ts + timedelta(hours=1)
+        cancelled = TicketTask(
+            ticket_id="GEN-579",
+            client="genhealth",
+            status=QueueItemStatus.CANCELLED,
+            created_at=old_ts,
+        )
+        running = TicketTask(
+            ticket_id="GEN-579",
+            client="genhealth",
+            status=QueueItemStatus.RUNNING,
+            session_id="sess-579",
+            created_at=new_ts,
+        )
+        store = DevQueueStore(tasks=[cancelled, running])
+        save_dev_queue(store)
+
+        loaded = load_dev_queue()
+        result = _find_ticket(loaded, "GEN-579", "genhealth")
+        assert result.status == QueueItemStatus.RUNNING
+        assert result.session_id == "sess-579"
+
+    def test_find_completed_only_returns_completed(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """Only a COMPLETED task in queue → returns it (no live tasks)."""
+        task = TicketTask(
+            ticket_id="GEN-580",
+            client="genhealth",
+            status=QueueItemStatus.COMPLETED,
+        )
+        store = DevQueueStore(tasks=[task])
+        save_dev_queue(store)
+
+        loaded = load_dev_queue()
+        result = _find_ticket(loaded, "GEN-580", "genhealth")
+        assert result.status == QueueItemStatus.COMPLETED
+
+    def test_find_multi_live_returns_newest_and_warns(
+        self, tmp_config_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Two live PENDING tasks → newest created_at wins; warning on stderr."""
+        from datetime import UTC, datetime, timedelta
+
+        old_ts = datetime(2025, 2, 1, tzinfo=UTC)
+        new_ts = old_ts + timedelta(hours=2)
+        older = TicketTask(
+            ticket_id="GEN-581",
+            client="genhealth",
+            status=QueueItemStatus.PENDING,
+            created_at=old_ts,
+        )
+        newer = TicketTask(
+            ticket_id="GEN-581",
+            client="genhealth",
+            status=QueueItemStatus.PENDING,
+            created_at=new_ts,
+        )
+        store = DevQueueStore(tasks=[older, newer])
+        save_dev_queue(store)
+
+        loaded = load_dev_queue()
+        result = _find_ticket(loaded, "GEN-581", "genhealth")
+        assert result.created_at == new_ts
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "GEN-581" in captured.err
+
+    def test_find_blocked_on_user_beats_cancelled(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """BLOCKED_ON_USER wins over CANCELLED when no live (PENDING/RUNNING) task."""
+        from datetime import UTC, datetime, timedelta
+
+        old_ts = datetime(2025, 3, 1, tzinfo=UTC)
+        new_ts = old_ts + timedelta(minutes=30)
+        cancelled = TicketTask(
+            ticket_id="GEN-582",
+            client="genhealth",
+            status=QueueItemStatus.CANCELLED,
+            created_at=old_ts,
+        )
+        blocked = TicketTask(
+            ticket_id="GEN-582",
+            client="genhealth",
+            status=QueueItemStatus.BLOCKED_ON_USER,
+            created_at=new_ts,
+        )
+        store = DevQueueStore(tasks=[cancelled, blocked])
+        save_dev_queue(store)
+
+        loaded = load_dev_queue()
+        result = _find_ticket(loaded, "GEN-582", "genhealth")
+        assert result.status == QueueItemStatus.BLOCKED_ON_USER
+
+    def test_find_explicit_created_at_tiebreak(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """Two RUNNING tasks → max created_at wins regardless of list position."""
+        from datetime import UTC, datetime, timedelta
+
+        base = datetime(2025, 4, 1, tzinfo=UTC)
+        earlier = TicketTask(
+            ticket_id="GEN-583",
+            client="genhealth",
+            status=QueueItemStatus.RUNNING,
+            session_id="sess-old",
+            created_at=base,
+        )
+        later = TicketTask(
+            ticket_id="GEN-583",
+            client="genhealth",
+            status=QueueItemStatus.RUNNING,
+            session_id="sess-new",
+            created_at=base + timedelta(hours=3),
+        )
+        # Put the later one FIRST in the list to confirm max() not index
+        store = DevQueueStore(tasks=[later, earlier])
+        save_dev_queue(store)
+
+        loaded = load_dev_queue()
+        result = _find_ticket(loaded, "GEN-583", "genhealth")
+        assert result.session_id == "sess-new"
+
 
 # ---------------------------------------------------------------------------
 # TestMoveTicket


### PR DESCRIPTION
## Summary

- chore: mark impl complete
- chore: fix ruff lint/format issues in new tests
- fix(dev-queue): wire fast-path to _find_ticket helper
- fix(dev-queue): update _find_ticket to prefer live tasks by created_at
- test(dev-queue): add regression tests for #579 duplicate task selection

## Test plan

- [ ] ruff check — zero violations
- [ ] mypy — zero type errors
- [ ] pytest — 100% pass rate
- [ ] No regressions in dispatch, reconcile, or other affected modules

Closes #579

🤖 Shipped via /prep-pr + project /ship-it