### PR TITLE
[RFC 0004 Phase 4b] cw orchestrate start --lane — ORCHESTRATE session + lane binding (#595)

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -68,7 +68,12 @@ from cw.doctor import (
     run_doctor,
 )
 from cw.events import advance_cursor, read_events, record_event
-from cw.exceptions import CwError, LaneNotFoundError, MissingWorkspaceError, WorktreeError
+from cw.exceptions import (
+    CwError,
+    LaneNotFoundError,
+    MissingWorkspaceError,
+    WorktreeError,
+)
 from cw.models import (
     DEFAULT_LANE,
     WORKER_PURPOSES,
@@ -2704,7 +2709,11 @@ def orchestrate_start(lane: str, client_name: str | None, as_json: bool) -> None
 
     # R5: Reject if a live ORCHESTRATE session already exists for (client, lane)
     state = load_state()
-    live_statuses = {SessionStatus.ACTIVE, SessionStatus.IDLE, SessionStatus.BACKGROUNDED}
+    live_statuses = {
+        SessionStatus.ACTIVE,
+        SessionStatus.IDLE,
+        SessionStatus.BACKGROUNDED,
+    }
     existing = next(
         (
             s
@@ -2743,7 +2752,9 @@ def orchestrate_start(lane: str, client_name: str | None, as_json: bool) -> None
 
     if as_json:
         click.echo(
-            json.dumps({"session_id": session_id, "lane": lane, "client": client_cfg.name})
+            json.dumps(
+                {"session_id": session_id, "lane": lane, "client": client_cfg.name}
+            )
         )
     else:
         click.echo(f"Spawned orchestrate session for lane '{lane}': {session_id}")

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -68,7 +68,7 @@ from cw.doctor import (
     run_doctor,
 )
 from cw.events import advance_cursor, read_events, record_event
-from cw.exceptions import CwError, MissingWorkspaceError, WorktreeError
+from cw.exceptions import CwError, LaneNotFoundError, MissingWorkspaceError, WorktreeError
 from cw.models import (
     DEFAULT_LANE,
     WORKER_PURPOSES,
@@ -2669,6 +2669,84 @@ def orchestrate_parent(worker_id: str, as_json: bool) -> None:
     else:
         surface = entry.surface_ref if entry.surface_ref is not None else "(none)"
         click.echo(f"{entry.id}  status={entry.status}  surface_ref={surface}")
+
+
+@orchestrate.command(name="start")
+@click.option(
+    "--lane",
+    "lane",
+    required=True,
+    help="Lane name to bind the ORCHESTRATE session to.",
+)
+@click.option(
+    "--client",
+    "client_name",
+    default=None,
+    help="Client name (defaults to first configured client).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON.")
+@handle_errors
+def orchestrate_start(lane: str, client_name: str | None, as_json: bool) -> None:
+    """Spawn an ORCHESTRATE-purpose session bound to a lane.
+
+    Records the lane-authority binding for use by Phase 4c.
+    At most one live ORCHESTRATE session is allowed per (client, lane).
+    """
+    client_cfg = _resolve_client(client_name)
+    declared = [ln.name for ln in client_cfg.effective_lanes]
+    if lane not in declared:
+        msg = (
+            f"Lane '{lane}' is not declared for client '{client_cfg.name}'. "
+            f"Declared lanes: {', '.join(declared)}. "
+            f"Run: cw lane add {client_cfg.name} {lane}"
+        )
+        raise LaneNotFoundError(msg)
+
+    # R5: Reject if a live ORCHESTRATE session already exists for (client, lane)
+    state = load_state()
+    live_statuses = {SessionStatus.ACTIVE, SessionStatus.IDLE, SessionStatus.BACKGROUNDED}
+    existing = next(
+        (
+            s
+            for s in state.sessions
+            if s.client == client_cfg.name
+            and s.purpose == SessionPurpose.ORCHESTRATE
+            and s.lane == lane
+            and s.status in live_statuses
+        ),
+        None,
+    )
+    if existing is not None:
+        msg = (
+            f"An ORCHESTRATE session for lane '{lane}' already exists: "
+            f"{existing.id!r} (status: {existing.status.value}). "
+            f"Clear it first with: cw spawn complete {existing.id} --status completed"
+        )
+        raise CwError(msg)
+
+    native_daemon = get_native_daemon_client()
+    session_id = spawn_create_impl(
+        client=client_cfg,
+        worktree=client_cfg.workspace_path,
+        prompt=(
+            f"You are the lane-authority binding for lane '{lane}' on client "
+            f"'{client_cfg.name}'. This session records the binding; the "
+            "event-consumption loop is added separately (Phase 4c). "
+            "You may end your turn now."
+        ),
+        label=f"orchestrate/{lane}",
+        purpose=SessionPurpose.ORCHESTRATE,
+        lane=lane,
+        permission_mode="acceptEdits",
+        native_daemon=native_daemon,
+    )
+
+    if as_json:
+        click.echo(
+            json.dumps({"session_id": session_id, "lane": lane, "client": client_cfg.name})
+        )
+    else:
+        click.echo(f"Spawned orchestrate session for lane '{lane}': {session_id}")
 
 
 # --- Spawn command group ---

--- a/src/cw/spawn.py
+++ b/src/cw/spawn.py
@@ -237,6 +237,7 @@ def spawn_create_impl(
     task: TicketTask | None = None,
     wall_clock_budget_seconds: int | None = None,
     lane: str | None = None,
+    purpose: SessionPurpose = SessionPurpose.IMPL,
 ) -> str:
     """Create a daemon-spawned session via the native Claude background daemon.
 
@@ -269,7 +270,7 @@ def spawn_create_impl(
     sess = Session(
         name=f"{client.name}/{session_label}",
         client=client.name,
-        purpose=SessionPurpose.IMPL,
+        purpose=purpose,
         origin=SessionOrigin.DAEMON,
         workspace_path=client.workspace_path,
         worktree_path=worktree,
@@ -285,7 +286,7 @@ def spawn_create_impl(
         session_id=sess.id,
         session_name=sess.name,
         client=client.name,
-        purpose=SessionPurpose.IMPL.value,
+        purpose=purpose.value,
         ticket_id=ticket_id,
         origin=SessionOrigin.DAEMON,
         headless=headless,

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -1505,15 +1505,39 @@ class TestTickSummaryLanes:
 # ---------------------------------------------------------------------------
 
 
-def _write_client_with_lane(tmp_config_dir: Path, lane_name: str = "impl") -> Path:
+def _write_client_with_lane(
+    tmp_config_dir: Path,
+    lane_name: str = "impl",
+) -> Path:
     """Write a clients.yaml with one client declaring a named lane.
 
-    Returns the workspace path so callers can create sessions against it.
+    Initialises the workspace as a minimal git repo so _validate_worktree
+    inside spawn_create_impl accepts it. Returns the workspace path.
     """
+    import os
+    import subprocess
+
     from cw.config import clients_file
 
     workspace = tmp_config_dir / "workspace" / "test-client"
     workspace.mkdir(parents=True, exist_ok=True)
+
+    # Initialise a bare-minimum git repo (validate_worktree runs git rev-parse).
+    clean_env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+    def _git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(workspace), *args],
+            capture_output=True,
+            check=True,
+            env=clean_env,
+        )
+
+    _git("init", "-b", "main")
+    _git("config", "user.email", "test@example.com")
+    _git("config", "user.name", "cw test")
+    _git("commit", "--allow-empty", "-m", "initial")
+
     clients_path = clients_file()
     clients_path.parent.mkdir(parents=True, exist_ok=True)
     clients_path.write_text(
@@ -1538,9 +1562,6 @@ class TestOrchestrateStart:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """start --lane <declared> spawns an ORCHESTRATE session with correct metadata."""
-        from cw.config import load_state
-        from cw.models import SessionPurpose
-
         workspace = _write_client_with_lane(tmp_config_dir, "impl")
         monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: mock_native_daemon)
 
@@ -1580,9 +1601,6 @@ class TestOrchestrateStart:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Second start on a lane with a live ORCHESTRATE session is rejected."""
-        from cw.config import save_state
-        from cw.models import CwState, Session, SessionPurpose, SessionStatus
-
         workspace = _write_client_with_lane(tmp_config_dir, "impl")
         monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: mock_native_daemon)
 
@@ -1612,9 +1630,6 @@ class TestOrchestrateStart:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """start succeeds when prior ORCHESTRATE session for lane is COMPLETED."""
-        from cw.config import load_state, save_state
-        from cw.models import CwState, Session, SessionPurpose, SessionStatus
-
         workspace = _write_client_with_lane(tmp_config_dir, "impl")
         monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: mock_native_daemon)
 

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -26,6 +26,7 @@ from cw.models import (
     SessionStatus,
     TicketTask,
 )
+from cw.native_daemon import FakeNativeDaemonClient
 from cw.orchestrate import (
     MissingWorkerEntry,
     OrchestratorStatus,
@@ -1497,3 +1498,169 @@ class TestTickSummaryLanes:
         parsed = json.loads(snapshot.model_dump_json())
         assert "legacy-json-client" in parsed["last_tick_by_client"]
         assert parsed["last_tick_by_client"]["legacy-json-client"]["lanes"] == {}
+
+
+# ---------------------------------------------------------------------------
+# TestOrchestrateStart — Phase 4b: cw orchestrate start --lane
+# ---------------------------------------------------------------------------
+
+
+def _write_client_with_lane(tmp_config_dir: Path, lane_name: str = "impl") -> Path:
+    """Write a clients.yaml with one client declaring a named lane.
+
+    Returns the workspace path so callers can create sessions against it.
+    """
+    from cw.config import clients_file
+
+    workspace = tmp_config_dir / "workspace" / "test-client"
+    workspace.mkdir(parents=True, exist_ok=True)
+    clients_path = clients_file()
+    clients_path.parent.mkdir(parents=True, exist_ok=True)
+    clients_path.write_text(
+        f"clients:\n"
+        f"  test-client:\n"
+        f"    workspace_path: {workspace}\n"
+        f"    default_branch: main\n"
+        f"    lanes:\n"
+        f"      - name: {lane_name}\n"
+        f"        max_parallel: 1\n"
+    )
+    return workspace
+
+
+class TestOrchestrateStart:
+    """Tests for `cw orchestrate start --lane` command (Phase 4b)."""
+
+    def test_start_happy_path(
+        self,
+        tmp_config_dir: Path,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """start --lane <declared> spawns an ORCHESTRATE session with correct metadata."""
+        from cw.config import load_state
+        from cw.models import SessionPurpose
+
+        workspace = _write_client_with_lane(tmp_config_dir, "impl")
+        monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: mock_native_daemon)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["orchestrate", "start", "--lane", "impl"])
+
+        assert result.exit_code == 0, result.output
+        assert "impl" in result.output
+
+        state = load_state()
+        assert len(state.sessions) == 1
+        sess = state.sessions[0]
+        assert sess.purpose == SessionPurpose.ORCHESTRATE
+        assert sess.lane == "impl"
+        assert sess.client == "test-client"
+
+    def test_start_undeclared_lane(
+        self,
+        tmp_config_dir: Path,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """start --lane <undeclared> exits non-zero with LaneNotFoundError message."""
+        _write_client_with_lane(tmp_config_dir, "impl")
+        monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: mock_native_daemon)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["orchestrate", "start", "--lane", "no-such-lane"])
+
+        assert result.exit_code != 0
+        assert "no-such-lane" in result.output
+
+    def test_start_rejects_live_duplicate(
+        self,
+        tmp_config_dir: Path,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Second start on a lane with a live ORCHESTRATE session is rejected."""
+        from cw.config import save_state
+        from cw.models import CwState, Session, SessionPurpose, SessionStatus
+
+        workspace = _write_client_with_lane(tmp_config_dir, "impl")
+        monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: mock_native_daemon)
+
+        # Seed a live ORCHESTRATE session for the lane.
+        existing = Session(
+            id="orch-live-01",
+            name="test-client/orchestrate/impl",
+            client="test-client",
+            purpose=SessionPurpose.ORCHESTRATE,
+            status=SessionStatus.ACTIVE,
+            workspace_path=workspace,
+            lane="impl",
+        )
+        save_state(CwState(sessions=[existing]))
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["orchestrate", "start", "--lane", "impl"])
+
+        assert result.exit_code != 0
+        assert "impl" in result.output
+        assert "orch-live-01" in result.output
+
+    def test_start_allows_rebind_on_terminal(
+        self,
+        tmp_config_dir: Path,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """start succeeds when prior ORCHESTRATE session for lane is COMPLETED."""
+        from cw.config import load_state, save_state
+        from cw.models import CwState, Session, SessionPurpose, SessionStatus
+
+        workspace = _write_client_with_lane(tmp_config_dir, "impl")
+        monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: mock_native_daemon)
+
+        # Prior ORCHESTRATE session is COMPLETED (terminal) — rebind allowed.
+        old = Session(
+            id="orch-done-01",
+            name="test-client/orchestrate/impl",
+            client="test-client",
+            purpose=SessionPurpose.ORCHESTRATE,
+            status=SessionStatus.COMPLETED,
+            workspace_path=workspace,
+            lane="impl",
+        )
+        save_state(CwState(sessions=[old]))
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["orchestrate", "start", "--lane", "impl"])
+
+        assert result.exit_code == 0, result.output
+        state = load_state()
+        # Two sessions now: the old completed one + new active one.
+        orch_sessions = [
+            s for s in state.sessions if s.purpose == SessionPurpose.ORCHESTRATE
+        ]
+        assert len(orch_sessions) == 2
+        new_sess = next(s for s in orch_sessions if s.id != "orch-done-01")
+        assert new_sess.lane == "impl"
+        assert new_sess.status == SessionStatus.ACTIVE
+
+    def test_start_json_output(
+        self,
+        tmp_config_dir: Path,
+        mock_native_daemon: FakeNativeDaemonClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--json emits parseable JSON with session_id, lane, client keys."""
+        _write_client_with_lane(tmp_config_dir, "impl")
+        monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: mock_native_daemon)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["orchestrate", "start", "--lane", "impl", "--json"]
+        )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert "session_id" in data
+        assert data["lane"] == "impl"
+        assert data["client"] == "test-client"

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -1561,9 +1561,11 @@ class TestOrchestrateStart:
         mock_native_daemon: FakeNativeDaemonClient,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """start --lane <declared> spawns an ORCHESTRATE session with correct metadata."""
-        workspace = _write_client_with_lane(tmp_config_dir, "impl")
-        monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: mock_native_daemon)
+        """start --lane <declared> spawns ORCHESTRATE session with correct metadata."""
+        _write_client_with_lane(tmp_config_dir, "impl")
+        monkeypatch.setattr(
+            "cw.cli.get_native_daemon_client", lambda: mock_native_daemon
+        )
 
         runner = CliRunner()
         result = runner.invoke(main, ["orchestrate", "start", "--lane", "impl"])
