### PR TITLE
docs(handoff): milestone 1.1 complete — operator state + Phase 4 pointer

### DIFF
--- a/docs/handoffs/2026-06-12-milestone-1.1-complete.md
+++ b/docs/handoffs/2026-06-12-milestone-1.1-complete.md
@@ -1,0 +1,62 @@
+# Handoff: Milestone 1.1 complete → RFC 0004 Phase 4
+
+**Date:** 2026-06-12. **From:** the 1.1 orchestration session (compacted once;
+this doc is the durable state). **Next milestone brief:** issue **#583**
+(RFC 0004 Phase 4 — ORCHESTRATE sessions), pre-split 4a/4b/4c with
+exclusions and traps documented there. Harden per sub-ticket before dispatch.
+
+## Shipped (all merged)
+
+- **Wave 0** — #387/#563 single state lock + `mutate_state`, #388/#567 writer
+  consolidation, #389/#566 per-tick config reload, #393/#565 event-inbox
+  robustness. #391/#392 closed obsolete (daemon.py deleted in #531).
+- **Wave 1 (ADR-0006, PR #568)** — #552/#570 detect–act split, #554/#572
+  `reap_policy` gate (signal_only default — **breaking**; see below),
+  #555/#573 `SESSION_REAP_PROPOSED` + `doctor --reap` + #542 wait fix,
+  #556/#574 doc inversion.
+- **Lanes (RFC 0004 Ph 1–3)** — #557/#575 schema, #558/#576 two-tier
+  scheduler, #559/#581 lane CLI + override store + `dev-queue move`
+  (folds #507), #561/#577 lane-aware status, #560/#582 per-lane
+  `reap_policy` (capstone re-scoped: Phase 4 deferred to #583).
+- **UX** — #509/#562 onboarding, #312/#569 dispatch auto-ff,
+  #476/#571 status CI/mergeable.
+- **Reliability fixes from this run** — #578/#584 sentinel-aware reconcile
+  routing (`ROUTE_EMITTED_SENTINEL`, 5-min `sentinel_unrouted_check_seconds`),
+  #579/#585 wait live-task binding, #580 post-sentinel prompt hardening +
+  salvage-ship recipe in the cw-followup skill.
+
+## Operator state (things a fresh session must know)
+
+- **Installed `cw` binary is ~20 PRs stale.** Everything above is on main but
+  NOT in `~/.local/bin/cw` until reinstalled (`uv tool install --force
+  git+...` or from the local clone). Until then: no auto-ff, no lane
+  scheduler, no sentinel-aware reconcile at runtime.
+- **`~/.claude-workspace/orchestrator.yaml`**: `per_client_max_parallel:
+  claude-workspace: 3` (drop to 2 for same-subsystem waves) and
+  **`reap_policy: auto`** — deliberate opt-out of the new signal_only
+  default so unattended dispatch self-heals. Post-reinstall the file's
+  legacy ceiling keys still load via the #558 migration validator.
+- Queue is empty; no sessions running; no monitors or wakeups pending.
+
+## Patterns that worked (use again)
+
+- **harden-ticket pre-flight per ticket** → near-every ticket shipped on
+  worker attempt 1–2. Resolution comments are binding specs; correct them
+  publicly when wrong (see #387/#388 premise corrections).
+- **Monitor (event-driven) over timed wakeups** for wave watching: poll
+  dev_queue.json for status transitions + >25-min transcript silence,
+  terminal-filtered, no per-minute counters (event spam).
+- **Salvage-ship recipe** (now in cw-followup skill): wedged worker with
+  pushed branch + sentinel → verify, close, sweep, ship the PR yourself.
+  Should become rare once the reinstalled binary routes sentinels (#584),
+  but #578's worker wedged even with the #580 prompt hardening — root
+  cause is host-side (turn never completes) and is still open on #578.
+
+## Known gotchas (also in global wiki auto-memory)
+
+- "main behind origin" gate failures: check `branch --show-current` first
+  (wrong-branch checkout mimics staleness); fetch before reading ranges.
+- Duplicate queue tasks after park/re-enqueue: fixed by #585 once binary
+  reinstalled; on the stale binary use `remove --all` + re-add.
+- Daemon auto-upgrade restarts (`claude` version bumps) drop just-spawned
+  workers — verify roster registration after dispatching near an upgrade.


### PR DESCRIPTION
Session handoff for the completed 1.1 milestone: shipped inventory, operator state (stale installed binary, orchestrator.yaml opt-ins), reusable patterns, gotchas. Next-milestone brief is #583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)