### PR TITLE
[RFC 0004 Phase 4c] orchestrate run + ORCHESTRATE phantom guard

### DIFF
--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import functools
 import json
 import logging
-import os
 import subprocess
 import sys
 import time
@@ -2764,7 +2763,7 @@ def orchestrate_start(lane: str, client_name: str | None, as_json: bool) -> None
         click.echo(f"Spawned orchestrate session for lane '{lane}': {session_id}")
 
 
-_POLL_INTERVAL_SECONDS = 5
+_POLL_INTERVAL_SECONDS: float = 5.0
 
 
 def _consumer_name(client: str, lane: str) -> str:
@@ -2773,8 +2772,8 @@ def _consumer_name(client: str, lane: str) -> str:
     Sanitizes path separators so events._cursor_path does not create nested
     directories under cursors/ when client or lane names contain slashes.
     """
-    sanitized_client = client.replace("/", "-").replace(os.sep, "-")
-    sanitized_lane = lane.replace("/", "-").replace(os.sep, "-")
+    sanitized_client = client.replace("/", "-")
+    sanitized_lane = lane.replace("/", "-")
     return f"orchestrate-{sanitized_client}-{sanitized_lane}"
 
 
@@ -2792,6 +2791,10 @@ def _drain_reap_proposals(client: str, lane: str) -> int:
         consumer=consumer,
         event_types=[OrchestratorEventType.SESSION_REAP_PROPOSED],
     )
+    # Load state once for the entire drain pass; sequential consumer, no
+    # lock needed here — _reap_session_by_selector acquires sessions_lock()
+    # itself when it mutates (cf. #387/#563 non-reentrancy constraint).
+    state = load_state()
     processed = 0
     for event in events:
         payload = event.payload
@@ -2805,12 +2808,12 @@ def _drain_reap_proposals(client: str, lane: str) -> int:
         proposed_action = payload.get("proposed_action", "")
 
         # Idempotency guard: skip already-terminal sessions.
-        state = load_state()
+        # Use {ACTIVE, IDLE} — mirrors reconcile._LIVE_STATUSES. BACKGROUNDED
+        # sessions are user-backgrounded; this consumer should not reap them.
         session = next((s for s in state.sessions if s.id == session_id), None)
         if session is None or session.status not in {
             SessionStatus.ACTIVE,
             SessionStatus.IDLE,
-            SessionStatus.BACKGROUNDED,
         }:
             logger.info(
                 "orchestrate run: session %s already resolved, skipping", session_id
@@ -2888,6 +2891,7 @@ def orchestrate_run(lane: str, client_name: str | None, once: bool) -> None:
         )
         raise LaneNotFoundError(msg)
 
+    _live = {SessionStatus.ACTIVE, SessionStatus.IDLE, SessionStatus.BACKGROUNDED}
     state = load_state()
     binding = next(
         (
@@ -2896,12 +2900,13 @@ def orchestrate_run(lane: str, client_name: str | None, once: bool) -> None:
             if s.client == client_cfg.name
             and s.purpose == SessionPurpose.ORCHESTRATE
             and s.lane == lane
+            and s.status in _live
         ),
         None,
     )
     if binding is None:
         msg = (
-            f"No ORCHESTRATE binding for lane '{lane}'; "
+            f"No live ORCHESTRATE binding for lane '{lane}'; "
             f"run `cw orchestrate start --lane {lane}` first."
         )
         raise CwError(msg)

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import json
 import logging
+import os
 import subprocess
 import sys
 import time
@@ -122,6 +123,7 @@ from cw.queue import (
     remove_item,
 )
 from cw.reconcile import (
+    ProposedAction,
     _apply_sentinel_to_task,
     _csid_from_transcript,
     _locate_session_transcript,
@@ -147,6 +149,8 @@ from cw.worktree import fast_forward_main
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
 
 
 def handle_errors[**P, R](fn: Callable[P, R]) -> Callable[P, R]:
@@ -2758,6 +2762,157 @@ def orchestrate_start(lane: str, client_name: str | None, as_json: bool) -> None
         )
     else:
         click.echo(f"Spawned orchestrate session for lane '{lane}': {session_id}")
+
+
+_POLL_INTERVAL_SECONDS = 5
+
+
+def _consumer_name(client: str, lane: str) -> str:
+    """Return the event cursor consumer name for an orchestrate run consumer.
+
+    Sanitizes path separators so events._cursor_path does not create nested
+    directories under cursors/ when client or lane names contain slashes.
+    """
+    sanitized_client = client.replace("/", "-").replace(os.sep, "-")
+    sanitized_lane = lane.replace("/", "-").replace(os.sep, "-")
+    return f"orchestrate-{sanitized_client}-{sanitized_lane}"
+
+
+def _drain_reap_proposals(client: str, lane: str) -> int:
+    """Drain one pass of SESSION_REAP_PROPOSED events for the given lane.
+
+    Authorizes REVERT_TASK and CRASH_COMPLETE by calling
+    _reap_session_by_selector. Logs-and-leaves PARK_BLOCKED_ON_USER (already
+    routed to operator review by reconcile).
+
+    Returns the count of events processed (consumed from cursor).
+    """
+    consumer = _consumer_name(client, lane)
+    events = read_events(
+        consumer=consumer,
+        event_types=[OrchestratorEventType.SESSION_REAP_PROPOSED],
+    )
+    processed = 0
+    for event in events:
+        payload = event.payload
+        if payload.get("lane") != lane:
+            # Advance cursor past events for other lanes so they are not
+            # replayed on every drain, but do not count them as processed
+            # by this consumer (lane isolation: each lane owns its events).
+            advance_cursor(consumer, event.id)
+            continue
+        session_id = payload.get("session_id", "")
+        proposed_action = payload.get("proposed_action", "")
+
+        # Idempotency guard: skip already-terminal sessions.
+        state = load_state()
+        session = next((s for s in state.sessions if s.id == session_id), None)
+        if session is None or session.status not in {
+            SessionStatus.ACTIVE,
+            SessionStatus.IDLE,
+            SessionStatus.BACKGROUNDED,
+        }:
+            logger.info(
+                "orchestrate run: session %s already resolved, skipping", session_id
+            )
+            advance_cursor(consumer, event.id)
+            processed += 1
+            continue
+
+        if proposed_action in {
+            ProposedAction.REVERT_TASK.value,
+            ProposedAction.CRASH_COMPLETE.value,
+        }:
+            # Why: _reap_session_by_selector acquires sessions_lock() itself and
+            # is NOT reentrant. Safe here because orchestrate run is a standalone
+            # command, NOT inside reconcile's held sessions_lock/_reconcile_locked
+            # window. Never invoke this from inside a held lock (cf. #387/#563).
+            # Why: under reap_policy=auto, sessions are already terminal when this
+            # consumer reads the event; the status guard above makes it a no-op.
+            _reap_session_by_selector(session_id)
+            logger.info(
+                "orchestrate run: authorized reap for session %s (action=%s)",
+                session_id,
+                proposed_action,
+            )
+        else:
+            # PARK_BLOCKED_ON_USER or unknown action: leave at BLOCKED_ON_USER
+            # routing for the operator. Salvage deferred to follow-on ticket.
+            logger.info(
+                "orchestrate run: action %s for session %s deferred"
+                " (not authorize-eligible)",
+                proposed_action,
+                session_id,
+            )
+
+        advance_cursor(consumer, event.id)
+        processed += 1
+    return processed
+
+
+@orchestrate.command(name="run")
+@click.option(
+    "--lane",
+    "lane",
+    required=True,
+    help="Lane name to consume SESSION_REAP_PROPOSED events for.",
+)
+@click.option(
+    "--client",
+    "client_name",
+    default=None,
+    help="Client name (defaults to first configured client).",
+)
+@click.option(
+    "--once",
+    "once",
+    is_flag=True,
+    help="Drain available events once and exit (default: poll loop).",
+)
+@handle_errors
+def orchestrate_run(lane: str, client_name: str | None, once: bool) -> None:
+    """Consume SESSION_REAP_PROPOSED events for a lane and authorize reaps.
+
+    Requires an ORCHESTRATE binding for the lane (created by
+    ``cw orchestrate start --lane <lane>``). Authorizes clear-cut phantom
+    reaps via the same path as ``cw doctor --reap``; defers salvage to a
+    follow-on ticket.
+    """
+    client_cfg = _resolve_client(client_name)
+    declared = [ln.name for ln in client_cfg.effective_lanes]
+    if lane not in declared:
+        msg = (
+            f"Lane '{lane}' is not declared for client '{client_cfg.name}'. "
+            f"Declared lanes: {', '.join(declared)}. "
+            f"Run: cw lane add {client_cfg.name} {lane}"
+        )
+        raise LaneNotFoundError(msg)
+
+    state = load_state()
+    binding = next(
+        (
+            s
+            for s in state.sessions
+            if s.client == client_cfg.name
+            and s.purpose == SessionPurpose.ORCHESTRATE
+            and s.lane == lane
+        ),
+        None,
+    )
+    if binding is None:
+        msg = (
+            f"No ORCHESTRATE binding for lane '{lane}'; "
+            f"run `cw orchestrate start --lane {lane}` first."
+        )
+        raise CwError(msg)
+
+    if once:
+        _drain_reap_proposals(client_cfg.name, lane)
+        return
+
+    while True:
+        _drain_reap_proposals(client_cfg.name, lane)
+        time.sleep(_POLL_INTERVAL_SECONDS)
 
 
 # --- Spawn command group ---

--- a/src/cw/cli.py
+++ b/src/cw/cli.py
@@ -2808,12 +2808,15 @@ def _drain_reap_proposals(client: str, lane: str) -> int:
         proposed_action = payload.get("proposed_action", "")
 
         # Idempotency guard: skip already-terminal sessions.
-        # Use {ACTIVE, IDLE} — mirrors reconcile._LIVE_STATUSES. BACKGROUNDED
-        # sessions are user-backgrounded; this consumer should not reap them.
+        # Use {ACTIVE, IDLE, BACKGROUNDED} per spec R3 — terminal statuses
+        # (COMPLETED, PENDING, etc.) trigger the skip; live sessions proceed.
+        # _reap_session_by_selector's own lock guard is the authoritative
+        # fence against double-reap (cf. #387/#563).
         session = next((s for s in state.sessions if s.id == session_id), None)
         if session is None or session.status not in {
             SessionStatus.ACTIVE,
             SessionStatus.IDLE,
+            SessionStatus.BACKGROUNDED,
         }:
             logger.info(
                 "orchestrate run: session %s already resolved, skipping", session_id
@@ -2891,7 +2894,7 @@ def orchestrate_run(lane: str, client_name: str | None, once: bool) -> None:
         )
         raise LaneNotFoundError(msg)
 
-    _live = {SessionStatus.ACTIVE, SessionStatus.IDLE, SessionStatus.BACKGROUNDED}
+    # Any-status match: orchestrate start's binding self-completes to COMPLETED.
     state = load_state()
     binding = next(
         (
@@ -2900,13 +2903,12 @@ def orchestrate_run(lane: str, client_name: str | None, once: bool) -> None:
             if s.client == client_cfg.name
             and s.purpose == SessionPurpose.ORCHESTRATE
             and s.lane == lane
-            and s.status in _live
         ),
         None,
     )
     if binding is None:
         msg = (
-            f"No live ORCHESTRATE binding for lane '{lane}'; "
+            f"No ORCHESTRATE binding for lane '{lane}'; "
             f"run `cw orchestrate start --lane {lane}` first."
         )
         raise CwError(msg)

--- a/src/cw/reconcile.py
+++ b/src/cw/reconcile.py
@@ -90,6 +90,7 @@ from cw.models import (
     ReapPolicy,
     ReapReason,
     SessionOrigin,
+    SessionPurpose,
     SessionStatus,
     TicketTask,
 )
@@ -288,6 +289,8 @@ def compute_drift(
         if session.surface_ref in native_live:
             continue
         if session.started_at > cutoff:
+            continue
+        if session.purpose is SessionPurpose.ORCHESTRATE:
             continue
         phantoms.append(session.id)
     return ReconcileReport(phantom_session_ids=phantoms)

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -1955,7 +1955,8 @@ def test_orchestrate_run_binding_gate_raises_without_binding(
     runner = CliRunner()
     result = runner.invoke(main, ["orchestrate", "run", "--lane", "lane-x", "--once"])
     assert result.exit_code != 0
-    assert "No ORCHESTRATE binding" in (result.output + str(result.exception or ""))
+    combined = result.output + str(result.exception or "")
+    assert "No live ORCHESTRATE binding" in combined
 
 
 def test_orchestrate_run_once_flag_exits(
@@ -1967,7 +1968,9 @@ def test_orchestrate_run_once_flag_exits(
     from cw.config import load_state, save_state
 
     state = load_state()
-    state.sessions.append(_mk_orchestrate_session("binding-1", lane="lane-x"))
+    state.sessions.append(
+        _mk_orchestrate_session("binding-1", lane="lane-x", status=SessionStatus.ACTIVE)
+    )
     save_state(state)
 
     drain_calls: list[tuple[str, str]] = []

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -17,6 +17,7 @@ from cw.dev_queue import add_ticket
 from cw.events import read_events, record_event
 from cw.exceptions import CwError
 from cw.models import (
+    DEFAULT_LANE,
     CompletionReason,
     CwState,
     OrchestratorEventType,
@@ -40,6 +41,7 @@ from cw.orchestrate import (
     retire_merged_prs,
     save_dispatch_record,
 )
+from cw.reconcile import ProposedAction
 
 _RunnerFn = Callable[[list[str]], subprocess.CompletedProcess[str]]
 
@@ -1689,3 +1691,295 @@ class TestOrchestrateStart:
         assert "session_id" in data
         assert data["lane"] == "impl"
         assert data["client"] == "test-client"
+
+
+# ---------------------------------------------------------------------------
+# cw orchestrate run — drain + authorize
+# ---------------------------------------------------------------------------
+
+
+def _mk_orchestrate_session(
+    sid: str,
+    lane: str,
+    client: str = "client-a",
+    status: SessionStatus = SessionStatus.COMPLETED,
+) -> Session:
+    """Create an ORCHESTRATE-purpose binding session for test setup."""
+    return Session(
+        id=sid,
+        name=f"{client}/orchestrate/{lane}",
+        client=client,
+        purpose=SessionPurpose.ORCHESTRATE,
+        status=status,
+        lane=lane,
+        workspace_path=Path("/tmp/ws"),
+        surface_ref=None,
+        started_at=datetime(2026, 4, 19, tzinfo=UTC),
+    )
+
+
+def _mk_impl_session(
+    sid: str,
+    lane: str = DEFAULT_LANE,
+    client: str = "client-a",
+    status: SessionStatus = SessionStatus.ACTIVE,
+) -> Session:
+    """Create an IMPL-purpose active session for reap candidate tests."""
+    return Session(
+        id=sid,
+        name=f"{client}/impl/{sid}",
+        client=client,
+        purpose=SessionPurpose.IMPL,
+        status=status,
+        lane=lane,
+        workspace_path=Path("/tmp/ws"),
+        surface_ref=f"surf-{sid}",
+        started_at=datetime(2026, 4, 19, tzinfo=UTC),
+    )
+
+
+def _emit_reap_event(
+    session_id: str,
+    lane: str,
+    proposed_action: ProposedAction,
+    client: str = "client-a",
+) -> None:
+    """Emit a SESSION_REAP_PROPOSED event for testing."""
+    record_event(
+        OrchestratorEventType.SESSION_REAP_PROPOSED,
+        {
+            "session_id": session_id,
+            "session_name": f"{client}/impl/{session_id}",
+            "client": client,
+            "ticket_id": None,
+            "lane": lane,
+            "proposed_action": proposed_action.value,
+            "reason": None,
+            "evidence": {},
+        },
+        correlation_id=session_id,
+    )
+
+
+@pytest.fixture
+def run_env(tmp_orchestrate_dirs: Path) -> Path:
+    """Set up a minimal client config with a lane for orchestrate run tests."""
+    from cw.config import clients_file
+
+    clients_path = clients_file()
+    clients_path.parent.mkdir(parents=True, exist_ok=True)
+    clients_path.write_text(
+        "clients:\n"
+        "  client-a:\n"
+        "    workspace_path: /tmp/ws\n"
+        "    lanes:\n"
+        "      - name: default\n"
+        "        reap_policy: signal_only\n"
+        "      - name: lane-x\n"
+        "        reap_policy: signal_only\n"
+        "      - name: lane-y\n"
+        "        reap_policy: signal_only\n"
+    )
+    return tmp_orchestrate_dirs
+
+
+def test_orchestrate_run_drain_authorizes_revert_task(
+    run_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drain authorizes REVERT_TASK by calling _reap_session_by_selector."""
+    from cw.cli import _drain_reap_proposals
+
+    reap_calls: list[str] = []
+
+    def fake_reap(selector: str) -> bool:
+        reap_calls.append(selector)
+        return True
+
+    monkeypatch.setattr("cw.cli._reap_session_by_selector", fake_reap)
+
+    # Seed state with an active IMPL session
+    from cw.config import load_state, save_state
+
+    state = load_state()
+    state.sessions.append(_mk_impl_session("s1", lane="default"))
+    save_state(state)
+
+    _emit_reap_event("s1", "default", ProposedAction.REVERT_TASK)
+    count = _drain_reap_proposals("client-a", "default")
+
+    assert count == 1
+    assert reap_calls == ["s1"]
+
+
+def test_orchestrate_run_drain_authorizes_crash_complete(
+    run_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drain authorizes CRASH_COMPLETE by calling _reap_session_by_selector."""
+    from cw.cli import _drain_reap_proposals
+
+    reap_calls: list[str] = []
+
+    def fake_reap(selector: str) -> bool:
+        reap_calls.append(selector)
+        return True
+
+    monkeypatch.setattr("cw.cli._reap_session_by_selector", fake_reap)
+
+    from cw.config import load_state, save_state
+
+    state = load_state()
+    state.sessions.append(_mk_impl_session("s2", lane="default"))
+    save_state(state)
+
+    _emit_reap_event("s2", "default", ProposedAction.CRASH_COMPLETE)
+    count = _drain_reap_proposals("client-a", "default")
+
+    assert count == 1
+    assert reap_calls == ["s2"]
+
+
+def test_orchestrate_run_drain_logs_and_leaves_park_blocked(
+    run_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drain does NOT reap for PARK_BLOCKED_ON_USER.
+
+    Leaves at BLOCKED_ON_USER routing for operator review.
+    """
+    from cw.cli import _drain_reap_proposals
+
+    reap_calls: list[str] = []
+
+    def fake_reap(selector: str) -> bool:
+        reap_calls.append(selector)
+        return True
+
+    monkeypatch.setattr("cw.cli._reap_session_by_selector", fake_reap)
+
+    from cw.config import load_state, save_state
+
+    state = load_state()
+    state.sessions.append(_mk_impl_session("s3", lane="default"))
+    save_state(state)
+
+    _emit_reap_event("s3", "default", ProposedAction.PARK_BLOCKED_ON_USER)
+    count = _drain_reap_proposals("client-a", "default")
+
+    assert count == 1
+    assert reap_calls == []  # NOT reaped
+
+
+def test_orchestrate_run_drain_idempotent_replay(
+    run_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drain is a no-op for already-terminal sessions (idempotent replay)."""
+    from cw.cli import _drain_reap_proposals
+
+    reap_calls: list[str] = []
+
+    def fake_reap(selector: str) -> bool:
+        reap_calls.append(selector)
+        return True
+
+    monkeypatch.setattr("cw.cli._reap_session_by_selector", fake_reap)
+
+    from cw.config import load_state, save_state
+
+    # Session already COMPLETED
+    state = load_state()
+    state.sessions.append(
+        _mk_impl_session("s4", lane="default", status=SessionStatus.COMPLETED)
+    )
+    save_state(state)
+
+    _emit_reap_event("s4", "default", ProposedAction.REVERT_TASK)
+    count = _drain_reap_proposals("client-a", "default")
+
+    assert count == 1
+    assert reap_calls == []  # No reap — already terminal
+
+
+def test_orchestrate_run_lane_isolation_adversarial(
+    run_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lane-X drain MUST NOT reap a lane-Y session (adversarial isolation test)."""
+    from cw.cli import _drain_reap_proposals
+
+    reap_calls: list[str] = []
+
+    def fake_reap(selector: str) -> bool:
+        reap_calls.append(selector)
+        return True
+
+    monkeypatch.setattr("cw.cli._reap_session_by_selector", fake_reap)
+
+    from cw.config import load_state, save_state
+
+    state = load_state()
+    state.sessions.append(_mk_impl_session("lane-y-session", lane="lane-y"))
+    save_state(state)
+
+    # Emit event for lane-Y
+    _emit_reap_event("lane-y-session", "lane-y", ProposedAction.REVERT_TASK)
+
+    # Drain lane-X — must not touch lane-Y session
+    count = _drain_reap_proposals("client-a", "lane-x")
+
+    # lane-X consumer does not count lane-Y events as processed
+    assert count == 0
+    state_after = load_state()
+    lane_y_session = next(s for s in state_after.sessions if s.id == "lane-y-session")
+    assert lane_y_session.status == SessionStatus.ACTIVE  # Unchanged
+
+
+def test_orchestrate_run_lane_validation_raises(
+    run_env: Path,
+) -> None:
+    """--lane with unknown lane raises LaneNotFoundError."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["orchestrate", "run", "--lane", "nonexistent-lane", "--once"]
+    )
+    assert result.exit_code != 0
+    assert "nonexistent-lane" in (result.output + str(result.exception or ""))
+
+
+def test_orchestrate_run_binding_gate_raises_without_binding(
+    run_env: Path,
+) -> None:
+    """cw orchestrate run errors if no ORCHESTRATE binding exists for lane."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["orchestrate", "run", "--lane", "lane-x", "--once"])
+    assert result.exit_code != 0
+    assert "No ORCHESTRATE binding" in (result.output + str(result.exception or ""))
+
+
+def test_orchestrate_run_once_flag_exits(
+    run_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--once flag: drains once and exits (does not poll)."""
+    # Seed a binding so the binding gate passes
+    from cw.config import load_state, save_state
+
+    state = load_state()
+    state.sessions.append(_mk_orchestrate_session("binding-1", lane="lane-x"))
+    save_state(state)
+
+    drain_calls: list[tuple[str, str]] = []
+
+    def counting_drain(client: str, lane: str) -> int:
+        drain_calls.append((client, lane))
+        return 0
+
+    monkeypatch.setattr("cw.cli._drain_reap_proposals", counting_drain)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["orchestrate", "run", "--lane", "lane-x", "--once"])
+
+    assert result.exit_code == 0
+    assert len(drain_calls) == 1  # Exactly one drain, then exit

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -1902,6 +1902,41 @@ def test_orchestrate_run_drain_idempotent_replay(
     assert reap_calls == []  # No reap — already terminal
 
 
+def test_orchestrate_run_drain_backgrounded_proceeds_to_reap_check(
+    run_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BACKGROUNDED sessions are not treated as terminal by the idempotency guard (R3).
+
+    A BACKGROUNDED session passes the outer guard and proceeds to
+    _reap_session_by_selector, which applies its own inner lock-guarded check.
+    """
+    from cw.cli import _drain_reap_proposals
+
+    reap_calls: list[str] = []
+
+    def fake_reap(selector: str) -> bool:
+        reap_calls.append(selector)
+        return False  # inner guard would reject BACKGROUNDED
+
+    monkeypatch.setattr("cw.cli._reap_session_by_selector", fake_reap)
+
+    from cw.config import load_state, save_state
+
+    state = load_state()
+    state.sessions.append(
+        _mk_impl_session("s5", lane="default", status=SessionStatus.BACKGROUNDED)
+    )
+    save_state(state)
+
+    _emit_reap_event("s5", "default", ProposedAction.REVERT_TASK)
+    count = _drain_reap_proposals("client-a", "default")
+
+    assert count == 1
+    # BACKGROUNDED is in the live set — drain forwards to _reap_session_by_selector
+    assert reap_calls == ["s5"]
+
+
 def test_orchestrate_run_lane_isolation_adversarial(
     run_env: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1956,7 +1991,7 @@ def test_orchestrate_run_binding_gate_raises_without_binding(
     result = runner.invoke(main, ["orchestrate", "run", "--lane", "lane-x", "--once"])
     assert result.exit_code != 0
     combined = result.output + str(result.exception or "")
-    assert "No live ORCHESTRATE binding" in combined
+    assert "No ORCHESTRATE binding" in combined
 
 
 def test_orchestrate_run_once_flag_exits(
@@ -1968,9 +2003,8 @@ def test_orchestrate_run_once_flag_exits(
     from cw.config import load_state, save_state
 
     state = load_state()
-    state.sessions.append(
-        _mk_orchestrate_session("binding-1", lane="lane-x", status=SessionStatus.ACTIVE)
-    )
+    # Default status is COMPLETED — matches 4b's self-completing binding
+    state.sessions.append(_mk_orchestrate_session("binding-1", lane="lane-x"))
     save_state(state)
 
     drain_calls: list[tuple[str, str]] = []

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -67,12 +67,13 @@ def _mk_session(
     surface_ref: str | None,
     status: SessionStatus = SessionStatus.ACTIVE,
     started_at: datetime | None = None,
+    purpose: SessionPurpose = SessionPurpose.IMPL,
 ) -> Session:
     return Session(
         id=sid,
         name=f"client-a/{sid}",
         client="client-a",
-        purpose=SessionPurpose.IMPL,
+        purpose=purpose,
         status=status,
         workspace_path=ClientConfig(
             name="client-a", workspace_path=Path("/tmp/ws")
@@ -258,6 +259,33 @@ def test_compute_drift_empty_live_set_from_both_backends_is_reconciled() -> None
     )
     report = compute_drift(state, set())
     assert set(report.phantom_session_ids) == {"s1", "s2"}
+
+
+def test_compute_drift_skips_orchestrate_purpose_session() -> None:
+    """ORCHESTRATE sessions are excluded from phantom detection (R5 guard).
+
+    ORCHESTRATE binding sessions have no live worker process by design,
+    so they must never be classified as phantoms.
+    """
+    state = CwState(
+        sessions=[
+            _mk_session("orch1", "missing-ref", purpose=SessionPurpose.ORCHESTRATE),
+        ]
+    )
+    report = compute_drift(state, set())
+    assert report.phantom_session_ids == []
+
+
+def test_compute_drift_still_flags_impl_phantom_with_orchestrate_present() -> None:
+    """ORCHESTRATE guard does not suppress IMPL phantom detection."""
+    state = CwState(
+        sessions=[
+            _mk_session("orch1", "missing-ref", purpose=SessionPurpose.ORCHESTRATE),
+            _mk_session("impl1", "also-missing"),
+        ]
+    )
+    report = compute_drift(state, set())
+    assert report.phantom_session_ids == ["impl1"]
 
 
 def test_reconcile_marks_phantom_completed_crashed(


### PR DESCRIPTION
## Summary

- Adds `cw orchestrate run --lane <name>` command that drains `SESSION_REAP_PROPOSED` events from the event bus and authorizes phantom reaps via `_reap_session_by_selector` (ADR-0006 single write path)
- Lane isolation enforced: foreign-lane events are cursor-advanced but not counted as processed
- Idempotency guard uses `{ACTIVE, IDLE, BACKGROUNDED}` per spec R3; `_reap_session_by_selector`'s own lock-guarded inner check is the authoritative fence
- Binding gate accepts any-status ORCHESTRATE session (4b's `orchestrate start` self-completes to COMPLETED — no live-status filter required)
- `PARK_BLOCKED_ON_USER` deferred to follow-on ticket (salvage work)
- Adds `SessionPurpose.ORCHESTRATE` guard in `compute_drift` so binding sessions are never classified as phantoms

## Changes

- `src/cw/cli.py` — `_consumer_name`, `_drain_reap_proposals`, `orchestrate run` command, module logger, `ProposedAction` import
- `src/cw/reconcile.py` — `SessionPurpose` import + ORCHESTRATE phantom guard in `compute_drift`
- `tests/test_orchestrate.py` — 9 new tests (drain authorization, idempotency, lane isolation, binding gate, once flag, BACKGROUNDED handling)
- `tests/test_reconcile.py` — `_mk_session` purpose param + 2 new tests for phantom guard

## Known deferred items

- `_reap_session_by_selector` does not emit an audit event to the event bus — a pre-existing gap that becomes load-bearing with this automated consumer. Follow-on ticket to add `record_event` in the caller.
- `while True` poll loop has no graceful `KeyboardInterrupt` handler. Follow-on.

## Test plan

- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run ruff format --check src/ tests/` — zero reformats
- [x] `uv run mypy --strict src/` — zero type errors
- [x] `uv run pytest tests/ -m 'not integration'` — 2063 passed
- [x] `uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90` — 94%
- [x] Lane isolation adversarial test
- [x] BACKGROUNDED idempotency test
- [x] Binding gate with COMPLETED binding (4b real-world scenario)

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)