@@ -1586,7 +1588,9 @@ class TestOrchestrateStart:
     ) -> None:
         """start --lane <undeclared> exits non-zero with LaneNotFoundError message."""
         _write_client_with_lane(tmp_config_dir, "impl")
-        monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: mock_native_daemon)
+        monkeypatch.setattr(
+            "cw.cli.get_native_daemon_client", lambda: mock_native_daemon
+        )
 
         runner = CliRunner()
         result = runner.invoke(main, ["orchestrate", "start", "--lane", "no-such-lane"])
@@ -1602,7 +1606,9 @@ class TestOrchestrateStart:
     ) -> None:
         """Second start on a lane with a live ORCHESTRATE session is rejected."""
         workspace = _write_client_with_lane(tmp_config_dir, "impl")
-        monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: mock_native_daemon)
+        monkeypatch.setattr(
+            "cw.cli.get_native_daemon_client", lambda: mock_native_daemon
+        )
 
         # Seed a live ORCHESTRATE session for the lane.
         existing = Session(
@@ -1631,7 +1637,9 @@ class TestOrchestrateStart:
     ) -> None:
         """start succeeds when prior ORCHESTRATE session for lane is COMPLETED."""
         workspace = _write_client_with_lane(tmp_config_dir, "impl")
-        monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: mock_native_daemon)
+        monkeypatch.setattr(
+            "cw.cli.get_native_daemon_client", lambda: mock_native_daemon
+        )
 
         # Prior ORCHESTRATE session is COMPLETED (terminal) — rebind allowed.
         old = Session(
@@ -1667,7 +1675,9 @@ class TestOrchestrateStart:
     ) -> None:
         """--json emits parseable JSON with session_id, lane, client keys."""
         _write_client_with_lane(tmp_config_dir, "impl")
