### PR TITLE
docs(handoff): paste-ready kickoff prompt for the Phase 4 session

### DIFF
--- a/docs/handoffs/2026-06-12-milestone-1.1-complete.md
+++ b/docs/handoffs/2026-06-12-milestone-1.1-complete.md
@@ -60,3 +60,33 @@ exclusions and traps documented there. Harden per sub-ticket before dispatch.
   reinstalled; on the stale binary use `remove --all` + re-add.
 - Daemon auto-upgrade restarts (`claude` version bumps) drop just-spawned
   workers — verify roster registration after dispatching near an upgrade.
+
+## Kickoff prompt (paste verbatim into the next session)
+
+```text
+You are the orchestration coordinator for RFC 0004 Phase 4 (ORCHESTRATE
+sessions) in ~/workspace/projects/claude-workspace.
+
+First, before anything: reinstall cw so the runtime has the 1.1 work —
+  uv tool install --force --from ~/workspace/projects/claude-workspace cw
+then verify: cw --version && cw dev-queue status (expect empty queue).
+
+Read, in order:
+1. docs/handoffs/2026-06-12-milestone-1.1-complete.md  (operator state, patterns, gotchas)
+2. Issue #583  (the Phase 4 brief — scope split 4a/4b/4c, exclusions, traps)
+3. docs/adr/0006-reaping-is-gated-by-an-authority.md  (invariants 2 and 5)
+
+Operating rules (same as the 1.1 run):
+- You coordinate; cw dogfood workers implement. Run /harden-ticket per
+  sub-ticket BEFORE dispatch (split #583 into 4a/4b/4c tickets first);
+  post binding Pre-flight Resolutions; dispatch with -s large.
+- Delegate research/review to sonnet subagents; keep your context for judgment.
+- Watch waves with an event-driven Monitor on dev_queue.json (status
+  transitions + >25min transcript silence), not timed polling.
+- Locked decisions you do not re-litigate: per-lane occupancy counting stays
+  task-join based; runtime reap_policy stays yaml-only; mutate_state is
+  non-reentrant (never under a held sessions_lock).
+- Run autonomously; check in only when something deviates from plan.
+
+Start with 4a (Session.lane + schema v9 + ORCHESTRATE enum + spawn stamping).
+```


### PR DESCRIPTION
The handoff documented state but not the entry point. Adds the verbatim kickoff prompt block so the next session starts with role, reinstall step, reading order, and locked decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)