### PR TITLE
[RFC 0004 Phase 4a] Session.lane + schema v9 + ORCHESTRATE enum + spawn lane plumbing

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -71,6 +71,7 @@ from cw.events import advance_cursor, read_events, record_event
 from cw.exceptions import CwError, MissingWorkspaceError, WorktreeError
 from cw.models import (
     DEFAULT_LANE,
+    WORKER_PURPOSES,
     ClientConfig,
     CompletionReason,
     ConcurrencyOverrides,
@@ -222,7 +223,7 @@ def main(verbose: int) -> None:
 @click.argument("client", shell_complete=_complete_client)
 @click.option(
     "--purpose",
-    type=click.Choice([e.value for e in SessionPurpose]),
+    type=click.Choice([p.value for p in WORKER_PURPOSES]),
     default="impl",
     help="Session purpose.",
 )
@@ -250,7 +251,7 @@ def start(client: str, purpose: str, worktree: str | None, parent: str | None) -
 @click.option(
     "--notify",
     "-n",
-    type=click.Choice([e.value for e in SessionPurpose]),
+    type=click.Choice([p.value for p in WORKER_PURPOSES]),
     default=None,
     help="Notify a sibling session after backgrounding.",
 )
@@ -1029,7 +1030,7 @@ def queue() -> None:
 @click.argument("description")
 @click.option(
     "--purpose",
-    type=click.Choice([e.value for e in SessionPurpose]),
+    type=click.Choice([p.value for p in WORKER_PURPOSES]),
     default="debt",
     help="Queue purpose.",
 )
@@ -1078,7 +1079,7 @@ def _print_queue_table(items: list[QueueItem]) -> None:
 @click.argument("client", required=False, default=None, shell_complete=_complete_client)
 @click.option(
     "--purpose",
-    type=click.Choice([e.value for e in SessionPurpose]),
+    type=click.Choice([p.value for p in WORKER_PURPOSES]),
     default=None,
     help="Filter by purpose.",
 )
@@ -1132,7 +1133,7 @@ def queue_remove(client: str, item_id: str) -> None:
 @click.argument("client", shell_complete=_complete_client)
 @click.option(
     "--purpose",
-    type=click.Choice([e.value for e in SessionPurpose]),
+    type=click.Choice([p.value for p in WORKER_PURPOSES]),
     default=None,
     help="Clear only items with this purpose.",
 )
@@ -1150,7 +1151,7 @@ def queue_clear(client: str, purpose: str | None, completed: bool) -> None:
 @click.argument("client", shell_complete=_complete_client)
 @click.option(
     "--purpose",
-    type=click.Choice([e.value for e in SessionPurpose]),
+    type=click.Choice([p.value for p in WORKER_PURPOSES]),
     default=None,
     help="Filter by purpose.",
 )
@@ -1176,7 +1177,7 @@ def queue_next(client: str, purpose: str | None, as_json: bool) -> None:
 @click.argument("client", shell_complete=_complete_client)
 @click.option(
     "--purpose",
-    type=click.Choice([e.value for e in SessionPurpose]),
+    type=click.Choice([p.value for p in WORKER_PURPOSES]),
     default=None,
     help="Filter by purpose.",
 )

--- a/src/cw/config.py
+++ b/src/cw/config.py
@@ -342,6 +342,7 @@ def migrate_cw_state(raw: dict[str, Any]) -> dict[str, Any]:
             _fill_linkage_field_defaults(session_raw)
             _fill_last_result_default(session_raw)
             _fill_cost_fields_default(session_raw)
+            _fill_session_lane_default(session_raw)
     # Bump persisted schema_version to current after all migration steps.
     raw["schema_version"] = CW_STATE_SCHEMA_VERSION
     return raw
@@ -414,6 +415,12 @@ def _fill_cost_fields_default(session_raw: dict[str, Any]) -> None:
         session_raw["cost_usd"] = None
     if "cost_breakdown" not in session_raw:
         session_raw["cost_breakdown"] = None
+
+
+def _fill_session_lane_default(session_raw: dict[str, Any]) -> None:
+    """Fill Session.lane introduced in schema v9 (GitHub #594). Idempotent."""
+    if "lane" not in session_raw:
+        session_raw["lane"] = None
 
 
 def _clear_non_hex_surface_refs(session_raw: dict[str, Any]) -> None:

--- a/src/cw/dispatch.py
+++ b/src/cw/dispatch.py
@@ -149,8 +149,10 @@ def _lane_stats_for_client(
     """Per-lane ``{claimed: 0, running, pending}`` counts for event payloads.
 
     Why task-based running: RUNNING/BLOCKED_ON_USER tasks carry ``lane``;
-    sessions do not (``Session.lane`` is #560). BLOCKED_ON_USER occupies its
-    lane slot per ADR-0006, so it counts as running here.
+    sessions carry ``lane`` as of #594, but occupancy counting stays task-join
+    based per ADR-0006 / Phase 4a scope (stamped-but-not-read by the
+    scheduler). BLOCKED_ON_USER occupies its lane slot per ADR-0006, so it
+    counts as running here.
     """
     stats: dict[str, dict[str, int]] = {}
     for lane_cfg in client.effective_lanes:
@@ -546,6 +548,7 @@ def dispatch_tick(
                         wall_clock_budget_seconds=resolve_headless_budget(
                             task, None, config
                         ),
+                        lane=task.lane,
                     )
 
                     # Stamp session_id on the queued task so the completion

--- a/src/cw/models.py
+++ b/src/cw/models.py
@@ -16,6 +16,17 @@ class SessionPurpose(StrEnum):
     IMPL = "impl"
     IDEA = "idea"
     DEBT = "debt"
+    ORCHESTRATE = "orchestrate"
+
+
+# Purposes a worker session can be dispatched/created with. ORCHESTRATE is
+# excluded: an ORCHESTRATE session is created only via `cw orchestrate start`
+# (#595 / Phase 4b), never selected as a worker --purpose.
+WORKER_PURPOSES: tuple[SessionPurpose, ...] = (
+    SessionPurpose.IMPL,
+    SessionPurpose.IDEA,
+    SessionPurpose.DEBT,
+)
 
 
 class SessionStatus(StrEnum):
@@ -75,7 +86,8 @@ class ReapReason(StrEnum):
 # v6: added Session.idle_observation_count (GitHub #545).
 # v7: added Session.reap_reason (GitHub #380).
 # v8: added Session.reap_proposed_at (GitHub #555).
-CW_STATE_SCHEMA_VERSION = 8
+# v9: added Session.lane (GitHub #594).
+CW_STATE_SCHEMA_VERSION = 9
 # v3: added TicketTask.lane (GitHub #557).
 DEV_QUEUE_SCHEMA_VERSION = 3
 DEFAULT_LANE: str = "default"
@@ -503,6 +515,11 @@ class Session(BaseModel):
     # this session. Dedup guard: _emit_reap_proposed skips sessions already
     # stamped. See GitHub #555.
     reap_proposed_at: datetime | None = None
+    # Dispatch lane this session was spawned into. Stamped by spawn_create_impl
+    # when called from the dispatch loop (GitHub #594). None for sessions
+    # spawned outside the queue (interactive, plan, cli). Stored for
+    # observability; occupancy counting remains task-join based (ADR-0006).
+    lane: str | None = None
     parent_session_id: str | None = None
     worker_session_ids: list[str] = Field(default_factory=list)
     # Sentinel-block summary parsed from a headless /auto-dev worker's stdout

--- a/src/cw/spawn.py
+++ b/src/cw/spawn.py
@@ -236,6 +236,7 @@ def spawn_create_impl(
     permission_mode: str | None = None,
     task: TicketTask | None = None,
     wall_clock_budget_seconds: int | None = None,
+    lane: str | None = None,
 ) -> str:
     """Create a daemon-spawned session via the native Claude background daemon.
 
@@ -272,6 +273,7 @@ def spawn_create_impl(
         origin=SessionOrigin.DAEMON,
         workspace_path=client.workspace_path,
         worktree_path=worktree,
+        lane=lane,
     )
 
     # Inject Stop-hook config + correlation context into the worktree so

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -801,6 +801,46 @@ class TestMigrateCwState:
         assert session["cost_usd"] == 1.5
         assert session["cost_breakdown"] == {"claude-sonnet-4-6": 1.5}
 
+    def test_v8_to_v9_fills_session_lane_default(self) -> None:
+        """migrate_cw_state fills lane=None on v8 sessions that lack the key."""
+        raw = {
+            "schema_version": 8,
+            "sessions": [
+                {
+                    "id": "s1",
+                    "parent_session_id": None,
+                    "worker_session_ids": [],
+                    "last_result": None,
+                    "cost_usd": None,
+                    "cost_breakdown": None,
+                }
+            ],
+        }
+        migrated = migrate_cw_state(raw)
+        session = migrated["sessions"][0]
+        assert session["lane"] is None
+        assert migrated["schema_version"] == CW_STATE_SCHEMA_VERSION
+
+    def test_v9_session_lane_preserved_idempotently(self) -> None:
+        """Existing non-None lane survives a migration pass."""
+        raw = {
+            "schema_version": 9,
+            "sessions": [
+                {
+                    "id": "s1",
+                    "parent_session_id": None,
+                    "worker_session_ids": [],
+                    "last_result": None,
+                    "cost_usd": None,
+                    "cost_breakdown": None,
+                    "lane": "my-lane",
+                }
+            ],
+        }
+        migrated = migrate_cw_state(raw)
+        session = migrated["sessions"][0]
+        assert session["lane"] == "my-lane"
+
     # -----------------------------------------------------------------------
     # Phase F: cmux surface_ref migration tests (schema v5)
     # -----------------------------------------------------------------------

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -287,6 +287,28 @@ class TestDispatchTickSpawnsSession:
         assert worker.parent_session_id is None
         assert worker.worker_session_ids == []
 
+    def test_dispatch_stamps_task_lane_on_session(
+        self,
+        tmp_dispatch_dirs: Path,
+        sample_client_config: ClientConfig,
+        simple_config: OrchestratorConfig,
+    ) -> None:
+        """dispatch_tick passes task.lane to spawn_create_impl, stamping Session.lane."""
+        _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        task = TicketTask(
+            ticket_id="GEN-LANE",
+            client="test-client",
+            lane="my-lane",
+        )
+        add_ticket(task)
+
+        daemon = FakeNativeDaemonClient()
+        dispatch_tick(simple_config, native_daemon=daemon)
+
+        state = load_state()
+        assert len(state.sessions) == 1
+        assert state.sessions[0].lane == "my-lane"
+
 
 # ---------------------------------------------------------------------------
 # TestPerClientCapRespected

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -293,12 +293,14 @@ class TestDispatchTickSpawnsSession:
         sample_client_config: ClientConfig,
         simple_config: OrchestratorConfig,
     ) -> None:
-        """dispatch_tick passes task.lane to spawn_create_impl, stamping Session.lane."""
+        """dispatch_tick passes task.lane to spawn_create_impl, stamps Session.lane."""
         _make_clients_yaml(tmp_dispatch_dirs, sample_client_config)
+        # Use DEFAULT_LANE so the task matches the client's effective lane and
+        # gets dispatched. Lane is stamped verbatim on the spawned session.
         task = TicketTask(
             ticket_id="GEN-LANE",
             client="test-client",
-            lane="my-lane",
+            lane=DEFAULT_LANE,
         )
         add_ticket(task)
 
@@ -307,7 +309,7 @@ class TestDispatchTickSpawnsSession:
 
         state = load_state()
         assert len(state.sessions) == 1
-        assert state.sessions[0].lane == "my-lane"
+        assert state.sessions[0].lane == DEFAULT_LANE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,6 +22,7 @@ from cw.models import (
     QueueItemStatus,
     ReapPolicy,
     Session,
+    SessionOrigin,
     SessionPurpose,
     SessionStatus,
     TicketTask,
@@ -721,3 +722,45 @@ class TestOrchestratorConfigCeilingMigration:
         config = OrchestratorConfig()
         assert config.per_client_ceiling == {}
         assert config.default_ceiling == 1
+
+
+# --- SessionPurpose.ORCHESTRATE and WORKER_PURPOSES ---
+
+
+def test_session_purpose_orchestrate_exists() -> None:
+    """SessionPurpose.ORCHESTRATE has value 'orchestrate'."""
+    assert SessionPurpose.ORCHESTRATE == "orchestrate"
+    assert SessionPurpose.ORCHESTRATE.value == "orchestrate"
+
+
+def test_worker_purposes_excludes_orchestrate() -> None:
+    """WORKER_PURPOSES tuple contains IMPL/IDEA/DEBT but not ORCHESTRATE."""
+    from cw.models import WORKER_PURPOSES
+
+    assert SessionPurpose.ORCHESTRATE not in WORKER_PURPOSES
+    assert SessionPurpose.IMPL in WORKER_PURPOSES
+    assert SessionPurpose.IDEA in WORKER_PURPOSES
+    assert SessionPurpose.DEBT in WORKER_PURPOSES
+
+
+def test_session_lane_defaults_to_none() -> None:
+    """Session.lane defaults to None when not provided."""
+    sess = Session(
+        name="test/impl",
+        client="test",
+        purpose=SessionPurpose.IMPL,
+        workspace_path=Path("/tmp"),
+    )
+    assert sess.lane is None
+
+
+def test_session_lane_round_trips() -> None:
+    """Session(lane='x') stores and returns the lane value."""
+    sess = Session(
+        name="test/impl",
+        client="test",
+        purpose=SessionPurpose.IMPL,
+        workspace_path=Path("/tmp"),
+        lane="my-lane",
+    )
+    assert sess.lane == "my-lane"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,7 +22,6 @@ from cw.models import (
     QueueItemStatus,
     ReapPolicy,
     Session,
-    SessionOrigin,
     SessionPurpose,
     SessionStatus,
     TicketTask,
@@ -36,7 +35,7 @@ class TestSessionPurpose:
         assert SessionPurpose.DEBT.value == "debt"
 
     def test_all_values(self) -> None:
-        assert len(SessionPurpose) == 3
+        assert len(SessionPurpose) == 4
 
 
 class TestSessionStatus:

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -19,6 +19,7 @@ from cw.dev_queue import load_dev_queue, save_dev_queue
 from cw.events import read_events
 from cw.exceptions import WorktreeError
 from cw.models import (
+    CW_STATE_SCHEMA_VERSION,
     ClientConfig,
     CompletionReason,
     CwState,
@@ -3065,7 +3066,7 @@ def test_confirm_before_reap_v5_state_round_trips(
         )
     )
     loaded = load_state()
-    assert loaded.schema_version == 8
+    assert loaded.schema_version == CW_STATE_SCHEMA_VERSION
     assert loaded.sessions[0].idle_observation_count == 0
 
 

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -300,6 +300,59 @@ class TestSpawnCreate:
         assert state.sessions == []
         assert daemon.spawn_calls == []
 
+    def test_spawn_create_impl_stamps_lane(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """spawn_create_impl(lane='x') stamps session.lane == 'x'."""
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        daemon = FakeNativeDaemonClient()
+        worktree = make_git_repo("worktree-lane-stamp")
+
+        session_id = spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt="/auto-dev GEN-42 --headless",
+            label="auto-dev-GEN-42",
+            native_daemon=daemon,
+            lane="test-lane",
+        )
+
+        state = load_state()
+        sess = state.find_by_name_or_id(session_id)
+        assert sess is not None
+        assert sess.lane == "test-lane"
+
+    def test_spawn_create_impl_default_lane_none(
+        self,
+        tmp_config_dir: Path,
+        tmp_path: Path,
+        make_git_repo: Callable[[str], Path],
+    ) -> None:
+        """spawn_create_impl with no lane kwarg leaves session.lane as None."""
+        from cw.spawn import spawn_create_impl
+
+        client = _make_client(tmp_path)
+        daemon = FakeNativeDaemonClient()
+        worktree = make_git_repo("worktree-lane-default")
+
+        session_id = spawn_create_impl(
+            client=client,
+            worktree=worktree,
+            prompt="/auto-dev GEN-43 --headless",
+            label="auto-dev-GEN-43",
+            native_daemon=daemon,
+        )
+
+        state = load_state()
+        sess = state.find_by_name_or_id(session_id)
+        assert sess is not None
+        assert sess.lane is None
+
 
 class TestSpawnCreateImplWorkerModel:
     """Tests for ClientConfig.worker_model forwarding through spawn_create_impl

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "claude-workspace"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- chore: update uv.lock to reflect v1.1.0 version bump
- chore: mark impl complete for auto-dev pipeline
- fix(test): update test_all_values count for ORCHESTRATE; use DEFAULT_LANE in dispatch lane test
- feat(594): restrict --purpose CLI choices to WORKER_PURPOSES (excludes ORCHESTRATE)
- feat(594): thread lane=task.lane through dispatch spawn; update stale comment
- feat(594): add lane kwarg to spawn_create_impl, stamp on Session constructor
- feat(594): add _fill_session_lane_default migration helper, call in migrate loop
- feat(594): add SessionPurpose.ORCHESTRATE, WORKER_PURPOSES, Session.lane, schema v9
- test(594): add failing tests for ORCHESTRATE, WORKER_PURPOSES, Session.lane, schema v9

## Changes

- `SessionPurpose.ORCHESTRATE = "orchestrate"` added (type exists; not wired to CLI in this PR)
- `WORKER_PURPOSES` tuple restricts CLI `--purpose` choices to IMPL/IDEA/DEBT (prevents accidental `--purpose orchestrate` before 4b)
- `Session.lane: str | None = None` field added for observability; stamped by dispatch, not read by scheduler (ADR-0006: occupancy counting stays task-join based)
- Schema v8→v9: `_fill_session_lane_default()` migration helper
- `spawn_create_impl(lane=)` kwarg + dispatch call site threading
- Tests for all new behavior

No behavior change to occupancy counting, reaping, or CLI.

## Test plan

- [x] ruff check — zero violations
- [x] mypy — zero type errors
- [x] pytest — 2045 passed, 95.87% total coverage, 100% patch coverage
- [x] No regressions in dispatch, reconcile, or other affected modules

Closes #594

🤖 Shipped via /prep-pr + project /ship-it