-        monkeypatch.setattr("cw.cli.get_native_daemon_client", lambda: mock_native_daemon)
+        monkeypatch.setattr(
+            "cw.cli.get_native_daemon_client", lambda: mock_native_daemon
+        )
 
         runner = CliRunner()
         result = runner.invoke(

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -1964,7 +1964,7 @@ def test_spawn_create_impl_orchestrate_purpose(
     tmp_path: Path,
     make_git_repo: Callable[[str], Path],
 ) -> None:
-    """spawn_create_impl with purpose=ORCHESTRATE stamps session.purpose and writes purpose.value to hook context."""
+    """spawn_create_impl(purpose=ORCHESTRATE) stamps session.purpose and context."""
     from cw.spawn import spawn_create_impl
 
     client = _make_client(tmp_path)

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -1957,3 +1957,62 @@ class TestWriteHookContextOriginShaSuccess:
 
         context = json.loads((worktree / ".claude" / "cw-context.json").read_text())
         assert context["world_state_snapshot"]["origin_main_sha_at_spawn"] == fake_sha
+
+
+def test_spawn_create_impl_orchestrate_purpose(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    make_git_repo: Callable[[str], Path],
+) -> None:
+    """spawn_create_impl with purpose=ORCHESTRATE stamps session.purpose and writes purpose.value to hook context."""
+    from cw.spawn import spawn_create_impl
+
+    client = _make_client(tmp_path)
+    daemon = FakeNativeDaemonClient()
+    worktree = make_git_repo("worktree-orchestrate-purpose")
+
+    session_id = spawn_create_impl(
+        client=client,
+        worktree=worktree,
+        prompt="You are the orchestrate session.",
+        label="orchestrate/impl",
+        native_daemon=daemon,
+        purpose=SessionPurpose.ORCHESTRATE,
+    )
+
+    state = load_state()
+    sess = state.find_by_name_or_id(session_id)
+    assert sess is not None
+    assert sess.purpose == SessionPurpose.ORCHESTRATE
+
+    context = json.loads((worktree / ".claude" / "cw-context.json").read_text())
+    assert context["purpose"] == "orchestrate"
+
+
+def test_spawn_create_impl_default_purpose(
+    tmp_config_dir: Path,
+    tmp_path: Path,
+    make_git_repo: Callable[[str], Path],
+) -> None:
+    """spawn_create_impl default path stamps IMPL."""
+    from cw.spawn import spawn_create_impl
+
+    client = _make_client(tmp_path)
+    daemon = FakeNativeDaemonClient()
+    worktree = make_git_repo("worktree-default-purpose")
+
+    session_id = spawn_create_impl(
+        client=client,
+        worktree=worktree,
+        prompt="Do the thing.",
+        label=None,
+        native_daemon=daemon,
+    )
+
+    state = load_state()
+    sess = state.find_by_name_or_id(session_id)
+    assert sess is not None
+    assert sess.purpose == SessionPurpose.IMPL
+
+    context = json.loads((worktree / ".claude" / "cw-context.json").read_text())
+    assert context["purpose"] == "impl"


### PR DESCRIPTION
## RFC 0004 Phase 4b — `cw orchestrate start --lane`

Adds `cw orchestrate start --lane <name>`: spawns an `ORCHESTRATE`-purpose session bound to a lane and records the lane-authority **binding** (per the operator decision on the 4b/4c boundary — 4b is binding-only; the live event-consumption loop is Phase 4c #596).

- `spawn_create_impl` gains a `purpose` param (defaults to `IMPL`; threaded to the `Session` + hook context).
- `cw orchestrate start` added to the existing `orchestrate` group; `orchestrator-start` (PR-events listener) untouched.
- `--lane` validated against the client's declared lanes (`LaneNotFoundError`).
- At most one **live** ORCHESTRATE session per (client, lane); a second is rejected with the existing session's id + status.
- `--json` output; `--client` defaults to first configured client.

Resolves the binding-only scope; no keep-alive / consumption loop (deferred to 4c).

### Provenance / salvage note
The dispatched worker implemented this on `dev/595` (4 TDD commits) but hit the weekly usage limit before opening a PR or emitting a terminal sentinel. The orchestrator verified the full CI gate locally — ruff ✓, ruff format ✓, mypy --strict ✓, 2052 unit tests pass, total coverage 95.9%, patch coverage 100% — and reviewed the diff against the ticket's Pre-flight Resolutions before opening this PR. Integration tests run on CI; auto-merge gates on green.

Closes #595.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
